### PR TITLE
(PC-5454) offers: Fix edition of stock for Allocine offers

### DIFF
--- a/tests/core/offers/test_api.py
+++ b/tests/core/offers/test_api.py
@@ -469,7 +469,8 @@ class UpdateOffersActiveStatusTest:
             [
                 mock.call(client=app.redis_client, offer_id=offer1.id),
                 mock.call(client=app.redis_client, offer_id=offer2.id),
-            ]
+            ],
+            any_order=True,
         )
 
     def test_deactivate(self):


### PR DESCRIPTION
The edition was not possible because the backend *wrongly* detected
changes in the `beginningDatetime` field, which is not allowed to be
modified.

The patch is ugly, it MUST be cleaned up.