### PR TITLE
(PC 4516) : move more tests to db rollback mode

### DIFF
--- a/src/pcapi/repository/providable_queries.py
+++ b/src/pcapi/repository/providable_queries.py
@@ -39,12 +39,7 @@ def _extract_dict_values_from_chunk(matching_tuples_in_chunk: List[Model]) -> Li
 
 
 def get_existing_object(model_type: Model, id_at_providers: str) -> Optional[Dict]:
-    conn = db.engine.connect()
-    query = select([model_type]). \
-        where(model_type.idAtProviders == id_at_providers)
-    db_object_dict = conn.execute(query).fetchone()
-
-    return _dict_to_object(db_object_dict, model_type) if db_object_dict else None
+    return model_type.query.filter_by(idAtProviders=id_at_providers).first()
 
 
 def get_last_update_for_provider(provider_id: int, pc_obj: Model) -> datetime:

--- a/tests/connectors/redis_test.py
+++ b/tests/connectors/redis_test.py
@@ -1,6 +1,7 @@
 import os
 from unittest.mock import patch, MagicMock
 
+import pytest
 import redis
 
 from pcapi.connectors.redis import add_offer_id, get_offer_ids, delete_offer_ids, \
@@ -12,8 +13,6 @@ from pcapi.connectors.redis import add_offer_id, get_offer_ids, delete_offer_ids
     delete_venue_provider_currently_in_sync, get_number_of_venue_providers_currently_in_sync, add_offer_ids_in_error, \
     get_offer_ids_in_error, delete_offer_ids_in_error
 from pcapi.repository import repository
-from tests.conftest import clean_database
-import pytest
 from pcapi.model_creators.generic_creators import create_venue_provider, create_venue, create_user, create_offerer, \
     create_user_offerer, create_provider
 
@@ -160,7 +159,7 @@ class AddVenueProviderTest:
 
     @patch('pcapi.connectors.redis._add_venue_provider')
     @patch('pcapi.connectors.redis.redis')
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_send_venue_provider_should_call_add_venue_provider_with_redis_client_and_venue_provider(self,
                                                                                                      mock_redis,
                                                                                                      mock_add_venue_provider,
@@ -250,7 +249,7 @@ class AddToIndexedOffersTest:
 
 
 class DeleteIndexedOffersTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_delete_indexed_offers(self, app):
         # Given
         client = MagicMock()

--- a/tests/emails/offer_cancellation_test.py
+++ b/tests/emails/offer_cancellation_test.py
@@ -2,7 +2,8 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from bs4 import BeautifulSoup
-from tests.conftest import clean_database
+import pytest
+
 from pcapi.model_creators.generic_creators import create_booking, create_offerer, create_user, create_venue
 from pcapi.model_creators.specific_creators import create_event_occurrence, create_offer_with_event_product, create_offer_with_thing_product, create_product_with_thing_type, \
     create_stock_from_event_occurrence, create_stock_from_offer
@@ -13,7 +14,7 @@ from pcapi.utils.mailing import make_offerer_driven_cancellation_email_for_offer
 
 
 class MakeOffererDrivenCancellationEmailForOffererTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_make_offerer_driven_cancellation_email_for_offerer_event_when_no_other_booking(self, app):
         # Given
         beginning_datetime = datetime(2019, 7, 20, 12, 0, 0, tzinfo=timezone.utc)
@@ -51,7 +52,7 @@ class MakeOffererDrivenCancellationEmailForOffererTest:
         assert email[
             'Subject'] == 'Confirmation de votre annulation de réservation pour Le théâtre des ombres, proposé par Le petit théâtre'
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_make_offerer_driven_cancellation_email_for_offerer_event_when_other_booking(self, app):
         # Given
         user1 = create_user(email='john@doe.fr', first_name='John', last_name='Doe', public_name='John Doe')
@@ -82,7 +83,7 @@ class MakeOffererDrivenCancellationEmailForOffererTest:
         assert 'jane@smith.fr' in html_recap_table
         assert '12345' in html_recap_table
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_make_offerer_driven_cancellation_email_for_offerer_thing_and_already_existing_booking(self, app):
         # Given
         user = create_user(email='john@doe.fr', first_name='John', last_name='Doe', public_name='John Doe')
@@ -323,7 +324,7 @@ class MakeOffererBookingRecapEmailAfterUserCancellationWithMailjetTemplateTest:
 
 
 class IsOfferActiveForRecapTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_true_when_offer_is_active_and_stock_still_bookable(self, app):
         # Given
         offerer = create_offerer()
@@ -338,7 +339,7 @@ class IsOfferActiveForRecapTest:
         # Then
         assert is_active
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_false_when_offer_is_not_active(self, app):
         # Given
         offerer = create_offerer()
@@ -353,7 +354,7 @@ class IsOfferActiveForRecapTest:
         # Then
         assert not is_active
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_false_when_stock_has_no_remaining_quantity(self, app):
         # Given
         user = create_user()
@@ -371,7 +372,7 @@ class IsOfferActiveForRecapTest:
         # Then
         assert not is_active
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_false_when_stock_booking_limit_is_past(self, app):
         # Given
         user = create_user()
@@ -389,7 +390,7 @@ class IsOfferActiveForRecapTest:
         # Then
         assert not is_active
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_true_when_stock_is_unlimited(self, app):
         # Given
         user = create_user()
@@ -406,7 +407,7 @@ class IsOfferActiveForRecapTest:
         # Then
         assert is_active
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_false_when_stock_is_unlimited_but_booking_date_is_past(self, app):
         # Given
         user = create_user()

--- a/tests/emails/offerer_attachment_validation_test.py
+++ b/tests/emails/offerer_attachment_validation_test.py
@@ -1,13 +1,14 @@
 from unittest.mock import patch
 
+import pytest
+
 from pcapi.repository import repository
 from pcapi.emails.offerer_attachment_validation import retrieve_data_for_offerer_attachment_validation_email
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_offerer, create_user, create_user_offerer
 
 
 class ProOffererAttachmentValidationEmailTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.emails.offerer_attachment_validation.DEV_EMAIL_ADDRESS', 'dev@example.com')
     @patch('pcapi.emails.offerer_attachment_validation.feature_send_mail_to_users_enabled', return_value=False)
     @patch('pcapi.emails.offerer_attachment_validation.format_environment_for_email', return_value='-testing')
@@ -42,7 +43,7 @@ class ProOffererAttachmentValidationEmailTest:
                 }
         }
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.emails.offerer_attachment_validation.feature_send_mail_to_users_enabled', return_value=True)
     @patch('pcapi.emails.offerer_attachment_validation.format_environment_for_email', return_value='')
     @patch('pcapi.emails.offerer_attachment_validation.find_user_offerer_email',

--- a/tests/emails/offerer_booking_recap_test.py
+++ b/tests/emails/offerer_booking_recap_test.py
@@ -1,12 +1,13 @@
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+import pytest
+
 from pcapi.domain.booking.booking import Booking
 from pcapi.domain.stock.stock import Stock
 from pcapi.emails.offerer_booking_recap import retrieve_data_for_offerer_booking_recap_email
 from pcapi.models import ThingType
 from pcapi.repository import repository
-from tests.conftest import clean_database
 from tests.domain_creators.generic_creators import create_domain_beneficiary
 from pcapi.model_creators.generic_creators import create_booking, create_user, create_offerer, create_venue, \
     create_deposit, create_stock
@@ -17,7 +18,7 @@ from pcapi.model_creators.specific_creators import create_stock_from_offer, crea
 class MakeOffererBookingRecapEmailWithMailjetTemplateTest:
     @patch('pcapi.emails.offerer_booking_recap.SUPPORT_EMAIL_ADDRESS', 'support@example.com')
     @patch('pcapi.utils.mailing.DEV_EMAIL_ADDRESS', 'dev@example.com')
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_write_email_with_right_data_when_offer_is_an_event(self, app):
         # Given
         user_sql_entity = create_user(idx=1, email='test@example.com', first_name='John', last_name='Doe')
@@ -80,7 +81,7 @@ class MakeOffererBookingRecapEmailWithMailjetTemplateTest:
 
     @patch('pcapi.emails.offerer_booking_recap.SUPPORT_EMAIL_ADDRESS', 'support@example.com')
     @patch('pcapi.utils.mailing.DEV_EMAIL_ADDRESS', 'dev@example.com')
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_write_email_with_right_data_when_offer_is_a_book(self, app):
         # Given
         user = create_user(idx=1, email='test@example.com', first_name='John', last_name='Doe')
@@ -142,7 +143,7 @@ class MakeOffererBookingRecapEmailWithMailjetTemplateTest:
 
     @patch('pcapi.emails.offerer_booking_recap.SUPPORT_EMAIL_ADDRESS', 'support@example.com')
     @patch('pcapi.utils.mailing.DEV_EMAIL_ADDRESS', 'dev@example.com')
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_truncate_price(self, app):
         # Given
         user_sql_entity = create_user(idx=1, email='test@example.com', first_name='John', last_name='Doe')
@@ -205,7 +206,7 @@ class MakeOffererBookingRecapEmailWithMailjetTemplateTest:
 
     @patch('pcapi.emails.offerer_booking_recap.SUPPORT_EMAIL_ADDRESS', 'support@example.com')
     @patch('pcapi.utils.mailing.DEV_EMAIL_ADDRESS', 'dev@example.com')
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_empty_ISBN_when_no_extra_data(self, app):
         # Given
         user_sql_entity = create_user(idx=1, email='test@example.com', first_name='John', last_name='Doe')
@@ -267,7 +268,7 @@ class MakeOffererBookingRecapEmailWithMailjetTemplateTest:
 
     @patch('pcapi.emails.offerer_booking_recap.SUPPORT_EMAIL_ADDRESS', 'support@example.com')
     @patch('pcapi.utils.mailing.DEV_EMAIL_ADDRESS', 'dev@example.com')
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_empty_ISBN_when_extra_data_has_no_key_isbn(self, app):
         # Given
         user_sql_entity = create_user(idx=1, email="test@example.com", first_name='John', last_name='Doe')
@@ -330,7 +331,7 @@ class MakeOffererBookingRecapEmailWithMailjetTemplateTest:
 
     @patch('pcapi.emails.offerer_booking_recap.SUPPORT_EMAIL_ADDRESS', 'support@example.com')
     @patch('pcapi.repository.feature_queries.IS_PROD', True)
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_recipients_email_when_production_environment(self, app):
         # Given
         user_sql_entity = create_user(email='test@example.com', first_name='John', last_name='Doe')
@@ -364,7 +365,7 @@ class MakeOffererBookingRecapEmailWithMailjetTemplateTest:
 
     @patch('pcapi.emails.offerer_booking_recap.SUPPORT_EMAIL_ADDRESS', 'support@example.com')
     @patch('pcapi.utils.mailing.DEV_EMAIL_ADDRESS', 'dev@example.com')
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_dev_email_adress_when_feature_send_mail_to_users_disabled(self, app):
         # Given
         user_sql_entity = create_user(idx=1, email='test@example.com', first_name='John', last_name='Doe')
@@ -400,7 +401,7 @@ class MakeOffererBookingRecapEmailWithMailjetTemplateTest:
 
     @patch('pcapi.emails.offerer_booking_recap.SUPPORT_EMAIL_ADDRESS', 'support@example.com')
     @patch('pcapi.utils.mailing.DEV_EMAIL_ADDRESS', 'dev@example.com')
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_email_with_correct_data_when_two_users_book_the_same_offer(self, app):
         # Given
         user_sql_entity_1 = create_user(idx=1, email='test@example.com', first_name='Jean', last_name='Dupont')
@@ -448,7 +449,7 @@ class MakeOffererBookingRecapEmailWithMailjetTemplateTest:
 
     @patch('pcapi.emails.offerer_booking_recap.SUPPORT_EMAIL_ADDRESS', 'support@example.com')
     @patch('pcapi.utils.mailing.DEV_EMAIL_ADDRESS', 'dev@example.com')
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_email_with_link_to_the_corresponding_offer(self, app):
         # Given
         user_sql_entity = create_user(idx=1, email='test@example.com', first_name='Jean', last_name='Dupont')

--- a/tests/emails/offerer_ongoing_attachment_test.py
+++ b/tests/emails/offerer_ongoing_attachment_test.py
@@ -1,13 +1,14 @@
 from unittest.mock import patch
 
+import pytest
+
 from pcapi.emails.offerer_ongoing_attachment import retrieve_data_for_offerer_ongoing_attachment_email
 from pcapi.repository import repository
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_offerer, create_user, create_user_offerer
 
 
 class ProOffererAttachmentValidationEmailTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.emails.offerer_ongoing_attachment.DEV_EMAIL_ADDRESS', 'dev@example.com')
     @patch('pcapi.emails.offerer_ongoing_attachment.feature_send_mail_to_users_enabled', return_value=False)
     @patch('pcapi.emails.offerer_ongoing_attachment.format_environment_for_email', return_value='-testing')
@@ -41,7 +42,7 @@ class ProOffererAttachmentValidationEmailTest:
                 }
         }
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.emails.offerer_ongoing_attachment.feature_send_mail_to_users_enabled', return_value=True)
     @patch('pcapi.emails.offerer_ongoing_attachment.format_environment_for_email', return_value='')
     @patch('pcapi.emails.offerer_ongoing_attachment.find_user_offerer_email',

--- a/tests/emails/pro_reset_password_test.py
+++ b/tests/emails/pro_reset_password_test.py
@@ -1,9 +1,10 @@
 from unittest.mock import patch
 
+import pytest
+
 from pcapi.emails.pro_reset_password import retrieve_data_for_reset_password_pro_email
 from pcapi.repository import repository
 from pcapi.model_creators.generic_creators import create_user, create_offerer, create_user_offerer
-from tests.conftest import clean_database
 
 
 class MakeProResetPasswordEmailDataTest:
@@ -12,7 +13,7 @@ class MakeProResetPasswordEmailDataTest:
     @patch('pcapi.emails.pro_reset_password.format_environment_for_email', return_value='-testing')
     @patch('pcapi.emails.pro_reset_password.feature_send_mail_to_users_enabled', return_value=False)
     @patch('pcapi.emails.pro_reset_password.PRO_URL', 'http://example.net')
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_email_is_sent_to_dev_at_passculture_when_not_production_environment(self,
                                                                                  mock_send_mail_enabled,
                                                                                  mock_format_env,
@@ -46,7 +47,7 @@ class MakeProResetPasswordEmailDataTest:
     @patch('pcapi.emails.pro_reset_password.format_environment_for_email', return_value='')
     @patch('pcapi.emails.pro_reset_password.feature_send_mail_to_users_enabled', return_value=True)
     @patch('pcapi.emails.pro_reset_password.PRO_URL', 'http://example.net')
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_email_is_sent_to_pro_offerer_when_production_environment(self,
                                                                       mock_send_mail_enabled,
                                                                       mock_format_env,

--- a/tests/emails/user_reset_password_test.py
+++ b/tests/emails/user_reset_password_test.py
@@ -1,10 +1,10 @@
 from unittest.mock import patch
 
+import pytest
+
 from pcapi.emails.user_reset_password import retrieve_data_for_reset_password_user_email
 from pcapi.repository import repository
 from pcapi.model_creators.generic_creators import create_user, create_offerer, create_user_offerer
-import pytest
-from tests.conftest import clean_database
 
 
 class MakeUserResetPasswordEmailDataTest:
@@ -12,7 +12,6 @@ class MakeUserResetPasswordEmailDataTest:
     @patch('pcapi.emails.user_reset_password.DEV_EMAIL_ADDRESS', 'dev@example.com')
     @patch('pcapi.emails.user_reset_password.format_environment_for_email', return_value='-testing')
     @patch('pcapi.emails.user_reset_password.feature_send_mail_to_users_enabled', return_value=False)
-    @clean_database
     @pytest.mark.usefixtures("db_session")
     def test_email_is_sent_to_dev_at_passculture_when_not_production_environment(self,
                                                                                  mock_send_mail_enabled,

--- a/tests/infrastructure/repository/booking/booking_sql_repository_test.py
+++ b/tests/infrastructure/repository/booking/booking_sql_repository_test.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from pcapi.domain.booking.booking import Booking
 from pcapi.domain.booking.booking_exceptions import BookingDoesntExist
@@ -8,7 +9,6 @@ from pcapi.infrastructure.repository.booking import booking_domain_converter
 from pcapi.infrastructure.repository.booking.booking_sql_repository import BookingSQLRepository
 from pcapi.models import ThingType
 from pcapi.repository import repository
-from tests.conftest import clean_database
 from tests.domain_creators.generic_creators import create_domain_beneficiary
 from pcapi.model_creators.generic_creators import create_booking, \
     create_offerer, create_user, \
@@ -22,7 +22,7 @@ class BookingSQLRepositoryTest:
         def setup_method(self):
             self.booking_sql_repository = BookingSQLRepository()
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.infrastructure.repository.booking.booking_sql_repository.get_expenses')
         def test_compute_expenses_without_cancelled_bookings(self, get_expenses_mock, app):
             # given
@@ -57,7 +57,7 @@ class BookingSQLRepositoryTest:
         def setup_method(self):
             self.booking_sql_repository = BookingSQLRepository()
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_create_booking_on_save_when_booking_does_not_exist(self, app):
             # given
             user_sql_entity = create_user(idx=4)
@@ -86,7 +86,7 @@ class BookingSQLRepositoryTest:
             assert booking_saved.stock.identifier == booking_to_save.stock.identifier
             assert booking_saved.identifier is not None
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_return_saved_booking_with_updated_user_wallet_balance_on_save(self, app):
             # given
             user_sql_entity = create_user(idx=4)
@@ -118,7 +118,7 @@ class BookingSQLRepositoryTest:
         def setup_method(self):
             self.booking_sql_repository = BookingSQLRepository()
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_returns_booking_by_offer_id_and_user_id_when_not_cancelled(self, app):
             # given
             user = create_user()
@@ -143,7 +143,7 @@ class BookingSQLRepositoryTest:
         def setup_method(self):
             self.booking_sql_repository = BookingSQLRepository()
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def should_return_booking_matching_identifier(self, app):
             # given
             user = create_user()
@@ -163,7 +163,7 @@ class BookingSQLRepositoryTest:
             # then
             assert found_booking.identifier == booking_sql_entity.id
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def should_raise_exception_when_no_booking_is_found(self, app):
             # given
             user = create_user()
@@ -184,7 +184,7 @@ class BookingSQLRepositoryTest:
             # then
             assert error.value.errors['bookingId'] == ['bookingId ne correspond à aucune réservation']
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def should_raise_exception_when_booking_does_not_belong_to_beneficiary(self, app):
             # given
             user = create_user()

--- a/tests/infrastructure/repository/venue/venue_with_basic_information/venue_with_basic_information_sql_repository_test.py
+++ b/tests/infrastructure/repository/venue/venue_with_basic_information/venue_with_basic_information_sql_repository_test.py
@@ -1,9 +1,10 @@
+import pytest
+
 from pcapi.domain.venue.venue_with_basic_information.venue_with_basic_information import VenueWithBasicInformation
 from pcapi.infrastructure.repository.venue.venue_with_basic_information import venue_with_basic_information_domain_converter
 from pcapi.infrastructure.repository.venue.venue_with_basic_information.venue_with_basic_information_sql_repository import \
     VenueWithBasicInformationSQLRepository
 from pcapi.repository import repository
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_offerer, create_venue
 
 
@@ -11,7 +12,7 @@ class VenueWithBasicInformationSQLRepositoryTest:
     def setup_method(self):
         self.venue_sql_repository = VenueWithBasicInformationSQLRepository()
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_a_venue_when_venue_with_siret_is_found(self, app: object):
         # given
         siret = "12345678912345"
@@ -30,7 +31,7 @@ class VenueWithBasicInformationSQLRepositoryTest:
         assert found_venue.siret == expected_venue.siret
         assert found_venue.identifier == expected_venue.identifier
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_none_when_no_venue_with_siret_was_found(self, app: object):
         # given
         siret = "12345678912345"
@@ -44,7 +45,7 @@ class VenueWithBasicInformationSQLRepositoryTest:
         # then
         assert found_venue is None
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_a_venue_when_venue_with_name_is_found(self, app: object):
         # given
         name = 'VENUE NAME'
@@ -66,7 +67,7 @@ class VenueWithBasicInformationSQLRepositoryTest:
         assert found_venue.identifier == expected_venue.identifier
         assert found_venue.siret is None
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_none_when_venue_with_name_was_found_but_in_another_offerer(self, app: object):
         # given
         name = 'Venue name'
@@ -81,7 +82,7 @@ class VenueWithBasicInformationSQLRepositoryTest:
         # then
         assert found_venue == []
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_none_when_no_venue_with_name_was_found(self, app: object):
         # given
         name = 'Venue name'

--- a/tests/local_providers/allocine_stocks_test.py
+++ b/tests/local_providers/allocine_stocks_test.py
@@ -4,12 +4,12 @@ from pathlib import Path
 from unittest.mock import patch
 
 from freezegun import freeze_time
+import pytest
 
 from pcapi.local_providers import AllocineStocks
 from pcapi.models import OfferSQLEntity, EventType, Product, StockSQLEntity
 from pcapi.repository import repository
 from pcapi.repository.provider_queries import get_provider_by_local_class
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_offerer, create_venue, \
     create_allocine_venue_provider_price_rule, create_allocine_venue_provider
 from pcapi.model_creators.provider_creators import activate_provider
@@ -22,7 +22,7 @@ class AllocineStocksTest:
     class InitTest:
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
         @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_call_allocine_api(self, mock_call_allocine_api, app):
             # Given
             theater_token = 'test'
@@ -47,7 +47,7 @@ class AllocineStocksTest:
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
         @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
         @freeze_time('2019-10-15 09:00:00')
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_return_providable_infos_for_each_movie(self, mock_call_allocine_api, app):
             # Given
             mock_call_allocine_api.return_value = iter([
@@ -170,7 +170,7 @@ class UpdateObjectsTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_create_one_product_and_one_local_version_offer_with_movie_info(self,
                                                                                    mock_call_allocine_api,
                                                                                    mock_api_poster,
@@ -301,7 +301,7 @@ class UpdateObjectsTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_create_one_product_and_one_original_version_offer_and_one_dubbed_version_offer_with_movie_info(
             self, mock_call_allocine_api, mock_api_poster, mock_redis, mock_feature, app):
         # Given
@@ -461,7 +461,7 @@ class UpdateObjectsTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_create_only_one_original_version_offer_when_only_original_showtimes_exist(self,
                                                                                               mock_call_allocine_api,
                                                                                               mock_api_poster,
@@ -585,7 +585,7 @@ class UpdateObjectsTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_update_existing_product_duration_and_update_matching_offers(self,
                                                                                 mock_call_allocine_api,
                                                                                 mock_api_poster,
@@ -726,7 +726,7 @@ class UpdateObjectsTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_update_existing_product_duration_and_create_new_offer_when_no_offer_exists(self,
                                                                                                mock_call_allocine_api,
                                                                                                mock_api_poster,
@@ -849,7 +849,7 @@ class UpdateObjectsTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_create_product_and_new_offer_with_missing_visa_and_stage_director(self,
                                                                                       mock_call_allocine_api,
                                                                                       mock_api_poster,
@@ -953,7 +953,7 @@ class UpdateObjectsTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_create_product_and_offer_when_missing_required_information_in_api_response(self,
                                                                                                    mock_call_allocine_api,
                                                                                                    mock_api_poster,
@@ -1044,7 +1044,7 @@ class UpdateObjectsTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch('pcapi.local_providers.allocine.allocine_stocks.AllocineStocks.get_object_thumb')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_create_product_with_correct_thumb_and_increase_thumbCount_by_1(self,
                                                                                    mock_get_object_thumb,
                                                                                    mock_call_allocine_api,
@@ -1155,7 +1155,7 @@ class UpdateObjectsTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch('pcapi.local_providers.allocine.allocine_stocks.AllocineStocks.get_object_thumb')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_replace_product_thumb_when_product_has_already_one_thumb(self,
                                                                              mock_get_object_thumb,
                                                                              mock_call_allocine_api,
@@ -1279,7 +1279,7 @@ class UpdateObjectsTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_create_one_product_and_one_offer_and_associated_stocks(self,
                                                                            mock_api_poster,
                                                                            mock_call_allocine_api,
@@ -1435,7 +1435,7 @@ class UpdateObjectsTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_create_one_product_and_two_offers_and_associated_stocks(self,
                                                                             mock_poster_get_allocine,
                                                                             mock_call_allocine_api,
@@ -1614,7 +1614,7 @@ class UpdateObjectsTest:
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
         @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_update_stocks_based_on_stock_date(self,
                                                           mock_poster_get_allocine,
                                                           mock_call_allocine_api,
@@ -1826,7 +1826,7 @@ class UpdateObjectsTest:
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
         @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_create_one_different_offer_and_stock_for_different_venues(self,
                                                                                   mock_poster_get_allocine,
                                                                                   mock_call_allocine_api,
@@ -1948,7 +1948,7 @@ class UpdateObjectsTest:
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
         @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_update_stocks_info_after_pro_user_modification(self,
                                                                        mock_poster_get_allocine,
                                                                        mock_call_allocine_api,
@@ -2174,7 +2174,7 @@ class UpdateObjectsTest:
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
         @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_preserve_manual_modification(self,
                                                      mock_poster_get_allocine,
                                                      mock_call_allocine_api,
@@ -2386,7 +2386,7 @@ class UpdateObjectsTest:
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
         @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_preserve_deletion(self, mock_poster_get_allocine, mock_call_allocine_api, app):
             # Given
             theater_token = 'test'
@@ -2576,7 +2576,7 @@ class UpdateObjectsTest:
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
         @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_preserve_is_duo_default_value(self,
                                                       mock_poster_get_allocine,
                                                       mock_call_allocine_api,
@@ -2778,7 +2778,7 @@ class UpdateObjectsTest:
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
         @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
         @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_preserve_quantity_default_value(self,
                                                         mock_poster_get_allocine,
                                                         mock_call_allocine_api,
@@ -2888,7 +2888,7 @@ class GetObjectThumbTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_get_movie_poster_if_poster_url_exist(self,
                                                          mock_poster_get_allocine,
                                                          mock_call_allocine_api,
@@ -2915,7 +2915,7 @@ class GetObjectThumbTest:
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes')
     @patch('pcapi.local_providers.allocine.allocine_stocks.get_movie_poster')
     @patch.dict('os.environ', {'ALLOCINE_API_KEY': 'token'})
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_empty_thumb_if_poster_does_not_exist(self,
                                                                 mock_poster_get_allocine,
                                                                 mock_call_allocine_api,

--- a/tests/local_providers/chunk_manager_test.py
+++ b/tests/local_providers/chunk_manager_test.py
@@ -1,16 +1,17 @@
 from sqlalchemy import Sequence
 
+import pytest
+
 from pcapi.local_providers.chunk_manager import save_chunks
 from pcapi.models import OfferSQLEntity, StockSQLEntity
 from pcapi.models.db import db
 from pcapi.repository import repository
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_stock, create_offerer, create_venue
 from pcapi.model_creators.specific_creators import create_product_with_thing_type, create_offer_with_thing_product
 
 
 class SaveChunksTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_save_chunks_insert_1_offer_in_chunk(self, app):
         # Given
         offerer = create_offerer()
@@ -35,7 +36,7 @@ class SaveChunksTest:
         # Then
         assert OfferSQLEntity.query.count() == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_save_chunks_insert_1_offer_and_1_stock_in_chunk(self, app):
         # Given
         offerer = create_offerer()
@@ -69,7 +70,7 @@ class SaveChunksTest:
         assert OfferSQLEntity.query.count() == 1
         assert StockSQLEntity.query.count() == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_save_chunks_update_1_offer_in_chunk(self, app):
         # Given
         offerer = create_offerer()
@@ -95,7 +96,7 @@ class SaveChunksTest:
         # Then
         assert OfferSQLEntity.query.count() == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_save_chunks_update_2_offers_and_1_stock_in_chunk(self, app):
         # Given
         offerer = create_offerer()

--- a/tests/local_providers/fnac_stocks_test.py
+++ b/tests/local_providers/fnac_stocks_test.py
@@ -6,7 +6,6 @@ import pytest
 from pcapi.local_providers.fnac.fnac_stocks import FnacStocks
 from pcapi.models import OfferSQLEntity, StockSQLEntity
 from pcapi.repository import repository
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_venue_provider, create_venue, create_offerer, create_stock, \
     create_booking, create_user
 from pcapi.model_creators.provider_creators import activate_provider
@@ -56,7 +55,7 @@ class FnacStocksTest:
             assert stock_providable_info.id_at_providers == '9780199536986@12345678912345'
 
     class UpdateObjectsTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.fnac.fnac_stocks.api_fnac_stocks.stocks_information')
         def test_fnac_stock_provider_create_one_stock_and_one_offer_with_wanted_attributes(self,
                                                                                            mock_fnac_api_response,
@@ -96,7 +95,7 @@ class FnacStocksTest:
             assert stock.quantity == 10
             assert stock.bookingLimitDatetime is None
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.fnac.fnac_stocks.api_fnac_stocks.stocks_information')
         def test_fnac_stock_provider_update_one_stock_and_update_matching_offer(self, mock_fnac_api_response,
                                                                                 app):
@@ -168,7 +167,7 @@ class FnacStocksTest:
             assert OfferSQLEntity.query.filter_by(lastProviderId=fnac_stocks_provider.id).count() == 2
             assert fnac_stocks.last_processed_isbn == '1550199555555'
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.fnac.fnac_stocks.api_fnac_stocks.stocks_information')
         def test_fnac_stock_provider_available_stock_is_sum_of_updated_available_and_bookings(self,
                                                                                               mock_fnac_api_response,

--- a/tests/local_providers/libraires_stocks_test.py
+++ b/tests/local_providers/libraires_stocks_test.py
@@ -6,7 +6,6 @@ import pytest
 from pcapi.local_providers.libraires.libraires_stocks import LibrairesStocks
 from pcapi.models import OfferSQLEntity, StockSQLEntity
 from pcapi.repository import repository
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_booking, create_offerer, create_stock, create_user, \
     create_venue, create_venue_provider
 from pcapi.model_creators.provider_creators import activate_provider
@@ -15,7 +14,7 @@ from pcapi.model_creators.specific_creators import create_offer_with_thing_produ
 
 class LibrairesStocksTest:
     class NextTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.libraires.libraires_stocks.api_libraires_stocks.stocks_information')
         def test_should_return_providable_infos_with_correct_data(self, mock_libraires_api_response, app):
             # Given
@@ -56,7 +55,7 @@ class LibrairesStocksTest:
 
     class UpdateObjectsTest:
         @pytest.mark.usefixtures("db_session")
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.libraires.libraires_stocks.api_libraires_stocks.stocks_information')
         def test_stock_provider_libraires_create_one_stock_and_one_offer_with_wanted_attributes(self,
                                                                                                 mock_libraires_api_response,
@@ -96,7 +95,7 @@ class LibrairesStocksTest:
             assert stock.quantity == 10
             assert stock.bookingLimitDatetime is None
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.libraires.libraires_stocks.api_libraires_stocks.stocks_information')
         def test_stock_provider_libraires_update_one_stock_and_update_matching_offer(self, mock_libraires_api_response,
                                                                                      app):
@@ -129,7 +128,7 @@ class LibrairesStocksTest:
             assert stock.quantity == 10
             assert OfferSQLEntity.query.count() == 1
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.libraires.libraires_stocks.api_libraires_stocks.stocks_information')
         def test_libraires_stocks_create_2_stocks_and_2_offers_even_if_existing_offer_on_same_product(self,
                                                                                                       mock_libraires_api_response,
@@ -167,7 +166,7 @@ class LibrairesStocksTest:
             assert OfferSQLEntity.query.filter_by(lastProviderId=libraires_stocks_provider.id).count() == 2
             assert libraires_stocks_local_provider.last_processed_isbn == '1550199555555'
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.libraires.libraires_stocks.api_libraires_stocks.stocks_information')
         def test_stock_provider_libraires_available_stock_is_sum_of_updated_available_and_bookings(self,
                                                                                                    mock_libraires_api_response,
@@ -219,7 +218,7 @@ class LibrairesStocksTest:
             assert stock.quantity == 67
 
     class WhenSynchronizedTwiceTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.libraires.libraires_stocks.api_libraires_stocks.stocks_information')
         def test_stock_provider_libraires_iterates_over_pagination(self, mock_libraires_api_response, app):
             # Given

--- a/tests/local_providers/praxiel_stocks_test.py
+++ b/tests/local_providers/praxiel_stocks_test.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 from unittest.mock import call, patch
 
-from tests.conftest import clean_database
+import pytest
+
 from pcapi.model_creators.generic_creators import create_booking, create_offerer, create_stock, create_user, create_venue, create_venue_provider
 from pcapi.model_creators.provider_creators import activate_provider
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product, create_product_with_thing_type
@@ -13,7 +14,7 @@ from pcapi.repository import repository
 
 class PraxielStocksTest:
     class NextTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.praxiel.praxiel_stocks.api_praxiel_stocks.stocks_information')
         def test_should_return_providable_infos_with_correct_data(self, mock_praxiel_api_response, app):
             # Given
@@ -53,7 +54,7 @@ class PraxielStocksTest:
             assert stock_providable_info.id_at_providers == '9780199536986@12345678912345'
 
     class UpdateObjectsTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.praxiel.praxiel_stocks.api_praxiel_stocks.stocks_information')
         def test_stock_provider_praxiel_create_one_stock_and_one_offer_with_wanted_attributes(self,
                                                                                               mock_praxiel_api_response,
@@ -93,7 +94,7 @@ class PraxielStocksTest:
             assert stock.quantity == 10
             assert stock.bookingLimitDatetime is None
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.praxiel.praxiel_stocks.api_praxiel_stocks.stocks_information')
         def test_stock_provider_praxiel_update_one_stock_and_update_matching_offer(self, mock_praxiel_api_response,
                                                                                    app):
@@ -126,7 +127,7 @@ class PraxielStocksTest:
             assert stock.quantity == 10
             assert OfferSQLEntity.query.count() == 1
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.praxiel.praxiel_stocks.api_praxiel_stocks.stocks_information')
         def test_praxiel_stocks_create_2_stocks_and_2_offers_even_if_existing_offer_on_same_product(self,
                                                                                                     mock_praxiel_api_response,
@@ -164,7 +165,7 @@ class PraxielStocksTest:
             assert OfferSQLEntity.query.filter_by(lastProviderId=praxiel_stocks_provider.id).count() == 2
             assert praxiel_stocks_local_provider.last_processed_isbn == '1550199555555'
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.praxiel.praxiel_stocks.api_praxiel_stocks.stocks_information')
         def test_stock_provider_praxiel_available_stock_is_sum_of_updated_available_and_bookings(self,
                                                                                                  mock_praxiel_api_response,
@@ -216,7 +217,7 @@ class PraxielStocksTest:
             assert stock.quantity == 67
 
     class WhenSynchronizedTwiceTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.praxiel.praxiel_stocks.api_praxiel_stocks.stocks_information')
         def test_stock_provider_praxiel_iterates_over_pagination(self, mock_praxiel_api_response, app):
             # Given

--- a/tests/local_providers/titelive_stocks_test.py
+++ b/tests/local_providers/titelive_stocks_test.py
@@ -2,11 +2,11 @@ from datetime import date, datetime, timedelta
 from unittest.mock import call, patch
 
 from freezegun import freeze_time
+import pytest
 
 from pcapi.local_providers import TiteLiveStocks
 from pcapi.models import OfferSQLEntity, StockSQLEntity
 from pcapi.repository import repository
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_booking, create_offerer, create_stock, create_user, \
     create_venue, create_venue_provider
 from pcapi.model_creators.provider_creators import activate_provider
@@ -15,7 +15,7 @@ from pcapi.model_creators.specific_creators import create_offer_with_thing_produ
 
 class TiteliveStocksTest:
     class NextTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.titelive_stocks.titelive_stocks.api_titelive_stocks.stocks_information')
         def test_should_return_providable_infos_with_correct_data(self, mock_titelive_api_response, app):
             # Given
@@ -54,7 +54,7 @@ class TiteliveStocksTest:
             assert stock_providable_info.id_at_providers == '0002730757438@12345678912345'
 
     class UpdateObjectsTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.titelive_stocks.titelive_stocks.api_titelive_stocks.stocks_information')
         def test_titelive_stock_provider_create_1_stock_and_1_offer_with_wanted_attributes(self,
                                                                                            stub_get_stocks_information,
@@ -94,7 +94,7 @@ class TiteliveStocksTest:
             assert stock.quantity == 10
             assert stock.bookingLimitDatetime is None
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.titelive_stocks.titelive_stocks.api_titelive_stocks.stocks_information')
         def test_titelive_stock_provider_update_1_stock_and_1_offer(self, stub_get_stocks_information, app):
             # Given
@@ -129,7 +129,7 @@ class TiteliveStocksTest:
             assert OfferSQLEntity.query.count() == 1
 
         @freeze_time('2019-01-03 12:00:00')
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.titelive_stocks.titelive_stocks.api_titelive_stocks.stocks_information')
         def test_titelive_stock_provider_always_update_the_stock_modification_date(self, stub_get_stocks_information,
                                                                                    app):
@@ -166,7 +166,7 @@ class TiteliveStocksTest:
             stock = StockSQLEntity.query.one()
             assert stock.dateModified == datetime.now()
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.titelive_stocks.titelive_stocks.api_titelive_stocks.stocks_information')
         def test_titelive_stock_provider_create_1_stock_and_update_1_existing_offer(self, stub_get_stocks_information,
 
@@ -200,7 +200,7 @@ class TiteliveStocksTest:
             assert StockSQLEntity.query.count() == 1
             assert OfferSQLEntity.query.count() == 1
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.titelive_stocks.titelive_stocks.api_titelive_stocks.stocks_information')
         def test_titelive_stock_provider_create_2_stocks_and_2_offers_even_if_existing_offer_on_same_product(
                 self, mock_stocks_information, app):
@@ -238,7 +238,7 @@ class TiteliveStocksTest:
             assert OfferSQLEntity.query.filter_by(lastProviderId=titelive_stocks_provider.id).count() == 2
             assert StockSQLEntity.query.count() == 2
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.titelive_stocks.titelive_stocks.api_titelive_stocks.stocks_information')
         def test_titelive_stock_provider_create_nothing_if_titelive_api_returns_no_results(self,
                                                                                            stub_get_stocks_information,
@@ -266,7 +266,7 @@ class TiteliveStocksTest:
             assert OfferSQLEntity.query.filter_by(lastProviderId=titelive_stocks_provider.id).count() == 0
             assert StockSQLEntity.query.count() == 0
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.titelive_stocks.titelive_stocks.api_titelive_stocks.stocks_information')
         def test_titelive_stock_provider_iterates_over_pagination(self, stub_get_stocks_information, app):
             # Given
@@ -308,7 +308,7 @@ class TiteliveStocksTest:
                                                                   call('77567146400110', '0002730757438', None),
                                                                   call('77567146400110', '0002736409898', None)]
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.titelive_stocks.titelive_stocks.api_titelive_stocks.stocks_information')
         def should_call_api_with_venue_siret_and_last_sync_date(self, stub_get_stocks_information, app):
             # Given
@@ -343,7 +343,7 @@ class TiteliveStocksTest:
                                                                   call('77567146400110', '0002730757438',
                                                                        last_sync_date)]
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.titelive_stocks.titelive_stocks.api_titelive_stocks.stocks_information')
         def test_titelive_stock_provider_return_last_elements_as_last_seen_isbn(self, stub_get_stocks_information,
 
@@ -377,7 +377,7 @@ class TiteliveStocksTest:
             assert stub_get_stocks_information.call_count == 2
             assert titelive_stocks.last_processed_isbn == "0002736409898"
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.titelive_stocks.titelive_stocks.api_titelive_stocks.stocks_information')
         def test_should_not_create_offer_when_product_is_not_gcu_compatible(self, stub_get_stocks_information,
                                                                             app):
@@ -408,7 +408,7 @@ class TiteliveStocksTest:
             assert OfferSQLEntity.query.count() == 0
             assert StockSQLEntity.query.count() == 0
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.local_providers.titelive_stocks.titelive_stocks.api_titelive_stocks.stocks_information')
         def test_titelive_stock_provider_available_stock_is_sum_of_updated_available_and_bookings(self,
                                                                                                   stub_get_stocks_information,

--- a/tests/local_providers/titelive_things_test.py
+++ b/tests/local_providers/titelive_things_test.py
@@ -1,12 +1,13 @@
 from datetime import datetime
 from unittest.mock import patch
 
+import pytest
+
 from pcapi.local_providers import TiteLiveThings
 from pcapi.models import Product, BookFormat, LocalProviderEvent, OfferSQLEntity
 from pcapi.models.local_provider_event import LocalProviderEventType
 from pcapi.repository import repository
 from pcapi.repository.provider_queries import get_provider_by_local_class
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_booking, create_user, create_stock, create_offerer, \
     create_venue
 from pcapi.model_creators.provider_creators import activate_provider
@@ -14,7 +15,7 @@ from pcapi.model_creators.specific_creators import create_product_with_thing_typ
 
 
 class TiteliveThingsTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file')
     def test_create_1_thing_from_one_data_line_in_one_file(self,
@@ -86,7 +87,7 @@ class TiteliveThingsTest:
         assert product.type == 'ThingType.LIVRE_EDITION'
         assert product.extraData.get('isbn') == '9782895026310'
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file')
     def test_does_not_create_product_when_product_is_a_school_book(self,
@@ -155,7 +156,7 @@ class TiteliveThingsTest:
         # Then
         assert Product.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file')
     def test_update_1_thing_from_one_data_line_in_one_file(self,
@@ -234,7 +235,7 @@ class TiteliveThingsTest:
         assert updated_product.name == 'nouvelles du Chili'
         assert updated_product.extraData.get('bookFormat') == BookFormat.BEAUX_LIVRES.value
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     def test_does_not_create_thing_when_no_files_found(self,
                                                        get_files_to_process_from_titelive_ftp,
@@ -252,7 +253,7 @@ class TiteliveThingsTest:
         # Then
         assert Product.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file')
     def test_does_not_create_thing_when_missing_columns_in_data_line(self,
@@ -278,7 +279,7 @@ class TiteliveThingsTest:
         # Then
         assert Product.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file')
     def test_does_not_create_thing_when_too_many_columns_in_data_line(self,
@@ -352,7 +353,7 @@ class TiteliveThingsTest:
         # Then
         assert Product.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file')
     def test_should_not_create_product_when_school_related_product(self,
@@ -422,7 +423,7 @@ class TiteliveThingsTest:
         # Then
         assert Product.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file')
     def test_should_delete_product_when_reference_changes_to_school_related_product(self,
@@ -500,7 +501,7 @@ class TiteliveThingsTest:
         # Then
         assert Product.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file')
     def test_should_delete_product_when_non_valid_product_type(self,
@@ -576,7 +577,7 @@ class TiteliveThingsTest:
         # Then
         assert Product.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file')
     def test_should_log_error_when_trying_to_delete_product_with_associated_bookings(self,
@@ -664,7 +665,7 @@ class TiteliveThingsTest:
             .one()
         assert provider_log_error.payload == 'Error deleting product with ISBN: 9782895026310'
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file')
     def test_should_not_create_product_when_product_is_paper_press(self,
@@ -784,7 +785,7 @@ class TiteliveThingsTest:
         assert len(products) == 1
         assert product.extraData['isbn'] == '9782895026310'
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file')
     def test_should_delete_product_when_it_changes_to_paper_press_product(self, get_lines_from_thing_file,
@@ -861,7 +862,7 @@ class TiteliveThingsTest:
         # Then
         assert Product.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file')
     def test_should_not_delete_product_and_deactivate_associated_offer_when_it_changes_to_paper_press_product(self,

--- a/tests/local_providers/titelive_thumbs_test.py
+++ b/tests/local_providers/titelive_thumbs_test.py
@@ -4,12 +4,13 @@ from pathlib import Path
 from unittest.mock import patch
 from zipfile import ZipFile
 
+import pytest
+
 from pcapi.local_providers import TiteLiveThingThumbs
 from pcapi.local_providers.titelive_thing_thumbs.titelive_thing_thumbs import extract_thumb_index
 from pcapi.models import Product
 from pcapi.repository import repository
 import pcapi.sandboxes
-from tests.conftest import clean_database
 from pcapi.model_creators.provider_creators import provider_test
 from pcapi.model_creators.specific_creators import create_product_with_thing_type
 
@@ -36,7 +37,7 @@ class TiteliveThingThumbsTest:
             # Then
             assert thumb_index == 4
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_thing_thumbs.titelive_thing_thumbs.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_thing_thumbs.titelive_thing_thumbs.get_zip_file_from_ftp')
     def test_compute_first_thumb_dominant_color_even_if_not_first_file(self,
@@ -66,7 +67,7 @@ class TiteliveThingThumbsTest:
                       Product=0
                       )
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @patch('pcapi.local_providers.titelive_thing_thumbs.titelive_thing_thumbs.get_files_to_process_from_titelive_ftp')
     @patch('pcapi.local_providers.titelive_thing_thumbs.titelive_thing_thumbs.get_zip_file_from_ftp')
     def test_updates_thumb_count_for_product_when_new_thumbs_added(self,

--- a/tests/recommendation_engine/recommendations_test.py
+++ b/tests/recommendation_engine/recommendations_test.py
@@ -1,10 +1,11 @@
 from typing import List
 from unittest.mock import patch
 
+import pytest
+
 from pcapi.recommendations_engine import give_requested_recommendation_to_user, create_recommendations_for_discovery
 from pcapi.models import Offerer, StockSQLEntity
 from pcapi.repository import repository, discovery_view_queries
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_user, create_stock, create_offerer, create_venue, \
     create_recommendation, create_mediation
 from pcapi.model_creators.specific_creators import create_stock_from_offer, create_offer_with_thing_product
@@ -12,7 +13,7 @@ from pcapi.utils.human_ids import humanize
 
 
 class CreateRecommendationsForDiscoveryTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_does_not_put_mediation_ids_of_inactive_mediations(self, app):
         # Given
         sent_offers_ids = []
@@ -40,7 +41,7 @@ class CreateRecommendationsForDiscoveryTest:
         assert humanize(mediation2.id) not in mediations
         assert humanize(mediation1.id) not in mediations
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_include_recommendations_on_offers_previously_displayed_in_search_results(
             self, app):
         # Given
@@ -83,7 +84,7 @@ class CreateRecommendationsForDiscoveryTest:
                                                                          sent_offers_ids=sent_offers_ids,
                                                                          user=user)
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_offer_in_all_ile_de_france_for_user_from_93(self, app):
         # given
         departements_ok = ['75', '77', '78', '91', '92', '93', '94', '95']
@@ -113,7 +114,7 @@ class CreateRecommendationsForDiscoveryTest:
         assert len(recommendations) == 8
         assert recommended_offer_ids == offer_ids_in_adjacent_department
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_offers_from_any_departement_for_user_from_00(self, app):
         # given
         departements_ok = ['97', '01', '93', '06', '78']
@@ -141,7 +142,7 @@ class CreateRecommendationsForDiscoveryTest:
 
 
 class GiveRequestedRecommendationToUserTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_when_recommendation_exists_returns_it(self, app):
         # Given
         user = create_user()
@@ -160,7 +161,7 @@ class GiveRequestedRecommendationToUserTest:
         # Then
         assert result_reco.id == reco_ok.id
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_when_recommendation_exists_for_other_user_returns_a_new_one_for_the_current_user(self, app):
         # Given
         user = create_user()

--- a/tests/repository/allocine_pivot_queries_test.py
+++ b/tests/repository/allocine_pivot_queries_test.py
@@ -1,11 +1,12 @@
+import pytest
+
 from pcapi.repository import repository
 from pcapi.repository.allocine_pivot_queries import has_allocine_pivot_for_venue, get_allocine_theaterId_for_venue
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_allocine_pivot, create_offerer, create_venue
 
 
 class HasAllocinePivotForVenueTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_false_when_venue_has_no_siret(self, app):
         # Given
         offerer = create_offerer()
@@ -21,7 +22,7 @@ class HasAllocinePivotForVenueTest:
 
 
 class GetAllocineTheaterIdForVenueTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_return_value_when_not_matching_in_allocine_pivot(self, app):
         # Given
         offerer = create_offerer()
@@ -35,7 +36,7 @@ class GetAllocineTheaterIdForVenueTest:
         # Then
         assert allocine_theater_id is None
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_theaterId_when_siret_is_present_in_allocine_pivot(self, app):
         # Given
         offerer = create_offerer()

--- a/tests/repository/beneficiary_import_queries_test.py
+++ b/tests/repository/beneficiary_import_queries_test.py
@@ -1,19 +1,19 @@
 from datetime import datetime, timedelta
 
 from freezegun import freeze_time
+import pytest
 
 from pcapi.models import BeneficiaryImport, ImportStatus, BeneficiaryImportSources
 from pcapi.repository import repository
 from pcapi.repository.beneficiary_import_queries import \
     find_applications_ids_to_retry, is_already_imported, \
     save_beneficiary_import_with_status
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_beneficiary_import, \
     create_user
 
 
 class IsAlreadyImportedTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_true_when_a_beneficiary_import_exist_with_status_created(self, app):
         # given
         now = datetime.utcnow()
@@ -29,7 +29,7 @@ class IsAlreadyImportedTest:
         # then
         assert result is True
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_true_when_a_beneficiary_import_exist_with_status_duplicate(self, app):
         # given
         now = datetime.utcnow()
@@ -46,7 +46,7 @@ class IsAlreadyImportedTest:
         # then
         assert result is True
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_true_when_a_beneficiary_import_exist_with_status_rejected(self, app):
         # given
         now = datetime.utcnow()
@@ -63,7 +63,7 @@ class IsAlreadyImportedTest:
         # then
         assert result is True
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_true_when_a_beneficiary_import_exist_with_status_error(self, app):
         # given
         now = datetime.utcnow()
@@ -80,7 +80,7 @@ class IsAlreadyImportedTest:
         # then
         assert result is True
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_false_when_a_beneficiary_import_exist_with_status_retry(self, app):
         # given
         now = datetime.utcnow()
@@ -97,7 +97,7 @@ class IsAlreadyImportedTest:
         # then
         assert result is False
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_false_when_no_beneficiary_import_exist_for_this_id(self, app):
         # given
         now = datetime.utcnow()
@@ -116,7 +116,7 @@ class IsAlreadyImportedTest:
 
 
 class SaveBeneficiaryImportWithStatusTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_a_status_is_set_on_a_new_import(self, app):
         # when
         save_beneficiary_import_with_status(ImportStatus.DUPLICATE, 123, source=BeneficiaryImportSources.demarches_simplifiees, source_id=14562,
@@ -126,7 +126,7 @@ class SaveBeneficiaryImportWithStatusTest:
         beneficiary_import = BeneficiaryImport.query.filter_by(applicationId=123).first()
         assert beneficiary_import.currentStatus == ImportStatus.DUPLICATE
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_a_beneficiary_import_is_saved_with_all_fields(self, app):
         # when
         save_beneficiary_import_with_status(ImportStatus.DUPLICATE, 123, source=BeneficiaryImportSources.demarches_simplifiees, source_id=145236,
@@ -138,7 +138,7 @@ class SaveBeneficiaryImportWithStatusTest:
         assert beneficiary_import.sourceId == 145236
         assert beneficiary_import.source == "demarches_simplifiees"
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_a_status_is_set_on_an_existing_import(self, app):
         # given
         two_days_ago = datetime.utcnow() - timedelta(days=2)
@@ -157,7 +157,7 @@ class SaveBeneficiaryImportWithStatusTest:
         assert beneficiary_imports[0].currentStatus == ImportStatus.CREATED
         assert beneficiary_imports[0].beneficiary == beneficiary
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_delete_beneficiary_when_import_already_exists(self, app):
         # Given
         two_days_ago = datetime.utcnow() - timedelta(days=2)
@@ -176,7 +176,7 @@ class SaveBeneficiaryImportWithStatusTest:
 
 
 class FindApplicationsIdsToRetryTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_applications_ids_with_current_status_retry(self, app):
         # given
         beneficiary = create_user()
@@ -194,7 +194,7 @@ class FindApplicationsIdsToRetryTest:
         # then
         assert ids == [123, 456]
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_an_empty_list_if_no_retry_imports_exist(self, app):
         # given
         beneficiary = create_user()

--- a/tests/repository/booking_queries_test.py
+++ b/tests/repository/booking_queries_test.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timedelta
 
-import pytest
 from dateutil import tz
+import pytest
 from pytest import fixture
-from tests.conftest import clean_database
+
 from pcapi.model_creators.activity_creators import create_booking_activity, save_all_activities
 from pcapi.model_creators.generic_creators import create_booking, create_deposit, create_offerer, create_payment, create_recommendation, create_stock, create_user, create_user_offerer, create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_event_product, create_offer_with_thing_product, create_stock_from_offer, create_stock_with_event_offer, \
@@ -24,7 +24,7 @@ FOUR_DAYS_AGO = NOW - timedelta(days=4)
 FIVE_DAYS_AGO = NOW - timedelta(days=5)
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_all_ongoing_bookings(app):
     # Given
     offerer = create_offerer()
@@ -44,7 +44,7 @@ def test_find_all_ongoing_bookings(app):
     assert all_ongoing_bookings == [ongoing_booking]
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_not_cancelled_bookings_by_stock(app):
     # Given
     offerer = create_offerer()
@@ -65,7 +65,7 @@ def test_find_not_cancelled_bookings_by_stock(app):
 
 
 class FindFinalOffererBookingsTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_bookings_for_given_offerer(self, app: fixture):
         # Given
         user = create_user()
@@ -91,7 +91,7 @@ class FindFinalOffererBookingsTest:
         assert booking1 in bookings
         assert booking2 in bookings
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_bookings_with_payment_first_ordered_by_date_created(self, app: fixture):
         # Given
         user = create_user()
@@ -117,7 +117,7 @@ class FindFinalOffererBookingsTest:
         assert bookings[2] == booking1
         assert bookings[3] == booking2
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_not_cancelled_bookings_for_offerer(self, app: fixture):
         # Given
         user = create_user()
@@ -137,7 +137,7 @@ class FindFinalOffererBookingsTest:
         assert len(bookings) == 1
         assert booking1 in bookings
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_only_used_bookings(self, app: fixture):
         # Given
         user = create_user()
@@ -157,7 +157,7 @@ class FindFinalOffererBookingsTest:
         assert len(bookings) == 1
         assert thing_booking1 in bookings
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_does_not_return_finished_for_more_than_the_automatic_refund_delay_bookings(self, app: fixture):
         # Given
         user = create_user()
@@ -192,7 +192,7 @@ class FindFinalOffererBookingsTest:
 
 
 class FindFinalVenueBookingsTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_bookings_for_given_venue_ordered_by_date_created(self, app: fixture):
         # Given
         user = create_user()
@@ -221,7 +221,7 @@ class FindFinalVenueBookingsTest:
 
 
 class FindDateUsedTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_date_used_if_not_none(self, app: fixture):
         # given
         user = create_user()
@@ -235,7 +235,7 @@ class FindDateUsedTest:
         # then
         assert date_used == datetime(2018, 2, 12)
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_none_when_date_used_is_none(self, app: fixture):
         # given
         user = create_user()
@@ -249,7 +249,7 @@ class FindDateUsedTest:
         # then
         assert date_used is None
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_find_date_used_on_booking_returns_none_if_no_update_recorded_in_activity_table(self, app: fixture):
         # given
         user = create_user()
@@ -267,7 +267,7 @@ class FindDateUsedTest:
 
 
 class FindUserActivationBookingTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_activation_thing_booking_linked_to_user(self, app: fixture):
         # given
         user = create_user()
@@ -285,7 +285,7 @@ class FindUserActivationBookingTest:
         # then
         assert booking == activation_booking
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_activation_event_booking_linked_to_user(self, app: fixture):
         # given
         user = create_user()
@@ -303,7 +303,7 @@ class FindUserActivationBookingTest:
         # then
         assert booking == activation_booking
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_false_is_no_booking_exists_on_such_stock(self, app: fixture):
         # given
         user = create_user()
@@ -323,7 +323,7 @@ class FindUserActivationBookingTest:
 
 
 class GetExistingTokensTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_a_set_of_tokens(self, app: fixture):
         # given
         user = create_user()
@@ -343,7 +343,7 @@ class GetExistingTokensTest:
         # then
         assert tokens == {booking1.token, booking2.token, booking3.token}
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_an_empty_set_if_no_bookings(self, app: fixture):
         # when
         tokens = booking_queries.find_existing_tokens()
@@ -354,7 +354,7 @@ class GetExistingTokensTest:
 
 class FindByTest:
     class ByTokenTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_returns_booking_if_token_is_known(self, app: fixture):
             # given
             user = create_user()
@@ -370,7 +370,7 @@ class FindByTest:
             # then
             assert result.id == booking.id
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_raises_an_exception_if_token_is_unknown(self, app: fixture):
             # given
             user = create_user()
@@ -389,7 +389,7 @@ class FindByTest:
                 "Cette contremarque n'a pas été trouvée"]
 
     class ByTokenAndEmailTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_returns_booking_if_token_and_email_are_known(self, app: fixture):
             # given
             user = create_user(email='user@example.com')
@@ -405,7 +405,7 @@ class FindByTest:
             # then
             assert result.id == booking.id
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_returns_booking_if_token_is_known_and_email_is_known_case_insensitively(self, app: fixture):
             # given
             user = create_user(email='USer@eXAMple.COm')
@@ -421,7 +421,7 @@ class FindByTest:
             # then
             assert result.id == booking.id
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_returns_booking_if_token_is_known_and_email_is_known_with_trailing_spaces(self, app: fixture):
             # given
             user = create_user(email='user@example.com')
@@ -437,7 +437,7 @@ class FindByTest:
             # then
             assert result.id == booking.id
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_raises_an_exception_if_token_is_known_but_email_is_unknown(self, app: fixture):
             # given
             user = create_user(email='user@example.com')
@@ -456,7 +456,7 @@ class FindByTest:
                 "Cette contremarque n'a pas été trouvée"]
 
     class ByTokenAndEmailAndOfferIdTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_returns_booking_if_token_and_email_and_offer_id_for_thing_are_known(self, app: fixture):
             # given
             user = create_user(email='user@example.com')
@@ -473,7 +473,7 @@ class FindByTest:
             # then
             assert result.id == booking.id
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_returns_booking_if_token_and_email_and_offer_id_for_event_are_known(self, app: fixture):
             # given
             user = create_user(email='user@example.com')
@@ -490,7 +490,7 @@ class FindByTest:
             # then
             assert result.id == booking.id
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_returns_booking_if_token_and_email_are_known_but_offer_id_is_unknown(self, app: fixture):
             # given
             user = create_user(email='user@example.com')
@@ -511,7 +511,7 @@ class FindByTest:
 
 
 class SaveBookingTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_saves_booking_when_enough_stocks_after_cancellation(self, app: fixture):
         # Given
         offerer = create_offerer()
@@ -531,7 +531,7 @@ class SaveBookingTest:
         assert BookingSQLEntity.query.filter_by(isCancelled=False).count() == 1
         assert BookingSQLEntity.query.filter_by(isCancelled=True).count() == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_raises_too_many_bookings_error_when_not_enough_stocks(self, app: fixture):
         # Given
         offerer = create_offerer()
@@ -554,7 +554,7 @@ class SaveBookingTest:
 
 
 class CountNonCancelledBookingsTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_1_if_one_user_has_one_non_cancelled_booking(self, app: fixture):
         # Given
         user_having_booked = create_user()
@@ -571,7 +571,7 @@ class CountNonCancelledBookingsTest:
         # Then
         assert count == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_if_one_user_has_one_cancelled_booking(self, app: fixture):
         # Given
         user_having_booked = create_user()
@@ -588,7 +588,7 @@ class CountNonCancelledBookingsTest:
         # Then
         assert count == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_zero_if_two_users_have_activation_booking(self, app: fixture):
         # Given
         user1 = create_user()
@@ -613,7 +613,7 @@ class CountNonCancelledBookingsTest:
 
 
 class CountNonCancelledBookingsByDepartementTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_1_if_one_user_has_one_non_cancelled_booking(self, app: fixture):
         # Given
         user_having_booked = create_user(departement_code='76')
@@ -630,7 +630,7 @@ class CountNonCancelledBookingsByDepartementTest:
         # Then
         assert count == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_if_one_user_has_one_cancelled_booking(self, app: fixture):
         # Given
         user_having_booked = create_user(departement_code='76')
@@ -647,7 +647,7 @@ class CountNonCancelledBookingsByDepartementTest:
         # Then
         assert count == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_if_user_comes_from_wrong_departement(self, app: fixture):
         # Given
         user_having_booked = create_user(departement_code='76')
@@ -664,7 +664,7 @@ class CountNonCancelledBookingsByDepartementTest:
         # Then
         assert count == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_zero_if_users_only_have_activation_bookings(self, app: fixture):
         # Given
         user1 = create_user(departement_code='76')
@@ -689,7 +689,7 @@ class CountNonCancelledBookingsByDepartementTest:
 
 
 class GetAllCancelledBookingsCountTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_if_no_cancelled_bookings(self, app: fixture):
         # Given
         offerer = create_offerer()
@@ -706,7 +706,7 @@ class GetAllCancelledBookingsCountTest:
         # Then
         assert number_of_bookings == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_1_if_one_cancelled_bookings(self, app: fixture):
         # Given
         beginning_datetime = datetime.utcnow() + timedelta(hours=4)
@@ -724,7 +724,7 @@ class GetAllCancelledBookingsCountTest:
         # Then
         assert number_of_bookings == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_zero_if_only_activation_offers(self, app: fixture):
         # Given
         beginning_datetime = datetime.utcnow() + timedelta(hours=47)
@@ -749,7 +749,7 @@ class GetAllCancelledBookingsCountTest:
 
 
 class GetAllCancelledBookingsByDepartementCountTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_if_no_cancelled_bookings(self, app: fixture):
         # Given
         beginning_datetime = datetime.utcnow() + timedelta(hours=47)
@@ -767,7 +767,7 @@ class GetAllCancelledBookingsByDepartementCountTest:
         # Then
         assert number_of_bookings == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_1_if_one_cancelled_bookings(self, app: fixture):
         # Given
         beginning_datetime = datetime.utcnow() + timedelta(hours=47)
@@ -785,7 +785,7 @@ class GetAllCancelledBookingsByDepartementCountTest:
         # Then
         assert number_of_bookings == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_1_when_filtered_on_user_departement(self, app: fixture):
         # Given
         user_in_76 = create_user(departement_code='76', email='user-76@example.net')
@@ -805,7 +805,7 @@ class GetAllCancelledBookingsByDepartementCountTest:
         # Then
         assert number_of_bookings == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_zero_if_only_activation_bookings(self, app: fixture):
         # Given
         user = create_user(departement_code='41')
@@ -829,7 +829,7 @@ class GetAllCancelledBookingsByDepartementCountTest:
 
 
 class CountAllBookingsTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_when_no_bookings(self, app: fixture):
         # When
         number_of_bookings = booking_queries.count()
@@ -837,7 +837,7 @@ class CountAllBookingsTest:
         # Then
         assert number_of_bookings == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_2_when_bookings_cancelled_or_not(self, app: fixture):
         # Given
         offerer = create_offerer()
@@ -855,7 +855,7 @@ class CountAllBookingsTest:
         # Then
         assert number_of_bookings == 2
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_2_when_bookings_cancelled_or_not(self, app: fixture):
         # Given
         offerer = create_offerer()
@@ -873,7 +873,7 @@ class CountAllBookingsTest:
         # Then
         assert number_of_bookings == 2
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_when_bookings_are_on_activation_offer(self, app: fixture):
         # Given
         offerer = create_offerer()
@@ -897,7 +897,7 @@ class CountAllBookingsTest:
 
 
 class CountBookingsByDepartementTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_when_no_bookings(self, app: fixture):
         # When
         number_of_bookings = booking_queries.count_by_departement('74')
@@ -905,7 +905,7 @@ class CountBookingsByDepartementTest:
         # Then
         assert number_of_bookings == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_2_when_bookings_cancelled_or_not(self, app: fixture):
         # Given
         offerer = create_offerer()
@@ -923,7 +923,7 @@ class CountBookingsByDepartementTest:
         # Then
         assert number_of_bookings == 2
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_1_when_bookings_are_filtered_by_departement(self, app: fixture):
         # Given
         user_in_76 = create_user(departement_code='76', email='user-76@example.net')
@@ -942,7 +942,7 @@ class CountBookingsByDepartementTest:
         # Then
         assert number_of_bookings == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_when_bookings_are_on_activation_offers(self, app: fixture):
         # Given
         user = create_user(departement_code='76')
@@ -966,7 +966,7 @@ class CountBookingsByDepartementTest:
 
 
 class FindAllNotUsedAndNotCancelledTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_no_booking_if_only_used(self, app: fixture):
         # Given
         user = create_user()
@@ -984,7 +984,7 @@ class FindAllNotUsedAndNotCancelledTest:
         # Then
         assert len(bookings) == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_no_booking_if_only_cancelled(self, app: fixture):
         # Given
         user = create_user()
@@ -1002,7 +1002,7 @@ class FindAllNotUsedAndNotCancelledTest:
         # Then
         assert len(bookings) == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_no_booking_if_used_but_cancelled(self, app: fixture):
         # Given
         user = create_user()
@@ -1020,7 +1020,7 @@ class FindAllNotUsedAndNotCancelledTest:
         # Then
         assert len(bookings) == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_1_booking_if_not_used_and_not_cancelled(self, app: fixture):
         # Given
         user = create_user()
@@ -1042,7 +1042,7 @@ class FindAllNotUsedAndNotCancelledTest:
 
 
 class GetValidBookingsByUserId:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_bookings_by_user_id(self, app: fixture):
         # Given
         user1 = create_user(email='me@example.net')
@@ -1063,7 +1063,7 @@ class GetValidBookingsByUserId:
         # Then
         assert bookings == [booking1]
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_bookings_when_there_is_one_cancelled_booking(self, app: fixture):
         # Given
         user = create_user()
@@ -1085,7 +1085,7 @@ class GetValidBookingsByUserId:
         # Then
         assert booking1 not in bookings
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_most_recent_booking_when_two_cancelled_on_same_stock(self, app: fixture):
         # Given
         user = create_user()
@@ -1104,7 +1104,7 @@ class GetValidBookingsByUserId:
         # Then
         assert bookings == [booking1]
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_bookings_ordered_by_beginning_date_time_ascendant(self, app: fixture):
         # Given
         two_days = NOW + timedelta(days=2, hours=10)
@@ -1136,7 +1136,7 @@ class GetValidBookingsByUserId:
 
 
 class FindByTokenTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_a_booking_when_valid_token_is_given(self, app: fixture):
         # Given
         beneficiary = create_user()
@@ -1150,7 +1150,7 @@ class FindByTokenTest:
         # Then
         assert booking == valid_booking
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_nothing_when_invalid_token_is_given(self, app: fixture):
         # Given
         invalid_token = 'fake_token'
@@ -1165,7 +1165,7 @@ class FindByTokenTest:
         # Then
         assert booking is None
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_nothing_when_valid_token_is_given_but_its_not_used(self, app: fixture):
         # Given
         beneficiary = create_user()
@@ -1181,7 +1181,7 @@ class FindByTokenTest:
 
 
 class IsOfferAlreadyBookedByUserTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_true_when_booking_exists_for_user_and_offer(self, app: fixture):
         # Given
         user = create_user()
@@ -1199,7 +1199,7 @@ class IsOfferAlreadyBookedByUserTest:
         # Then
         assert is_offer_already_booked
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_false_when_no_booking_exists_for_same_user_and_offer(self, app: fixture):
         # Given
         user = create_user()
@@ -1215,7 +1215,7 @@ class IsOfferAlreadyBookedByUserTest:
         # Then
         assert not is_offer_already_booked
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_false_when_there_is_a_booking_on_offer_but_from_different_user(self, app: fixture):
         # Given
         user = create_user()
@@ -1232,7 +1232,7 @@ class IsOfferAlreadyBookedByUserTest:
         # Then
         assert not is_offer_already_booked
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_false_when_a_booking_exists_for_same_user_and_offer_but_is_cancelled(self,
                                                                                                 app: fixture):
         # Given
@@ -1253,7 +1253,7 @@ class IsOfferAlreadyBookedByUserTest:
 
 
 class CountNotCancelledBookingsQuantityByStocksTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_sum_of_bookings_quantity_that_are_not_cancelled_for_given_stock(self, app: fixture):
         # Given
         user = create_user()
@@ -1274,7 +1274,7 @@ class CountNotCancelledBookingsQuantityByStocksTest:
         # Then
         assert result == 15
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_0_when_no_bookings_found(self, app: fixture):
         # Given
         user = create_user()
@@ -1301,7 +1301,7 @@ class CountNotCancelledBookingsQuantityByStocksTest:
 
 
 class FindByProUserIdTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_only_expected_booking_attributes(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com', first_name='Ron', last_name='Weasley')
@@ -1340,7 +1340,7 @@ class FindByProUserIdTest:
             tz.gettz('Europe/Paris'))
         assert expected_booking_recap.venue_is_virtual == venue.isVirtual
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_booking_as_duo_when_quantity_is_two(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com')
@@ -1361,7 +1361,7 @@ class FindByProUserIdTest:
         expected_booking_recap = bookings_recap_paginated.bookings_recap[0]
         assert expected_booking_recap.booking_is_duo is True
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_booking_with_reimbursed_when_a_payment_was_sent(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com',
@@ -1395,7 +1395,7 @@ class FindByProUserIdTest:
         assert expected_booking_recap.booking_is_cancelled is True
         assert expected_booking_recap.booking_is_reimbursed is True
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_event_booking_when_booking_is_on_an_event(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com',
@@ -1430,7 +1430,7 @@ class FindByProUserIdTest:
             tz.gettz('Europe/Paris'))
         assert expected_booking_recap.venue_identifier == venue.id
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_payment_date_when_booking_has_been_reimbursed(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com',
@@ -1458,7 +1458,7 @@ class FindByProUserIdTest:
         assert expected_booking_recap.booking_status_history.payment_date == yesterday.astimezone(
             tz.gettz('Europe/Paris'))
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_cancellation_date_when_booking_has_been_cancelled(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com',
@@ -1483,7 +1483,7 @@ class FindByProUserIdTest:
         assert expected_booking_recap.booking_is_cancelled is True
         assert expected_booking_recap.booking_status_history.cancellation_date is not None
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_validation_date_when_booking_has_been_used_and_not_cancelled_not_reimbursed(self,
                                                                                                        app: fixture):
         # Given
@@ -1511,7 +1511,7 @@ class FindByProUserIdTest:
         assert expected_booking_recap.booking_is_reimbursed is False
         assert expected_booking_recap.booking_status_history.date_used is not None
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_correct_number_of_matching_offerers_bookings_linked_to_user(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com')
@@ -1537,7 +1537,7 @@ class FindByProUserIdTest:
         # Then
         assert len(bookings_recap_paginated.bookings_recap) == 2
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_bookings_from_first_page(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com')
@@ -1563,7 +1563,7 @@ class FindByProUserIdTest:
         assert bookings_recap_paginated.pages == 2
         assert bookings_recap_paginated.total == 2
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_bookings_from_second_page(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com')
@@ -1589,7 +1589,7 @@ class FindByProUserIdTest:
         assert bookings_recap_paginated.pages == 2
         assert bookings_recap_paginated.total == 2
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_return_bookings_when_offerer_link_is_not_validated(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com')
@@ -1608,7 +1608,7 @@ class FindByProUserIdTest:
         # Then
         assert bookings_recap_paginated.bookings_recap == []
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_booking_recap_item_when_quantity_booked_is_one(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com')
@@ -1633,7 +1633,7 @@ class FindByProUserIdTest:
         assert bookings_recap_paginated.pages == 1
         assert bookings_recap_paginated.total == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_two_booking_recap_items_when_quantity_booked_is_two(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com')
@@ -1659,7 +1659,7 @@ class FindByProUserIdTest:
         assert bookings_recap_paginated.pages == 1
         assert bookings_recap_paginated.total == 2
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_booking_date_with_offerer_timezone_when_venue_is_digital(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com',
@@ -1681,7 +1681,7 @@ class FindByProUserIdTest:
         expected_booking_recap = bookings_recap_paginated.bookings_recap[0]
         assert expected_booking_recap.booking_date == booking_date.astimezone(tz.gettz('America/Cayenne'))
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_booking_isbn_when_information_is_available(self, app: fixture):
         # Given
         beneficiary = create_user(email='beneficiary@example.com',
@@ -1705,7 +1705,7 @@ class FindByProUserIdTest:
         assert isinstance(expected_booking_recap, BookBookingRecap)
         assert expected_booking_recap.offer_isbn == '9876543234'
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_booking_with_venue_name_when_public_name_is_not_provided(self, app):
         # Given
         beneficiary = create_user(email='beneficiary@example.com', first_name='Ron', last_name='Weasley')
@@ -1760,7 +1760,7 @@ class FindByProUserIdTest:
         assert bookings_recap_paginated.bookings_recap[1].venue_name == venue_for_book.name
         assert bookings_recap_paginated.bookings_recap[2].venue_name == venue_for_thing.name
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_booking_with_venue_public_name_when_public_name_is_provided(self, app):
         # Given
         beneficiary = create_user(email='beneficiary@example.com', first_name='Ron', last_name='Weasley')
@@ -1820,7 +1820,7 @@ class FindByProUserIdTest:
 
 
 class FindFirstMatchingFromOfferByUserTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_nothing_when_no_bookings(self, app: fixture):
         # Given
         beneficiary = create_user()
@@ -1835,7 +1835,7 @@ class FindFirstMatchingFromOfferByUserTest:
         # Then
         assert booking is None
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_nothing_when_beneficiary_has_no_bookings(self, app: fixture):
         # Given
         beneficiary = create_user(idx=1)
@@ -1854,7 +1854,7 @@ class FindFirstMatchingFromOfferByUserTest:
         # Then
         assert booking is None
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_first_booking_for_user(self, app: fixture):
         # Given
         beneficiary = create_user(idx=1)

--- a/tests/repository/get_offers_for_recommendation_test.py
+++ b/tests/repository/get_offers_for_recommendation_test.py
@@ -1,12 +1,13 @@
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
+import pytest
+
 from pcapi.models.db import db
 from pcapi.models.offer_type import EventType, ThingType
 from pcapi.repository import repository, discovery_view_queries
 from pcapi.repository.discovery_view_queries import order_by_digital_offers
 from pcapi.repository.offer_queries import get_offers_for_recommendation
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_booking, create_criterion, \
     create_user, create_offerer, create_venue, \
     create_favorite, create_mediation, create_seen_offer
@@ -17,7 +18,7 @@ from pcapi.model_creators.specific_creators import create_stock_from_offer, \
 
 class GetOfferForRecommendationsTest:
     class FiltersTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_when_department_code_00_should_return_offers_of_all_departements(self, app):
             # Given
             offerer = create_offerer(siren='123456789')
@@ -50,7 +51,7 @@ class GetOfferForRecommendationsTest:
             assert offer_93 in offers
             assert offer_75 in offers
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_return_offer_when_offer_is_national(self, app):
             # Given
             offerer = create_offerer(siren='123456789')
@@ -76,7 +77,7 @@ class GetOfferForRecommendationsTest:
             assert offer_34 not in offers
             assert offer_national in offers
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_not_return_activation_event(self, app):
             # Given
             offerer = create_offerer(siren='123456789')
@@ -103,7 +104,7 @@ class GetOfferForRecommendationsTest:
             assert offer_93 in offers
             assert offer_activation_93 not in offers
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_not_return_activation_thing(self, app):
             # Given
             offerer = create_offerer(siren='123456789')
@@ -129,7 +130,7 @@ class GetOfferForRecommendationsTest:
             assert offer_93 in offers
             assert offer_activation_93 not in offers
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_return_offers_with_stock(self, app):
             # Given
             product = create_product_with_thing_type(
@@ -151,7 +152,7 @@ class GetOfferForRecommendationsTest:
             # Then
             assert len(offers) == 1
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_return_offers_with_mediation_only(self, app):
             # Given
             offerer = create_offerer()
@@ -172,7 +173,7 @@ class GetOfferForRecommendationsTest:
             assert len(offers) == 1
             assert offers[0].name == 'thing_with_mediation'
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_not_return_offers_with_no_stock(self, app):
             # Given
             product = create_product_with_thing_type(
@@ -197,7 +198,7 @@ class GetOfferForRecommendationsTest:
             # Then
             assert len(offers) == 0
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_not_return_booked_offers(self, app):
             # Given
             offerer = create_offerer()
@@ -218,7 +219,7 @@ class GetOfferForRecommendationsTest:
             # Then
             assert offers == []
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_not_return_favorite_offers(self, app):
             # Given
             offerer = create_offerer()
@@ -242,7 +243,7 @@ class GetOfferForRecommendationsTest:
             assert offers == []
 
     class OrderTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_should_order_offers_by_criterion_score_first(self, app):
             # Given
             offerer = create_offerer()
@@ -273,7 +274,7 @@ class GetOfferForRecommendationsTest:
             # Then
             assert offers == [physical_offer, digital_offer]
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.repository.offer_queries.feature_queries.is_active', return_value=True)
         def test_should_return_ordered_offers_by_dateSeen_when_feature_is_active(self, app):
             # Given
@@ -306,7 +307,7 @@ class GetOfferForRecommendationsTest:
             # Then
             assert offers == [offer_1, offer_2]
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.repository.offer_queries.feature_queries.is_active', return_value=True)
         def test_should_return_unseen_offers_first_for_specific_beneficiary_when_feature_is_active(self, app):
             # Given
@@ -340,7 +341,7 @@ class GetOfferForRecommendationsTest:
             # Then
             assert offers == [offer_2]
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         @patch('pcapi.repository.offer_queries.feature_queries.is_active', return_value=False)
         @patch('pcapi.repository.offer_queries.order_offers_by_unseen_offers_first')
         def test_should_not_order_offers_by_dateSeen_when_feature_is_not_active(self, mock_order_offers_by_unseen_offers_first, app):

--- a/tests/repository/get_offers_for_recommendation_v3_test.py
+++ b/tests/repository/get_offers_for_recommendation_v3_test.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
+import pytest
 from shapely.geometry import Polygon
 
 from pcapi.models import EventType, ThingType
 from pcapi.repository import repository, discovery_view_v3_queries
 from pcapi.repository.offer_queries import get_offers_for_recommendation_v3
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_booking, \
     create_criterion, \
     create_favorite, create_iris, \
@@ -24,7 +24,7 @@ from tests.test_utils import POLYGON_TEST
 class GetOffersForRecommendationV3Test:
     class UniversalBehaviorTest:
         class FiltersTest:
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_not_return_activation_event(self, app):
                 # Given
                 offerer = create_offerer(siren='123456789')
@@ -49,7 +49,7 @@ class GetOffersForRecommendationV3Test:
                 assert offer in offers
                 assert offer_activation not in offers
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_not_return_activation_thing(self, app):
                 # Given
                 offerer = create_offerer(siren='123456789')
@@ -74,7 +74,7 @@ class GetOffersForRecommendationV3Test:
                 assert offer_93 in offers
                 assert offer_activation_93 not in offers
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_return_offers_with_stock(self, app):
                 # Given
                 product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
@@ -96,7 +96,7 @@ class GetOffersForRecommendationV3Test:
                 # Then
                 assert len(offers) == 1
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_return_offers_with_mediation_only(self, app):
                 # Given
                 offerer = create_offerer()
@@ -116,7 +116,7 @@ class GetOffersForRecommendationV3Test:
                 assert len(offers) == 1
                 assert offers[0].name == 'thing_with_mediation'
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_not_return_offers_with_no_stock(self, app):
                 # Given
                 product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
@@ -139,7 +139,7 @@ class GetOffersForRecommendationV3Test:
                 # Then
                 assert len(offers) == 0
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_not_return_offers_having_only_soft_deleted_stocks(self, app):
                 # Given
                 product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
@@ -161,7 +161,7 @@ class GetOffersForRecommendationV3Test:
                 # Then
                 assert len(offers) == 0
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_not_return_offers_from_non_validated_venue(self, app):
                 # Given
                 product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
@@ -183,7 +183,7 @@ class GetOffersForRecommendationV3Test:
                 # Then
                 assert len(offers) == 0
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_not_return_offers_from_non_validated_offerers(self, app):
                 # Given
                 product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
@@ -205,7 +205,7 @@ class GetOffersForRecommendationV3Test:
                 # Then
                 assert len(offers) == 0
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_not_return_offers_having_only_stocks_with_past_booking_limit_date_time(self, app):
                 # Given
                 product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
@@ -229,7 +229,7 @@ class GetOffersForRecommendationV3Test:
                 assert len(offers) == 0
 
         class OrderTest:
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_order_with_criteria_should_return_offer_with_highest_base_score_first(self, app):
                 # Given
                 offerer = create_offerer()
@@ -257,7 +257,7 @@ class GetOffersForRecommendationV3Test:
                 # Then
                 assert offers[0].offer == offer2
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             @patch('pcapi.repository.offer_queries.feature_queries.is_active', return_value=True)
             def test_order_should_return_ordered_offers_by_dateSeen_when_feature_is_active(self, app):
                 # Given
@@ -290,7 +290,7 @@ class GetOffersForRecommendationV3Test:
                 # Then
                 assert offers == [offer_1, offer_2]
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             @patch('pcapi.repository.offer_queries.feature_queries.is_active', return_value=True)
             def test_order_should_return_unseen_offers_first_when_feature_is_active(self, app):
                 # Given
@@ -322,7 +322,7 @@ class GetOffersForRecommendationV3Test:
                 # Then
                 assert offers[0] == offer_1
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             @patch('pcapi.repository.offer_queries.feature_queries.is_active', return_value=False)
             @patch('pcapi.repository.offer_queries.order_offers_by_unseen_offers_first')
             def test_order_should_not_order_offers_by_dateSeen_when_feature_is_not_active(self, mock_order_offers_by_unseen_offers_first, app):
@@ -347,7 +347,7 @@ class GetOffersForRecommendationV3Test:
                 mock_order_offers_by_unseen_offers_first.assert_not_called()
 
     class UserSpecificBehaviorTest:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_filter_should_not_return_booked_offers(self, app):
             # Given
             offerer = create_offerer()
@@ -368,7 +368,7 @@ class GetOffersForRecommendationV3Test:
             # Then
             assert offers == []
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def test_filter_should_not_return_favorite_offers(self, app):
             # Given
             offerer = create_offerer()
@@ -392,7 +392,7 @@ class GetOffersForRecommendationV3Test:
 
         class WhenUserIsGeolocatedTest:
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_return_offer_when_offer_is_national(self, app):
                 # Given
                 offerer = create_offerer(siren='123456789')
@@ -422,7 +422,7 @@ class GetOffersForRecommendationV3Test:
                 # Then
                 assert offers == [offer]
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_not_return_offers_from_venue_outside_user_iris(self, app):
                 # given
                 offerer = create_offerer(siren='123456789')
@@ -452,7 +452,7 @@ class GetOffersForRecommendationV3Test:
                 # then
                 assert offers == []
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_return_only_national_offers_when_user_is_geolocated_abroad(self, app):
                 # given
                 offerer = create_offerer(siren='123456789')
@@ -484,7 +484,7 @@ class GetOffersForRecommendationV3Test:
 
         class WhenUserIsNotGeolocatedTest:
 
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_filter_should_return_offers_regardless_of_location(self, app):
                 # given
                 offerer = create_offerer(siren='123456789')

--- a/tests/repository/iris_venues_queries_test.py
+++ b/tests/repository/iris_venues_queries_test.py
@@ -1,18 +1,19 @@
 from shapely.geometry import Polygon
 
+import pytest
+
 from pcapi.domain.iris import MAXIMUM_DISTANCE_IN_METERS
 from pcapi.models import IrisVenues
 from pcapi.repository import repository
 from pcapi.repository.iris_venues_queries import find_ids_of_irises_located_near_venue, insert_venue_in_iris_venue, \
     delete_venue_from_iris_venues, get_iris_containing_user_location, find_venues_located_near_iris
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_venue, create_offerer, create_iris, create_iris_venue
 
 WGS_SPATIAL_REFERENCE_IDENTIFIER = 4326
 
 
 class FindIrisesLocatedNearVenueTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_ids_list_of_iris_located_near_given_venue(self, app):
         # given
         offerer = create_offerer()
@@ -35,7 +36,7 @@ class FindIrisesLocatedNearVenueTest:
         # then
         assert iris_id == [iris_beauvais.id]
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_empty_list_when_no_iris_found_near_given_venue(self, app):
         # given
         offerer = create_offerer()
@@ -51,7 +52,7 @@ class FindIrisesLocatedNearVenueTest:
 
 
 class InsertVenueInIrisVenueTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_insert_venue_in_iris_venues(self, app):
         # Given
         polygon_1 = Polygon([(0.1, 0.1), (0.1, 0.2), (0.2, 0.2), (0.2, 0.1)])
@@ -75,7 +76,7 @@ class InsertVenueInIrisVenueTest:
 
 
 class DeleteVenueFromIrisVenuesTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_delete_given_venue_from_iris_venues(self, app):
         # Given
         offerer = create_offerer()
@@ -104,7 +105,7 @@ class DeleteVenueFromIrisVenuesTest:
         assert iris_venue[0].venueId == venue_2.id
         assert iris_venue[0].irisId == iris_2.id
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_delete_from_iris_venues_if_venue_id_is_none(self, app):
         # Given
         offerer = create_offerer()
@@ -124,7 +125,7 @@ class DeleteVenueFromIrisVenuesTest:
 
 
 class GetIrisContainingUserLocationTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_link_user_to_iris_when_his_location_is_in_one_iris(self, app):
         # Given
         user_latitude = 49.894171
@@ -145,7 +146,7 @@ class GetIrisContainingUserLocationTest:
         # Then
         assert iris_id == iris_2.id
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_link_user_to_first_iris_returned_when_his_location_is_in_two_irises(self, app):
         # Given
         user_latitude = 49.894171
@@ -167,7 +168,7 @@ class GetIrisContainingUserLocationTest:
         # Then
         assert iris_id == iris_1.id
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_link_user_to_iris_if_no_iris_is_found(self, app):
         # Given
         user_latitude = 0
@@ -181,7 +182,7 @@ class GetIrisContainingUserLocationTest:
 
 
 class FindVenuesLocatedNearIrisTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_ids_list_of_venues_located_near_given_iris(self, app):
         # given
         offerer = create_offerer()
@@ -201,7 +202,7 @@ class FindVenuesLocatedNearIrisTest:
         # then
         assert venues_ids == [venue.id]
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_empty_list_when_no_venue_found_near_given_iris(self, app):
         # given
         polygon = Polygon([(0.1, 0.1), (0.1, 0.2), (0.2, 0.2), (0.2, 0.1)])
@@ -216,7 +217,7 @@ class FindVenuesLocatedNearIrisTest:
         # then
         assert venues_ids == []
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_empty_list_when_iris_does_not_exist(self, app):
         # when
         venues_ids = find_venues_located_near_iris(None)

--- a/tests/repository/offer_queries_test.py
+++ b/tests/repository/offer_queries_test.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from freezegun import freeze_time
+import pytest
 from sqlalchemy import func
 
 from pcapi.models import OfferSQLEntity, StockSQLEntity, Product
@@ -15,7 +16,6 @@ from pcapi.repository.offer_queries import department_or_national_offers, \
     get_offers_by_ids, \
     get_paginated_expired_offer_ids, \
     _build_bookings_quantity_subquery
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_booking, create_user, create_offerer, \
     create_venue, create_provider
 from pcapi.model_creators.specific_creators import create_product_with_thing_type, create_offer_with_thing_product, \
@@ -24,7 +24,7 @@ from pcapi.model_creators.specific_creators import create_product_with_thing_typ
 
 
 class DepartmentOrNationalOffersTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_national_thing_with_different_department(self, app):
         # given
         product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
@@ -40,7 +40,7 @@ class DepartmentOrNationalOffersTest:
         # then
         assert product in query.all()
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_national_event_with_different_department(self, app):
         # given
         product = create_product_with_event_type('Voir une pièce', is_national=True)
@@ -56,7 +56,7 @@ class DepartmentOrNationalOffersTest:
         # then
         assert product in query.all()
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_nothing_if_event_is_not_in_given_department_list(self, app):
         # given
         product = create_product_with_event_type('Voir une pièce', is_national=False)
@@ -72,7 +72,7 @@ class DepartmentOrNationalOffersTest:
         # then
         assert query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_an_event_regardless_of_department_if_department_list_contains_00(self, app):
         # given
         product = create_product_with_event_type('Voir une pièce', is_national=False)
@@ -88,7 +88,7 @@ class DepartmentOrNationalOffersTest:
         # then
         assert query.count() == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_an_event_if_it_is_given_in_department_list(self, app):
         # given
         product = create_product_with_event_type('Voir une pièce', is_national=False)
@@ -106,7 +106,7 @@ class DepartmentOrNationalOffersTest:
 
 
 class FindActivationOffersTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_find_activation_offers_returns_activation_offers_in_given_department(self, app):
         # given
         offerer = create_offerer(siren='123456789')
@@ -126,7 +126,7 @@ class FindActivationOffersTest:
         # then
         assert len(offers) == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_find_activation_offers_returns_activation_offers_if_offer_is_national(self, app):
         # given
         offerer = create_offerer(siren='123456789')
@@ -148,7 +148,7 @@ class FindActivationOffersTest:
         # then
         assert len(offers) == 3
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_find_activation_offers_returns_activation_offers_in_all_ile_de_france_if_department_is_93(self, app):
         # given
         offerer = create_offerer(siren='123456789')
@@ -169,7 +169,7 @@ class FindActivationOffersTest:
         # then
         assert len(offers) == 2
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_find_activation_offers_returns_activation_offers_with_available_stocks(self, app):
         # given
         user = create_user()
@@ -196,7 +196,7 @@ class FindActivationOffersTest:
         # then
         assert len(offers) == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_find_activation_offers_returns_activation_offers_with_future_booking_limit_datetime(self, app):
         # given
         now = datetime.utcnow()
@@ -224,7 +224,7 @@ class FindActivationOffersTest:
 
 
 class FindOffersTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_get_offers_by_venue_id_returns_offers_matching_venue_id(self, app):
         # Given
         product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
@@ -242,7 +242,7 @@ class FindOffersTest:
 
 
 class QueryOfferWithRemainingStocksTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_0_offer_when_there_is_no_stock(self, app):
         # Given
         thing = create_product_with_thing_type()
@@ -260,7 +260,7 @@ class QueryOfferWithRemainingStocksTest:
         # Then
         assert offers_count == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_1_offer_when_all_available_stock_is_not_booked(self, app):
         # Given
         thing = create_product_with_thing_type()
@@ -285,7 +285,7 @@ class QueryOfferWithRemainingStocksTest:
         # Then
         assert offers_count == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_0_offer_when_all_available_stock_is_booked(self, app):
         # Given
         thing = create_product_with_thing_type()
@@ -310,7 +310,7 @@ class QueryOfferWithRemainingStocksTest:
         # Then
         assert offers_count == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_1_offer_when_booking_was_cancelled(self, app):
         # Given
         user = create_user()
@@ -334,7 +334,7 @@ class QueryOfferWithRemainingStocksTest:
         # Then
         assert offers_count == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_0_offer_when_there_is_no_remaining_stock(app):
         # Given
         product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
@@ -359,7 +359,7 @@ class QueryOfferWithRemainingStocksTest:
         # Then
         assert offers_count == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_1_offer_when_there_are_one_full_stock_and_one_empty_stock(app):
         # Given
         product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
@@ -394,7 +394,7 @@ def _create_event_stock_and_offer_for_date(venue, date):
 
 
 class GetOffersByIdsTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_all_existing_offers_when_offer_ids_are_given(self, app):
         # Given
         offerer = create_offerer()
@@ -414,7 +414,7 @@ class GetOffersByIdsTest:
 
 
 class GetPaginatedActiveOfferIdsTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_two_offer_ids_from_first_page_when_limit_is_two_and_two_active_offers(self, app):
         # Given
         offerer = create_offerer()
@@ -435,7 +435,7 @@ class GetPaginatedActiveOfferIdsTest:
         assert (offer3.id,) not in offer_ids
         assert (offer4.id,) not in offer_ids
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_from_second_page_when_limit_is_1_and_three_active_offers(self, app):
         # Given
         offerer = create_offerer()
@@ -456,7 +456,7 @@ class GetPaginatedActiveOfferIdsTest:
         assert (offer2.id,) not in offer_ids
         assert (offer4.id,) not in offer_ids
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_from_third_page_when_limit_is_1_and_three_active_offers(self, app):
         # Given
         offerer = create_offerer()
@@ -479,7 +479,7 @@ class GetPaginatedActiveOfferIdsTest:
 
 
 class GetPaginatedOfferIdsByVenueIdTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_in_two_offers_from_first_page_when_limit_is_one(self, app):
         # Given
         offerer = create_offerer()
@@ -496,7 +496,7 @@ class GetPaginatedOfferIdsByVenueIdTest:
         assert (offer1.id,) in offer_ids
         assert (offer2.id,) not in offer_ids
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_in_two_offers_from_second_page_when_limit_is_one(self, app):
         # Given
         offerer = create_offerer()
@@ -515,7 +515,7 @@ class GetPaginatedOfferIdsByVenueIdTest:
 
 
 class GetPaginatedOfferIdsByVenueIdAndLastProviderIdTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_offer_ids_when_exist_and_venue_id_and_last_provider_id_match(self, app):
         # Given
         provider1 = create_provider(idx=1, local_class='OpenAgenda', is_active=False, is_enable_for_pro=False)
@@ -536,7 +536,7 @@ class GetPaginatedOfferIdsByVenueIdAndLastProviderIdTest:
         assert len(offer_ids) == 1
         assert offer_ids[0] == (offer1.id,)
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_when_exist_and_venue_id_and_last_provider_id_match_from_first_page_only(self,
                                                                                                                 app):
         # Given
@@ -557,7 +557,7 @@ class GetPaginatedOfferIdsByVenueIdAndLastProviderIdTest:
         assert len(offer_ids) == 1
         assert offer_ids[0] == (offer1.id,)
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_when_exist_and_venue_id_and_last_provider_id_match_from_second_page_only(self,
                                                                                                                  app):
         # Given
@@ -578,7 +578,7 @@ class GetPaginatedOfferIdsByVenueIdAndLastProviderIdTest:
         assert len(offer_ids) == 1
         assert offer_ids[0] == (offer2.id,)
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_return_offer_ids_when_venue_id_and_last_provider_id_do_not_match(self, app):
         # Given
         provider1 = create_provider(idx=1, local_class='OpenAgenda', is_active=False, is_enable_for_pro=False)
@@ -598,7 +598,7 @@ class GetPaginatedOfferIdsByVenueIdAndLastProviderIdTest:
         # Then
         assert len(offer_ids) == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_return_offer_ids_when_venue_id_matches_but_last_provider_id_do_not_match(self, app):
         # Given
         provider1 = create_provider(idx=1, local_class='OpenAgenda', is_active=False, is_enable_for_pro=False)
@@ -618,7 +618,7 @@ class GetPaginatedOfferIdsByVenueIdAndLastProviderIdTest:
         # Then
         assert len(offer_ids) == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_return_offer_ids_when_venue_id_do_not_matches_but_last_provider_id_matches(self, app):
         # Given
         provider1 = create_provider(idx=1, local_class='OpenAgenda', is_active=False, is_enable_for_pro=False)
@@ -641,7 +641,7 @@ class GetPaginatedOfferIdsByVenueIdAndLastProviderIdTest:
 
 @freeze_time('2020-01-01 10:00:00')
 class GetPaginatedExpiredOfferIdsTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_from_first_page_when_active_and_booking_limit_datetime_is_expired(self, app):
         # Given
         offerer = create_offerer()
@@ -666,7 +666,7 @@ class GetPaginatedExpiredOfferIdsTest:
         assert (offer3.id,) not in results
         assert (offer4.id,) not in results
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_two_offer_ids_from_second_page_when_active_and_booking_limit_datetime_is_expired(self, app):
         # Given
         offerer = create_offerer()
@@ -691,7 +691,7 @@ class GetPaginatedExpiredOfferIdsTest:
         assert (offer3.id,) in results
         assert (offer4.id,) in results
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_return_offer_ids_when_not_active_and_booking_limit_datetime_is_expired(self, app):
         # Given
         offerer = create_offerer()
@@ -712,7 +712,7 @@ class GetPaginatedExpiredOfferIdsTest:
         # Then
         assert len(results) == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_return_offer_ids_when_active_and_booking_limit_datetime_is_not_expired(self, app):
         # Given
         offerer = create_offerer()
@@ -733,7 +733,7 @@ class GetPaginatedExpiredOfferIdsTest:
         # Then
         assert len(results) == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_from_first_page_when_active_and_beginning_datetime_is_null(self, app):
         # Given
         offerer = create_offerer()
@@ -760,7 +760,7 @@ class GetPaginatedExpiredOfferIdsTest:
         assert (offer3.id,) not in results
         assert (offer4.id,) not in results
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_when_two_offers_are_expired_and_the_second_one_is_out_of_range(self, app):
         # Given
         offerer = create_offerer()
@@ -780,7 +780,7 @@ class GetPaginatedExpiredOfferIdsTest:
         assert (offer1.id,) in results
         assert (offer2.id,) not in results
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_no_offer_ids_when_offers_are_expired_since_more_than_two_days(self, app):
         # Given
         offerer = create_offerer()
@@ -799,7 +799,7 @@ class GetPaginatedExpiredOfferIdsTest:
         # Then
         assert len(results) == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_when_offers_are_expired_since_more_than_two_days_and_one_second(self, app):
         # Given
         offerer = create_offerer()
@@ -819,7 +819,7 @@ class GetPaginatedExpiredOfferIdsTest:
         assert offer1 in results
         assert offer2 not in results
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_when_offers_are_expired_since_more_than_two_days_and_one_second(self, app):
         # Given
         offerer = create_offerer()
@@ -839,7 +839,7 @@ class GetPaginatedExpiredOfferIdsTest:
         assert offer1 in results
         assert offer2 not in results
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_when_offers_are_expired_exactly_since_two_days(self, app):
         # Given
         offerer = create_offerer()
@@ -859,7 +859,7 @@ class GetPaginatedExpiredOfferIdsTest:
         assert offer1 in results
         assert offer2 not in results
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_offer_id_when_offers_are_expired_exactly_since_one_day(self, app):
         # Given
         offerer = create_offerer()
@@ -879,7 +879,7 @@ class GetPaginatedExpiredOfferIdsTest:
         assert offer1 in results
         assert offer2 not in results
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def should_not_get_offer_with_valid_stocks(self, app):
         # Given
         offerer = create_offerer()

--- a/tests/repository/offerer_queries_test.py
+++ b/tests/repository/offerer_queries_test.py
@@ -1,6 +1,8 @@
 import secrets
 from datetime import datetime, timedelta
 
+import pytest
+
 from pcapi.models import Offerer, VenueSQLEntity, ThingType
 from pcapi.repository import repository
 from pcapi.repository.offerer_queries import find_all_offerers_with_managing_user_information, \
@@ -10,14 +12,13 @@ from pcapi.repository.offerer_queries import find_all_offerers_with_managing_use
     find_filtered_offerers, filter_offerers_with_keywords_string, find_by_id, count_offerer, count_offerer_with_stock, \
     count_offerer_by_departement, count_offerer_with_stock_by_departement, find_new_offerer_user_email
 from pcapi.repository.user_queries import find_all_emails_of_user_offerers_admins
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_bank_information, create_offerer, create_stock, create_user, create_user_offerer, create_venue
 from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence, create_stock_with_thing_offer, \
     create_offer_with_thing_product, create_offer_with_event_product, create_event_occurrence
 
 
 class OffererQueriesTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_find_by_id_returns_the_right_offerer(self, app):
         # Given
         id = 52325
@@ -33,7 +34,7 @@ class OffererQueriesTest:
 
 
 class CountOffererTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_zero_if_no_offerer(self, app):
         # When
         number_of_offerers = count_offerer()
@@ -41,7 +42,7 @@ class CountOffererTest:
         # Then
         assert number_of_offerers == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_1_if_offerer_with_user_offerer(self, app):
         # Given
         user = create_user()
@@ -55,7 +56,7 @@ class CountOffererTest:
         # Then
         assert number_of_offerers == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_0_if_offerer_without_user_offerer(self, app):
         # Given
         offerer = create_offerer()
@@ -67,7 +68,7 @@ class CountOffererTest:
         # Then
         assert number_of_offerers == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_1_if_offerer_with_2_user_offerer(self, app):
         # Given
         user1 = create_user()
@@ -85,7 +86,7 @@ class CountOffererTest:
 
 
 class CountOffererByDepartementTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_zero_if_no_offerer(self, app):
         # When
         number_of_offerers = count_offerer_by_departement('54')
@@ -93,7 +94,7 @@ class CountOffererByDepartementTest:
         # Then
         assert number_of_offerers == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_1_if_offerer_with_user_offerer(self, app):
         # Given
         user = create_user()
@@ -108,7 +109,7 @@ class CountOffererByDepartementTest:
         # Then
         assert number_of_offerers == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_1_with_two_venues_but_only_one_in_the_departement(self, app):
         # Given
         user = create_user()
@@ -125,7 +126,7 @@ class CountOffererByDepartementTest:
         # Then
         assert number_of_offerers == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_0_if_offerer_without_venue(self, app):
         # Given
         user = create_user()
@@ -140,7 +141,7 @@ class CountOffererByDepartementTest:
         # Then
         assert number_of_offerers == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_1_if_offerer_with_2_user_offerers_and_2_venues(self, app):
         # Given
         user1 = create_user()
@@ -167,7 +168,7 @@ class CountOffererWithStockTest:
         # Then
         assert number_of_offerers == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_1_if_offerer_with_user_offerer_and_stock(self, app):
         # Given
         user = create_user()
@@ -184,7 +185,7 @@ class CountOffererWithStockTest:
         # Then
         assert number_of_offerers == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_0_if_offerer_without_user_offerer(self, app):
         # Given
         offerer = create_offerer()
@@ -199,7 +200,7 @@ class CountOffererWithStockTest:
         # Then
         assert number_of_offerers == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_0_if_offerer_without_stock(self, app):
         # Given
         offerer = create_offerer()
@@ -214,7 +215,7 @@ class CountOffererWithStockTest:
         # Then
         assert number_of_offerers == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_1_if_offerer_with_user_offerer_and_two_stock(self, app):
         # Given
         user = create_user()
@@ -232,7 +233,7 @@ class CountOffererWithStockTest:
         # Then
         assert number_of_offerers == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_1_if_offerer_with_2_user_offerers_and_stock(self, app):
         # Given
         user1 = create_user()
@@ -252,7 +253,7 @@ class CountOffererWithStockTest:
         # Then
         assert number_of_offerers == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_when_only_offerers_with_activation_offers(self, app):
         # Given
         user = create_user(email='first@example.net')
@@ -281,7 +282,7 @@ class CountOffererWithStockByDepartementTest:
         # Then
         assert number_of_offerers == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_0_if_offerer_without_user_offerer(self, app):
         # Given
         offerer = create_offerer()
@@ -296,7 +297,7 @@ class CountOffererWithStockByDepartementTest:
         # Then
         assert number_of_offerers == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_0_if_offerer_without_stock(self, app):
         # Given
         offerer = create_offerer()
@@ -312,7 +313,7 @@ class CountOffererWithStockByDepartementTest:
         # Then
         assert number_of_offerers == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_1_if_offerer_with_user_offerer_and_two_stock(self, app):
         # Given
         user = create_user()
@@ -330,7 +331,7 @@ class CountOffererWithStockByDepartementTest:
         # Then
         assert number_of_offerers == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_counts_offerer_only_once_even_if_it_has_multiple_user_offerers_and_stock_in_departement(self, app):
         # Given
         user1 = create_user()
@@ -350,7 +351,7 @@ class CountOffererWithStockByDepartementTest:
         # Then
         assert number_of_offerers == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_1_when_filtered_by_departement(self, app):
         # Given
         first_user = create_user(email='first@example.net')
@@ -375,7 +376,7 @@ class CountOffererWithStockByDepartementTest:
         # Then
         assert number_of_offerers == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_0_when_filtered_by_departement_and_none_is_found(self, app):
         # Given
         first_user = create_user(email='first@example.net')
@@ -400,7 +401,7 @@ class CountOffererWithStockByDepartementTest:
         # Then
         assert number_of_offerers == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_when_only_offerers_with_activation_offers(self, app):
         # Given
         user = create_user(email='first@example.net')
@@ -421,7 +422,7 @@ class CountOffererWithStockByDepartementTest:
         assert number_of_offerers == 0
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_all_emails_of_user_offerers_admins_returns_list_of_user_emails_having_user_offerer_with_admin_rights_on_offerer(
         app):
     # Given
@@ -446,7 +447,7 @@ def test_find_all_emails_of_user_offerers_admins_returns_list_of_user_emails_hav
     assert set(emails) == {'admin1@offerer.com', 'admin2@offerer.com'}
     assert type(emails) == list
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_email_of_user_offerer_should_returns_email(
         app):
     # Given
@@ -462,7 +463,7 @@ def test_find_email_of_user_offerer_should_returns_email(
     # Then
     assert result == 'pro@example.com'
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_all_offerers_with_managing_user_information(app):
     # given
     user_admin1 = create_user(email='admin1@offerer.com')
@@ -487,7 +488,7 @@ def test_find_all_offerers_with_managing_user_information(app):
     assert user_admin2.email in offerers[3].email
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_all_offerers_with_managing_user_information_and_venue(app):
     # given
     user_admin1 = create_user(email='admin1@offerer.com')
@@ -516,7 +517,7 @@ def test_find_all_offerers_with_managing_user_information_and_venue(app):
     assert offerer2.siren == offerers[3].siren
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_all_offerers_with_managing_user_information_and_not_virtual_venue(app):
     # given
     user_admin1 = create_user(email='admin1@offerer.com')
@@ -542,7 +543,7 @@ def test_find_all_offerers_with_managing_user_information_and_not_virtual_venue(
     assert offerer2.siren == offerers[1].siren
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_all_offerers_with_venue(app):
     # given
     offerer1 = create_offerer(name='offerer1')
@@ -563,7 +564,7 @@ def test_find_all_offerers_with_venue(app):
     assert venue1.bookingEmail in offerers[0].bookingEmail
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_get_all_pending_offerers_return_requested_tokens_in_case_only_venue_not_validated(app):
     # given
     user_validated = create_user(can_book_free_offers=False, email="user@user.pro", is_admin=False)
@@ -588,7 +589,7 @@ def test_get_all_pending_offerers_return_requested_tokens_in_case_only_venue_not
     assert venue.validationToken == venue_not_validated.validationToken
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_get_all_pending_offerers_return_requested_tokens_in_case_only_user_not_validated(app):
     # given
     user_not_validated = create_user(can_book_free_offers=False, email="user@user.pro", is_admin=False,
@@ -613,7 +614,7 @@ def test_get_all_pending_offerers_return_requested_tokens_in_case_only_user_not_
     assert venue.validationToken == venue_validated.validationToken
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_get_all_pending_offerers_return_requested_tokens_in_case_only_user_offerer_not_validated(app):
     # given
     user_validated = create_user(can_book_free_offers=False, email="user@user.pro", is_admin=False)
@@ -638,7 +639,7 @@ def test_get_all_pending_offerers_return_requested_tokens_in_case_only_user_offe
     assert venue.validationToken == venue_validated.validationToken
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_get_all_pending_offerers_return_nothing_in_case_only_offerer_not_validated(app):
     # given
     user_validated = create_user(can_book_free_offers=False, email="user@user.pro", is_admin=False)
@@ -662,7 +663,7 @@ def test_get_all_pending_offerers_return_nothing_in_case_only_offerer_not_valida
     assert venue.validationToken == venue_validated.validationToken
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_get_all_pending_offerers_return_empty_list_in_case_all_validated(app):
     # given
     user_validated = create_user(can_book_free_offers=False, email="user@user.pro", is_admin=False)
@@ -677,7 +678,7 @@ def test_get_all_pending_offerers_return_empty_list_in_case_all_validated(app):
     assert offerers == []
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_first_by_user_offerer_id_returns_the_first_offerer_that_was_created(app):
     # given
     user = create_user()
@@ -695,7 +696,7 @@ def test_find_first_by_user_offerer_id_returns_the_first_offerer_that_was_create
     assert offerer.id == offerer1.id
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_sirens_params_return_filtered_offerers(app):
     # given
     offerer_123456789 = create_offerer(name="offerer_123456789", siren="123456789")
@@ -718,7 +719,7 @@ def test_find_filtered_offerers_with_sirens_params_return_filtered_offerers(app)
     assert offerer_123456784 not in query_with_sirens
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_dpts_param_return_filtered_offerers(app):
     # Given
     offerer_93 = create_offerer(postal_code="93125")
@@ -747,7 +748,7 @@ def test_find_filtered_offerers_with_dpts_param_return_filtered_offerers(app):
     assert offerer_2A in query_with_dpts
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_zipcodes_param_return_filtered_offerers(app):
     # Given
     offerer_93125 = create_offerer(postal_code="93125")
@@ -765,7 +766,7 @@ def test_find_filtered_offerers_with_zipcodes_param_return_filtered_offerers(app
     assert offerer_34758 in query_with_zipcodes
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_date_params_return_filtered_offerers(app):
     # Given
     offerer_in_date_range = create_offerer(siren="123456781", date_created=datetime(2018, 7, 15))
@@ -789,7 +790,7 @@ def test_find_filtered_offerers_with_date_params_return_filtered_offerers(app):
     assert offerer_after_date_range not in query_with_date
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_has_siren_param_return_filtered_offerers(app):
     # Given
     offerer_with_siren = create_offerer(siren="123456789")
@@ -805,7 +806,7 @@ def test_find_filtered_offerers_with_has_siren_param_return_filtered_offerers(ap
     assert offerer_without_siren in query_no_siren
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_is_validated_param_return_filtered_offerers(app):
     # Given
     offerer_validated = create_offerer(siren="123456789", validation_token=None)
@@ -821,7 +822,7 @@ def test_find_filtered_offerers_with_is_validated_param_return_filtered_offerers
     assert offerer_not_validated not in query_only_validated
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_is_active_param_return_filtered_offerers(app):
     # Given
     offerer_active = create_offerer(siren="123456789", is_active=True)
@@ -837,7 +838,7 @@ def test_find_filtered_offerers_with_is_active_param_return_filtered_offerers(ap
     assert offerer_not_active not in query_only_active
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_has_bank_information_param_return_filtered_offerers(app):
     # Given
     offerer_without_bank_information = create_offerer(siren="123456781")
@@ -856,7 +857,7 @@ def test_find_filtered_offerers_with_has_bank_information_param_return_filtered_
     assert offerer_without_bank_information not in query_with_bank_information
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_True_has_validated_user_param_return_filtered_offerers(app):
     # Given
     offerer_with_not_validated_user = create_offerer(siren="123456781")
@@ -885,7 +886,7 @@ def test_find_filtered_offerers_with_True_has_validated_user_param_return_filter
     assert offerer_with_both in query_validated_user
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_False_has_validated_user_param_return_filtered_offerers(app):
     # Given
     offerer_with_not_validated_user = create_offerer(siren="123456781")
@@ -914,7 +915,7 @@ def test_find_filtered_offerers_with_False_has_validated_user_param_return_filte
     assert offerer_with_both not in query_not_validated
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_True_has_not_virtual_venue_param_return_filtered_offerers(app):
     # Given
     offerer_with_only_virtual_venue = create_offerer(siren="123456789")
@@ -934,7 +935,7 @@ def test_find_filtered_offerers_with_True_has_not_virtual_venue_param_return_fil
     assert offerer_with_both_virtual_and_not_virtual_venue in query_with_not_virtual
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_False_has_not_virtual_venue_param_return_filtered_offerers(app):
     # Given
     offerer_with_only_virtual_venue = create_offerer(siren="123456789")
@@ -954,7 +955,7 @@ def test_find_filtered_offerers_with_False_has_not_virtual_venue_param_return_fi
     assert offerer_with_both_virtual_and_not_virtual_venue not in query_only_virtual
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_True_has_validated_venue_param_return_filtered_offerers(app):
     # Given
     offerer_with_not_validated_venue = create_offerer(siren="123456789")
@@ -982,7 +983,7 @@ def test_find_filtered_offerers_with_True_has_validated_venue_param_return_filte
     assert offerer_with_both in query_validated
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_False_has_validated_venue_param_return_filtered_offerers(app):
     # Given
     offerer_with_not_validated_venue = create_offerer(siren="123456789")
@@ -1010,7 +1011,7 @@ def test_find_filtered_offerers_with_False_has_validated_venue_param_return_filt
     assert offerer_with_both not in query_not_validated
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_True_has_venue_with_siret_param_return_filtered_offerers(app):
     # Given
     offerer_with_venue_without_siret_comment = create_offerer(siren="123456789")
@@ -1046,7 +1047,7 @@ def test_find_filtered_offerers_with_True_has_venue_with_siret_param_return_filt
     assert offerer_with_both_virtual in query_with_siret
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_False_has_venue_with_siret_param_return_filtered_offerers(app):
     # Given
     offerer_with_venue_without_siret_comment = create_offerer(siren="123456789")
@@ -1081,7 +1082,7 @@ def test_find_filtered_offerers_with_False_has_venue_with_siret_param_return_fil
     assert offerer_with_both_virtual not in query_whitout_siret
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_True_has_validated_user_offerer_param_return_filtered_offerers(app):
     # Given
     offerer_with_not_validated_user_offerer = create_offerer(siren="123456781")
@@ -1109,7 +1110,7 @@ def test_find_filtered_offerers_with_True_has_validated_user_offerer_param_retur
     assert offerer_with_both in query_validated
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_False_has_validated_user_offerer_param_return_filtered_offerers(app):
     # Given
     offerer_with_not_validated_user_offerer = create_offerer(siren="123456781")
@@ -1137,7 +1138,7 @@ def test_find_filtered_offerers_with_False_has_validated_user_offerer_param_retu
     assert offerer_with_both not in query_not_validated
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_offer_status_with_VALID_param_return_filtered_offerers(app):
     # Given
     offerer_without_offer = create_offerer(siren="123456781")
@@ -1220,7 +1221,7 @@ def test_find_filtered_offerers_with_offer_status_with_VALID_param_return_filter
     assert offerer_with_not_available_event_product not in query_has_valid_offer
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_offer_status_with_EXPIRED_param_return_filtered_offerers(app):
     # Given
     offerer_without_offer = create_offerer(siren="123456781")
@@ -1299,7 +1300,7 @@ def test_find_filtered_offerers_with_offer_status_with_EXPIRED_param_return_filt
     assert offerer_with_not_available_event in query_has_expired_offer
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_offer_status_with_WITHOUT_param_return_filtered_offerers(app):
     # Given
     offerer_without_offer = create_offerer(siren="123456781")
@@ -1378,7 +1379,7 @@ def test_find_filtered_offerers_with_offer_status_with_WITHOUT_param_return_filt
     assert offerer_with_not_available_event not in query_without_offer
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_offer_status_with_ALL_param_return_filtered_offerers(app):
     # Given
     offerer_without_offer = create_offerer(siren="123456781")
@@ -1457,7 +1458,7 @@ def test_find_filtered_offerers_with_offer_status_with_ALL_param_return_filtered
     assert offerer_with_not_available_event in query_with_all_offer
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_offer_status_with_ALL_param_and_False_has_not_virtual_venues_return_filtered_offerers(
         app):
     # Given
@@ -1503,7 +1504,7 @@ def test_find_filtered_offerers_with_offer_status_with_ALL_param_and_False_has_n
     assert offerer_with_both_venues_offer_on_not_virtual not in query_with_all_offer
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_offer_status_with_ALL_param_and_True_has_not_virtual_venues_return_filtered_offerers(
         app):
     # Given
@@ -1549,7 +1550,7 @@ def test_find_filtered_offerers_with_offer_status_with_ALL_param_and_True_has_no
     assert offerer_with_both_venues_offer_on_not_virtual in query_with_all_offer
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_default_param_return_all_offerers(app):
     # Given
     offerer_67 = create_offerer(siren="123456781", postal_code="67520")
@@ -1594,7 +1595,7 @@ def test_find_filtered_offerers_with_default_param_return_all_offerers(app):
     assert offerer_not_active in default_query
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_one_keyword_at_venue_public_name_level(app):
     # given
     offerer_with_only_virtual_venue_with_offer = create_offerer(siren="123456785")
@@ -1644,7 +1645,7 @@ def test_find_filtered_offerers_with_one_keyword_at_venue_public_name_level(app)
     assert offerer_with_both_venues_offer_on_not_virtual in offerers
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_one_partial_keyword_at_venue_public_name_level(app):
     # given
     offerer_with_only_virtual_venue_with_offer = create_offerer(siren="123456785")
@@ -1694,7 +1695,7 @@ def test_find_filtered_offerers_with_one_partial_keyword_at_venue_public_name_le
     assert offerer_with_both_venues_offer_on_not_virtual in offerers
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_several_keywords_at_venue_public_name_level(app):
     # given
     offerer_with_only_virtual_venue_with_offer = create_offerer(siren="123456785")
@@ -1744,7 +1745,7 @@ def test_find_filtered_offerers_with_several_keywords_at_venue_public_name_level
     assert offerer_with_both_venues_offer_on_not_virtual in offerers
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_offerers_with_several_partial_keywords_at_venue_public_name_level(app):
     # given
     offerer_with_only_virtual_venue_with_offer = create_offerer(siren="123456785")

--- a/tests/repository/payment_queries_test.py
+++ b/tests/repository/payment_queries_test.py
@@ -1,8 +1,9 @@
 import uuid
 
+import pytest
+
 from pcapi.models.payment_status import PaymentStatus, TransactionStatus
 from pcapi.repository import payment_queries, repository
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_bank_information, \
     create_booking, create_deposit, create_offerer, create_payment, \
     create_payment_message, create_user, create_venue
@@ -12,7 +13,7 @@ from pcapi.models.bank_information import BankInformationStatus
 
 
 class FindMessageChecksumTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_a_checksum_if_message_id_is_known(self, app):
         # given
         message_id = 'ABCD1234'
@@ -25,7 +26,7 @@ class FindMessageChecksumTest:
         # then
         assert checksum == message.checksum
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_none_is_message_id_is_unknown(self, app):
         # given
         message_id = 'ABCD1234'
@@ -40,7 +41,7 @@ class FindMessageChecksumTest:
 
 
 class FindErrorPaymentsTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_payments_with_last_payment_status_error(self, app):
         # Given
         user = create_user()
@@ -62,7 +63,7 @@ class FindErrorPaymentsTest:
         for payment in payments:
             assert payment.currentStatus.status == TransactionStatus.ERROR
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_does_not_return_payment_if_has_status_error_but_not_last(self, app):
         # Given
         user = create_user()
@@ -87,7 +88,7 @@ class FindErrorPaymentsTest:
 
 
 class FindRetryPaymentsTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_payments_with_last_payment_status_retry(self, app):
         # Given
         user = create_user()
@@ -110,7 +111,7 @@ class FindRetryPaymentsTest:
         for payment in payments:
             assert payment.currentStatus.status == TransactionStatus.RETRY
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_does_not_return_payment_if_has_status_retry_but_not_last(self, app):
         # Given
         user = create_user()
@@ -137,7 +138,7 @@ class FindRetryPaymentsTest:
 
 
 class FindPaymentsByMessageTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_payments_matching_message(self, app):
         # given
         user = create_user()
@@ -170,7 +171,7 @@ class FindPaymentsByMessageTest:
         for payment in matching_payments:
             assert payment.paymentMessageName == 'XML1'
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_nothing_if_message_is_not_matched(self, app):
         # given
         user = create_user()
@@ -200,7 +201,7 @@ class FindPaymentsByMessageTest:
 
 
 class GeneratePayementsByMessageIdTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_only_returns_payments_with_given_message(self, app):
         # Given
         offerer = create_offerer()
@@ -233,7 +234,7 @@ class GeneratePayementsByMessageIdTest:
 
 
 class FindNotProcessableWithBankInformationTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_return_payments_to_retry_if_no_bank_information(self, app):
         # Given
         offerer = create_offerer()
@@ -253,7 +254,7 @@ class FindNotProcessableWithBankInformationTest:
         # Then
         assert payments_to_retry == []
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_payment_to_retry_if_bank_information_linked_to_offerer_and_current_status_is_not_processable(self, app):
         # Given
         offerer = create_offerer()
@@ -274,7 +275,7 @@ class FindNotProcessableWithBankInformationTest:
         # Then
         assert not_processable_payment in payments_to_retry
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_return_payments_to_retry_if_bank_information_linked_to_offerer_and_current_status_is_not_not_processable(self, app):
         # Given
         offerer = create_offerer()
@@ -297,7 +298,7 @@ class FindNotProcessableWithBankInformationTest:
         # Then
         assert payments_to_retry == []
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_return_payment_to_retry_if_bank_information_status_is_not_accepted(self, app):
         # Given
         offerer = create_offerer()
@@ -318,7 +319,7 @@ class FindNotProcessableWithBankInformationTest:
         # Then
         assert payments_to_retry == []
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_payment_to_retry_if_bank_information_linked_to_venue_and_current_status_is_not_processable(self, app):
         # Given
         offerer = create_offerer()
@@ -341,7 +342,7 @@ class FindNotProcessableWithBankInformationTest:
 
 
 class FindByBookingIdTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_a_payment_when_one_linked_to_booking(self, app):
         # Given
         beneficiary = create_user()
@@ -357,7 +358,7 @@ class FindByBookingIdTest:
         # Then
         assert payment == valid_payment
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_nothing_when_no_payment_linked_to_booking(self, app):
         # Given
         invalid_booking_id = '99999'

--- a/tests/repository/product_queries_test.py
+++ b/tests/repository/product_queries_test.py
@@ -1,5 +1,5 @@
 import pytest
-from tests.conftest import clean_database
+
 from pcapi.model_creators.generic_creators import create_booking, \
     create_favorite, create_mediation, create_offerer, create_recommendation, \
     create_stock, create_user, create_venue
@@ -12,7 +12,7 @@ from pcapi.repository.product_queries import delete_unwanted_existing_product, f
 
 
 class DeleteUnwantedExistingProductTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_delete_product_when_isbn_found(self, app):
         # Given
         isbn = '1111111111111'
@@ -25,7 +25,7 @@ class DeleteUnwantedExistingProductTest:
         # Then
         assert Product.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_delete_product_when_isbn_not_found(self, app):
         # Given
         isbn = '1111111111111'
@@ -38,7 +38,7 @@ class DeleteUnwantedExistingProductTest:
         # Then
         assert Product.query.count() == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_delete_nothing_when_product_not_found(self, app):
         # Given
         isbn = '1111111111111'
@@ -55,7 +55,7 @@ class DeleteUnwantedExistingProductTest:
         # Then
         assert Product.query.count() == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_delete_product_when_it_has_offer_and_stock_but_not_booked(self, app):
         # Given
         isbn = '1111111111111'
@@ -74,7 +74,7 @@ class DeleteUnwantedExistingProductTest:
         assert OfferSQLEntity.query.count() == 0
         assert StockSQLEntity.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_set_isGcuCompatible_at_false_in_product_and_deactivate_offer_when_bookings_related_to_offer(self, app):
         # Given
         isbn = '1111111111111'
@@ -97,7 +97,7 @@ class DeleteUnwantedExistingProductTest:
         assert Product.query.one() == product
         assert not product.isGcuCompatible
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_delete_product_when_related_offer_has_mediation(self, app):
         # Given
         isbn = '1111111111111'
@@ -122,7 +122,7 @@ class DeleteUnwantedExistingProductTest:
         assert Recommendation.query.count() == 0
         assert MediationSQLEntity.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_delete_product_when_related_offer_is_on_user_favorite_list(self, app):
         # Given
         isbn = '1111111111111'
@@ -151,7 +151,7 @@ class DeleteUnwantedExistingProductTest:
 
 
 class FindActiveBookProductByIsbnTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_active_book_product_when_existing_isbn_is_given(self, app):
         # Given
         isbn = '1111111111111'
@@ -164,7 +164,7 @@ class FindActiveBookProductByIsbnTest:
         # Then
         assert existing_product == product
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_nothing_when_non_existing_isbn_is_given(self, app):
         # Given
         invalid_isbn = '99999999999'
@@ -178,7 +178,7 @@ class FindActiveBookProductByIsbnTest:
         # Then
         assert existing_product is None
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_not_return_not_gcu_compatible_product(self, app):
         # Given
         valid_isbn = '1111111111111'

--- a/tests/repository/reimbursement_queries_test.py
+++ b/tests/repository/reimbursement_queries_test.py
@@ -1,10 +1,11 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
 
+import pytest
+
 from pcapi.models.payment_status import TransactionStatus
 from pcapi.repository import repository
 from pcapi.repository.reimbursement_queries import find_all_offerer_payments
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_booking, create_user, create_offerer, create_venue, \
     create_deposit, \
     create_payment, create_payment_status
@@ -12,7 +13,7 @@ from pcapi.model_creators.specific_creators import create_stock_with_thing_offer
 
 
 class FindAllOffererPaymentsTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_payment_info_with_error_status(self, app):
         # Given
         user = create_user(last_name='User', first_name='Plus')
@@ -52,7 +53,7 @@ class FindAllOffererPaymentsTest:
             TransactionStatus.ERROR,
             'Iban non fourni')
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_one_payment_info_with_sent_status(self, app):
         # Given
         user = create_user(last_name='User', first_name='Plus')
@@ -98,7 +99,7 @@ class FindAllOffererPaymentsTest:
             TransactionStatus.SENT,
             'All good')
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_last_matching_status_based_on_date_for_each_payment(self, app):
         # Given
         user = create_user(last_name='User', first_name='Plus')

--- a/tests/repository/seen_offer_queries_test.py
+++ b/tests/repository/seen_offer_queries_test.py
@@ -1,17 +1,17 @@
 from datetime import datetime
 
 from freezegun import freeze_time
+import pytest
 
 from pcapi.models import SeenOffer
 from pcapi.repository import repository
 from pcapi.repository.seen_offer_queries import find_by_offer_id_and_user_id, remove_old_seen_offers
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_offerer, create_venue, create_user, create_seen_offer
 from pcapi.model_creators.specific_creators import create_offer_with_event_product, create_offer_with_thing_product
 
 
 class FindByOfferIdAndUserIdTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_seen_offer_if_matching_user_id_and_offer_id(self, app):
         # given
         offerer = create_offerer()
@@ -27,7 +27,7 @@ class FindByOfferIdAndUserIdTest:
         # then
         assert queried_seen_offer == seen_offer
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_none_if_unmatching_user_id(self, app):
         # given
         offerer = create_offerer()
@@ -43,7 +43,7 @@ class FindByOfferIdAndUserIdTest:
         # then
         assert queried_seen_offer is None
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_none_if_unmatching_offer_id(self, app):
         # given
         offerer = create_offerer()
@@ -61,7 +61,7 @@ class FindByOfferIdAndUserIdTest:
 
 
 class RemoveOldSeenOffersTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     @freeze_time("2020-5-5 16:22:00")
     def test_should_remove_seen_offers_after_one_month(self, app):
         # given

--- a/tests/repository/stock_queries_test.py
+++ b/tests/repository/stock_queries_test.py
@@ -1,14 +1,15 @@
+import pytest
+
 from pcapi.models import ThingType
 from pcapi.models.activity import load_activity
 from pcapi.repository import repository
 from pcapi.repository.stock_queries import find_online_activation_stock
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_offerer, create_venue
 from pcapi.model_creators.specific_creators import create_stock_from_offer, \
     create_offer_with_thing_product, create_offer_with_event_product
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_create_stock_triggers_insert_activities(app):
     # Given
     offerer = create_offerer()
@@ -28,7 +29,7 @@ def test_create_stock_triggers_insert_activities(app):
     assert {"insert"} == set([a.verb for a in activities])
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_online_activation_stock(app):
     # given
     offerer = create_offerer(siren='123456789', name='pass Culture')

--- a/tests/repository/user_offerer_queries_test.py
+++ b/tests/repository/user_offerer_queries_test.py
@@ -6,13 +6,12 @@ from pcapi.repository import repository
 from pcapi.repository.user_offerer_queries import find_one_or_none_by_user_id, \
     find_user_offerer_email, \
     filter_query_where_user_is_user_offerer_and_is_validated
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_user, create_offerer, create_venue, create_user_offerer
 from pcapi.model_creators.specific_creators import create_product_with_thing_type, create_product_with_event_type, \
     create_offer_with_thing_product, create_offer_with_event_product
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_user_offerer_email(app):
     # Given
     user = create_user(email='offerer@email.com')
@@ -27,7 +26,7 @@ def test_find_user_offerer_email(app):
     assert email == 'offerer@email.com'
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_one_or_none_by_user_id_should_return_one_user_offerer_with_same_user_id(app):
     # Given
     user = create_user(email='offerer@email.com')
@@ -43,7 +42,7 @@ def test_find_one_or_none_by_user_id_should_return_one_user_offerer_with_same_us
     assert first_user_offerer.id == user_offerer.id
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_one_or_none_by_user_id_raises_exception_when_several_are_found(app):
     # Given
     user = create_user(email='offerer@email.com')
@@ -59,7 +58,7 @@ def test_find_one_or_none_by_user_id_raises_exception_when_several_are_found(app
 
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_one_or_none_by_user_id_should_return_none_user_offerer_when_none_are_found(app):
     # Given
     user = create_user(email='offerer@email.com')
@@ -74,7 +73,7 @@ def test_find_one_or_none_by_user_id_should_return_none_user_offerer_when_none_a
 
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_filter_query_where_user_is_user_offerer_and_is_validated(app):
     # Given
     user = create_user(email='offerer@email.com')

--- a/tests/repository/user_queries_test.py
+++ b/tests/repository/user_queries_test.py
@@ -1,5 +1,7 @@
 from datetime import MINYEAR, datetime, timedelta
 
+import pytest
+
 from pcapi.models import EventType, ImportStatus, ThingType, BeneficiaryImportSources
 from pcapi.repository import repository
 from pcapi.repository.user_queries import \
@@ -8,7 +10,6 @@ from pcapi.repository.user_queries import \
     find_by_civility, \
     find_most_recent_beneficiary_creation_date_for_source, \
     get_all_users_wallet_balances
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_beneficiary_import, \
     create_booking, create_deposit, create_offerer, create_stock, create_user, \
     create_venue
@@ -17,7 +18,7 @@ from pcapi.model_creators.specific_creators import \
 
 
 class GetAllUsersWalletBalancesTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_users_are_sorted_by_user_id(self, app):
         # given
         user1 = create_user(email='user1@example.com')
@@ -40,7 +41,7 @@ class GetAllUsersWalletBalancesTest:
         assert len(balances) == 2
         assert balances[0].user_id < balances[1].user_id
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_users_with_no_deposits_are_ignored(self, app):
         # given
         user1 = create_user(email='user1@example.com')
@@ -59,7 +60,7 @@ class GetAllUsersWalletBalancesTest:
         # then
         assert len(balances) == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_current_balances(self, app):
         # given
         user1 = create_user(email='user1@example.com')
@@ -82,7 +83,7 @@ class GetAllUsersWalletBalancesTest:
         assert balances[0].current_balance == 50
         assert balances[1].current_balance == 80
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_real_balances(self, app):
         # given
         user1 = create_user(email='user1@example.com')
@@ -107,7 +108,7 @@ class GetAllUsersWalletBalancesTest:
 
 
 class FindByCivilityTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_users_with_matching_criteria_ignoring_case(self, app):
         # given
         user1 = create_user(date_of_birth=datetime(2000, 5, 1), email='john@example.com', first_name="john",
@@ -123,7 +124,7 @@ class FindByCivilityTest:
         assert len(users) == 1
         assert users[0].email == 'john@example.com'
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_users_with_matching_criteria_ignoring_dash(self, app):
         # given
         user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@example.com', first_name="jaNE",
@@ -139,7 +140,7 @@ class FindByCivilityTest:
         assert len(users) == 1
         assert users[0].email == 'john.b@example.com'
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_users_with_matching_criteria_ignoring_spaces(self, app):
         # given
         user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@example.com', first_name="jaNE",
@@ -155,7 +156,7 @@ class FindByCivilityTest:
         assert len(users) == 1
         assert users[0].email == 'john.b@example.com'
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_users_with_matching_criteria_ignoring_accents(self, app):
         # given
         user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@example.com', first_name="jaNE",
@@ -171,7 +172,7 @@ class FindByCivilityTest:
         assert len(users) == 1
         assert users[0].email == 'john.b@example.com'
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_nothing_if_one_criteria_does_not_match(self, app):
         # given
         user = create_user(date_of_birth=datetime(2000, 5, 1), first_name="Jean", last_name='DOe')
@@ -183,7 +184,7 @@ class FindByCivilityTest:
         # then
         assert not users
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_users_with_matching_criteria_first_and_last_names_and_birthdate_and_invalid_email(self, app):
         # given
         user1 = create_user(date_of_birth=datetime(2000, 5, 1), email='john@example.com', first_name="john",
@@ -201,7 +202,7 @@ class FindByCivilityTest:
 
 
 class FindMostRecentBeneficiaryCreationDateByProcedureIdTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_created_at_date_of_most_recent_beneficiary_import_with_created_status_for_one_procedure(
             self, app):
         # given
@@ -231,7 +232,7 @@ class FindMostRecentBeneficiaryCreationDateByProcedureIdTest:
         # then
         assert most_recent_creation_date == three_days_ago
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_min_year_if_no_beneficiary_import_exist_for_given_source_id(self, app):
         # given
         old_source_id = 1
@@ -252,7 +253,7 @@ class FindMostRecentBeneficiaryCreationDateByProcedureIdTest:
         # then
         assert most_recent_creation_date == datetime(MINYEAR, 1, 1)
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_min_year_if_no_beneficiary_import_exist(self, app):
         # given
         yesterday = datetime.utcnow() - timedelta(days=1)
@@ -267,7 +268,7 @@ class FindMostRecentBeneficiaryCreationDateByProcedureIdTest:
 
 
 class CountAllActivatedUsersTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_1_when_only_one_active_user(self, app):
         # Given
         user_activated = create_user(can_book_free_offers=True)
@@ -280,7 +281,7 @@ class CountAllActivatedUsersTest:
         # Then
         assert number_of_active_users == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_when_no_active_user(self, app):
         # Given
         user_activated = create_user(can_book_free_offers=False)
@@ -295,7 +296,7 @@ class CountAllActivatedUsersTest:
 
 
 class CountActivatedUsersByDepartementTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_1_when_only_one_active_user_in_departement(self, app):
         # Given
         user_activated = create_user(can_book_free_offers=True, departement_code='74')
@@ -308,7 +309,7 @@ class CountActivatedUsersByDepartementTest:
         # Then
         assert number_of_active_users == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_when_no_active_user_in_departement_74(self, app):
         # Given
         user_activated = create_user(can_book_free_offers=False, departement_code='74')
@@ -321,7 +322,7 @@ class CountActivatedUsersByDepartementTest:
         # Then
         assert number_of_active_users == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_0_when_no_active_user_in_departement_76(self, app):
         # Given
         user_activated = create_user(can_book_free_offers=True, departement_code='76')
@@ -336,7 +337,7 @@ class CountActivatedUsersByDepartementTest:
 
 
 class CountUsersHavingBookedTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_one_when_user_with_one_cancelled_and_one_non_cancelled_bookings(self, app):
         # Given
         user_having_booked = create_user()
@@ -356,7 +357,7 @@ class CountUsersHavingBookedTest:
         # Then
         assert number_of_users_having_booked == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_two_when_two_users_with_cancelled_bookings(self, app):
         # Given
         user_having_booked1 = create_user()
@@ -375,7 +376,7 @@ class CountUsersHavingBookedTest:
         # Then
         assert number_of_users_having_booked == 2
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_zero_when_no_user_with_booking(self, app):
         # Given
         user = create_user()
@@ -387,7 +388,7 @@ class CountUsersHavingBookedTest:
         # Then
         assert number_of_users_having_booked == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_zero_when_user_with_only_activation_booking(self, app):
         # Given
         user_having_booked1 = create_user()
@@ -404,7 +405,7 @@ class CountUsersHavingBookedTest:
         # Then
         assert number_of_users_having_booked == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_zero_when_users_have_only_activation_bookings(self, app):
         # Given
         tomorrow = datetime.utcnow() + timedelta(days=1)
@@ -429,7 +430,7 @@ class CountUsersHavingBookedTest:
 
 
 class CountUsersHavingBookedByDepartementTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_counts_only_user_from_the_right_departement(self, app):
         # Given
         user_having_booked_from_73 = create_user(departement_code='73', email='email73@example.net')
@@ -448,7 +449,7 @@ class CountUsersHavingBookedByDepartementTest:
         # Then
         assert number_of_users_having_booked == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_one_when_user_with_one_cancelled_and_one_non_cancelled_bookings(self, app):
         # Given
         user_having_booked = create_user(departement_code='73')
@@ -468,7 +469,7 @@ class CountUsersHavingBookedByDepartementTest:
         # Then
         assert number_of_users_having_booked == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_two_when_two_users_with_cancelled_bookings(self, app):
         # Given
         user_having_booked1 = create_user(departement_code='87')
@@ -487,7 +488,7 @@ class CountUsersHavingBookedByDepartementTest:
         # Then
         assert number_of_users_having_booked == 2
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_zero_when_no_user_with_booking(self, app):
         # Given
         user = create_user()
@@ -499,7 +500,7 @@ class CountUsersHavingBookedByDepartementTest:
         # Then
         assert number_of_users_having_booked == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_zero_when_user_with_only_activation_booking(self, app):
         # Given
         user_having_booked1 = create_user()
@@ -516,7 +517,7 @@ class CountUsersHavingBookedByDepartementTest:
         # Then
         assert number_of_users_having_booked == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_zero_when_two_users_with_activation_bookings(self, app):
         # Given
         user_having_booked1 = create_user(departement_code='87')

--- a/tests/repository/venue_provider_queries_test.py
+++ b/tests/repository/venue_provider_queries_test.py
@@ -1,15 +1,16 @@
+import pytest
+
 from pcapi.models import AllocineVenueProvider, VenueProvider
 from pcapi.repository import repository
 from pcapi.repository.venue_provider_queries import get_venue_providers_to_sync, get_nb_containers_at_work, \
     get_venue_provider_by_id, get_active_venue_providers_for_specific_provider
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_offerer, create_venue, create_venue_provider, \
     create_allocine_venue_provider
 from pcapi.model_creators.provider_creators import activate_provider
 
 
 class GetActiveVenueProvidersForSpecificProviderTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_all_venue_provider_matching_provider_id(self, app):
         # Given
         offerer = create_offerer()
@@ -27,7 +28,7 @@ class GetActiveVenueProvidersForSpecificProviderTest:
         # Then
         assert venue_providers == [venue_provider1]
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_all_active_venue_providers_matching_provider_id(self, app):
         # Given
         offerer = create_offerer()
@@ -46,7 +47,7 @@ class GetActiveVenueProvidersForSpecificProviderTest:
 
 
 class GetVenueProvidersToSyncTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_only_venue_provider_for_specified_provider(self, app):
         # Given
         offerer = create_offerer()
@@ -63,7 +64,7 @@ class GetVenueProvidersToSyncTest:
         # Then
         assert venue_providers == [venue_provider_titelive]
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_venue_provider_with_no_worker_id(self, app):
         # Given
         offerer = create_offerer()
@@ -83,7 +84,7 @@ class GetVenueProvidersToSyncTest:
 
 
 class GetNbContainersAtWorkTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_number_of_venue_provider_with_worker_id(self, app):
         # Given
         offerer = create_offerer()
@@ -102,7 +103,7 @@ class GetNbContainersAtWorkTest:
 
 
 class GetVenueProviderByIdTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_matching_venue_provider(self):
         # Given
         offerer = create_offerer()
@@ -118,7 +119,7 @@ class GetVenueProviderByIdTest:
         assert existing_venue_provider == venue_provider
         assert isinstance(venue_provider, VenueProvider)
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_return_matching_venue_provider_with_allocine_attributes(self):
         # Given
         offerer = create_offerer()

--- a/tests/repository/venue_queries_test.py
+++ b/tests/repository/venue_queries_test.py
@@ -1,7 +1,8 @@
+import pytest
+
 from pcapi.repository import repository
 from pcapi.repository.venue_queries import find_filtered_venues, find_by_managing_user, \
     find_by_managing_offerer_id_and_siret
-from tests.conftest import clean_database
 from pcapi.model_creators.activity_creators import create_venue_activity, save_all_activities
 from pcapi.model_creators.generic_creators import create_user, create_offerer, create_venue, create_user_offerer
 from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence, create_stock_with_thing_offer, \
@@ -9,7 +10,7 @@ from pcapi.model_creators.specific_creators import create_stock_from_event_occur
 from datetime import datetime, timedelta
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_sirens_params_return_filtered_venues(app):
     # given
     offerer_123456789 = create_offerer(
@@ -49,7 +50,7 @@ def test_find_filtered_venues_with_sirens_params_return_filtered_venues(app):
     assert venue_123456784 not in query_with_sirens
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_has_validated_offerer_param_return_filtered_venues(app):
     # Given
     offerer_valid = create_offerer()
@@ -69,7 +70,7 @@ def test_find_filtered_venues_with_has_validated_offerer_param_return_filtered_v
     assert venue_with_offerer_not_valid in query_with_not_valid_offerer_only
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_dpts_param_return_filtered_venues(app):
     # Given
     offerer = create_offerer()
@@ -97,7 +98,7 @@ def test_find_filtered_venues_with_dpts_param_return_filtered_venues(app):
     assert venue_virtual not in query_with_dpts
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_zipcodes_param_return_filtered_venues(app):
     # Given
     offerer = create_offerer()
@@ -119,7 +120,7 @@ def test_find_filtered_venues_with_zipcodes_param_return_filtered_venues(app):
     assert venue_67000 not in query_with_zipcodes
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_date_params_return_filtered_venues(app):
     # Given
     offerer = create_offerer()
@@ -146,7 +147,7 @@ def test_find_filtered_venues_with_date_params_return_filtered_venues(app):
     assert venue_20180730 in query_with_date
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_is_virtual_param_return_filtered_venues(app):
     # Given
     offerer = create_offerer()
@@ -163,7 +164,7 @@ def test_find_filtered_venues_with_is_virtual_param_return_filtered_venues(app):
     assert venue_not_virtual not in query_only_virtual
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_has_siret_param_return_filtered_venues(app):
     # Given
     offerer = create_offerer()
@@ -182,7 +183,7 @@ def test_find_filtered_venues_with_has_siret_param_return_filtered_venues(app):
     assert venue_with_siret not in query_no_siret
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_is_validated_param_return_filtered_venues(app):
     # Given
     offerer = create_offerer()
@@ -199,7 +200,7 @@ def test_find_filtered_venues_with_is_validated_param_return_filtered_venues(app
     assert venue_validated in query_only_validated
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_has_offerer_with_siren_param_return_filtered_venues(app):
     # Given
     offerer_with_siren = create_offerer(siren='123456789')
@@ -219,7 +220,7 @@ def test_find_filtered_venues_with_has_offerer_with_siren_param_return_filtered_
     assert venue_with_offerer_with_siren in query_validated
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_True_has_validated_user_offerer_param_return_filtered_venues(app):
     # Given
     user = create_user()
@@ -254,7 +255,7 @@ def test_find_filtered_venues_with_True_has_validated_user_offerer_param_return_
     assert venue_with_both in query_validated
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_False_has_validated_user_offerer_param_return_filtered_venues(app):
     # Given
     user = create_user()
@@ -290,7 +291,7 @@ def test_find_filtered_venues_with_False_has_validated_user_offerer_param_return
     assert venue_with_both not in query_not_validated
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_True_has_validated_user_param_return_filtered_venues(app):
     # Given
     validated_user = create_user()
@@ -323,7 +324,7 @@ def test_find_filtered_venues_with_True_has_validated_user_param_return_filtered
     assert venue_with_both in query_validated
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_False_has_validated_user_param_return_filtered_venues(app):
     # Given
     validated_user = create_user()
@@ -356,7 +357,7 @@ def test_find_filtered_venues_with_False_has_validated_user_param_return_filtere
     assert venue_with_both not in query_not_validated
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_offer_status_with_VALID_param_return_filtered_venues(app):
     # Given
     offerer = create_offerer()
@@ -434,7 +435,7 @@ def test_find_filtered_venues_with_offer_status_with_VALID_param_return_filtered
     assert venue_with_not_available_event not in query_has_valid_offer
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_offer_status_with_EXPIRED_param_return_filtered_venues(app):
     # Given
     offerer = create_offerer()
@@ -512,7 +513,7 @@ def test_find_filtered_venues_with_offer_status_with_EXPIRED_param_return_filter
     assert venue_with_not_available_event in query_has_expired_offer
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_offer_status_with_WITHOUT_param_return_filtered_venues(app):
     # Given
     offerer = create_offerer()
@@ -590,7 +591,7 @@ def test_find_filtered_venues_with_offer_status_with_WITHOUT_param_return_filter
     assert venue_with_not_available_event not in query_without_offer
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_offer_status_with_ALL_param_return_filtered_venues(app):
     # Given
     offerer = create_offerer()
@@ -668,7 +669,7 @@ def test_find_filtered_venues_with_offer_status_with_ALL_param_return_filtered_v
     assert venue_with_not_available_event in query_with_all_offer
 
 
-@clean_database
+@pytest.mark.usefixtures("db_session")
 def test_find_filtered_venues_with_default_param_return_all_venues(app):
     # Given
     offerer = create_offerer()
@@ -710,7 +711,7 @@ def test_find_filtered_venues_with_default_param_return_all_venues(app):
 
 
 class FindVenuesByManagingUserTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_returns_venues_that_a_user_manages(self):
         # given
         user = create_user(email='user@example.net')
@@ -741,7 +742,7 @@ class FindVenuesByManagingUserTest:
 
 
 class FindByManagingOffererIdAndSiretTest:
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_none_when_not_matching_venues(self):
         # Given
         offerer = create_offerer()
@@ -755,7 +756,7 @@ class FindByManagingOffererIdAndSiretTest:
         # Then
         assert venue is None
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_return_matching_venue(self):
         # Given
         offerer = create_offerer()

--- a/tests/routes/delete_favorites_test.py
+++ b/tests/routes/delete_favorites_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.conftest import TestClient, clean_database
 from pcapi.model_creators.generic_creators import API_URL, create_favorite, \
     create_mediation, create_offerer, create_recommendation, create_user, create_venue
@@ -10,7 +12,7 @@ from pcapi.utils.human_ids import humanize
 
 class Delete:
     class Returns204:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def when_favorite_exists_with_offerId(self, app):
             # Given
             user = create_user(email='test@email.com')
@@ -34,7 +36,7 @@ class Delete:
             assert deleted_favorite is None
 
     class Returns404:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def when_expected_parameters_are_not_given(self, app):
             # Given
             user = create_user(email='test@email.com')
@@ -53,7 +55,7 @@ class Delete:
             # Then
             assert response.status_code == 404
 
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def when_favorite_does_not_exist(self, app):
             # Given
             user = create_user(email='test@email.com')

--- a/tests/routes/put_recommendations_test.py
+++ b/tests/routes/put_recommendations_test.py
@@ -1,10 +1,11 @@
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
+import pytest
+
 from pcapi.models import ThingType
 from pcapi.models.recommendation import Recommendation
 from pcapi.repository import repository, discovery_view_queries, discovery_view_v3_queries
-from tests.conftest import TestClient, clean_database
 from pcapi.model_creators.generic_creators import create_booking, \
     create_mediation, create_offerer, create_recommendation, \
     create_user, create_venue, create_iris_venue, create_iris
@@ -12,15 +13,17 @@ from pcapi.model_creators.specific_creators import create_event_occurrence, \
     create_offer_with_event_product, \
     create_offer_with_thing_product, create_stock_from_event_occurrence, \
     create_stock_from_offer, create_stock_with_thing_offer
-from tests.test_utils import POLYGON_TEST
 from pcapi.utils.human_ids import humanize
+from tests.conftest import TestClient
+from tests.test_utils import POLYGON_TEST
+
 
 RECOMMENDATION_URL = '/recommendations'
 
 
 class Put:
     class Returns401:
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def when_not_logged_in(self, app):
             # when
             response = TestClient(app.test_client()).put(
@@ -33,7 +36,7 @@ class Put:
 
     class Returns404:
         @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def when_given_mediation_does_not_match_given_offer(self, mock_geolocation_feature, app):
             # given
             user = create_user()
@@ -58,7 +61,7 @@ class Put:
             assert response.status_code == 404
 
         @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def when_offer_is_unknown_and_mediation_is_known(self, mock_geolocation_feature, app):
             # given
             user = create_user()
@@ -80,7 +83,7 @@ class Put:
             assert response.status_code == 404
 
         @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def when_mediation_is_unknown(self, mock_geolocation_feature, app):
             # given
             user = create_user()
@@ -96,7 +99,7 @@ class Put:
             assert response.status_code == 404
 
         @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def when_offer_is_known_and_mediation_is_unknown(self, mock_geolocation_feature, app):
             # given
             user = create_user()
@@ -118,7 +121,7 @@ class Put:
             assert response.status_code == 404
 
         @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def when_offer_is_unknown_and_mediation_is_unknown(self, mock_geolocation_feature, app):
             # given
             user = create_user()
@@ -135,7 +138,7 @@ class Put:
             assert response.status_code == 404
 
         @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-        @clean_database
+        @pytest.mark.usefixtures("db_session")
         def when_venue_of_given_offer_is_not_validated(self, mock_geolocation_feature, app):
             # given
             user = create_user()
@@ -161,7 +164,7 @@ class Put:
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
             @patch('pcapi.routes.recommendations.create_recommendations_for_discovery')
             @patch('pcapi.routes.recommendations.create_recommendations_for_discovery_v3')
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_updating_read_recommendations(self, mock_create_recommendations_for_discovery_v3,
                                                    mock_create_recommendations_for_discovery, mock_geolocation_feature,
                                                    app):
@@ -203,7 +206,7 @@ class Put:
                 assert any(reco.dateRead is not None for reco in Recommendation.query.all())
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_user_has_no_offer_in_his_department(self, mock_geolocation_feature, app):
                 # given
                 user = create_user(can_book_free_offers=True, departement_code='973', is_admin=False)
@@ -239,7 +242,7 @@ class Put:
                 assert len(response.json) == 0
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_user_has_one_offer_in_his_department(self, mock_geolocation_feature, app):
                 # given
                 user = create_user(can_book_free_offers=True, departement_code='93', is_admin=False)
@@ -274,7 +277,7 @@ class Put:
                 assert 'validationToken' not in recommendation_response['offer']['venue']['managingOfferer']
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_offers_have_soft_deleted_stocks(self, mock_geolocation_feature, app):
                 # Given
                 user = create_user()
@@ -314,7 +317,7 @@ class Put:
                 assert humanize(thing_offer2_id) in offer_ids
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_offers_have_no_stocks(self, mock_geolocation_feature, app):
                 # given
                 user = create_user()
@@ -333,7 +336,7 @@ class Put:
                 assert len(response.json) == 0
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_offers_have_a_thumb_count_for_thing_and_no_mediation(self, mock_geolocation_feature, app):
                 # given
                 user = create_user()
@@ -353,7 +356,7 @@ class Put:
                 assert len(response.json) == 0
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_offers_have_no_thumb_count_for_thing_and_no_mediation(self, mock_geolocation_feature, app):
                 # given
                 user = create_user()
@@ -373,7 +376,7 @@ class Put:
                 assert len(response.json) == 0
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_offers_have_no_thumb_count_for_thing_and_a_mediation(
                     self, mock_geolocation_feature, app):
                 # given
@@ -396,7 +399,7 @@ class Put:
                 assert len(response.json) == 1
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_offers_have_no_thumb_count_for_event_and_no_mediation(self, mock_geolocation_feature, app):
                 # given
                 now = datetime.utcnow()
@@ -424,7 +427,7 @@ class Put:
                 assert len(response.json) == 0
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_offers_have_no_thumb_count_for_event_and_have_mediation(
                     self, mock_geolocation_feature, app):
                 # given
@@ -454,7 +457,7 @@ class Put:
                 assert len(response.json) == 1
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_offers_have_a_thumb_count_for_event_and_no_mediation(
                     self, mock_geolocation_feature, app):
                 # given
@@ -482,7 +485,7 @@ class Put:
                 assert len(response.json) == 0
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_offers_have_non_validated_venues(self, mock_geolocation_feature, app):
                 # Given
                 offerer = create_offerer()
@@ -514,7 +517,7 @@ class Put:
                 assert humanize(venue_not_validated_id) not in venue_ids
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_offers_have_active_mediations(self, mock_geolocation_feature, app):
                 # given
                 user = create_user()
@@ -547,7 +550,7 @@ class Put:
                 assert humanize(mediation1_id) not in mediation_ids
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_a_recommendation_is_requested(self, mock_geolocation_feature, app):
                 # given
                 user = create_user()
@@ -595,7 +598,7 @@ class Put:
                 assert humanize(offer4_id) in offer_ids
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_returns_two_recommendations_with_one_event_and_one_thing(self, mock_geolocation_feature, app):
                 # given
                 now = datetime.utcnow()
@@ -626,7 +629,7 @@ class Put:
                 assert len(response.json) == 2
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_discovery_recommendations_should_not_include_search_recommendations(self, mock_geolocation_feature,
                                                                                          app):
                 # Given
@@ -657,7 +660,7 @@ class Put:
                 assert recommendations[0]['search'] is None
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_a_recommendation_with_an_offer_and_a_mediation_is_requested(self, mock_geolocation_feature, app):
                 # given
                 user = create_user()
@@ -680,7 +683,7 @@ class Put:
                 assert recos[0]['mediationId'] == humanize(mediation.id)
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_a_recommendation_with_an_offer_and_no_mediation_is_requested(self, mock_geolocation_feature, app):
                 # given
                 user = create_user()
@@ -704,7 +707,7 @@ class Put:
                 assert recos[0]['mediationId'] == humanize(mediation_id)
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_a_recommendation_with_no_offer_and_a_mediation_is_requested(self, mock_geolocation_feature, app):
                 # given
                 user = create_user()
@@ -729,7 +732,7 @@ class Put:
                 assert recos[0]['offerId'] == humanize(offer_thing_id)
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_returns_new_recommendation_with_active_mediation_for_already_existing_but_invalid_recommendations(
                     self, mock_geolocation_feature, app):
                 # given
@@ -761,7 +764,7 @@ class Put:
                 assert humanize(inactive_mediation_id) not in mediation_ids
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_stock_has_past_booking_limit_date(self, mock_geolocation_feature, app):
                 # Given
                 one_day_ago = datetime.utcnow() - timedelta(days=1)
@@ -784,7 +787,7 @@ class Put:
                 assert not recommendations.json
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_user_has_already_seen_offer_sent_in_last_call(self, mock_geolocation_feature, app):
                 # given
                 user = create_user()
@@ -806,7 +809,7 @@ class Put:
                 assert response.json == []
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_returns_same_quantity_of_recommendations_in_different_orders(self, mock_geolocation_feature, app):
                 # given
                 now = datetime.utcnow()
@@ -846,7 +849,7 @@ class Put:
                      range(0, len(recommendations1.json))])
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def test_returns_stocks_with_isBookable_property(self, mock_geolocation_feature, app):
                 # Given
                 expired_booking_limit_date = datetime(1970, 1, 1)
@@ -880,7 +883,7 @@ class Put:
                 assert all('isBookable' in stocks_response[i] for i in range(0, len(stocks_response)))
 
             @patch('pcapi.routes.recommendations.feature_queries.is_active', return_value=False)
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_user_has_bookings_on_recommended_offers(self, mock_geolocation_feature, app):
                 # given
                 user = create_user(can_book_free_offers=True, departement_code='93', is_admin=False)
@@ -908,7 +911,7 @@ class Put:
             @patch('pcapi.routes.recommendations.current_user')
             @patch('pcapi.routes.recommendations.serialize_recommendations')
             @patch('pcapi.routes.recommendations.update_read_recommendations')
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_user_is_geolocated(self, mock_update_read_recommendations,
                                                               mock_serialize_recommendations,
                                                               mock_current_user,
@@ -959,7 +962,7 @@ class Put:
             @patch('pcapi.routes.recommendations.create_recommendations_for_discovery_v3')
             @patch('pcapi.routes.recommendations.current_user')
             @patch('pcapi.routes.recommendations.serialize_recommendations')
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_user_is_not_located(self, mock_serialize_recommendations,
                                                                mock_current_user,
                                                                mock_create_recommendations_for_discovery_v3,
@@ -995,7 +998,7 @@ class Put:
             @patch('pcapi.routes.recommendations.create_recommendations_for_discovery_v3')
             @patch('pcapi.routes.recommendations.current_user')
             @patch('pcapi.routes.recommendations.serialize_recommendations')
-            @clean_database
+            @pytest.mark.usefixtures("db_session")
             def when_user_is_located_outside_known_iris(self, mock_serialize_recommendations,
                                                                               mock_current_user,
                                                                               mock_create_recommendations_for_discovery_v3,

--- a/tests/scripts/update_booking_cancellation_date_from_activity_test.py
+++ b/tests/scripts/update_booking_cancellation_date_from_activity_test.py
@@ -1,8 +1,9 @@
+import pytest
+
 from pcapi.models import BookingSQLEntity
 from pcapi.models.db import db
 from pcapi.repository import repository
 from pcapi.scripts.update_booking_cancellation_date_from_activity import update_booking_cancellation_date_from_activity
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_user, create_stock, create_booking, create_deposit
 
 
@@ -16,7 +17,7 @@ class UpdateBookingCancellationDateFromActivityTest:
     def teardown_method():
         db.engine.execute("ALTER TABLE booking ENABLE TRIGGER stock_update_cancellation_date;")
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def test_should_fill_cancellation_date_using_activity(self, app):
         # Given
         user = create_user()

--- a/tests/use_cases/connect_allocine_to_venue_test.py
+++ b/tests/use_cases/connect_allocine_to_venue_test.py
@@ -1,9 +1,10 @@
 from decimal import Decimal
 from unittest.mock import MagicMock
 
+import pytest
+
 from pcapi.models import AllocineVenueProvider, AllocineVenueProviderPriceRule
 from pcapi.repository import repository
-from tests.conftest import clean_database
 from pcapi.model_creators.generic_creators import create_allocine_pivot, create_offerer, create_venue
 from pcapi.model_creators.provider_creators import activate_provider
 from pcapi.use_cases.connect_venue_to_allocine import connect_venue_to_allocine
@@ -15,7 +16,7 @@ class ConnectAllocineToVenueTest:
         self.find_by_id = MagicMock()
         self.get_theaterid_for_venue = MagicMock()
 
-    @clean_database
+    @pytest.mark.usefixtures("db_session")
     def should_connect_venue_to_allocine_provider(self, app):
         # Given
         offerer = create_offerer()


### PR DESCRIPTION
Fixes `get_existing_object` which was using its own DB connection (might lead to some staled connection after) and broke some tests when using `db_session` instead of `clean_database`