### PR TITLE
(PC-4715)  requirements: Pin Flask and SQLAlchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ beautifulsoup4==4.9.3
 blinker==1.4
 coveralls==2.1.2
 factory-boy
+Flask==1.1.*
 Flask-Admin==1.5.6
 Flask-Cors==3.0.9
 Flask-Login==0.5.0
@@ -45,4 +46,5 @@ schwifty==2020.9.0
 sentry-sdk==0.18.0
 simplejson==3.17.2
 spectree==0.3.8
+SQLAlchemy==1.3.*
 wheel==0.35.1


### PR DESCRIPTION
These libraries used to be pinned until 9823c24db24b1d98. They should
still be pinned (albeit lightly) to avoid uncontrolled upgrades.

-----

J'ai pris les versions utilisées par le dernier build master, que l'on connaît depuis 1b28192e8b03b3698e2fb64241b742d33ff1a08a.