### PR TITLE
(PC-5243) Track routes to be migrated with Tyrion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ dev_env_file
 
 # licenses
 licenses.html
+
+# Reports from Tyrion (https://github.com/theodo/tyrion)
+tyrion_report.html

--- a/.tyrion-config.json
+++ b/.tyrion-config.json
@@ -1,0 +1,10 @@
+{
+  "standard": 0,
+  "ignorePath": [
+    "node_modules",
+    "README.md"
+  ],
+  "debtTags": [
+    "@debt"
+  ]
+}

--- a/src/pcapi/routes/external/bank_informations.py
+++ b/src/pcapi/routes/external/bank_informations.py
@@ -6,6 +6,7 @@ from pcapi.validation.routes.bank_informations import check_demarches_simplifiee
 from pcapi.workers.bank_information_job import bank_information_job
 
 
+# @debt api-migration
 @public_api.route("/bank_informations/venue/application_update", methods=["POST"])
 def update_venue_demarches_simplifiees_application():
     check_demarches_simplifiees_webhook_token(request.args.get("token"))
@@ -15,6 +16,7 @@ def update_venue_demarches_simplifiees_application():
     return "", 202
 
 
+# @debt api-migration
 @public_api.route("/bank_informations/offerer/application_update", methods=["POST"])
 def update_offerer_demarches_simplifiees_application():
     check_demarches_simplifiees_webhook_token(request.args.get("token"))

--- a/src/pcapi/routes/pro/bookings.py
+++ b/src/pcapi/routes/pro/bookings.py
@@ -40,6 +40,7 @@ from pcapi.validation.routes.users_authorizations import check_user_can_validate
 from pcapi.validation.routes.users_authorizations import check_user_can_validate_bookings_v2
 
 
+# @debt api-migration
 @public_api.route("/bookings/token/<token>", methods=["GET"])
 def get_booking_by_token(token: str):
     email = request.args.get("email", None)
@@ -58,6 +59,7 @@ def get_booking_by_token(token: str):
     return "", 204
 
 
+# @debt api-migration
 @public_api.route("/bookings/token/<token>", methods=["PATCH"])
 def patch_booking_by_token(token: str):
     email = request.args.get("email", None)
@@ -79,6 +81,7 @@ def patch_booking_by_token(token: str):
     return "", 204
 
 
+# @debt api-migration
 @private_api.route("/bookings/pro", methods=["GET"])
 @login_required
 def get_all_bookings():
@@ -96,6 +99,7 @@ def get_all_bookings():
     return serialize_bookings_recap_paginated(bookings_recap_paginated), 200
 
 
+# @debt api-migration
 @public_api.route("/v2/bookings/token/<token>", methods=["GET"])
 @login_or_api_key_required_v2
 def get_booking_by_token_v2(token: str):
@@ -118,6 +122,7 @@ def get_booking_by_token_v2(token: str):
     return jsonify(response), 200
 
 
+# @debt api-migration
 @public_api.route("/v2/bookings/use/token/<token>", methods=["PATCH"])
 @login_or_api_key_required_v2
 def patch_booking_use_by_token(token: str):
@@ -142,6 +147,7 @@ def patch_booking_use_by_token(token: str):
     return "", 204
 
 
+# @debt api-migration
 @private_api.route("/v2/bookings/cancel/token/<token>", methods=["PATCH"])
 @login_or_api_key_required_v2
 def patch_cancel_booking_by_token(token: str):
@@ -162,6 +168,7 @@ def patch_cancel_booking_by_token(token: str):
     return "", 204
 
 
+# @debt api-migration
 @public_api.route("/v2/bookings/keep/token/<token>", methods=["PATCH"])
 @login_or_api_key_required_v2
 def patch_booking_keep_by_token(token: str):

--- a/src/pcapi/routes/pro/offerers.py
+++ b/src/pcapi/routes/pro/offerers.py
@@ -41,6 +41,7 @@ def get_dict_offerers(offerers: List[Offerer]) -> list:
     return [as_dict(offerer, includes=OFFERER_INCLUDES) for offerer in offerers]
 
 
+# @debt api-migration
 @private_api.route("/offerers", methods=["GET"])
 @login_required
 def list_offerers():
@@ -76,6 +77,7 @@ def list_offerers():
     return response, 200
 
 
+# @debt api-migration
 @private_api.route("/offerers/<id>", methods=["GET"])
 @login_required
 def get_offerer(id):
@@ -85,6 +87,7 @@ def get_offerer(id):
     return jsonify(get_dict_offerer(offerer)), 200
 
 
+# @debt api-migration
 @private_api.route("/offerers", methods=["POST"])
 @login_or_api_key_required
 @expect_json_data

--- a/src/pcapi/routes/pro/providers.py
+++ b/src/pcapi/routes/pro/providers.py
@@ -11,6 +11,7 @@ from pcapi.routes.serialization import as_dict
 from pcapi.utils.rest import load_or_404
 
 
+# @debt api-migration
 @private_api.route("/providers", methods=["GET"])
 @login_required
 def list_providers():
@@ -24,6 +25,7 @@ def list_providers():
     return jsonify(result)
 
 
+# @debt api-migration
 @private_api.route("/providers/<venue_id>", methods=["GET"])
 @login_required
 def get_providers_by_venue(venue_id: str):

--- a/src/pcapi/routes/pro/reimbursements.py
+++ b/src/pcapi/routes/pro/reimbursements.py
@@ -10,6 +10,7 @@ from pcapi.routes.serialization.reimbursement_csv_serialize import find_all_offe
 from pcapi.routes.serialization.reimbursement_csv_serialize import generate_reimbursement_details_csv
 
 
+# @debt api-migration
 @private_api.route("/reimbursements/csv", methods=["GET"])
 @login_required
 def get_reimbursements_csv():

--- a/src/pcapi/routes/pro/signup.py
+++ b/src/pcapi/routes/pro/signup.py
@@ -19,6 +19,7 @@ from pcapi.utils.mailing import subscribe_newsletter
 from pcapi.validation.routes.users import check_valid_signup_pro
 
 
+# @debt api-migration
 @private_api.route("/users/signup/pro", methods=["POST"])
 def signup_pro():
     objects_to_save = []

--- a/src/pcapi/routes/pro/types.py
+++ b/src/pcapi/routes/pro/types.py
@@ -5,6 +5,7 @@ from pcapi.domain.types import get_formatted_active_product_types
 from pcapi.flask_app import private_api
 
 
+# @debt api-migration
 @private_api.route("/types", methods=["GET"])
 @login_required
 def list_types():

--- a/src/pcapi/routes/pro/user_offerers.py
+++ b/src/pcapi/routes/pro/user_offerers.py
@@ -9,6 +9,7 @@ from pcapi.utils.human_ids import dehumanize
 from pcapi.utils.includes import USER_OFFERER_INCLUDES
 
 
+# @debt api-migration
 @private_api.route("/userOfferers/<offerer_id>", methods=["GET"])
 @login_required
 def get_user_offerer(offerer_id):

--- a/src/pcapi/routes/pro/validate.py
+++ b/src/pcapi/routes/pro/validate.py
@@ -25,6 +25,7 @@ from pcapi.validation.routes.validate import check_valid_token_for_user_validati
 from pcapi.validation.routes.validate import check_validation_request
 
 
+# @debt api-migration
 @public_api.route("/validate/user-offerer/<token>", methods=["GET"])
 def validate_offerer_attachment(token):
     check_validation_request(token)
@@ -42,6 +43,7 @@ def validate_offerer_attachment(token):
     return "Validation du rattachement de la structure effectuée", 202
 
 
+# @debt api-migration
 @public_api.route("/validate/offerer/<token>", methods=["GET"])
 def validate_new_offerer(token):
     check_validation_request(token)
@@ -67,6 +69,7 @@ def validate_new_offerer(token):
     return "Validation effectuée", 202
 
 
+# @debt api-migration
 @private_api.route("/validate/user/<token>", methods=["PATCH"])
 def validate_user(token):
     user_to_validate = user_queries.find_by_validation_token(token)

--- a/src/pcapi/routes/pro/venue_labels.py
+++ b/src/pcapi/routes/pro/venue_labels.py
@@ -6,6 +6,7 @@ from pcapi.infrastructure.container import get_venue_labels
 from pcapi.routes.serialization.venue_labels_serialize import serialize_venue_label
 
 
+# @debt api-migration
 @private_api.route("/venue-labels", methods=["GET"])
 @login_required
 def fetch_venue_labels():

--- a/src/pcapi/routes/pro/venue_providers.py
+++ b/src/pcapi/routes/pro/venue_providers.py
@@ -31,6 +31,7 @@ from pcapi.validation.routes.venue_providers import check_existing_provider
 from pcapi.validation.routes.venue_providers import check_new_venue_provider_information
 
 
+# @debt api-migration
 @private_api.route("/venueProviders", methods=["GET"])
 @login_required
 def list_venue_providers():
@@ -44,6 +45,7 @@ def list_venue_providers():
     return jsonify([as_dict(venue_provider, includes=VENUE_PROVIDER_INCLUDES) for venue_provider in vp_query.all()])
 
 
+# @debt api-migration
 @private_api.route("/venueProviders", methods=["POST"])
 @login_required
 @expect_json_data

--- a/src/pcapi/routes/pro/venue_types.py
+++ b/src/pcapi/routes/pro/venue_types.py
@@ -7,6 +7,7 @@ from pcapi.routes.serialization import as_dict
 from pcapi.use_cases.get_types_of_venues import get_types_of_venues
 
 
+# @debt api-migration
 @private_api.route("/venue-types", methods=["GET"])
 @login_required
 def get_venue_types():

--- a/src/pcapi/routes/pro/venues.py
+++ b/src/pcapi/routes/pro/venues.py
@@ -32,6 +32,7 @@ from pcapi.validation.routes.venues import check_valid_edition
 from pcapi.validation.routes.venues import validate_coordinates
 
 
+# @debt api-migration
 @private_api.route("/venues/<venue_id>", methods=["GET"])
 @login_required
 def get_venue(venue_id):
@@ -40,6 +41,7 @@ def get_venue(venue_id):
     return jsonify(as_dict(venue, includes=VENUE_INCLUDES)), 200
 
 
+# @debt api-migration
 @private_api.route("/venues", methods=["GET"])
 @login_required
 def get_venues():
@@ -51,6 +53,7 @@ def get_venues():
     return jsonify(serialize_venues_with_offerer_name(venues)), 200
 
 
+# @debt api-migration
 @private_api.route("/venues", methods=["POST"])
 @login_required
 @expect_json_data
@@ -62,6 +65,7 @@ def post_create_venue():
     return jsonify(as_dict(venue, includes=VENUE_INCLUDES)), 201
 
 
+# @debt api-migration
 @private_api.route("/venues/<venue_id>", methods=["PATCH"])
 @login_required
 @expect_json_data
@@ -86,6 +90,7 @@ def edit_venue(venue_id):
     return jsonify(as_dict(venue, includes=VENUE_INCLUDES)), 200
 
 
+# @debt api-migration
 @private_api.route("/venues/<venue_id>/offers/activate", methods=["PUT"])
 @login_required
 def activate_venue_offers(venue_id):
@@ -99,6 +104,7 @@ def activate_venue_offers(venue_id):
     return jsonify([as_dict(offer, includes=OFFER_INCLUDES) for offer in activated_offers]), 200
 
 
+# @debt api-migration
 @private_api.route("/venues/<venue_id>/offers/deactivate", methods=["PUT"])
 @login_required
 def deactivate_venue_offers(venue_id):

--- a/src/pcapi/routes/shared/passwords.py
+++ b/src/pcapi/routes/shared/passwords.py
@@ -24,6 +24,7 @@ from pcapi.utils.rest import expect_json_data
 from pcapi.validation.routes.passwords import validate_reset_password_token
 
 
+# @debt api-migration
 @private_api.route("/users/current/change-password", methods=["POST"])
 @login_required
 @expect_json_data
@@ -40,6 +41,7 @@ def post_change_password():
     return "", 204
 
 
+# @debt api-migration
 @private_api.route("/users/reset-password", methods=["POST"])
 @spectree_serialize(on_success_status=204)
 def post_for_password_token(body: ResetPasswordBodyModel) -> None:
@@ -67,6 +69,7 @@ def post_for_password_token(body: ResetPasswordBodyModel) -> None:
             app.logger.exception("[send_reset_password_email_to_pro] " "Mail service failure", mail_service_exception)
 
 
+# @debt api-migration
 @private_api.route("/users/new-password", methods=["POST"])
 @expect_json_data
 def post_new_password():

--- a/src/pcapi/routes/shared/users.py
+++ b/src/pcapi/routes/shared/users.py
@@ -25,6 +25,7 @@ from pcapi.utils.rest import login_or_api_key_required
 from pcapi.validation.routes.users import check_valid_signin
 
 
+# @debt api-migration
 @private_api.route("/users/current", methods=["GET"])
 @login_required
 def get_profile():
@@ -32,6 +33,7 @@ def get_profile():
     return jsonify(as_dict(user, includes=USER_INCLUDES)), 200
 
 
+# @debt api-migration
 @private_api.route("/users/token/<token>", methods=["GET"])
 def check_activation_token_exists(token):
     user = find_user_by_reset_password_token(token)
@@ -54,6 +56,7 @@ def patch_profile(body: PatchUserBodyModel) -> PatchUserResponseModel:
     return response_user_model
 
 
+# @debt api-migration
 @private_api.route("/users/signin", methods=["POST"])
 def signin():
     json = request.get_json()

--- a/src/pcapi/routes/webapp/beneficiaries.py
+++ b/src/pcapi/routes/webapp/beneficiaries.py
@@ -25,6 +25,7 @@ from pcapi.validation.routes.users import check_valid_signin
 from pcapi.workers.beneficiary_job import beneficiary_job
 
 
+# @debt api-migration
 @private_api.route("/beneficiaries/current", methods=["GET"])
 @login_required
 def get_beneficiary_profile():
@@ -32,6 +33,7 @@ def get_beneficiary_profile():
     return jsonify(as_dict(user, includes=BENEFICIARY_INCLUDES)), 200
 
 
+# @debt api-migration
 @private_api.route("/beneficiaries/current", methods=["PATCH"])
 @login_or_api_key_required
 @expect_json_data
@@ -58,6 +60,7 @@ def patch_beneficiary():
     return jsonify(formattedUser), 200
 
 
+# @debt api-migration
 @private_api.route("/beneficiaries/signin", methods=["POST"])
 def signin_beneficiary():
     json = request.get_json()
@@ -82,6 +85,7 @@ def signin_beneficiary():
     return jsonify(), 200
 
 
+# @debt api-migration
 @public_api.route("/beneficiaries/licence_verify", methods=["POST"])
 def verify_id_check_licence_token():
     check_verify_licence_token_payload(request)
@@ -95,6 +99,7 @@ def verify_id_check_licence_token():
     return "", 200
 
 
+# @debt api-migration
 @public_api.route("/beneficiaries/application_update", methods=["POST"])
 def id_check_application_update():
     check_application_update_payload(request)

--- a/src/pcapi/routes/webapp/favorites.py
+++ b/src/pcapi/routes/webapp/favorites.py
@@ -19,6 +19,7 @@ from pcapi.utils.rest import load_or_404
 from pcapi.validation.routes.offers import check_offer_id_is_present_in_request
 
 
+# @debt api-migration
 @private_api.route("/favorites", methods=["POST"])
 @login_required
 def add_to_favorite():
@@ -42,6 +43,7 @@ def add_to_favorite():
     return jsonify(serialize_favorite(favorite)), 201
 
 
+# @debt api-migration
 @private_api.route("/favorites/<offer_id>", methods=["DELETE"])
 @login_required
 def delete_favorite(offer_id):

--- a/src/pcapi/routes/webapp/mailing_contacts.py
+++ b/src/pcapi/routes/webapp/mailing_contacts.py
@@ -6,6 +6,7 @@ from pcapi.validation.routes.mailing_contacts import validate_save_mailing_conta
 from pcapi.workers.mailing_contacts_job import mailing_contacts_job
 
 
+# @debt api-migration
 @public_api.route("/mailing-contacts", methods=["POST"])
 @expect_json_data
 def save_mailing_contact():

--- a/src/pcapi/routes/webapp/recommendations.py
+++ b/src/pcapi/routes/webapp/recommendations.py
@@ -27,7 +27,7 @@ from pcapi.utils.rest import expect_json_data
 
 DEFAULT_PAGE = 1
 
-
+# @debt api-migration
 @private_api.route("/recommendations/offers/<offer_id>", methods=["GET"])
 @login_required
 def get_recommendation(offer_id):
@@ -38,6 +38,7 @@ def get_recommendation(offer_id):
     return jsonify(serialize_recommendation(recommendation, user_id=current_user.id)), 200
 
 
+# @debt api-migration
 @private_api.route("/recommendations/<recommendation_id>", methods=["PATCH"])
 @login_required
 @expect_json_data
@@ -49,6 +50,7 @@ def patch_recommendation(recommendation_id):
     return jsonify(serialize_recommendation(recommendation, user_id=current_user.id)), 200
 
 
+# @debt api-migration
 @private_api.route("/recommendations/read", methods=["PUT"])
 @login_required
 @expect_json_data
@@ -61,6 +63,7 @@ def put_read_recommendations():
     return jsonify(serialize_recommendations(read_recommendations, user_id=current_user.id)), 200
 
 
+# @debt api-migration
 @private_api.route("/recommendations", methods=["PUT"])
 @login_required
 @expect_json_data

--- a/src/pcapi/routes/webapp/seen_offers.py
+++ b/src/pcapi/routes/webapp/seen_offers.py
@@ -11,6 +11,7 @@ from pcapi.utils.rest import expect_json_data
 from pcapi.validation.routes.seen_offers import check_payload_is_valid
 
 
+# @debt api-migration
 @private_api.route("/seen_offers", methods=["PUT"])
 @feature_required(FeatureToggle.SAVE_SEEN_OFFERS)
 @login_required

--- a/src/pcapi/routes/webapp/signup.py
+++ b/src/pcapi/routes/webapp/signup.py
@@ -19,6 +19,7 @@ from pcapi.utils.mailing import subscribe_newsletter
 from pcapi.validation.routes.users import check_valid_signup_webapp
 
 
+# @debt api-migration
 @private_api.route("/users/signup/webapp", methods=["POST"])
 @feature_required(FeatureToggle.WEBAPP_SIGNUP)
 def signup_webapp():


### PR DESCRIPTION
Lien du répo Tyrion avec la doc associée:
https://github.com/theodo/tyrion

Sur le projet j'utilise le mot clé `@debt` pour éviter de "polluer" le nombre de routes restantes à migrer sur le graphe d'évolution avec tous les autres `FIXME` présents pour d'autres raisons.
C'est challengeable et à terme j'aimerais qu'on track tous les commentaires de dettes pour les traiter et ne pas les laisser pourrir. 

Les commandes utilisées pour générer très rapidement les graphes:
`tyrion -p ./src`:
![Screenshot from 2020-11-26 16-57-05](https://user-images.githubusercontent.com/19763200/100371753-8e49b980-3008-11eb-885b-812a8a0b7d42.png)

`tyrion -p ./src -b -e 2`:
![tyrionevolution](https://user-images.githubusercontent.com/19763200/100371821-a4577a00-3008-11eb-8c22-45222109d735.png)
 