### PR TITLE
(PC-5072) : reject token "null" on licence-verify endpoint.

### DIFF
--- a/src/pcapi/validation/routes/beneficiaries.py
+++ b/src/pcapi/validation/routes/beneficiaries.py
@@ -9,7 +9,7 @@ def check_verify_licence_token_payload(payload: Request) -> None:
         errors = ApiErrors()
         errors.add_error('token', "Missing token")
         raise errors
-    if not token:
+    if not token or token == "null":
         errors = ApiErrors()
         errors.add_error('token', "Empty token")
         raise errors

--- a/tests/routes/post_verify_id_check_licence_token_test.py
+++ b/tests/routes/post_verify_id_check_licence_token_test.py
@@ -63,6 +63,18 @@ class Post:
             # Then
             assert response.status_code == 400
 
+        @patch("pcapi.routes.beneficiaries.is_licence_token_valid", check_token_failed_mock)
+        def when_token_is_the_string_null(self, app):
+            # Given
+            data = {'token': "null"}
+
+            # When
+            response = TestClient(app.test_client()) \
+                .post(f'/beneficiaries/licence_verify', json=data)
+
+            # Then
+            assert response.status_code == 400
+
         @patch("pcapi.routes.beneficiaries.is_licence_token_valid", check_token_mock)
         def when_has_wrong_token_key(self, app):
             # Given


### PR DESCRIPTION
For some reason, the token can be the string "null" instead of
the null value when calling `verify_id_check_licence_token`.
Since we don't want to crash on that, `verify_id_check_licence_token`
also needs to reject calls with {"token": "null"}.