### PR TITLE
ci: Lancer isort et black avec l'option --diff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,11 +55,11 @@ jobs:
       - run:
           name: Check imports are well organized with isort
           when: always
-          command: venv/bin/isort . --check-only
+          command: venv/bin/isort . --check-only --diff
       - run:
           name: Check code is well formatted with black
           when: always
-          command: venv/bin/black . --check
+          command: venv/bin/black . --check --diff
       - when:
           condition: << parameters.is_nightly_build >>
           steps:


### PR DESCRIPTION
Ces options semblent souhaitées par certains développeurs. Attention, ajouter `--diff` à la commande black n'est pas gratuit, même si aucun fichier n'est à reformater (17s vs. 0.7s sans l'option `--diff`) :

```
$ time black . --check --diff
All done! ✨ 🍰 ✨
1198 files would be left unchanged.
black . --check --diff  55,21s user 1,55s system 332% cpu 17,062 total
$ time black . --check       
All done! ✨ 🍰 ✨
1198 files would be left unchanged.
black . --check  0,59s user 0,07s system 99% cpu 0,662 total
```
