### PR TITLE
(PC-4708) Do not use nltk stopwords list when searching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,6 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            python -m nltk.downloader punkt stopwords &> /dev/null
             if [ ! -z "$(alembic branches)" ]; then echo "Multiple alembic heads found"; exit 1; fi
       - run:
           name: Running tests
@@ -106,7 +105,6 @@ jobs:
             . venv/bin/activate
             pip install -e .
             pip install -r requirements.txt;
-            python -m nltk.downloader punkt stopwords;
             python install_database_extensions.py;
             alembic upgrade head;
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
           name: Running tests
           command: |
             . venv/bin/activate
-            RUN_ENV=tests pytest tests --cov --cov-report html --junitxml=test-results/junit.xml -x
+            RUN_ENV=tests pytest tests --cov --cov-report html --junitxml=test-results/junit.xml
             coveralls
       - store_test_results:
           path: test-results

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,4 @@ RUN apt update && apt-get -y install gcc
 RUN apt-get install -y libpq-dev
 COPY ./requirements.txt ./
 RUN pip install -r ./requirements.txt
-RUN python -m nltk.downloader punkt stopwords
 EXPOSE 5000

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ isbnlib==3.10.3
 lxml==4.5.2
 mailjet-rest==1.3.3
 mypy==0.782
-nltk==3.5
 pgcli==2.2.0
 Pillow==7.2.0
 PostgreSQL-Audit==0.10.0

--- a/src/pcapi/domain/ts_vector.py
+++ b/src/pcapi/domain/ts_vector.py
@@ -1,6 +1,5 @@
 from typing import List
 
-from nltk.corpus import stopwords
 from sqlalchemy import and_, func, Index
 from sqlalchemy.sql.expression import or_
 
@@ -8,9 +7,10 @@ from pcapi.utils.string_processing import remove_single_letters_for_search, toke
 
 
 LANGUAGE = 'french'
-CUSTOM_STOPWORDS = ['où']
-STOP_WORDS = set(stopwords.words(LANGUAGE))
-STOP_WORDS.update(CUSTOM_STOPWORDS)
+# PostgreSQL takes care of filtering out stopwords, except a few words
+# that we use to filter out when we used nltk stopwords. To avoid a
+# regression, we'll filter them out manually.
+STOP_WORDS = {'ils', 'les'}
 
 
 def create_fts_index(name, ts_vector) -> Index:

--- a/src/pcapi/utils/nltk_downloader.py
+++ b/src/pcapi/utils/nltk_downloader.py
@@ -1,4 +1,0 @@
-import nltk
-
-nltk.download('punkt')
-nltk.download('stopwords')

--- a/start-api-when-database-is-ready.sh
+++ b/start-api-when-database-is-ready.sh
@@ -10,7 +10,6 @@ apt-get install -y libpq-dev
 
 pip install -e .
 pip install -r ./requirements.txt;
-python -m nltk.downloader punkt stopwords;
 
 until psql $DATABASE_URL -c '\q'; do
   >&2 echo -e "\033[0;33mPostgres is unavailable - sleeping"

--- a/tests/domain/ts_vector_test.py
+++ b/tests/domain/ts_vector_test.py
@@ -23,28 +23,6 @@ def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_s
     assert keywords_result == ['pnl:*', 'chante:*', 'marx:*']
 
 
-def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_string_ignoring_stop_words():
-    # given
-    keywords_string = 'PNL  chante avec Marx'
-
-    # when
-    keywords_result = _get_ts_queries_from_keywords_string(keywords_string)
-
-    # then
-    assert keywords_result == ['pnl:*', 'chante:*', 'marx:*']
-
-
-def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_string_ignoring_stop_words_with_capital_letter():
-    # given
-    keywords_string = 'Un lit sous une rivière'
-
-    # when
-    keywords_result = _get_ts_queries_from_keywords_string(keywords_string)
-
-    # then
-    assert keywords_result == ['lit:*', 'sous:*', 'rivière:*']
-
-
 def test_get_ts_queries_from_keywords_url_parses_keywords_string_ignoring_special_chars():
     # given
     keywords_string = "http://www.test.com"
@@ -54,17 +32,6 @@ def test_get_ts_queries_from_keywords_url_parses_keywords_string_ignoring_specia
 
     # then
     assert keywords_result == ['http:*', 'www:*', 'test:*', 'com:*']
-
-
-def test_get_ts_queries_from_keywords_url_parses_keywords_string_ignoring_ou_with_accent():
-    # given
-    keywords_string = "yolo bonjour où va"
-
-    # when
-    keywords_result = _get_ts_queries_from_keywords_string(keywords_string)
-
-    # then
-    assert keywords_result == ['yolo:*', 'bonjour:*', 'va:*']
 
 
 def test_get_ts_queries_from_keywords_string_with_coma_parses_keywords_string_ignoring_words_with_less_than_one_char():


### PR DESCRIPTION
We use nltk stopwords to filter out stopwords before querying the
database for a search. This is mostly useless because PostgreSQL
already does the same filtering with a very similar list of
stopwords. Example:

    # select to_tsvector('french_unaccent', 'Le chocolat est bon')
             @@ to_tsquery('french_unaccent', 'le:*');
    NOTICE:  text-search query contains only stop words or doesn't contain lexemes, ignored
     ?column?
    ----------
     f

There are only two words that PostgreSQL does not consider as
stopwords [1]: "les" and "ils". I would be inclined to just use
PostgreSQL stopwords to simplify our code, but let's be conservative.

Removing nltk will avoid the need to download the stopwords, which we
did on every deployment. The download sometimes failed, which made the
deployment fail too.

[1] As of version 12.3, the list of PostgreSQL stopwords is here:
    https://github.com/postgres/postgres/blob/5060275aa8a1ead56e0a41308d7a43049a6cbe43/src/backend/snowball/stopwords/french.stop