### PR TITLE
(PC-5078) add script to update past event bookings without confirmationDate

### DIFF
--- a/src/pcapi/core/bookings/factories.py
+++ b/src/pcapi/core/bookings/factories.py
@@ -22,7 +22,13 @@ class BookingFactory(BaseFactory):
     amount = factory.SelfAttribute('stock.price')
 
     @factory.post_generation
-    def confirmationDate(self, create, extracted, **kwargs):
+    def compute_confirmation_date(self, create, extracted, **kwargs):
         self.confirmationDate = api.compute_confirmation_date(self.stock.beginningDatetime, self.dateCreated)
         db.session.add(self)
         db.session.commit()
+
+
+class BookingWithoutConfirmationDateFactory(BookingFactory):
+    @factory.post_generation
+    def compute_confirmation_date(self, create, extracted, **kwargs):
+        pass

--- a/src/pcapi/core/bookings/factories.py
+++ b/src/pcapi/core/bookings/factories.py
@@ -25,7 +25,7 @@ class BookingFactory(BaseFactory):
     def compute_confirmation_date(self, create, extracted, **kwargs):
         self.confirmationDate = api.compute_confirmation_date(self.stock.beginningDatetime, self.dateCreated)
         db.session.add(self)
-        db.session.commit()
+        db.session.flush()
 
 
 class BookingWithoutConfirmationDateFactory(BookingFactory):

--- a/src/pcapi/core/bookings/factories.py
+++ b/src/pcapi/core/bookings/factories.py
@@ -3,6 +3,7 @@ import factory
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.testing import BaseFactory
 import pcapi.core.users.factories as users_factories
+from pcapi.models.db import db
 from pcapi.repository import repository
 from pcapi.utils.token import random_token
 
@@ -21,9 +22,7 @@ class BookingFactory(BaseFactory):
     amount = factory.SelfAttribute('stock.price')
 
     @factory.post_generation
-    def confirmationDate(self, create, override, **extra):
-        if override:
-            self.confirmationDate = override
-        else:
-            self.confirmationDate = api.compute_confirmation_date(self.stock.beginningDatetime, self.dateCreated)
-        repository.save(self)
+    def confirmationDate(self, create, extracted, **kwargs):
+        self.confirmationDate = api.compute_confirmation_date(self.stock.beginningDatetime, self.dateCreated)
+        db.session.add(self)
+        db.session.commit()

--- a/src/pcapi/scripts/booking/update_confirmation_date_from_existing_bookings.py
+++ b/src/pcapi/scripts/booking/update_confirmation_date_from_existing_bookings.py
@@ -1,0 +1,95 @@
+import datetime
+
+import typing
+from flask_sqlalchemy import BaseQuery
+
+from pcapi.models import db, StockSQLEntity
+from pcapi.core.bookings.api import compute_confirmation_date
+from pcapi.core.bookings.models import Booking
+from pcapi.utils.logger import logger
+
+
+def fill_missing_confirmation_dates_of_event_bookings_without_confirmation_date_not_cancelled_not_used(
+        batch_size: int = 100
+) -> None:
+    """Run this first: This will update about 8k records"""
+    target_bookings_query = _select_event_bookings_without_confirmation_date_not_cancelled_not_used()
+    try:
+        updated_count = _update_target_bookings(target_bookings_query, batch_size)
+        print(f"{updated_count} Bookings had their confirmationDate updated successfully!")
+    except Exception as exc:
+        logger.exception("Encountered unexpected error while updating confirmationDate: %s", exc)
+
+
+def fill_missing_confirmation_dates_of_all_event_bookings_without_confirmation_date(batch_size: int = 100) -> None:
+    """This will update about 60k records"""
+    print(f"[{datetime.datetime.utcnow()}] Starting to update all event bookings bookings...")
+    target_bookings_query = _select_all_event_bookings_without_confirmation_date()
+    try:
+        updated_count = _update_target_bookings(target_bookings_query, batch_size)
+        print(f"{updated_count} Bookings had their confirmationDate updated successfully!")
+    except Exception as exc:
+        logger.exception("Encountered unexpected error while updating confirmationDate: %s", exc)
+
+
+def get_all_event_bookings_without_confirmation_date_count() -> int:
+    return _select_all_event_bookings_without_confirmation_date().count()
+
+
+def get_event_bookings_without_confirmation_date_not_cancelled_not_used_count() -> int:
+    return _select_event_bookings_without_confirmation_date_not_cancelled_not_used().count()
+
+
+def _select_all_event_bookings_without_confirmation_date() -> BaseQuery:
+    """
+    récupérer les Bookings d'events passés sans date de confirmation aka
+    Bookings qui ont une stock.beginningDatetime non null avec confirmationDate null
+    """
+    return Booking.query.join(StockSQLEntity). \
+        with_entities(Booking.id, StockSQLEntity.beginningDatetime, Booking.dateCreated). \
+        filter(Booking.confirmationDate.is_(None)). \
+        filter(StockSQLEntity.beginningDatetime.isnot(None))
+
+
+def _select_event_bookings_without_confirmation_date_not_cancelled_not_used() -> BaseQuery:
+    return _select_all_event_bookings_without_confirmation_date(). \
+        filter(Booking.isCancelled.is_(False)). \
+        filter(Booking.isUsed.is_(False))
+
+
+def _get_batches(target_bookings_query: list, batch_size: int) -> typing.Generator:
+    total_length = len(target_bookings_query)
+    for i in range(0, total_length, batch_size):
+        yield target_bookings_query[i: i + batch_size]
+
+
+def _update_target_bookings(target_bookings_query: BaseQuery, batch_size: int) -> int:
+    print(f"[{datetime.datetime.utcnow()}] Starting to update target bookings...")
+    assert isinstance(batch_size, int)
+    batch_number = 1
+    updated_count = 0
+    batches_count = target_bookings_query.count() // batch_size + (target_bookings_query.count() % batch_size > 0)
+    for bookings in _get_batches(target_bookings_query.all(), batch_size):
+        start_updating_batch = datetime.datetime.now()
+        update_mappings = []
+
+        try:
+            for booking_id, event_date, creation_date in bookings:
+                confirmation_date = compute_confirmation_date(event_date, creation_date)
+                update_mappings.append(
+                    {"id": booking_id, "confirmationDate": confirmation_date}
+                )
+
+            db.session.bulk_update_mappings(Booking, update_mappings)
+            db.session.commit()
+            end_updating_batch = datetime.datetime.now()
+            updated_count += len(update_mappings)
+            duration = f"{(end_updating_batch - start_updating_batch).total_seconds():.2f}"
+            print(f"[{datetime.datetime.utcnow()}]  Updated batch {batch_number}/{batches_count} in {duration} seconds")
+
+        except Exception as exc:
+            raise exc
+
+        batch_number += 1
+
+    return updated_count

--- a/src/pcapi/scripts/booking/update_confirmation_date_from_existing_bookings.py
+++ b/src/pcapi/scripts/booking/update_confirmation_date_from_existing_bookings.py
@@ -9,6 +9,7 @@ from pcapi.core.bookings.models import Booking
 from pcapi.utils.logger import logger
 
 
+# FIXME(fseguin, 2020-11-10): Delete this file once the script has been successfully executed in prod
 def fill_missing_confirmation_dates_of_event_bookings_without_confirmation_date_not_cancelled_not_used(
         batch_size: int = 100
 ) -> None:
@@ -73,22 +74,18 @@ def _update_target_bookings(target_bookings_query: BaseQuery, batch_size: int) -
         start_updating_batch = datetime.datetime.now()
         update_mappings = []
 
-        try:
-            for booking_id, event_date, creation_date in bookings:
-                confirmation_date = compute_confirmation_date(event_date, creation_date)
-                update_mappings.append(
-                    {"id": booking_id, "confirmationDate": confirmation_date}
-                )
+        for booking_id, event_date, creation_date in bookings:
+            confirmation_date = compute_confirmation_date(event_date, creation_date)
+            update_mappings.append(
+                {"id": booking_id, "confirmationDate": confirmation_date}
+            )
 
-            db.session.bulk_update_mappings(Booking, update_mappings)
-            db.session.commit()
-            end_updating_batch = datetime.datetime.now()
-            updated_count += len(update_mappings)
-            duration = f"{(end_updating_batch - start_updating_batch).total_seconds():.2f}"
-            print(f"[{datetime.datetime.utcnow()}]  Updated batch {batch_number}/{batches_count} in {duration} seconds")
-
-        except Exception as exc:
-            raise exc
+        db.session.bulk_update_mappings(Booking, update_mappings)
+        db.session.commit()
+        end_updating_batch = datetime.datetime.now()
+        updated_count += len(update_mappings)
+        duration = f"{(end_updating_batch - start_updating_batch).total_seconds():.2f}"
+        print(f"[{datetime.datetime.utcnow()}]  Updated batch {batch_number}/{batches_count} in {duration} seconds")
 
         batch_number += 1
 

--- a/src/pcapi/scripts/booking/update_confirmation_date_from_existing_bookings.py
+++ b/src/pcapi/scripts/booking/update_confirmation_date_from_existing_bookings.py
@@ -1,11 +1,12 @@
 import datetime
-
 import typing
+
 from flask_sqlalchemy import BaseQuery
 
-from pcapi.models import db, StockSQLEntity
 from pcapi.core.bookings.api import compute_confirmation_date
 from pcapi.core.bookings.models import Booking
+from pcapi.models import StockSQLEntity
+from pcapi.models import db
 from pcapi.utils.logger import logger
 
 

--- a/tests/core/bookings/test_factories.py
+++ b/tests/core/bookings/test_factories.py
@@ -1,0 +1,26 @@
+import datetime
+
+import pytest
+
+from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.models import Booking
+
+
+@pytest.mark.usefixtures("db_session")
+class BookingFactoryTest:
+    def test_confirmation_date_is_saved_to_db(self):
+        booking = BookingFactory(stock__beginningDatetime=datetime.datetime.utcnow())
+        generated_confirmation_date = booking.confirmationDate
+
+        booking_from_db = Booking.query.first()
+
+        assert booking_from_db.confirmationDate == generated_confirmation_date
+
+    def test_confirmation_date_is_none_for_non_event(self):
+        non_event_booking = BookingFactory()
+        assert not non_event_booking.confirmationDate
+
+    def test_confirmation_date_is_generated_for_event(self):
+        event_booking = BookingFactory(stock__beginningDatetime=datetime.datetime.utcnow())
+        assert event_booking.confirmationDate
+

--- a/tests/core/bookings/test_factories.py
+++ b/tests/core/bookings/test_factories.py
@@ -16,8 +16,8 @@ class BookingFactoryTest:
 
         assert booking_from_db.confirmationDate == generated_confirmation_date
 
-    def test_confirmation_date_is_none_for_non_event(self):
-        non_event_booking = BookingFactory()
+    def test_confirmation_date_is_none_for_a_thing(self):
+        non_event_booking = BookingFactory(stock__beginningDatetime=None)
         assert not non_event_booking.confirmationDate
 
     def test_confirmation_date_is_generated_for_event(self):

--- a/tests/scripts/booking/test_update_confirmation_date_from_existing_bookings.py
+++ b/tests/scripts/booking/test_update_confirmation_date_from_existing_bookings.py
@@ -3,8 +3,9 @@ from collections import namedtuple
 
 import pytest
 
-from pcapi.core.bookings import factories as bookings_factories
-from pcapi.core.offers import factories as offers_factories
+from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import BookingWithoutConfirmationDateFactory
+from pcapi.core.offers.factories import StockFactory
 from pcapi.core.users.factories import UserFactory
 from pcapi.scripts.booking.update_confirmation_date_from_existing_bookings import _select_all_event_bookings_without_confirmation_date, _update_target_bookings, \
     fill_missing_confirmation_dates_of_all_event_bookings_without_confirmation_date, \
@@ -20,7 +21,7 @@ class UpdateConfirmationDateFromExistingBookingsTest:
         today_at_2 = datetime.datetime(2020, 11, 5, 2)
         tomorrow_at_13 = datetime.datetime(2020, 11, 6, 13)
         user = UserFactory()
-        event_stock = offers_factories.StockFactory(beginningDatetime=tomorrow_at_13, price=0)
+        event_stock = StockFactory(beginningDatetime=tomorrow_at_13, price=0)
         TestDataFixture = namedtuple(
             'TestDataFixture',
             ['last_year', 'today_at_2', 'tomorrow_at_13', 'user', 'event_stock']
@@ -28,33 +29,25 @@ class UpdateConfirmationDateFromExistingBookingsTest:
         return TestDataFixture(last_year, today_at_2, tomorrow_at_13, user, event_stock)
 
     def test_select_existing_event_bookings_without_confirmation_date(self, test_data):
-        event_booking_with_confirmation_date = bookings_factories.BookingFactory(dateCreated=test_data.today_at_2, stock__beginningDatetime=test_data.tomorrow_at_13)
-        assert event_booking_with_confirmation_date.confirmationDate == event_booking_with_confirmation_date.dateCreated == test_data.today_at_2
-
-        event_booking_without_confirmation_date = bookings_factories.BookingWithoutConfirmationDateFactory(dateCreated=test_data.today_at_2, stock__beginningDatetime=test_data.tomorrow_at_13)
-        assert event_booking_without_confirmation_date.confirmationDate is None
-
-        event_booking_without_confirmation_date_from_last_year = bookings_factories.BookingWithoutConfirmationDateFactory(
+        event_booking_with_confirmation_date = BookingFactory(dateCreated=test_data.today_at_2, stock__beginningDatetime=test_data.tomorrow_at_13)
+        event_booking_without_confirmation_date = BookingWithoutConfirmationDateFactory(dateCreated=test_data.today_at_2, stock__beginningDatetime=test_data.tomorrow_at_13)
+        event_booking_without_confirmation_date_from_last_year = BookingWithoutConfirmationDateFactory(
             dateCreated=test_data.last_year, stock__beginningDatetime=test_data.tomorrow_at_13
         )
-        assert event_booking_without_confirmation_date_from_last_year.confirmationDate is None
 
         bookings_without_confirmation_date = _select_all_event_bookings_without_confirmation_date().all()
 
         assert bookings_without_confirmation_date == [event_booking_without_confirmation_date, event_booking_without_confirmation_date_from_last_year]
+        assert event_booking_with_confirmation_date not in bookings_without_confirmation_date
         assert get_all_event_bookings_without_confirmation_date_count() == 2
 
     def test_update_target_bookings(self, test_data):
-        event_booking_without_confirmation_date = bookings_factories.BookingWithoutConfirmationDateFactory(dateCreated=test_data.today_at_2, stock__beginningDatetime=test_data.tomorrow_at_13)
-        assert event_booking_without_confirmation_date.confirmationDate is None
-
-        event_booking_without_confirmation_date_from_last_year = bookings_factories.BookingWithoutConfirmationDateFactory(
+        event_booking_without_confirmation_date = BookingWithoutConfirmationDateFactory(dateCreated=test_data.today_at_2, stock__beginningDatetime=test_data.tomorrow_at_13)
+        event_booking_without_confirmation_date_from_last_year = BookingWithoutConfirmationDateFactory(
             dateCreated=test_data.last_year, stock__beginningDatetime=test_data.tomorrow_at_13
         )
-        assert event_booking_without_confirmation_date_from_last_year.confirmationDate is None
 
         bookings_without_confirmation_date_query = _select_all_event_bookings_without_confirmation_date()
-
         _update_target_bookings(target_bookings_query=bookings_without_confirmation_date_query, batch_size=100)
 
         assert get_all_event_bookings_without_confirmation_date_count() == 0
@@ -62,16 +55,17 @@ class UpdateConfirmationDateFromExistingBookingsTest:
         assert event_booking_without_confirmation_date_from_last_year.confirmationDate == test_data.last_year + datetime.timedelta(hours=48)
 
     def test_fill_missing_confirmation_dates_of_all_event_bookings_without_confirmation_date(self, test_data):
-        bookings_factories.BookingWithoutConfirmationDateFactory.create_batch(100, dateCreated=test_data.today_at_2, stock=test_data.event_stock, user=test_data.user)
+        BookingWithoutConfirmationDateFactory.create_batch(100, dateCreated=test_data.today_at_2, stock=test_data.event_stock, user=test_data.user)
         assert get_all_event_bookings_without_confirmation_date_count() == 100
+
         fill_missing_confirmation_dates_of_all_event_bookings_without_confirmation_date(batch_size=10)
 
         assert get_all_event_bookings_without_confirmation_date_count() == 0
 
     def test_fill_missing_confirmation_dates_of_event_bookings_without_confirmation_date_not_cancelled_not_used(self, test_data):
-        bookings_factories.BookingWithoutConfirmationDateFactory.create_batch(7, dateCreated=test_data.today_at_2, stock=test_data.event_stock, user=test_data.user)
-        bookings_factories.BookingWithoutConfirmationDateFactory.create_batch(5, dateCreated=test_data.today_at_2, stock=test_data.event_stock, user=test_data.user, isUsed=True)
-        bookings_factories.BookingWithoutConfirmationDateFactory.create_batch(5, dateCreated=test_data.today_at_2, stock=test_data.event_stock, user=test_data.user, isCancelled=True)
+        BookingWithoutConfirmationDateFactory.create_batch(7, dateCreated=test_data.today_at_2, stock=test_data.event_stock, user=test_data.user)
+        BookingWithoutConfirmationDateFactory.create_batch(5, dateCreated=test_data.today_at_2, stock=test_data.event_stock, user=test_data.user, isUsed=True)
+        BookingWithoutConfirmationDateFactory.create_batch(5, dateCreated=test_data.today_at_2, stock=test_data.event_stock, user=test_data.user, isCancelled=True)
 
         assert get_event_bookings_without_confirmation_date_not_cancelled_not_used_count() == 7
         assert get_all_event_bookings_without_confirmation_date_count() == 17

--- a/tests/scripts/booking/test_update_confirmation_date_from_existing_bookings.py
+++ b/tests/scripts/booking/test_update_confirmation_date_from_existing_bookings.py
@@ -1,0 +1,82 @@
+import datetime
+from collections import namedtuple
+
+import pytest
+
+from pcapi.core.bookings import factories as bookings_factories
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.users.factories import UserFactory
+from pcapi.scripts.booking.update_confirmation_date_from_existing_bookings import _select_all_event_bookings_without_confirmation_date, _update_target_bookings, \
+    fill_missing_confirmation_dates_of_all_event_bookings_without_confirmation_date, \
+    fill_missing_confirmation_dates_of_event_bookings_without_confirmation_date_not_cancelled_not_used, get_all_event_bookings_without_confirmation_date_count, \
+    get_event_bookings_without_confirmation_date_not_cancelled_not_used_count
+
+
+@pytest.mark.usefixtures("db_session")
+class UpdateConfirmationDateFromExistingBookingsTest:
+    @pytest.fixture(name='test_data')
+    def test_data_fixture(self):
+        last_year = datetime.datetime(2019, 7, 14, 3)
+        today_at_2 = datetime.datetime(2020, 11, 5, 2)
+        tomorrow_at_13 = datetime.datetime(2020, 11, 6, 13)
+        user = UserFactory()
+        event_stock = offers_factories.StockFactory(beginningDatetime=tomorrow_at_13, price=0)
+        TestDataFixture = namedtuple(
+            'TestDataFixture',
+            ['last_year', 'today_at_2', 'tomorrow_at_13', 'user', 'event_stock']
+        )
+        return TestDataFixture(last_year, today_at_2, tomorrow_at_13, user, event_stock)
+
+    def test_select_existing_event_bookings_without_confirmation_date(self, test_data):
+        event_booking_with_confirmation_date = bookings_factories.BookingFactory(dateCreated=test_data.today_at_2, stock__beginningDatetime=test_data.tomorrow_at_13)
+        assert event_booking_with_confirmation_date.confirmationDate == event_booking_with_confirmation_date.dateCreated == test_data.today_at_2
+
+        event_booking_without_confirmation_date = bookings_factories.BookingWithoutConfirmationDateFactory(dateCreated=test_data.today_at_2, stock__beginningDatetime=test_data.tomorrow_at_13)
+        assert event_booking_without_confirmation_date.confirmationDate is None
+
+        event_booking_without_confirmation_date_from_last_year = bookings_factories.BookingWithoutConfirmationDateFactory(
+            dateCreated=test_data.last_year, stock__beginningDatetime=test_data.tomorrow_at_13
+        )
+        assert event_booking_without_confirmation_date_from_last_year.confirmationDate is None
+
+        bookings_without_confirmation_date = _select_all_event_bookings_without_confirmation_date().all()
+
+        assert bookings_without_confirmation_date == [event_booking_without_confirmation_date, event_booking_without_confirmation_date_from_last_year]
+        assert get_all_event_bookings_without_confirmation_date_count() == 2
+
+    def test_update_target_bookings(self, test_data):
+        event_booking_without_confirmation_date = bookings_factories.BookingWithoutConfirmationDateFactory(dateCreated=test_data.today_at_2, stock__beginningDatetime=test_data.tomorrow_at_13)
+        assert event_booking_without_confirmation_date.confirmationDate is None
+
+        event_booking_without_confirmation_date_from_last_year = bookings_factories.BookingWithoutConfirmationDateFactory(
+            dateCreated=test_data.last_year, stock__beginningDatetime=test_data.tomorrow_at_13
+        )
+        assert event_booking_without_confirmation_date_from_last_year.confirmationDate is None
+
+        bookings_without_confirmation_date_query = _select_all_event_bookings_without_confirmation_date()
+
+        _update_target_bookings(target_bookings_query=bookings_without_confirmation_date_query, batch_size=100)
+
+        assert get_all_event_bookings_without_confirmation_date_count() == 0
+        assert event_booking_without_confirmation_date.confirmationDate == test_data.today_at_2
+        assert event_booking_without_confirmation_date_from_last_year.confirmationDate == test_data.last_year + datetime.timedelta(hours=48)
+
+    def test_fill_missing_confirmation_dates_of_all_event_bookings_without_confirmation_date(self, test_data):
+        bookings_factories.BookingWithoutConfirmationDateFactory.create_batch(100, dateCreated=test_data.today_at_2, stock=test_data.event_stock, user=test_data.user)
+        assert get_all_event_bookings_without_confirmation_date_count() == 100
+        fill_missing_confirmation_dates_of_all_event_bookings_without_confirmation_date(batch_size=10)
+
+        assert get_all_event_bookings_without_confirmation_date_count() == 0
+
+    def test_fill_missing_confirmation_dates_of_event_bookings_without_confirmation_date_not_cancelled_not_used(self, test_data):
+        bookings_factories.BookingWithoutConfirmationDateFactory.create_batch(7, dateCreated=test_data.today_at_2, stock=test_data.event_stock, user=test_data.user)
+        bookings_factories.BookingWithoutConfirmationDateFactory.create_batch(5, dateCreated=test_data.today_at_2, stock=test_data.event_stock, user=test_data.user, isUsed=True)
+        bookings_factories.BookingWithoutConfirmationDateFactory.create_batch(5, dateCreated=test_data.today_at_2, stock=test_data.event_stock, user=test_data.user, isCancelled=True)
+
+        assert get_event_bookings_without_confirmation_date_not_cancelled_not_used_count() == 7
+        assert get_all_event_bookings_without_confirmation_date_count() == 17
+
+        fill_missing_confirmation_dates_of_event_bookings_without_confirmation_date_not_cancelled_not_used(batch_size=50)
+
+        assert get_event_bookings_without_confirmation_date_not_cancelled_not_used_count() == 0
+        assert get_all_event_bookings_without_confirmation_date_count() == 10

--- a/tests/scripts/booking/test_update_confirmation_date_from_existing_bookings.py
+++ b/tests/scripts/booking/test_update_confirmation_date_from_existing_bookings.py
@@ -1,5 +1,5 @@
-import datetime
 from collections import namedtuple
+import datetime
 
 import pytest
 
@@ -7,10 +7,22 @@ from pcapi.core.bookings.factories import BookingFactory
 from pcapi.core.bookings.factories import BookingWithoutConfirmationDateFactory
 from pcapi.core.offers.factories import StockFactory
 from pcapi.core.users.factories import UserFactory
-from pcapi.scripts.booking.update_confirmation_date_from_existing_bookings import _select_all_event_bookings_without_confirmation_date, _update_target_bookings, \
-    fill_missing_confirmation_dates_of_all_event_bookings_without_confirmation_date, \
-    fill_missing_confirmation_dates_of_event_bookings_without_confirmation_date_not_cancelled_not_used, get_all_event_bookings_without_confirmation_date_count, \
-    get_event_bookings_without_confirmation_date_not_cancelled_not_used_count
+from pcapi.scripts.booking.update_confirmation_date_from_existing_bookings import (
+    _select_all_event_bookings_without_confirmation_date,
+)
+from pcapi.scripts.booking.update_confirmation_date_from_existing_bookings import (
+    fill_missing_confirmation_dates_of_all_event_bookings_without_confirmation_date,
+)
+from pcapi.scripts.booking.update_confirmation_date_from_existing_bookings import (
+    fill_missing_confirmation_dates_of_event_bookings_without_confirmation_date_not_cancelled_not_used,
+)
+from pcapi.scripts.booking.update_confirmation_date_from_existing_bookings import (
+    get_all_event_bookings_without_confirmation_date_count,
+)
+from pcapi.scripts.booking.update_confirmation_date_from_existing_bookings import (
+    get_event_bookings_without_confirmation_date_not_cancelled_not_used_count,
+)
+from pcapi.scripts.booking.update_confirmation_date_from_existing_bookings import _update_target_bookings
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Performance test on local DB: updated 50k Bookings in 75s