### PR TITLE
[PC-4709] Webapp - Le tutoriel ne s'affiche pas lors de la première connexion sur téléphone

### DIFF
--- a/src/pcapi/models/user_sql_entity.py
+++ b/src/pcapi/models/user_sql_entity.py
@@ -213,7 +213,7 @@ class UserSQLEntity(PcObject,
 
     @property
     def needsToSeeTutorials(self):
-        return self.canBookFreeOffers and self.hasSeenTutorials is False
+        return self.canBookFreeOffers and not self.hasSeenTutorials
 
     @property
     def hasOffers(self):


### PR DESCRIPTION
Link to Jira : https://passculture.atlassian.net/browse/PC-4709

Why : we discovered that some users can have their `hasSeenTutorials` set to `None`, resulting in them not seeing the tutorials.