### PR TITLE
.circleci: edit run-tests name when running in separate workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,6 +289,7 @@ workflows:
   commit:
     jobs:
       - run-tests:
+          name: "Run tests after commit"
           filters:
             branches:
               ignore:
@@ -312,4 +313,5 @@ workflows:
       - functional-tests-pro
       - tests-data-analytics
       - run-tests:
+          name: "Run nightly tests"
           is_nightly_build: true


### PR DESCRIPTION
This will help distinguish the jobs ran in the commit and nightly workflows,
as the jobs of the commit workflow are currently automatically renamed by CircleCI `run-tests-1`

<img width="1573" alt="job_names" src="https://user-images.githubusercontent.com/33030007/98229061-ba1dd600-1f59-11eb-96d8-4ca25d8542b9.png">
