### PR TITLE
PC-4526 : Meilleur affichage des tests en échec dans CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,10 @@ jobs:
           name: Running tests
           command: |
             . venv/bin/activate
-            RUN_ENV=tests pytest tests --cov --cov-report html -x
+            RUN_ENV=tests pytest tests --cov --cov-report html --junitxml=test-results/junit.xml -x
             coveralls
+      - store_test_results:
+          path: test-results
       - store_artifacts:
           path: htmlcov
 


### PR DESCRIPTION
Exemple de résumé désormais automatiquement fourni par CircleCI : https://app.circleci.com/pipelines/github/pass-culture/pass-culture-api/316/workflows/87bca590-2c17-4c66-8393-bbd2634acfb8/jobs/450/tests.