### PR TITLE
(PC-5005) : fix beneficiaries/licence_verify crash

### DIFF
--- a/src/pcapi/connectors/api_recaptcha.py
+++ b/src/pcapi/connectors/api_recaptcha.py
@@ -20,6 +20,9 @@ class ReCaptchaException(Exception):
 
 
 def validate_recaptcha_token(token: str, original_action: str) -> bool:
+    if not token:
+        return False
+
     params = {
         "secret": RECAPTCHA_SECRET,
         "response": token

--- a/src/pcapi/validation/routes/beneficiaries.py
+++ b/src/pcapi/validation/routes/beneficiaries.py
@@ -4,10 +4,14 @@ from pcapi.models.api_errors import ApiErrors
 
 def check_verify_licence_token_payload(payload: Request) -> None:
     try:
-        payload.get_json()['token']
+        token = payload.get_json()['token']
     except:
         errors = ApiErrors()
         errors.add_error('token', "Missing token")
+        raise errors
+    if not token:
+        errors = ApiErrors()
+        errors.add_error('token', "Empty token")
         raise errors
 
 def check_application_update_payload(payload: Request) -> None:

--- a/tests/connectors/api_recaptcha_test.py
+++ b/tests/connectors/api_recaptcha_test.py
@@ -87,6 +87,19 @@ def test_valid_response_from_api(request_post, response_return_value, expected_r
     assert api_response == expected_result
 
 
+@patch('pcapi.connectors.api_recaptcha.requests.post')
+def test_with_empty_token(request_post):
+    # Given
+    request_post.return_value = errors_return_value
+
+    # When
+    api_response = validate_recaptcha_token(None, ORIGINAL_ACTION)
+
+    # Then
+    request_post.assert_not_called()
+    assert api_response is False
+
+
 @pytest.mark.parametrize("response_return_value,exception_value", test_api_recaptcha_exceptions_data.values(), ids=test_api_recaptcha_exceptions_data.keys())
 @patch('pcapi.connectors.api_recaptcha.RECAPTCHA_SECRET', "recaptcha-secret")
 @patch('pcapi.connectors.api_recaptcha.requests.post')

--- a/tests/routes/post_verify_id_check_licence_token_test.py
+++ b/tests/routes/post_verify_id_check_licence_token_test.py
@@ -1,9 +1,17 @@
+import typing
 from unittest.mock import patch
+
+from pcapi.connectors.api_recaptcha import ReCaptchaException
 from tests.conftest import TestClient
 
 
 def check_token_mock(token: str):
     return token == 'authorized-token'
+
+
+def check_token_failed_mock(token: typing.Optional[str]):
+    raise ReCaptchaException("Encountered the following error(s): whatever")
+
 
 class Post:
     class Returns200:
@@ -32,12 +40,25 @@ class Post:
             # Then
             assert response.status_code == 422
 
+
     class Returns400:
         @patch("pcapi.routes.beneficiaries.is_licence_token_valid", check_token_mock)
         def when_has_no_payload(self, app):
             # When
             response = TestClient(app.test_client()) \
                 .post('/beneficiaries/licence_verify')
+
+            # Then
+            assert response.status_code == 400
+
+        @patch("pcapi.routes.beneficiaries.is_licence_token_valid", check_token_failed_mock)
+        def when_token_is_null(self, app):
+            # Given
+            data = {'token': None}
+
+            # When
+            response = TestClient(app.test_client()) \
+                .post(f'/beneficiaries/licence_verify', json=data)
 
             # Then
             assert response.status_code == 400


### PR DESCRIPTION
The licence_verify will crash whenever a null token is sent.
Ensure we stay on track when a token is null or empty.