### PR TITLE
(PC-4923) : Create pcapi.settings to centralize settings

### DIFF
--- a/src/pcapi/alembic/env.py
+++ b/src/pcapi/alembic/env.py
@@ -6,11 +6,10 @@ import os
 from alembic import context
 from sqlalchemy import create_engine
 
-from pcapi.models.db import db
-
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
-from pcapi.utils.config import IS_DEV
+from pcapi import settings
+from pcapi.models.db import db
 
 
 config = context.config
@@ -53,11 +52,11 @@ def run_migrations_online() -> None:
             include_schemas=True,
             transaction_per_migration=False,
         )
-        if not IS_DEV:
+        if not settings.IS_DEV:
             connection.execute("UPDATE feature SET \"isActive\" = FALSE WHERE name = 'UPDATE_DISCOVERY_VIEW'")
         with context.begin_transaction():
             context.run_migrations()
-        if not IS_DEV:
+        if not settings.IS_DEV:
             connection.execute("UPDATE feature SET \"isActive\" = TRUE WHERE name = 'UPDATE_DISCOVERY_VIEW'")
 
 

--- a/src/pcapi/app.py
+++ b/src/pcapi/app.py
@@ -3,6 +3,7 @@ import os
 
 from werkzeug.middleware.profiler import ProfilerMiddleware
 
+from pcapi import settings
 from pcapi.admin.install import install_admin_views
 from pcapi.documentation import install_documentation
 from pcapi.flask_app import admin
@@ -16,7 +17,6 @@ from pcapi.models.install import install_materialized_views
 from pcapi.repository.feature_queries import feature_request_profiling_enabled
 from pcapi.routes import install_routes
 from pcapi.routes.native.v1.blueprint import native_v1
-from pcapi.utils.config import IS_DEV
 from pcapi.utils.logger import configure_json_logger
 from pcapi.utils.logger import disable_werkzeug_request_logs
 
@@ -38,7 +38,7 @@ def install_login_manager() -> None:
 with app.app_context():
     load_environment_variables()
 
-    if IS_DEV:
+    if settings.IS_DEV:
         install_activity()
         install_materialized_views()
         install_local_providers()
@@ -53,4 +53,4 @@ with app.app_context():
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 5000))
-    app.run(host="0.0.0.0", port=port, debug=IS_DEV, use_reloader=True)
+    app.run(host="0.0.0.0", port=port, debug=settings.IS_DEV, use_reloader=True)

--- a/src/pcapi/connectors/redis.py
+++ b/src/pcapi/connectors/redis.py
@@ -8,7 +8,7 @@ import redis
 from redis import Redis
 from redis.client import Pipeline
 
-from pcapi.utils.config import REDIS_URL
+from pcapi import settings
 from pcapi.utils.logger import logger
 
 
@@ -42,7 +42,7 @@ def add_venue_id(client: Redis, venue_id: int) -> None:
 
 
 def send_venue_provider_data_to_redis(venue_provider) -> None:
-    redis_client = redis.from_url(url=REDIS_URL, decode_responses=True)
+    redis_client = redis.from_url(url=settings.REDIS_URL, decode_responses=True)
     _add_venue_provider(client=redis_client, venue_provider=venue_provider)
 
 

--- a/src/pcapi/connectors/scalingo_api.py
+++ b/src/pcapi/connectors/scalingo_api.py
@@ -2,7 +2,7 @@ import os
 
 import requests
 
-from pcapi.utils.config import API_APPLICATION_NAME
+from pcapi import settings
 
 
 SCALINGO_AUTH_URL = "https://auth.scalingo.com/v1"
@@ -17,7 +17,7 @@ class ScalingoApiException(Exception):
 
 def run_process_in_one_off_container(command: str) -> str:
     app_bearer_token = _get_application_bearer_token()
-    run_one_off_endpoint = f"/apps/{API_APPLICATION_NAME}/run"
+    run_one_off_endpoint = f"/apps/{settings.API_APPLICATION_NAME}/run"
     command_parameters = {
         "command": command,
         "region": SCALINGO_API_REGION,

--- a/src/pcapi/emails/beneficiary_activation.py
+++ b/src/pcapi/emails/beneficiary_activation.py
@@ -2,11 +2,11 @@ from typing import Dict
 from typing import Union
 from urllib.parse import quote
 
+from pcapi import settings
 from pcapi.core.users import models
 from pcapi.domain.beneficiary.beneficiary import Beneficiary
 from pcapi.models import UserSQLEntity
 from pcapi.repository.feature_queries import feature_send_mail_to_users_enabled
-from pcapi.utils.config import NATIVE_APP_URL
 from pcapi.utils.mailing import DEV_EMAIL_ADDRESS
 from pcapi.utils.mailing import SUPPORT_EMAIL_ADDRESS
 from pcapi.utils.mailing import format_environment_for_email
@@ -30,7 +30,7 @@ def get_activation_email_data(user: Union[UserSQLEntity, Beneficiary]) -> Dict:
 def get_activation_email_data_for_native(user: UserSQLEntity, token: models.Token) -> Dict:
     expiration_timestamp = int(token.expirationDate.timestamp())
     email_confirmation_link = (
-        f"{NATIVE_APP_URL}/email-confirmation?token={token.value}&expiration_timestamp={expiration_timestamp}"
+        f"{settings.NATIVE_APP_URL}/email-confirmation?token={token.value}&expiration_timestamp={expiration_timestamp}"
     )
     return {
         "FromEmail": SUPPORT_EMAIL_ADDRESS,

--- a/src/pcapi/emails/pro_reset_password.py
+++ b/src/pcapi/emails/pro_reset_password.py
@@ -1,8 +1,8 @@
 from typing import Dict
 
+from pcapi import settings
 from pcapi.models import UserSQLEntity
 from pcapi.repository.feature_queries import feature_send_mail_to_users_enabled
-from pcapi.utils.config import PRO_URL
 from pcapi.utils.mailing import DEV_EMAIL_ADDRESS
 from pcapi.utils.mailing import SUPPORT_EMAIL_ADDRESS
 from pcapi.utils.mailing import format_environment_for_email
@@ -12,7 +12,7 @@ def retrieve_data_for_reset_password_pro_email(user: UserSQLEntity) -> Dict:
     user_email = user.email if feature_send_mail_to_users_enabled() else DEV_EMAIL_ADDRESS
     user_reset_password_token = user.resetPasswordToken
     env = format_environment_for_email()
-    reinit_password_url = f"{PRO_URL}/mot-de-passe-perdu?token={user_reset_password_token}"
+    reinit_password_url = f"{settings.PRO_URL}/mot-de-passe-perdu?token={user_reset_password_token}"
 
     return {
         "FromEmail": SUPPORT_EMAIL_ADDRESS,

--- a/src/pcapi/emails/user_reset_password.py
+++ b/src/pcapi/emails/user_reset_password.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from typing import Dict
 
+from pcapi import settings
 from pcapi.models import UserSQLEntity
 from pcapi.repository.feature_queries import feature_send_mail_to_users_enabled
-from pcapi.utils.config import NATIVE_APP_URL
 from pcapi.utils.mailing import DEV_EMAIL_ADDRESS
 from pcapi.utils.mailing import SUPPORT_EMAIL_ADDRESS
 from pcapi.utils.mailing import format_environment_for_email
@@ -28,7 +28,7 @@ def retrieve_data_for_reset_password_native_app_email(
     user_email: str, token_value: str, expiration_date: datetime
 ) -> Dict:
     reset_password_link = (
-        f"{NATIVE_APP_URL}/mot-de-passe-perdu?token={token_value}"
+        f"{settings.NATIVE_APP_URL}/mot-de-passe-perdu?token={token_value}"
         f"&expiration_timestamp={int(expiration_date.timestamp())}"
     )
 

--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -27,12 +27,10 @@ from spectree import SpecTree
 from sqlalchemy import orm
 from werkzeug.middleware.profiler import ProfilerMiddleware
 
+from pcapi import settings
 from pcapi.models.db import db
 from pcapi.repository.feature_queries import feature_request_profiling_enabled
 from pcapi.serialization.utils import before_handler
-from pcapi.utils.config import ENV
-from pcapi.utils.config import IS_DEV
-from pcapi.utils.config import REDIS_URL
 from pcapi.utils.health_checker import read_version_from_file
 from pcapi.utils.json_encoder import EnumJSONEncoder
 from pcapi.utils.logger import json_logger
@@ -40,12 +38,12 @@ from pcapi.utils.mailing import MAILJET_API_KEY
 from pcapi.utils.mailing import MAILJET_API_SECRET
 
 
-if IS_DEV is False:
+if settings.IS_DEV is False:
     sentry_sdk.init(
         dsn="https://0470142cf8d44893be88ecded2a14e42@logs.passculture.app/5",
         integrations=[FlaskIntegration(), RqIntegration()],
         release=read_version_from_file(),
-        environment=ENV,
+        environment=settings.ENV,
         traces_sample_rate=float(os.environ.get("SENTRY_SAMPLE_RATE", 0)),
     )
 
@@ -76,9 +74,9 @@ app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get("DATABASE_URL")
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 app.config["SQLALCHEMY_ECHO"] = False
 app.config["SESSION_COOKIE_HTTPONLY"] = True
-app.config["SESSION_COOKIE_SECURE"] = not IS_DEV
+app.config["SESSION_COOKIE_SECURE"] = not settings.IS_DEV
 app.config["REMEMBER_COOKIE_HTTPONLY"] = True
-app.config["REMEMBER_COOKIE_SECURE"] = not IS_DEV
+app.config["REMEMBER_COOKIE_SECURE"] = not settings.IS_DEV
 app.config["REMEMBER_COOKIE_DURATION"] = 90 * 24 * 3600
 app.config["PERMANENT_SESSION_LIFETIME"] = 90 * 24 * 3600
 app.config["FLASK_ADMIN_SWATCH"] = "flatly"
@@ -146,4 +144,4 @@ app.url_map.strict_slashes = False
 
 with app.app_context():
     app.mailjet_client = Client(auth=(MAILJET_API_KEY, MAILJET_API_SECRET), version="v3")
-    app.redis_client = redis.from_url(url=REDIS_URL, decode_responses=True)
+    app.redis_client = redis.from_url(url=settings.REDIS_URL, decode_responses=True)

--- a/src/pcapi/load_environment_variables.py
+++ b/src/pcapi/load_environment_variables.py
@@ -1,17 +1,8 @@
-import os
-from pathlib import Path
-
-from dotenv import load_dotenv
-
-from pcapi.utils.config import ENV
-from pcapi.utils.config import IS_DEV
+from pcapi import settings  # pylint: disable=unused-import
 
 
+# TODO: eventually this file will be removed once all the
+# settings will be migrated to pcapi.settings and we have
+# NO `os.environ` outside pcapi.settings
 def load_environment_variables() -> None:
-    env_path = Path(f"./.env.{ENV}")
-    load_dotenv(dotenv_path=env_path)
-
-    if IS_DEV:
-        load_dotenv(dotenv_path=".env.local.secret", override=True)
-    if os.environ.get("RUN_ENV") == "tests":
-        load_dotenv(dotenv_path=".env.testauto", override=True)
+    pass

--- a/src/pcapi/models/user_sql_entity.py
+++ b/src/pcapi/models/user_sql_entity.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
 
+from pcapi import settings
 from pcapi.core.bookings.models import Booking
 from pcapi.core.offers.models import Stock
 from pcapi.domain.expenses import get_expenses
@@ -30,7 +31,6 @@ from pcapi.models.pc_object import PcObject
 from pcapi.models.user_offerer import RightsType
 from pcapi.models.user_offerer import UserOfferer
 from pcapi.models.versioned_mixin import VersionedMixin
-from pcapi.utils.config import IS_DEV
 
 
 def _hash_password_with_bcrypt(clear_text: str) -> bytes:
@@ -42,25 +42,25 @@ def _check_password_with_bcrypt(clear_text: str, hashed: str) -> bool:
 
 
 def _hash_password_with_md5(clear_text: str) -> bytes:
-    if not IS_DEV:
+    if not settings.IS_DEV:
         raise RuntimeError("This password hasher should not be used outside tests.")
     return md5(clear_text.encode("utf-8")).hexdigest().encode("utf-8")
 
 
 def _check_password_with_md5(clear_text: str, hashed: str) -> bool:
-    if not IS_DEV:
+    if not settings.IS_DEV:
         raise RuntimeError("This password hasher should not be used outside tests.")
     # non constant-time comparison because it's test-only
     return _hash_password_with_md5(clear_text) == hashed
 
 
 def hash_password(clear_text: str) -> bytes:
-    hasher = _hash_password_with_md5 if IS_DEV else _hash_password_with_bcrypt
+    hasher = _hash_password_with_md5 if settings.IS_DEV else _hash_password_with_bcrypt
     return hasher(clear_text)
 
 
 def check_password(clear_text: str, hashed: str) -> bool:
-    checker = _check_password_with_md5 if IS_DEV else _check_password_with_bcrypt
+    checker = _check_password_with_md5 if settings.IS_DEV else _check_password_with_bcrypt
     return checker(clear_text, hashed)
 
 

--- a/src/pcapi/repository/clean_database.py
+++ b/src/pcapi/repository/clean_database.py
@@ -1,3 +1,4 @@
+from pcapi import settings
 from pcapi.core.offers.models import Mediation
 from pcapi.local_providers.install import install_local_providers
 from pcapi.models import AllocinePivot
@@ -37,13 +38,12 @@ from pcapi.models.email import Email
 from pcapi.models.install import install_features
 from pcapi.models.install import install_materialized_views
 from pcapi.models.venue_label_sql_entity import VenueLabelSQLEntity
-from pcapi.utils.config import ENV
 
 
 def clean_all_database(*args, **kwargs):
     """ Order of deletions matters because of foreign key constraints """
-    if ENV not in ("development", "testing"):
-        raise ValueError(f"You cannot do this on this environment: '{ENV}'")
+    if settings.ENV not in ("development", "testing"):
+        raise ValueError(f"You cannot do this on this environment: '{settings.ENV}'")
     Activity = load_activity()
     LocalProviderEvent.query.delete()
     AllocineVenueProviderPriceRule.query.delete()

--- a/src/pcapi/repository/feature_queries.py
+++ b/src/pcapi/repository/feature_queries.py
@@ -1,10 +1,9 @@
 import os
 
+from pcapi import settings
 from pcapi.models import Feature
 from pcapi.models.api_errors import ResourceNotFoundError
 from pcapi.models.feature import FeatureToggle
-from pcapi.utils.config import IS_INTEGRATION
-from pcapi.utils.config import IS_PROD
 
 
 def find_all():
@@ -18,7 +17,7 @@ def is_active(feature_toggle: FeatureToggle) -> bool:
 
 
 def feature_send_mail_to_users_enabled() -> bool:
-    return IS_PROD or IS_INTEGRATION
+    return settings.IS_PROD or settings.IS_INTEGRATION
 
 
 def feature_request_profiling_enabled() -> bool:

--- a/src/pcapi/routes/internal/__init__.py
+++ b/src/pcapi/routes/internal/__init__.py
@@ -1,12 +1,12 @@
 from flask import Flask
 
-from pcapi.utils.config import IS_DEV
+from pcapi import settings
 
 
 def install_routes(app: Flask) -> None:
     # pylint: disable=unused-import
     from . import health_check
 
-    if IS_DEV:
+    if settings.IS_DEV:
         from . import sandboxes
         from . import storage

--- a/src/pcapi/routes/pro/signup.py
+++ b/src/pcapi/routes/pro/signup.py
@@ -1,6 +1,7 @@
 from flask import jsonify
 from flask import request
 
+from pcapi import settings
 from pcapi.domain.postal_code.postal_code import PostalCode
 from pcapi.domain.user_emails import send_user_validation_email
 from pcapi.flask_app import private_api
@@ -10,7 +11,6 @@ from pcapi.models.user_offerer import RightsType
 from pcapi.models.venue_sql_entity import create_digital_venue
 from pcapi.repository import repository
 from pcapi.routes.serialization import as_dict
-from pcapi.utils.config import IS_INTEGRATION
 from pcapi.utils.includes import USER_INCLUDES
 from pcapi.utils.logger import logger
 from pcapi.utils.mailing import MailServiceException
@@ -59,7 +59,7 @@ def signup_pro():
 
 def _generate_user_offerer_when_existing_offerer(new_user, offerer):
     user_offerer = offerer.give_rights(new_user, RightsType.editor)
-    if not IS_INTEGRATION:
+    if not settings.IS_INTEGRATION:
         user_offerer.generate_validation_token()
     return user_offerer
 
@@ -68,13 +68,13 @@ def _generate_offerer(data):
     offerer = Offerer()
     offerer.populate_from_dict(data)
 
-    if not IS_INTEGRATION:
+    if not settings.IS_INTEGRATION:
         offerer.generate_validation_token()
     return offerer
 
 
 def _set_offerer_departement_code(new_user: UserSQLEntity, offerer: Offerer) -> UserSQLEntity:
-    if IS_INTEGRATION:
+    if settings.IS_INTEGRATION:
         new_user.departementCode = "00"
     elif offerer.postalCode is not None:
         new_user.departementCode = PostalCode(offerer.postalCode).get_departement_code()

--- a/src/pcapi/routes/pro/validate.py
+++ b/src/pcapi/routes/pro/validate.py
@@ -1,5 +1,6 @@
 from flask import current_app as app
 
+from pcapi import settings
 from pcapi.connectors import redis
 from pcapi.domain.admin_emails import maybe_send_offerer_validation_email
 from pcapi.domain.iris import link_valid_venue_to_irises
@@ -17,7 +18,6 @@ from pcapi.repository import repository
 from pcapi.repository import user_offerer_queries
 from pcapi.repository import user_queries
 from pcapi.repository.user_offerer_queries import count_pro_attached_to_offerer
-from pcapi.utils.config import IS_INTEGRATION
 from pcapi.utils.mailing import MailServiceException
 from pcapi.utils.mailing import send_raw_email
 from pcapi.validation.routes.users import check_validation_token_has_been_already_used
@@ -81,7 +81,7 @@ def validate_user(token):
         number_of_pro_attached_to_offerer = count_pro_attached_to_offerer(user_offerer.offererId)
         offerer = user_offerer.offerer
 
-        if IS_INTEGRATION:
+        if settings.IS_INTEGRATION:
             _validate_offerer(offerer, user_offerer)
         else:
             _ask_for_validation(offerer, user_offerer)

--- a/src/pcapi/routes/webapp/recommendations.py
+++ b/src/pcapi/routes/webapp/recommendations.py
@@ -6,6 +6,7 @@ from flask import request
 from flask_login import current_user
 from flask_login import login_required
 
+from pcapi import settings
 from pcapi.domain.build_recommendations import move_requested_recommendation_first
 from pcapi.flask_app import private_api
 from pcapi.models import Recommendation
@@ -19,7 +20,6 @@ from pcapi.repository.iris_venues_queries import get_iris_containing_user_locati
 from pcapi.repository.recommendation_queries import update_read_recommendations
 from pcapi.routes.serialization.recommendation_serialize import serialize_recommendation
 from pcapi.routes.serialization.recommendation_serialize import serialize_recommendations
-from pcapi.utils.config import BLOB_SIZE
 from pcapi.utils.human_ids import dehumanize
 from pcapi.utils.human_ids import dehumanize_ids_list
 from pcapi.utils.rest import expect_json_data
@@ -85,7 +85,7 @@ def _put_geolocated_recommendations(request: Request) -> (Dict, int):
         user_iris_id=user_iris_id,
         user_is_geolocated=user_is_geolocated,
         sent_offers_ids=sent_offers_ids,
-        limit=BLOB_SIZE,
+        limit=settings.BLOB_SIZE,
     )
 
     return jsonify(serialize_recommendations(recommendations, user_id=current_user.id)), 200
@@ -101,7 +101,7 @@ def _put_non_geolocated_recommendations(request: Request) -> (Dict, int):
     requested_recommendation = give_requested_recommendation_to_user(current_user, offer_id, mediation_id)
 
     recommendations = create_recommendations_for_discovery(
-        limit=BLOB_SIZE, user=current_user, sent_offers_ids=sent_offers_ids
+        limit=settings.BLOB_SIZE, user=current_user, sent_offers_ids=sent_offers_ids
     )
 
     if requested_recommendation:

--- a/src/pcapi/routes/webapp/signup.py
+++ b/src/pcapi/routes/webapp/signup.py
@@ -2,6 +2,7 @@ from flask import current_app as app
 from flask import jsonify
 from flask import request
 
+from pcapi import settings
 from pcapi.connectors.google_spreadsheet import get_authorized_emails_and_dept_codes
 from pcapi.flask_app import private_api
 from pcapi.models import ApiErrors
@@ -10,7 +11,6 @@ from pcapi.models import UserSQLEntity
 from pcapi.models.feature import FeatureToggle
 from pcapi.repository import repository
 from pcapi.routes.serialization import as_dict
-from pcapi.utils.config import IS_INTEGRATION
 from pcapi.utils.feature import feature_required
 from pcapi.utils.includes import BENEFICIARY_INCLUDES
 from pcapi.utils.logger import logger
@@ -27,7 +27,7 @@ def signup_webapp():
 
     new_user = UserSQLEntity(from_dict=request.json)
 
-    if IS_INTEGRATION:
+    if settings.IS_INTEGRATION:
         new_user.departementCode = "00"
         objects_to_save.append(_create_initial_deposit(new_user))
     else:

--- a/src/pcapi/scripts/grant_wallet_to_existing_users.py
+++ b/src/pcapi/scripts/grant_wallet_to_existing_users.py
@@ -1,13 +1,13 @@
 from typing import List
 
+from pcapi import settings
 from pcapi.model_creators.generic_creators import create_deposit
 from pcapi.models import UserSQLEntity
 from pcapi.repository import repository
-from pcapi.utils import config
 
 
 def grant_wallet_to_existing_users(user_ids: List[int]):
-    if config.IS_PROD:
+    if settings.IS_PROD:
         raise ValueError("This action is not available on production")
     users = UserSQLEntity.query.filter(UserSQLEntity.id.in_(user_ids)).all()
     maximum_wallet_balance = 500

--- a/src/pcapi/scripts/interact.py
+++ b/src/pcapi/scripts/interact.py
@@ -11,8 +11,8 @@ import sys
 from flask import Flask
 from mailjet_rest import Client
 
+from pcapi import settings
 from pcapi.models.db import db
-from pcapi.utils import config
 from pcapi.utils.mailing import MAILJET_API_KEY
 from pcapi.utils.mailing import MAILJET_API_SECRET
 
@@ -39,7 +39,7 @@ from pcapi.sandboxes import *
 from pcapi.scripts.beneficiary import old_remote_import
 from pcapi.scripts.beneficiary import remote_import
 from pcapi.scripts.booking import *
-from pcapi.utils.config import *
+from pcapi.settings import *
 from pcapi.utils.human_ids import *
 from pcapi.utils.import_module import *
 from pcapi.utils.includes import *
@@ -51,7 +51,7 @@ from pcapi.utils.token import *
 
 
 def set_python_prompt():
-    env = config.ENV
+    env = settings.ENV
     if env == "production":
         color = "\x1b[1;49;31m"  # red
     elif env == "staging":

--- a/src/pcapi/scripts/pc.py
+++ b/src/pcapi/scripts/pc.py
@@ -11,9 +11,9 @@ from flask_script import Manager
 from mailjet_rest import Client
 import redis
 
+from pcapi import settings
 from pcapi.models.db import db
 from pcapi.scripts.install import install_scripts
-from pcapi.utils.config import REDIS_URL
 from pcapi.utils.mailing import MAILJET_API_KEY
 from pcapi.utils.mailing import MAILJET_API_SECRET
 
@@ -35,7 +35,7 @@ with app.app_context():
     install_scripts()
 
     app.mailjet_client = Client(auth=(MAILJET_API_KEY, MAILJET_API_SECRET), version="v3")
-    app.redis_client = redis.from_url(url=REDIS_URL, decode_responses=True)
+    app.redis_client = redis.from_url(url=settings.REDIS_URL, decode_responses=True)
 
 
 if __name__ == "__main__":

--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -1,6 +1,9 @@
 """ config """
 from logging import INFO as LOG_LEVEL_INFO
 import os
+from pathlib import Path
+
+from dotenv import load_dotenv
 
 
 ENV = os.environ.get("ENV", "development")
@@ -9,9 +12,21 @@ IS_INTEGRATION = ENV == "integration"
 IS_STAGING = ENV == "staging"
 IS_PROD = ENV == "production"
 IS_TESTING = ENV == "testing"
-LOG_LEVEL = int(os.environ.get("LOG_LEVEL", LOG_LEVEL_INFO))
-REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379")
 
+
+# Load configuration files
+env_path = Path(f"./.env.{ENV}")
+load_dotenv(dotenv_path=env_path)
+
+if IS_DEV:
+    load_dotenv(dotenv_path=".env.local.secret", override=True)
+if os.environ.get("RUN_ENV") == "tests":
+    load_dotenv(dotenv_path=".env.testauto", override=True)
+
+LOG_LEVEL = int(os.environ.get("LOG_LEVEL", LOG_LEVEL_INFO))
+
+
+# TODO: move those to .env.{ENV}
 if IS_DEV:
     API_URL = "http://localhost"
     API_APPLICATION_NAME = None
@@ -38,3 +53,7 @@ else:
     NATIVE_APP_URL = f"passculture://app.passculture.{ENV}"
 
 BLOB_SIZE = 30
+
+
+# REDIS
+REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379")

--- a/src/pcapi/utils/logger.py
+++ b/src/pcapi/utils/logger.py
@@ -3,7 +3,7 @@ import logging
 
 from pythonjsonlogger import jsonlogger
 
-from pcapi.utils.config import LOG_LEVEL
+from pcapi import settings
 
 
 def disable_werkzeug_request_logs() -> None:
@@ -34,7 +34,7 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
 logger = logging.getLogger()
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
-    level=LOG_LEVEL,
+    level=settings.LOG_LEVEL,
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 json_logger = logging.getLogger(__name__)

--- a/src/pcapi/utils/object_storage.py
+++ b/src/pcapi/utils/object_storage.py
@@ -5,8 +5,8 @@ from pathlib import PurePath
 
 import swiftclient
 
+from pcapi import settings
 from pcapi.models.db import Model
-from pcapi.utils.config import IS_DEV
 from pcapi.utils.human_ids import humanize
 from pcapi.utils.inflect_engine import inflect_engine
 
@@ -45,7 +45,7 @@ def local_path(bucket, id):
 
 
 def store_public_object(bucket, id, blob, content_type, symlink_path=None):
-    if IS_DEV:
+    if settings.IS_DEV:
         os.makedirs(local_dir(bucket, id), exist_ok=True)
 
         file_local_path = local_path(bucket, id)

--- a/src/pcapi/workers/worker.py
+++ b/src/pcapi/workers/worker.py
@@ -14,14 +14,14 @@ from rq import Queue
 from rq import Worker
 from rq.job import Job
 
-from pcapi.utils.config import REDIS_URL
+from pcapi import settings
 from pcapi.utils.logger import logger
 from pcapi.workers.logger import JobStatus
 from pcapi.workers.logger import build_job_log_message
 
 
 listen = ["default"]
-conn = redis.from_url(REDIS_URL)
+conn = redis.from_url(settings.REDIS_URL)
 redis_queue = Queue(connection=conn)
 logging.getLogger("rq.worker").setLevel(logging.CRITICAL)
 

--- a/tests/connectors/scalingo_api_test.py
+++ b/tests/connectors/scalingo_api_test.py
@@ -41,7 +41,7 @@ class GetApplicationBearerTokenTest:
 
 class RunProcessInOneOffContainerTest:
     @patch.dict("os.environ", {"SCALINGO_APP_TOKEN": "token123"})
-    @patch("pcapi.connectors.scalingo_api.API_APPLICATION_NAME", "pass-culture-api-app")
+    @patch("pcapi.settings.API_APPLICATION_NAME", "pass-culture-api-app")
     @patch("pcapi.connectors.scalingo_api.requests.post")
     @patch("pcapi.connectors.scalingo_api._get_application_bearer_token")
     def test_should_call_scalingo_api_with_expected_payload(self, mock_get_app_token, mock_post):
@@ -64,7 +64,7 @@ class RunProcessInOneOffContainerTest:
         assert container_id == "12345678987654ERTY"
 
     @patch.dict("os.environ", {"SCALINGO_APP_TOKEN": "token123"})
-    @patch("pcapi.connectors.scalingo_api.API_APPLICATION_NAME", "pass-culture-api-app")
+    @patch("pcapi.settings.API_APPLICATION_NAME", "pass-culture-api-app")
     @patch("pcapi.connectors.scalingo_api.requests.post")
     @patch("pcapi.connectors.scalingo_api._get_application_bearer_token")
     def test_should_raise_errors_when_error_during_api_call(self, mock_get_app_token, mock_post):

--- a/tests/emails/offerer_booking_recap_test.py
+++ b/tests/emails/offerer_booking_recap_test.py
@@ -150,7 +150,7 @@ def test_should_not_truncate_price():
     assert email_data == expected
 
 
-@patch("pcapi.repository.feature_queries.IS_PROD", True)
+@patch("pcapi.settings.IS_PROD", True)
 @pytest.mark.usefixtures("db_session")
 def test_recipients_on_production():
     booking = make_booking()

--- a/tests/emails/pro_reset_password_test.py
+++ b/tests/emails/pro_reset_password_test.py
@@ -12,7 +12,7 @@ from pcapi.repository import repository
 class MakeProResetPasswordEmailDataTest:
     @patch("pcapi.emails.pro_reset_password.format_environment_for_email", return_value="-testing")
     @patch("pcapi.emails.pro_reset_password.feature_send_mail_to_users_enabled", return_value=False)
-    @patch("pcapi.emails.pro_reset_password.PRO_URL", "http://example.net")
+    @patch("pcapi.settings.PRO_URL", "http://example.net")
     @pytest.mark.usefixtures("db_session")
     def test_email_is_sent_to_dev_at_passculture_when_not_production_environment(
         self, mock_send_mail_enabled, mock_format_env, app
@@ -38,7 +38,7 @@ class MakeProResetPasswordEmailDataTest:
 
     @patch("pcapi.emails.pro_reset_password.format_environment_for_email", return_value="")
     @patch("pcapi.emails.pro_reset_password.feature_send_mail_to_users_enabled", return_value=True)
-    @patch("pcapi.emails.pro_reset_password.PRO_URL", "http://example.net")
+    @patch("pcapi.settings.PRO_URL", "http://example.net")
     @pytest.mark.usefixtures("db_session")
     def test_email_is_sent_to_pro_offerer_when_production_environment(
         self, mock_send_mail_enabled, mock_format_env, app

--- a/tests/models/users_sql_entity_test.py
+++ b/tests/models/users_sql_entity_test.py
@@ -351,7 +351,7 @@ class DevEnvironmentPasswordHasherTest:
         assert user_sql_entity.check_password("secret", hashed)
 
 
-@patch("pcapi.models.user_sql_entity.IS_DEV", False)
+@patch("pcapi.settings.IS_DEV", False)
 class ProdEnvironmentPasswordHasherTest:
     def test_hash_password_uses_bcrypt(self):
         hashed = user_sql_entity.hash_password("secret")

--- a/tests/routes/pro/signup_pro_test.py
+++ b/tests/routes/pro/signup_pro_test.py
@@ -476,7 +476,7 @@ class Post:
 
 
 class SetOffererDepartementCodeTest:
-    @patch("pcapi.routes.pro.signup.IS_INTEGRATION", True)
+    @patch("pcapi.settings.IS_INTEGRATION", True)
     def should_set_user_department_to_all_departments_in_integration(self):
         # Given
         new_user = create_user()

--- a/tests/routes/pro/validate_user_test.py
+++ b/tests/routes/pro/validate_user_test.py
@@ -87,7 +87,7 @@ class Patch:
             )
 
         @pytest.mark.usefixtures("db_session")
-        @patch("pcapi.routes.pro.validate.IS_INTEGRATION", False)
+        @patch("pcapi.settings.IS_INTEGRATION", False)
         @patch("pcapi.routes.pro.validate.maybe_send_offerer_validation_email", return_value=True)
         @patch("pcapi.routes.pro.validate.send_raw_email", return_value=True)
         def test_maybe_send_offerer_validation_email_when_not_in_integration_env(
@@ -112,7 +112,7 @@ class Patch:
             mock_maybe_send_offerer_validation_email.assert_called_once_with(offerer, user_offerer, mock_send_raw_email)
 
         @pytest.mark.usefixtures("db_session")
-        @patch("pcapi.routes.pro.validate.IS_INTEGRATION", True)
+        @patch("pcapi.settings.IS_INTEGRATION", True)
         @patch("pcapi.routes.pro.validate.maybe_send_offerer_validation_email", return_value=True)
         def test_validate_offerer_and_user_offerer_when_in_integration_env(
             self, mock_maybe_send_offerer_validation_email, app

--- a/tests/utils/mailing_test.py
+++ b/tests/utils/mailing_test.py
@@ -211,7 +211,7 @@ class GetUsersInformationFromStockBookingsTest:
 
 
 class BuildPcProOfferLinkTest:
-    @patch("pcapi.utils.mailing.PRO_URL", "http://pcpro.com")
+    @patch("pcapi.settings.PRO_URL", "http://pcpro.com")
     @pytest.mark.usefixtures("db_session")
     def test_should_return_pc_pro_offer_link(self, app):
         # Given


### PR DESCRIPTION
All variables comingg from the environment should be ventralized
here because `pcapi.settings` will garantee the various environment
files are loaded before.
Also will clean the fragile import and call to load_environment_variables()