### PR TITLE
(PC-4233) Activate reCaptcha challenge for ID CHECK

### DIFF
--- a/src/pcapi/connectors/api_recaptcha.py
+++ b/src/pcapi/connectors/api_recaptcha.py
@@ -4,11 +4,22 @@ import requests
 
 RECAPTCHA_API_URL = 'https://www.google.com/recaptcha/api/siteverify'
 RECAPTCHA_SECRET = os.environ.get("RECAPTCHA_SECRET")
+RECAPTCHA_REQUIRED_SCORE = os.environ.get("RECAPTCHA_REQUIRED_SCORE", 0.5)
+RECAPTCHA_ERROR_CODES = {
+    'missing-input-secret': 'The secret parameter is missing.',
+    'invalid-input-secret': 'The secret parameter is invalid or malformed.',
+    'missing-input-response': 'The response parameter is missing.',
+    'invalid-input-response': 'The response parameter is invalid or malformed.',
+    'bad-request': 'The request is invalid or malformed.',
+    'timeout-or-duplicate': 'The response is no longer valid: either is too old or has been used previously.',
+}
+
 
 class ReCaptchaException(Exception):
     pass
 
-def validate_recaptcha_token(token: str) -> bool:
+
+def validate_recaptcha_token(token: str, original_action: str) -> bool:
     params = {
         "secret": RECAPTCHA_SECRET,
         "response": token
@@ -19,4 +30,22 @@ def validate_recaptcha_token(token: str) -> bool:
         raise ReCaptchaException(f"Couldn't reach recaptcha api: {api_response.status_code} {api_response.text}")
 
     json_response = api_response.json()
-    return json_response["success"]
+
+    errors_list = []
+    for error in json_response.get("error-codes", []):
+        if error in RECAPTCHA_ERROR_CODES:
+            errors_list.append(RECAPTCHA_ERROR_CODES[error])
+        else:
+            errors_list.append(error)
+    if errors_list:
+        raise ReCaptchaException(f"Encountered the following error(s): {errors_list}")
+
+    if json_response["success"]:
+        action = json_response.get('action', "")
+        if action != original_action:
+            raise ReCaptchaException(f"The action '{action}' does not match '{original_action}' from the form")
+
+        score = json_response.get('score', 0)
+        return score >= RECAPTCHA_REQUIRED_SCORE
+
+    raise ReCaptchaException("This is not a valid reCAPTCHA token")

--- a/src/pcapi/domain/beneficiary/beneficiary_licence.py
+++ b/src/pcapi/domain/beneficiary/beneficiary_licence.py
@@ -2,4 +2,4 @@ from pcapi.connectors.api_recaptcha import validate_recaptcha_token
 
 
 def is_licence_token_valid(token: str) -> bool:
-    return validate_recaptcha_token(token)
+    return validate_recaptcha_token(token, 'submit')

--- a/tests/connectors/api_recaptcha_test.py
+++ b/tests/connectors/api_recaptcha_test.py
@@ -1,41 +1,103 @@
-from unittest.mock import patch, MagicMock
+import datetime
+import uuid
 
 import pytest
+from unittest.mock import patch, MagicMock
 
 from pcapi.connectors.api_recaptcha import validate_recaptcha_token, RECAPTCHA_API_URL, ReCaptchaException
 
 
+ORIGINAL_ACTION = 'submit'
+high_score_return_value = MagicMock(status_code=200, text='')
+high_score_return_value.json = MagicMock(
+    return_value={
+        'success': True,
+        'score': 0.5,
+        'action': 'submit',
+        "challenge_ts": datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S%Z'),
+        "hostname": "url",
+    }
+)
+low_score_return_value = MagicMock(status_code=200, text='')
+low_score_return_value.json = MagicMock(
+    return_value={
+        'success': True,
+        'score': 0.4,
+        'action': 'submit',
+        "challenge_ts": datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S%Z'),
+        "hostname": "url",
+    }
+)
+bad_request_return_value = MagicMock(status_code=400, text='')
+invalid_recaptcha_without_specific_error_return_value = MagicMock(status_code=200, text='')
+invalid_recaptcha_without_specific_error_return_value.json = MagicMock(
+    return_value={
+        'success': False,
+    }
+)
+wrong_action_return_value = MagicMock(status_code=200, text='')
+wrong_action_return_value.json = MagicMock(
+    return_value={
+        'success': True,
+        'score': 0.9,
+        'action': 'send',
+        "challenge_ts": datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S%Z'),
+        "hostname": "url",
+    }
+)
+errors_return_value = MagicMock(status_code=200, text='')
+errors_return_value.json = MagicMock(
+    return_value={
+        'success': False,
+        "error-codes": ['timeout-or-duplicate', 'unknown-error'],
+    }
+)
+test_api_recaptcha_exceptions_data = {
+    'bad_request': (bad_request_return_value, "Couldn't reach recaptcha api: 400 "),
+    'invalid_request': (invalid_recaptcha_without_specific_error_return_value, "This is not a valid reCAPTCHA token"),
+    'wrong_action': (wrong_action_return_value, "The action 'send' does not match 'submit' from the form"),
+    'errors': (errors_return_value, "Encountered the following error(s): ['The response is no longer valid: either is too old or has been used previously.', 'unknown-error']"),
+}
+test_valid_response_from_api_data = {
+    'high_score': (high_score_return_value, True),
+    'low_score': (low_score_return_value, False),
+}
+
+
+def generate_fake_token() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.mark.parametrize("response_return_value,expected_result", test_valid_response_from_api_data.values(), ids=test_valid_response_from_api_data.keys())
 @patch('pcapi.connectors.api_recaptcha.RECAPTCHA_SECRET', "recaptcha-secret")
 @patch('pcapi.connectors.api_recaptcha.requests.post')
-def test_should_return_request_response_from_api(request_post):
+def test_valid_response_from_api(request_post, response_return_value, expected_result):
     # Given
-    expected_response = True
-    token = 'my-token'
-
-    response_return_value = MagicMock(status_code=200, text='')
-    response_return_value.json = MagicMock(return_value={'success': expected_response})
+    token = generate_fake_token()
     request_post.return_value = response_return_value
 
     # When
-    api_response = validate_recaptcha_token(token)
+    api_response = validate_recaptcha_token(token, ORIGINAL_ACTION)
 
     # Then
-    request_post.assert_called_once_with(RECAPTCHA_API_URL,
-                                         data={"secret": "recaptcha-secret", "response": token})
-    assert api_response == expected_response
+    request_post.assert_called_once_with(
+        RECAPTCHA_API_URL,
+        data={"secret": "recaptcha-secret", "response": token}
+    )
+    assert api_response == expected_result
 
+
+@pytest.mark.parametrize("response_return_value,exception_value", test_api_recaptcha_exceptions_data.values(), ids=test_api_recaptcha_exceptions_data.keys())
 @patch('pcapi.connectors.api_recaptcha.RECAPTCHA_SECRET', "recaptcha-secret")
 @patch('pcapi.connectors.api_recaptcha.requests.post')
-def test_should_raise_exception_when_api_call_fails(request_post):
+def test_api_recaptcha_exceptions(request_post, response_return_value, exception_value):
     # Given
-    token = 'test'
-
-    response_return_value = MagicMock(status_code=400, text='')
+    token = generate_fake_token()
     request_post.return_value = response_return_value
 
     # When
     with pytest.raises(ReCaptchaException) as exception:
-        validate_recaptcha_token(token)
+        validate_recaptcha_token(token, ORIGINAL_ACTION)
 
     # Then
-    assert str(exception.value) == "Couldn't reach recaptcha api: 400 "
+    assert str(exception.value) == exception_value


### PR DESCRIPTION
[Jira ticket](https://passculture.atlassian.net/browse/PC-4233)

Google's reCaptcha docs can be found at https://developers.google.com/recaptcha/docs/v3

This change allows us to handle the different errors that the Google API can return,
and implements stricter control over the reCaptcha v3, via the score and a check on the action.

The minimum required score is 0.5 by default, and it can be tuned via a new env variable.