### PR TITLE
requirements: Install pcapi (local) package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,6 @@ jobs:
           paths:
             - "venv"
       - run:
-          name: Install pcapi Python package
-          command: |
-              venv/bin/pip install -e .
-      - run:
           name: Check for alembic multiple heads
           command: |
             python3 -m venv venv
@@ -104,7 +100,6 @@ jobs:
             cd pass-culture-api;
             python3 -m venv venv
             . venv/bin/activate
-            pip install -e .
             pip install -r requirements.txt;
             python -m nltk.downloader punkt stopwords;
             python install_database_extensions.py;

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /usr/local/bin
 RUN apt update && apt-get -y install gcc
 RUN apt-get install -y libpq-dev
 COPY ./requirements.txt ./
-RUN pip install -e .
 RUN pip install -r ./requirements.txt
 RUN python -m nltk.downloader punkt stopwords
 EXPOSE 5000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-e .
 alembic==1.4.3
 algoliasearch==2.4.0
 APScheduler==3.6.3

--- a/start-api-when-database-is-ready.sh
+++ b/start-api-when-database-is-ready.sh
@@ -8,7 +8,6 @@ apt-get install -y libpq-dev
 
 >&2 echo -e "\n\033[0;32mInstalling application requirements\n"
 
-pip install -e .
 pip install -r ./requirements.txt;
 python -m nltk.downloader punkt stopwords;
 


### PR DESCRIPTION
Now everything can be installed in a single command:

    pip install -r requirements.txt

This will help with Scalingo deployments for which we don't seem to
have other manual steps where we could specifically install the
"pcapi" local package.