### PR TITLE
repository: Allow to clean the database on testing environment

### DIFF
--- a/src/pcapi/repository/clean_database.py
+++ b/src/pcapi/repository/clean_database.py
@@ -42,7 +42,7 @@ from pcapi.utils.config import ENV
 
 def clean_all_database(*args, **kwargs):
     """ Order of deletions matters because of foreign key constraints """
-    if ENV != "development":
+    if ENV not in ("development", "testing"):
         raise ValueError(f"You cannot do this on this environment: '{ENV}'")
     Activity = load_activity()
     LocalProviderEvent.query.delete()


### PR DESCRIPTION
Otherwise the CI cannot regularly build a new database for testing.