### PR TITLE
ci: Do not stop at the first test error/failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
             - run:
                 name: Running tests
                 command: |
-                  RUN_ENV=tests venv/bin/pytest tests --cov --cov-report html --junitxml=test-results/junit.xml -x
+                  RUN_ENV=tests venv/bin/pytest tests --cov --cov-report html --junitxml=test-results/junit.xml
                   venv/bin/coveralls
       - unless:
           condition: << parameters.is_nightly_build >>


### PR DESCRIPTION
We will now have an exhaustive view of all failing tests, not only the
first one.

When the build was long, this behaviour may have made sense (depending
on the developer's workflow). But now that the build is relatively
short, it's not worth much to stop the build as soon as possible.