### PR TITLE
(PC-4517) Do not include pcapi (local) package in requirements.txt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,10 @@ jobs:
           paths:
             - "venv"
       - run:
+          name: Install pcapi Python package
+          command: |
+              venv/bin/pip install -e .
+      - run:
           name: Check for alembic multiple heads
           command: |
             python3 -m venv venv
@@ -100,6 +104,7 @@ jobs:
             cd pass-culture-api;
             python3 -m venv venv
             . venv/bin/activate
+            pip install -e .
             pip install -r requirements.txt;
             python -m nltk.downloader punkt stopwords;
             python install_database_extensions.py;

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/local/bin
 RUN apt update && apt-get -y install gcc
 RUN apt-get install -y libpq-dev
 COPY ./requirements.txt ./
+RUN pip install -e .
 RUN pip install -r ./requirements.txt
 RUN python -m nltk.downloader punkt stopwords
 EXPOSE 5000

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This file is used by Scalingo to install the "pcapi" (local) package
+# after it has installed all Python dependencies (which Scalingo does
+# because it detects that we have a "requirements.txt" file.
+
+pip install -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--e .
 alembic==1.4.3
 algoliasearch==2.4.0
 APScheduler==3.6.3

--- a/start-api-when-database-is-ready.sh
+++ b/start-api-when-database-is-ready.sh
@@ -8,6 +8,7 @@ apt-get install -y libpq-dev
 
 >&2 echo -e "\n\033[0;32mInstalling application requirements\n"
 
+pip install -e .
 pip install -r ./requirements.txt;
 python -m nltk.downloader punkt stopwords;
 


### PR DESCRIPTION
This reverts commit eadf0104382f1526072b445009399da23434851e.

The "-e ." part of `pip install -r requirements.txt` failed in the
"build-container" job on CircleCI when building a Docker image,
because at that point of the Dockerfile, the source code is not
accessible from the container. Also, it was a bad idea: the Docker
image is used as part of a Docker Compose file which includes the
local version of the API through a volume. That is, it's the Docker
Compose file that installs the "pcapi" package. It should not be part
of the Docker image.

The point of the reverted commit was to fix the deployment on
Scalingo. Since we cannot include the installation of the "pcapi"
package through requirements.txt file, we should use a post-compile
hook that does just that.

(The main point here is that we don't deploy the Docker image on
Scalingo. I have the feeling that we could (and should) come up with a
more unified build/deployment system in the near future.)