### PR TITLE
PC-4514 et 4515 : Modifications sur le password hasher : meilleure perf en tests + correction mineure de sécurité

### DIFF
--- a/domain/password.py
+++ b/domain/password.py
@@ -2,17 +2,15 @@ import re
 from datetime import datetime, timedelta
 from typing import Dict
 
-import bcrypt
-
 from models import ApiErrors, UserSQLEntity
+from models.user_sql_entity import hash_password
 from utils.token import random_token
 
 RESET_PASSWORD_TOKEN_LENGTH = 10
 
 
-def random_password():
-    return bcrypt.hashpw(random_token(length=12).encode('utf-8'), bcrypt.gensalt())
-
+def random_password() -> bytes:
+    return hash_password(random_token(length=12))
 
 
 def check_password_validity(new_password: str, new_confirmation_password: str, old_password: str, user: UserSQLEntity) -> None:

--- a/models/user_sql_entity.py
+++ b/models/user_sql_entity.py
@@ -33,7 +33,7 @@ def _hash_password_with_bcrypt(clear_text: str) -> bytes:
 
 
 def _check_password_with_bcrypt(clear_text: str, hashed: str) -> bool:
-    return bcrypt.hashpw(clear_text.encode('utf-8'), hashed) == hashed
+    return bcrypt.checkpw(clear_text.encode('utf-8'), hashed)
 
 
 def _hash_password_with_md5(clear_text: str) -> bytes:

--- a/scripts/beneficiary/file_import.py
+++ b/scripts/beneficiary/file_import.py
@@ -4,13 +4,12 @@ import re
 from datetime import datetime
 from typing import List, Set, Iterable, Callable
 
-import bcrypt
-
 from domain.admin_emails import send_users_activation_report
 from domain.password import generate_reset_token, random_password
 from domain.user_activation import generate_activation_users_csv
 from models import UserSQLEntity, BookingSQLEntity, StockSQLEntity
 from models.booking_sql_entity import ActivationUser
+from models.user_sql_entity import hash_password
 from repository import booking_queries, repository
 from repository.stock_queries import find_online_activation_stock
 from repository.user_queries import find_user_by_email
@@ -201,6 +200,6 @@ def _extract_departement_code(plain_department: str) -> str:
 def _get_password(csv_row: List[List[str]]) -> str:
     has_password_in_csv = len(csv_row) - 1 == PASSWORD_INDEX
     if has_password_in_csv:
-        return bcrypt.hashpw(csv_row[PASSWORD_INDEX].encode('utf-8'), bcrypt.gensalt())
+        return hash_password(csv_row[PASSWORD_INDEX])
     else:
         return random_password()

--- a/tests/scripts/beneficiary/file_import_test.py
+++ b/tests/scripts/beneficiary/file_import_test.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import Mock, patch
 
 from models import UserSQLEntity, BookingSQLEntity
 from scripts.beneficiary.file_import import fill_user_from, \
@@ -25,7 +25,7 @@ class FillUserFromTest:
             'super_secure_password'
         ]
 
-    @patch('bcrypt.hashpw')
+    @patch('scripts.beneficiary.file_import.hash_password')
     def test_returns_an_user_with_data_from_csv_row(self, hashpw):
         # when
         user = fill_user_from(self.csv_row, UserSQLEntity())
@@ -39,7 +39,7 @@ class FillUserFromTest:
         assert user.departementCode == '22'
         assert user.postalCode == '22850'
         assert user.dateOfBirth == datetime(1923, 3, 15)
-        hashpw.assert_called_with('super_secure_password'.encode('utf-8'), ANY)
+        hashpw.assert_called_with('super_secure_password')
 
     def test_returns_a_formatted_phone_number(self):
         # given

--- a/tests/scripts/offerer/file_import_test.py
+++ b/tests/scripts/offerer/file_import_test.py
@@ -159,8 +159,7 @@ class FillUserFromTest:
             'MyBletcheyCompany'
         ]
 
-    @patch('bcrypt.hashpw')
-    def test_returns_an_user_with_data_from_csv_row(self, hashpw):
+    def test_returns_an_user_with_data_from_csv_row(self):
         # when
         user = fill_user_from(self.csv_row, UserSQLEntity())
 


### PR DESCRIPTION
2 commits à relire individuellement (dans la même _pull request_ parce que le second dépend du premier).

Sur ma machine, `pytest tests/routes` passe de 170s à 80s. Sur Circle CI, l'amélioration n'est pas aussi notable. En fait ça semble difficile à quantifier : les 3 runs successifs de cette branche ont pris 6min38s, 5min57s et 5min41s. Le temps de run a donc l'air déjà très variable de base.