### PR TITLE
(PC-5160) fix booking cancellation by user

### DIFF
--- a/src/pcapi/core/bookings/validation.py
+++ b/src/pcapi/core/bookings/validation.py
@@ -1,4 +1,5 @@
 import datetime
+import pytz
 
 from pcapi.core.bookings import conf
 from pcapi.core.bookings import exceptions
@@ -163,8 +164,8 @@ def check_can_be_mark_as_unused(booking: Booking) -> None:
 
 # TODO(fseguin, 2020-11-03): cleanup after next MEP
 def _is_confirmed(event_beginning, booking_creation):
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    now = datetime.datetime.utcnow()
     before_event_limit = event_beginning - conf.CONFIRM_BOOKING_BEFORE_EVENT_DELAY
     after_booking_limit = booking_creation + conf.CONFIRM_BOOKING_AFTER_CREATION_DELAY
     confirmation_date = max(min(before_event_limit, after_booking_limit), now)
-    return datetime.datetime.utcnow() <= confirmation_date
+    return datetime.datetime.utcnow() >= confirmation_date

--- a/tests/core/bookings/test_validation.py
+++ b/tests/core/bookings/test_validation.py
@@ -9,7 +9,7 @@ import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
 import pcapi.core.users.factories as users_factories
 
-from pcapi.models import ApiErrors, ThingType, EventType
+from pcapi.models import ApiErrors, ThingType, EventType, db
 from pcapi.models import api_errors
 
 
@@ -278,6 +278,75 @@ class CheckBeneficiaryCanCancelBookingTest:
             stock__beginningDatetime=datetime.utcnow() + timedelta(days=1),
             dateCreated=datetime.utcnow() - timedelta(days=2)
         )
+        with pytest.raises(exceptions.CannotCancelConfirmedBooking) as exc:
+            validation.check_beneficiary_can_cancel_booking(booking.user, booking)
+        assert exc.value.errors['booking'] == ["Impossible d'annuler une réservation plus de 48h après l'avoir réservée et moins de 72h avant le début de l'événement"]
+
+
+# TODO(fseguin, 2020-11-09): cleanup when all past event bookings have a confirmationDate
+@pytest.mark.usefixtures("db_session")
+class CheckBeneficiaryCanCancelBookingNoConfirmationDateTest:
+    def test_can_cancel(self):
+        booking = factories.BookingFactory()
+        booking.confirmationDate = None
+        db.session.add(booking)
+        db.session.commit()
+        validation.check_beneficiary_can_cancel_booking(booking.user, booking)  # should not raise
+
+    def test_can_cancel_if_event_is_in_a_long_time(self):
+        booking = factories.BookingFactory(
+            stock__beginningDatetime=datetime.utcnow() + timedelta(days=10),
+        )
+        booking.confirmationDate = None
+        db.session.add(booking)
+        db.session.commit()
+        validation.check_beneficiary_can_cancel_booking(booking.user, booking)  # should not raise
+
+    def test_raise_if_not_the_beneficiary(self):
+        booking = factories.BookingFactory()
+        other_user = users_factories.UserFactory()
+        with pytest.raises(exceptions.BookingDoesntExist):
+            validation.check_beneficiary_can_cancel_booking(other_user, booking)
+
+    def test_raise_if_already_used(self):
+        booking = factories.BookingFactory(isUsed=True)
+        booking.confirmationDate = None
+        db.session.add(booking)
+        db.session.commit()
+        with pytest.raises(exceptions.BookingIsAlreadyUsed):
+            validation.check_beneficiary_can_cancel_booking(booking.user, booking)
+
+    def test_raise_if_event_too_close(self):
+        booking = factories.BookingFactory(
+            stock__beginningDatetime=datetime.utcnow() + timedelta(days=1),
+        )
+        booking.confirmationDate = None
+        db.session.add(booking)
+        db.session.commit()
+        with pytest.raises(exceptions.CannotCancelConfirmedBooking) as exc:
+            validation.check_beneficiary_can_cancel_booking(booking.user, booking)
+        assert exc.value.errors['booking'] == ["Impossible d'annuler une réservation plus de 48h après l'avoir réservée et moins de 72h avant le début de l'événement"]
+
+    def test_raise_if_booked_long_ago(self):
+        booking = factories.BookingFactory(
+            stock__beginningDatetime=datetime.utcnow() + timedelta(days=10),
+            dateCreated=datetime.utcnow() - timedelta(days=2)
+        )
+        booking.confirmationDate = None
+        db.session.add(booking)
+        db.session.commit()
+        with pytest.raises(exceptions.CannotCancelConfirmedBooking) as exc:
+            validation.check_beneficiary_can_cancel_booking(booking.user, booking)
+        assert exc.value.errors['booking'] == ["Impossible d'annuler une réservation plus de 48h après l'avoir réservée et moins de 72h avant le début de l'événement"]
+
+    def test_raise_if_event_too_close_and_booked_long_ago(self):
+        booking = factories.BookingFactory(
+            stock__beginningDatetime=datetime.utcnow() + timedelta(days=1),
+            dateCreated=datetime.utcnow() - timedelta(days=2)
+        )
+        booking.confirmationDate = None
+        db.session.add(booking)
+        db.session.commit()
         with pytest.raises(exceptions.CannotCancelConfirmedBooking) as exc:
             validation.check_beneficiary_can_cancel_booking(booking.user, booking)
         assert exc.value.errors['booking'] == ["Impossible d'annuler une réservation plus de 48h après l'avoir réservée et moins de 72h avant le début de l'événement"]


### PR DESCRIPTION
This fixes typos in the fallback method that was called in the transition period
 (before past event Bookings without confirmationDate are updated by a script)