### PR TITLE
(PC-4699) Fix Sentry on non local envs by bypassing utils config file

### DIFF
--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -29,7 +29,7 @@ from pcapi.models.db import db
 from pcapi.repository.feature_queries import feature_request_profiling_enabled
 from pcapi.serialization.utils import before_handler
 from pcapi.utils.config import IS_DEV, \
-    ENV, REDIS_URL, SENTRY_SAMPLE_RATE
+    ENV, REDIS_URL
 from pcapi.utils.health_checker import read_version_from_file
 from pcapi.utils.json_encoder import EnumJSONEncoder
 from pcapi.utils.logger import json_logger
@@ -43,7 +43,7 @@ if IS_DEV is False:
         integrations=[FlaskIntegration(), RqIntegration()],
         release=read_version_from_file(),
         environment=ENV,
-        traces_sample_rate=float(SENTRY_SAMPLE_RATE) if SENTRY_SAMPLE_RATE else None
+        traces_sample_rate=float(os.environ.get('SENTRY_SAMPLE_RATE', 0))
     )
 
 app = Flask(__name__, static_url_path='/static')

--- a/src/pcapi/utils/config.py
+++ b/src/pcapi/utils/config.py
@@ -12,7 +12,6 @@ IS_PROD = ENV == 'production'
 IS_TESTING = ENV == 'testing'
 LOG_LEVEL = int(os.environ.get('LOG_LEVEL', LOG_LEVEL_INFO))
 REDIS_URL = os.environ.get('REDIS_URL', 'redis://localhost:6379')
-SENTRY_SAMPLE_RATE = os.environ.get('SENTRY_SAMPLE_RATE', 0)
 
 if IS_DEV:
     API_URL = 'http://localhost'


### PR DESCRIPTION
Je ne comprends pas pourquoi mais le fait de déclarer la varialbe SENTRY_SAMPLE_RATE dans utils/config l'empêche de bien fonctionner:
![pb](https://user-images.githubusercontent.com/19763200/98345682-493bf400-2015-11eb-8fdc-4f1312c3d761.png)
