### PR TITLE
(PC-5077) Zipper le fichier CSV joint au mail "Détails des paiements"

### DIFF
--- a/tests/scripts/payment/batch_steps_test.py
+++ b/tests/scripts/payment/batch_steps_test.py
@@ -324,7 +324,7 @@ def test_send_payment_details_sends_a_csv_attachment(app):
     app.mailjet_client.send.create.assert_called_once()
     args = app.mailjet_client.send.create.call_args
     assert len(args[1]['data']['Attachments']) == 1
-    assert args[1]['data']['Attachments'][0]['ContentType'] == 'text/csv'
+    assert args[1]['data']['Attachments'][0]['ContentType'] == 'application/zip'
 
 
 @mocked_mail


### PR DESCRIPTION
cf. le ticket Jira pour plus de détails, ou le message de commit,
reproduit ci-dessous :

---

The "payment details" CSV file that we send by e-mail is getting too
large. The last (2020-11-03) CSV file is 12 Mb. Once base64-encoded,
it is around 16.6 Mb, which is above the 15 Mb limit set by Mailjet.
When we tried to send the e-mail with that file, we got the following
error when POSTing to Mailjet API:

    Connection aborted: BrokenPipeError(32, 'Broken pipe')

It's not clear whether the error happens because of the size limit: I
could not find any reference in Mailjet documentation nor elsewhere.
But it's a good guess. :)

At least, I have been able to successfully send a zipped CSV file,
which weighted a bit more than 1 Mb.