### PR TITLE
PcObject: allow more standard instances creation

### DIFF
--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -44,9 +44,6 @@ def book_offer(
     validation.check_quantity(stock.offer, quantity)
     validation.check_stock_is_bookable(stock)
 
-    # FIXME (dbaty, 2020-11-06): this is not right. PcOject's constructor
-    # should allow to call it with `Booking(stock=stock, ...)`
-    booking = Booking()
     # FIXME (dbaty, 2020-10-20): if we directly set relations (for
     # example with `booking.user = beneficiary`) instead of foreign keys,
     # the session tries to add the object when `get_user_expenses()`
@@ -58,11 +55,13 @@ def book_offer(
     # where exceptions are caught. Since we are using flask-sqlalchemy,
     # I don't think that we should use autoflush, nor should we use
     # the `pcapi.repository.repository` module.
-    booking.userId = beneficiary.id
-    booking.stockId = stock.id
-    booking.amount = stock.price
-    booking.quantity = quantity
-    booking.token = random_token()
+    booking = Booking(
+        userId=beneficiary.id,
+        stockId=stock.id,
+        amount=stock.price,
+        quantity=quantity,
+        token=random_token(),
+    )
     if recommendation:
         booking.recommendationId = recommendation.id
 

--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -92,14 +92,13 @@ def create_stock(
     validation.check_offer_is_editable(offer)
     validation.check_stocks_are_editable_for_offer(offer)
 
-    # FIXME (dbaty, 2020-11-06): this is not right. PcOject's constructor
-    # should allow to call it with `Stock(offer=offer, ...)`
-    stock = models.Stock()
-    stock.offer = offer
-    stock.price = price
-    stock.quantity = quantity
-    stock.beginningDatetime = beginning
-    stock.bookingLimitDatetime = booking_limit_datetime
+    stock = models.Stock(
+        offer=offer,
+        price=price,
+        quantity=quantity,
+        beginningDatetime=beginning,
+        bookingLimitDatetime=booking_limit_datetime,
+    )
 
     repository.save(stock)
 

--- a/src/pcapi/core/testing.py
+++ b/src/pcapi/core/testing.py
@@ -53,29 +53,7 @@ class BaseFactory(factory.alchemy.SQLAlchemyModelFactory):
                 f"Possible arguments are: {', '.join(sorted(known_fields))}"
             )
 
-        # Factory Boy expects that a model instance can be built with this:
-        #
-        #    instance = Model(attr1='value1', attr2='value2')
-        #
-        # But PcObject's constructor does not do that, so we have to
-        # call `setattr` manually here.
-        #
-        # FIXME: PcObject.__init__ should be changed. In fact, we
-        # should not use PcObject.populate_from_dict to build model
-        # instances from JSON input. Hopefully, this will be handled
-        # by the future pydantic-based data validation system.
-        obj = model_class()
-        for attr, value in kwargs.items():
-            setattr(obj, attr, value)
-
-        # The rest of the method if the same as the original.
-        session.add(obj)
-        session_persistence = cls._meta.sqlalchemy_session_persistence
-        if session_persistence == factory.alchemy.SESSION_PERSISTENCE_FLUSH:
-            session.flush()
-        elif session_persistence == factory.alchemy.SESSION_PERSISTENCE_COMMIT:
-            session.commit()
-        return obj
+        return super()._save(model_class, session, *args, **kwargs)
 
     @classmethod
     def _get_or_create(cls, model_class, session, *args, **kwargs):

--- a/src/pcapi/models/pc_object.py
+++ b/src/pcapi/models/pc_object.py
@@ -40,10 +40,11 @@ class DeletedRecordException(Exception):
 class PcObject:
     id = Column(BigInteger, primary_key=True, autoincrement=True)
 
-    def __init__(self, **options):
-        from_dict = options.get("from_dict")
+    def __init__(self, **kwargs):
+        from_dict = kwargs.pop("from_dict", None)
         if from_dict:
             self.populate_from_dict(from_dict)
+        super().__init__(**kwargs)
 
     def __repr__(self):
         id = "unsaved" if self.id is None else str(self.id) + "/" + humanize(self.id)


### PR DESCRIPTION
Previously discussed and agreed in standardization meeting.
Let any class inheriting from `PcObject` be created by using
standard keyword arguments:

    User(email="jon@doe", firstname="jon")

Still keeps the former creation form since it has not been cleaned
yet:

    User(from_dict={"email": "jon@doe", "firstname": "jon"})