### PR TITLE
(PC-4692) edit reimbursement rules

### DIFF
--- a/src/pcapi/alembic/versions/0c6a4a8bbcdb_add_confirmation_date_to_booking.py
+++ b/src/pcapi/alembic/versions/0c6a4a8bbcdb_add_confirmation_date_to_booking.py
@@ -1,0 +1,25 @@
+"""
+add_confirmation_date_to_booking
+
+Revision ID: 0c6a4a8bbcdb
+Revises: a96683bbf3be
+Create Date: 2020-11-02 14:17:00.068785
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0c6a4a8bbcdb'
+down_revision = 'a96683bbf3be'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('booking', sa.Column('confirmationDate', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('booking', 'confirmationDate')

--- a/src/pcapi/core/bookings/conf.py
+++ b/src/pcapi/core/bookings/conf.py
@@ -1,0 +1,17 @@
+import datetime
+
+
+USE_BOOKING_BEFORE_EVENT_DELAY = datetime.timedelta(hours=72)
+
+CONFIRM_BOOKING_AFTER_CREATION_DELAY = datetime.timedelta(hours=48)
+CONFIRM_BOOKING_BEFORE_EVENT_DELAY = datetime.timedelta(hours=72)
+
+
+def _get_hours_from_timedelta(td: datetime.timedelta) -> float:
+    return td.total_seconds()/3600
+
+
+BOOKING_CONFIRMATION_ERROR_CLAUSES = {
+    CONFIRM_BOOKING_AFTER_CREATION_DELAY: f"plus de {_get_hours_from_timedelta(CONFIRM_BOOKING_AFTER_CREATION_DELAY):.0f}h après l'avoir réservée et ",
+    CONFIRM_BOOKING_BEFORE_EVENT_DELAY: f"moins de {_get_hours_from_timedelta(CONFIRM_BOOKING_BEFORE_EVENT_DELAY):.0f}h avant le début de l'événement",
+}

--- a/src/pcapi/core/bookings/exceptions.py
+++ b/src/pcapi/core/bookings/exceptions.py
@@ -46,10 +46,12 @@ class BookingIsAlreadyUsed(ClientError):
         super().__init__('booking', 'Impossible d\'annuler une réservation consommée')
 
 
-class EventHappensInLessThan72Hours(ClientError):
-    def __init__(self):
-        super().__init__('booking',
-                         "Impossible d'annuler une réservation moins de 72h avant le début de l'évènement")
+class CannotCancelConfirmedBooking(ClientError):
+    def __init__(self, after_creation, before_event):
+        super().__init__(
+            'booking',
+            f"Impossible d'annuler une réservation {after_creation}{before_event}"
+        )
 
 
 class BookingDoesntExist(ClientError):

--- a/src/pcapi/core/bookings/factories.py
+++ b/src/pcapi/core/bookings/factories.py
@@ -3,9 +3,11 @@ import factory
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core.testing import BaseFactory
+from pcapi.repository import repository
 from pcapi.utils.token import random_token
 
-from . import models
+
+from . import api, models
 
 
 class BookingFactory(BaseFactory):
@@ -17,3 +19,11 @@ class BookingFactory(BaseFactory):
     token = factory.LazyFunction(random_token)
     user = factory.SubFactory(users_factories.UserFactory)
     amount = factory.SelfAttribute('stock.price')
+
+    @factory.post_generation
+    def confirmationDate(self, create, override, **extra):
+        if override:
+            self.confirmationDate = override
+        else:
+            self.confirmationDate = api.compute_confirmation_date(self.stock.beginningDatetime, self.dateCreated)
+        repository.save(self)

--- a/src/pcapi/core/bookings/models.py
+++ b/src/pcapi/core/bookings/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import BigInteger, \
     ForeignKey, \
     Integer, \
     String, Numeric
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
 
@@ -80,6 +81,8 @@ class Booking(PcObject, Model, VersionedMixin):
                     nullable=False,
                     default=False)
 
+    confirmationDate = Column(DateTime, nullable=True)
+
     @property
     def total_amount(self):
         return self.amount * self.quantity
@@ -143,6 +146,10 @@ class Booking(PcObject, Model, VersionedMixin):
         if self.isUsed or self.isCancelled:
             return None
         return api.generate_qr_code(self.token, self.stock.offer.extraData)
+
+    @hybrid_property
+    def isConfirmed(self):
+        return self.confirmationDate and self.confirmationDate <= datetime.utcnow()
 
 
 # FIXME: move this out of the `models` module

--- a/src/pcapi/model_creators/generic_creators.py
+++ b/src/pcapi/model_creators/generic_creators.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 from typing import Optional, Union
 
@@ -7,6 +7,7 @@ from decimal import Decimal
 from geoalchemy2.shape import from_shape
 from shapely.geometry import Polygon
 
+from pcapi.core.bookings import api as bookings_api
 from pcapi.domain.payments import PaymentDetails
 from pcapi.domain.price_rule import PriceRule
 from pcapi.models import AllocinePivot, AllocineVenueProviderPriceRule, ApiKey, \
@@ -143,6 +144,7 @@ def create_booking(user: UserSQLEntity,
     booking.stock = stock
     booking.token = token if token is not None else random_token()
     booking.userId = user.id
+    booking.confirmationDate = bookings_api.compute_confirmation_date(stock.beginningDatetime, date_created)
 
     return booking
 

--- a/src/pcapi/routes/error_handlers/bookings_error_handlers.py
+++ b/src/pcapi/routes/error_handlers/bookings_error_handlers.py
@@ -2,7 +2,7 @@ from flask import current_app as app, jsonify
 
 from pcapi.core.bookings.exceptions import OfferIsAlreadyBooked, QuantityIsInvalid, StockIsNotBookable, \
     CannotBookFreeOffers, PhysicalExpenseLimitHasBeenReached, UserHasInsufficientFunds, \
-    DigitalExpenseLimitHasBeenReached, BookingIsAlreadyUsed, EventHappensInLessThan72Hours, BookingDoesntExist
+    DigitalExpenseLimitHasBeenReached, BookingIsAlreadyUsed, CannotCancelConfirmedBooking, BookingDoesntExist
 from pcapi.domain.stock.stock_exceptions import StockDoesntExist
 from pcapi.domain.users import UnauthorizedForAdminUser
 
@@ -25,7 +25,7 @@ def handle_get_all_bookings_exceptions(exception):
 
 
 @app.errorhandler(BookingIsAlreadyUsed)
-@app.errorhandler(EventHappensInLessThan72Hours)
+@app.errorhandler(CannotCancelConfirmedBooking)
 def handle_cancel_a_booking(exception):
     return jsonify(exception.errors), 400
 

--- a/src/pcapi/sandboxes/scripts/creators/helpers/sql_creators.py
+++ b/src/pcapi/sandboxes/scripts/creators/helpers/sql_creators.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import random
 from typing import Optional, List, Dict
 
+from pcapi.core.bookings import api as bookings_api
 from pcapi.models import UserSQLEntity, Deposit, Offerer, UserOfferer, RightsType, VenueSQLEntity, OfferSQLEntity, Product, Provider, \
     EventType, StockSQLEntity, ThingType, Booking, Recommendation, MediationSQLEntity, PaymentMessage, Payment
 from pcapi.models.payment_status import TransactionStatus, PaymentStatus
@@ -441,6 +442,7 @@ def create_booking(user: UserSQLEntity,
     booking.stock = stock
     booking.token = token if token is not None else random_token()
     booking.userId = user.id
+    booking.confirmationDate = bookings_api.compute_confirmation_date(stock.beginningDatetime, date_created)
 
     return booking
 

--- a/tests/routes/bookings/get_booking_by_id_test.py
+++ b/tests/routes/bookings/get_booking_by_id_test.py
@@ -37,6 +37,7 @@ class Get:
                 'amount': 0.0,
                 'cancellationDate': None,
                 'completedUrl': completed_url,
+                'confirmationDate': None,
                 'dateCreated': format_into_utc_date(booking.dateCreated),
                 'dateUsed': None,
                 'id': humanize(booking.id),


### PR DESCRIPTION
Cette PR implémente les nouvelles règles d'annulation de réservations d'événements, à savoir ajouter la condition suivante: la réservation d'événement a été faite il y a moins de 48h.
Techniquement, on remplit une nouvelle colonnne confirmationDate lors de la réservation, et on vérifie lors de l'annulation si cette date est passée.
Cela implique d'ajouter les dates de confirmation aux réservations d'événement passées, ce qui sera fait via un script, une fois la MEP passée.
Un mécanisme de fallback est en place et sera supprimé ultérieurement, lorsque les réservations seront bien mises à jour.