### PR TITLE
___ wip: introduce marshmallow for serialization and deserializatio in the web API

### DIFF
--- a/routes/error_handlers/generic_error_handlers.py
+++ b/routes/error_handlers/generic_error_handlers.py
@@ -103,3 +103,15 @@ def date_time_cast_error(error: DateTimeCastError) -> Tuple[Dict, int]:
 def already_activated_exception(error: AlreadyActivatedException) -> Tuple[Dict, int]:
     app.logger.error(json.dumps(error.errors))
     return jsonify(error.errors), 405
+
+
+import marshmallow
+@app.errorhandler(marshmallow.ValidationError)
+def deserialization_error(error: marshmallow.ValidationError) -> Tuple[Dict, int]:
+    api_errors = ApiErrors()
+    for key, error_messages in error.messages:
+        # marshmallow peut détecter plusieurs erreurs par champ. Ici
+        # on s'adapte à ce qui est fait actuellement : ne renvoyer
+        # qu'une erreur par champ.
+        api_errors.add_error(key, error_messages[0])
+    return jsonify(api_errors.errors), 400

--- a/routes/openapi.py
+++ b/routes/openapi.py
@@ -1,0 +1,28 @@
+from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
+from apispec_webframeworks.flask import FlaskPlugin
+
+from flask_app import app
+
+
+spec = APISpec(
+    title="Pass culture API",
+    version="1.0.0",
+    openapi_version="3.0.3",
+    plugins=[FlaskPlugin(), MarshmallowPlugin()],
+)
+
+
+with app.test_request_context():
+    # Routes need to be imported within the context manager, otherwise
+    # Flask raises a RuntimeError: "Working outside of application
+    # context".
+    from routes import users
+
+    spec.path(view=users.patch_profile)
+
+
+if __name__ == '__main__':
+    # On peut aussi exporter en JSON:
+    # print(json.dumps(spec.to_dict()))
+    print(spec.to_yaml())

--- a/routes/users.py
+++ b/routes/users.py
@@ -83,6 +83,18 @@ class UserSerializer(marshmallow.Schema):
 @login_or_api_key_required
 @expect_json_data
 def patch_profile():
+    """Update user's profile.
+
+    ---
+    post:
+      description: Update the logged-in user's profile.
+      responses:
+        200:
+          description: Return the user's profile
+          content:
+            application/json:
+              schema: UserSerializer
+    """
     request_data = request.json.keys()
 
     schema = UserUpdateSchema()

--- a/routes/users.py
+++ b/routes/users.py
@@ -72,12 +72,25 @@ class UserUpdateSchema(marshmallow.Schema):
 class UserSerializer(marshmallow.Schema):
     id  = fields.Integer()
     email = fields.Email()
-    phone_number = fields.Email()
+    phone_number = fields.String()
     # [...]
     has_physical_venues = fields.Boolean()
     has_offers = fields.Boolean()
 
 
+# Avec un peu d'outillage, je pense qu'on peut facilement arriver à
+# une docstring plus concise, du genre :
+#
+#     """Update user's profile
+#
+#     ---
+#     patch:
+#       description: Return the user's profile
+#       body: UserUpdateSchema
+#       serializer: UserSerializer
+#     """
+#
+# cf. https://apispec.readthedocs.io/en/latest/writing_plugins.html#example-docstring-parsing-plugin
 
 @app.route('/users/current', methods=['PATCH'])
 @login_or_api_key_required
@@ -86,11 +99,16 @@ def patch_profile():
     """Update user's profile.
 
     ---
-    post:
+    patch:
       description: Update the logged-in user's profile.
+      requestBody:
+        content:
+          application/json:
+            schema: UserUpdateSchema
       responses:
         200:
           description: Return the user's profile
+          parameters:
           content:
             application/json:
               schema: UserSerializer

--- a/routes/users.py
+++ b/routes/users.py
@@ -29,29 +29,76 @@ def check_activation_token_exists(token):
     return jsonify(), 200
 
 
+import marshmallow
+from marshmallow import fields
+
+
+# Note : Il y a une recette assez simple pour gérer automatiquement la
+# conversion CamelCase vs. snake_case, si besoin :
+# https://marshmallow.readthedocs.io/en/latest/examples.html#inflection-camel-casing-keys
+# Attention à la génération OpenAPI, par contre.
+
+
+def validate_department_code(code):
+    if code in ('2A', '2B'):
+        return
+    try:
+        int(code)
+    except ValueError:
+        raise marshmallow.ValidationError("Département incorrect")
+    # [...]
+
+
+class UserUpdateSchema(marshmallow.Schema):
+    public_name = fields.String()
+    email = fields.Email()
+    phone_number = fields.String()
+    department_code = fields.String(validate=validate_department_code)
+    postal_code = fields.String()
+    has_seen_tutorials = fields.Boolean()
+    cultural_survey_id = fields.Integer()
+    cultural_survey_filled_date = fields.DateTime()
+    needs_to_fill_cultural_survey = fields.Boolean()
+
+    @marshmallow.validates_schema
+    def validate_postal_and_department_codes_match(self, data, **kwargs):
+        # simpliste, évidemment, c'est juste pour donner un exemple
+        postal_code = data['postal_code']
+        department_code = data['department_code']
+        if not postal_code.startswith(department_code):
+            raise marshmallow.ValidationError("Le code postal et le département ne correspondent pas.")
+
+
+class UserSerializer(marshmallow.Schema):
+    id  = fields.Integer()
+    email = fields.Email()
+    phone_number = fields.Email()
+    # [...]
+    has_physical_venues = fields.Boolean()
+    has_offers = fields.Boolean()
+
+
+
 @app.route('/users/current', methods=['PATCH'])
 @login_or_api_key_required
 @expect_json_data
 def patch_profile():
-    data = request.json.keys()
-    check_allowed_changes_for_user(data)
+    request_data = request.json.keys()
 
-    user_informations = AlterableUserInformations(
-        id= current_user.id,
-        cultural_survey_id=request.json.get('culturalSurveyId'),
-        cultural_survey_filled_date=request.json.get('culturalSurveyFilledDate'),
-        department_code=request.json.get('departementCode'),
-        email=request.json.get('email'),
-        needs_to_fill_cultural_survey=request.json.get('needsToFillCulturalSurvey'),
-        phone_number=request.json.get('phoneNumber'),
-        postal_code=request.json.get('postalCode'),
-        public_name=request.json.get('publicName'),
-        has_seen_tutorials=request.json.get('hasSeenTutorials')
-    )
-    user = update_user_informations(user_informations)
+    schema = UserUpdateSchema()
+    # load() peut lever une ValidationError, cf. deserialization_error
+    # pour le renvoi d'une erreur HTTP 400 automatique.
+    schema.load(request_data)
 
-    formattedUser = as_dict(user, includes=USER_INCLUDES)
-    return jsonify(formattedUser), 200
+    # je n'aime pas trop cette façon de passer un objet à une fonction
+    # de mise à jour, mais c'est un autre sujet.
+    user = update_user_informations(schema)
+
+    # On pourrait utiliser `dumps()` (avec un "s") qui renvoie
+    # directement du JSON. À voir si `jsonify()` a un intérêt
+    # particulier.
+    serialized = UserSerializer().dump(user)
+    return jsonify(serialized), 200
 
 
 @app.route("/users/signin", methods=["POST"])


### PR DESCRIPTION
Sortie YAML via `python routes/openapi.py` (on peut aussi exporter la spéc en JSON) :

```yaml
components:
  schemas:
    UserSerializer:
      properties:
        email:
          format: email
          type: string
        has_offers:
          type: boolean
        has_physical_venues:
          type: boolean
        id:
          type: integer
        phone_number:
          type: string
      type: object
    UserUpdate:
      properties:
        cultural_survey_filled_date:
          format: date-time
          type: string
        cultural_survey_id:
          type: integer
        department_code:
          type: string
        email:
          format: email
          type: string
        has_seen_tutorials:
          type: boolean
        needs_to_fill_cultural_survey:
          type: boolean
        phone_number:
          type: string
        postal_code:
          type: string
        public_name:
          type: string
      type: object
info:
  title: Pass culture API
  version: 1.0.0
openapi: 3.0.3
paths:
  /users/current:
    patch:
      description: Update the logged-in user's profile.
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/UserUpdate'
      responses:
        '200':
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/UserSerializer'
          description: Return the user's profile
          parameters: null
```