### PR TITLE
Fix cors header validation

### DIFF
--- a/src/pcapi/validation/routes/headers.py
+++ b/src/pcapi/validation/routes/headers.py
@@ -11,7 +11,7 @@ def check_origin_header_validity(header, endpoint, path):
         return True
 
     if not header:
-        return False
+        return True
 
     white_list = _get_origin_header_whitelist()
     combined_white_list = "(" + ")|(".join(white_list) + ")"


### PR DESCRIPTION
Not having a "Origin" header means two things:
- The person calling the API is not on a browser (no need for CORS header validation)
- The person calling the API is on the same domain as the API itself (no need for CORS header validation since it's a same-domain call)

Hence, we should return true when no Origin Header is received