### PR TITLE
(PC-4887) : JWT token auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ blinker==1.4
 coveralls==2.1.2
 Flask-Admin==1.5.6
 Flask-Cors==3.0.9
+Flask-JWT-Extended==3.24.1
 Flask-Login==0.5.0
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.4.4
@@ -27,6 +28,7 @@ Pillow==7.2.0
 PostgreSQL-Audit==0.10.0
 pydantic[email]==1.6.1
 pygsheets==2.0.3.1
+PyJWT==1.7.1
 pylint==2.6.0
 PyMemoize==1.0.3
 pytest-cov==2.10.1

--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -8,16 +8,17 @@ from pcapi.load_environment_variables import load_environment_variables
 load_environment_variables()
 
 import flask.wrappers
-import redis
-import sentry_sdk
 from flask import Flask, \
     g, \
     request, \
     Blueprint
 from flask_admin import Admin
 from flask_cors import CORS
+from flask_jwt_extended import JWTManager
 from flask_login import LoginManager
 from mailjet_rest import Client
+import redis
+import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from spectree import SpecTree
 from sqlalchemy import orm
@@ -75,6 +76,11 @@ app.config['REMEMBER_COOKIE_DURATION'] = 90 * 24 * 3600
 app.config['PERMANENT_SESSION_LIFETIME'] = 90 * 24 * 3600
 app.config['FLASK_ADMIN_SWATCH'] = 'flatly'
 app.config['FLASK_ADMIN_FLUID_LAYOUT'] = True
+app.config['JWT_SECRET_KEY'] = os.environ.get(
+    'JWT_SECRET_KEY', 'baheon0UIX2li3katood7RotTiedez3bUF8xohtheex1eeBithee9AopePhom5vi',
+)
+
+jwt = JWTManager(app)
 
 
 @app.before_request

--- a/src/pcapi/routes/native/v1/authentication.py
+++ b/src/pcapi/routes/native/v1/authentication.py
@@ -1,4 +1,7 @@
-from flask_login import login_user
+from flask_jwt_extended import (
+    jwt_required, create_access_token,
+    get_jwt_identity
+)
 
 from pcapi.utils.credentials import get_user_with_credentials
 from pcapi.utils.login_manager import stamp_session
@@ -12,7 +15,15 @@ from .serialization import authentication
 @spectree_serialize(response_model=authentication.SigninResponseModel, on_success_status=200, api=blueprint.api)  # type: ignore
 def signin(body: authentication.SigninRequestModel) -> authentication.SigninResponseModel:
     user = get_user_with_credentials(body.identifier, body.password)
-    login_user(user, remember=True)
-    stamp_session(user)
+    access_token = create_access_token(identity=body.identifier)
+    return authentication.SigninResponseModel(access_token=access_token)
 
-    return authentication.SigninResponseModel()
+
+# TODO: temporary resource to test JWT authentication on a resource
+@blueprint.native_v1.route('/protected', methods=['GET'])
+@jwt_required
+def protected():
+    # Access the identity of the current user with get_jwt_identity
+    from flask import jsonify
+    current_user = get_jwt_identity()
+    return jsonify(logged_in_as=current_user), 200

--- a/src/pcapi/routes/native/v1/serialization/authentication.py
+++ b/src/pcapi/routes/native/v1/serialization/authentication.py
@@ -7,4 +7,4 @@ class SigninRequestModel(BaseModel):
 
 
 class SigninResponseModel(BaseModel):
-    pass
+    access_token: str


### PR DESCRIPTION
```
xordoquy@mbp15dexavier api % curl -v -H "Content-Type: application/json" -X POST http://localhost/native/v1/signin -d '{"password": "user@AZERTY123", "identifier": "pctest.jeune93.has-booked-some@btmx.fr"}'
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 80 (#0)
> POST /native/v1/signin HTTP/1.1
> Host: localhost
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 86
> 
* upload completely sent off: 86 out of 86 bytes
< HTTP/1.1 200 OK
< Server: nginx/1.19.2
< Date: Thu, 22 Oct 2020 10:04:16 GMT
< Content-Type: application/json
< Content-Length: 340
< Connection: keep-alive
< Vary: Accept-Encoding
< X-Frame-Options: SAMEORIGIN
< X-Content-Security-Policy: default-src 'self'
< Content-Security-Policy: default-src 'self'
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Strict-Transport-Security: 31536000; includeSubDomains; preload
< 
* Connection #0 to host localhost left intact
{"access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2MDMzNjEwNTYsIm5iZiI6MTYwMzM2MTA1NiwianRpIjoiOWFmNzZlYzItNTlkMC00NzQzLWE3YzItYjVhNTVlYTkxMmEzIiwiZXhwIjoxNjAzMzYxOTU2LCJpZGVudGl0eSI6InBjdGVzdC5qZXVuZTkzLmhhcy1ib29rZWQtc29tZUBidG14LmZyIiwiZnJlc2giOmZhbHNlLCJ0eXBlIjoiYWNjZXNzIn0.3lexTDgwDCP5xYwrzSpiiTaPOb7AeMuHT3BEZyS2u1c"}* Closing connection 0


xordoquy@mbp15dexavier api % curl -v -H "Content-Type: application/json" -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2MDMzNjEwNTYsIm5iZiI6MTYwMzM2MTA1NiwianRpIjoiOWFmNzZlYzItNTlkMC00NzQzLWE3YzItYjVhNTVlYTkxMmEzIiwiZXhwIjoxNjAzMzYxOTU2LCJpZGVudGl0eSI6InBjdGVzdC5qZXVuZTkzLmhhcy1ib29rZWQtc29tZUBidG14LmZyIiwiZnJlc2giOmZhbHNlLCJ0eXBlIjoiYWNjZXNzIn0.3lexTDgwDCP5xYwrzSpiiTaPOb7AeMuHT3BEZyS2u1c" http://localhost/native/v1/protected
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 80 (#0)
> GET /native/v1/protected HTTP/1.1
> Host: localhost
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Type: application/json
> Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2MDMzNjEwNTYsIm5iZiI6MTYwMzM2MTA1NiwianRpIjoiOWFmNzZlYzItNTlkMC00NzQzLWE3YzItYjVhNTVlYTkxMmEzIiwiZXhwIjoxNjAzMzYxOTU2LCJpZGVudGl0eSI6InBjdGVzdC5qZXVuZTkzLmhhcy1ib29rZWQtc29tZUBidG14LmZyIiwiZnJlc2giOmZhbHNlLCJ0eXBlIjoiYWNjZXNzIn0.3lexTDgwDCP5xYwrzSpiiTaPOb7AeMuHT3BEZyS2u1c
> 
< HTTP/1.1 200 OK
< Server: nginx/1.19.2
< Date: Thu, 22 Oct 2020 10:04:45 GMT
< Content-Type: application/json
< Content-Length: 63
< Connection: keep-alive
< X-Frame-Options: SAMEORIGIN
< X-Content-Security-Policy: default-src 'self'
< Content-Security-Policy: default-src 'self'
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Strict-Transport-Security: 31536000; includeSubDomains; preload
< 
{
  "logged_in_as": "pctest.jeune93.has-booked-some@btmx.fr"
}
* Connection #0 to host localhost left intact
* Closing connection 0
xordoquy@mbp15dexavier api % 
```