### PR TITLE
CircleCI: Show all installed Python packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
           name: Install pcapi Python package
           command: |
               venv/bin/pip install -e .
+              venv/bin/pip freeze
       - run:
           name: Check for alembic multiple heads
           command: |


### PR DESCRIPTION
Since some dependencies are not pinned, it's useful to know the exact
versions used on CircleCI when test failures t be reproduced locally.