### PR TITLE
[pc xxx] secure migrations

### DIFF
--- a/src/pcapi/alembic/env.py
+++ b/src/pcapi/alembic/env.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 from logging.config import fileConfig
 import os
 
@@ -43,7 +41,10 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
     """
     database_url = os.environ.get("DATABASE_URL")
-    connectable = create_engine(database_url)
+    db_options = []
+    if settings.DB_MIGRATION_STATEMENT_TIMEOUT:
+        db_options.append("-c statement_timeout=%i" % settings.DB_MIGRATION_STATEMENT_TIMEOUT)
+    connectable = create_engine(database_url, connect_args={"options": " ".join(db_options)})
     with connectable.connect() as connection:
         context.configure(
             connection=connection,

--- a/src/pcapi/alembic/env.py
+++ b/src/pcapi/alembic/env.py
@@ -51,7 +51,7 @@ def run_migrations_online() -> None:
             target_metadata=target_metadata,
             include_object=include_object,
             include_schemas=True,
-            transaction_per_migration=False,
+            transaction_per_migration=True,
         )
         if not settings.IS_DEV:
             connection.execute("UPDATE feature SET \"isActive\" = FALSE WHERE name = 'UPDATE_DISCOVERY_VIEW'")

--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -55,6 +55,10 @@ else:
 BLOB_SIZE = 30
 
 
+# DATABASE
+DB_MIGRATION_STATEMENT_TIMEOUT = int(os.environ.get("DB_MIGRATION_STATEMENT_TIMEOUT", 60000))
+
+
 # REDIS
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379")
 REDIS_OFFER_IDS_CHUNK_SIZE = int(os.environ.get("REDIS_OFFER_IDS_CHUNK_SIZE", 1000))


### PR DESCRIPTION
- Limit the lock on the database during the migration
- isolate each migration into a single transaction to limit the lock duration