### PR TITLE
(PC-5372): Better FNAC CRON synchronization performance

### DIFF
--- a/src/pcapi/infrastructure/repository/stock_provider/stock_provider_fnac.py
+++ b/src/pcapi/infrastructure/repository/stock_provider/stock_provider_fnac.py
@@ -10,7 +10,7 @@ from pcapi.infrastructure.repository.stock_provider.provider_api import Provider
 class StockProviderFnacRepository(StockProviderRepository):
     def __init__(self) -> None:
         self.fnac_api = ProviderAPI(
-            api_url="https://passculture-fr.ws.fnac.com/api/v1/pass-culture/stocks",
+            api_url=settings.FNAC_API_URL,
             name="Fnac",
             authentication_token=settings.FNAC_API_TOKEN,
         )

--- a/src/pcapi/local_providers/fnac/fnac_stocks_provider.py
+++ b/src/pcapi/local_providers/fnac/fnac_stocks_provider.py
@@ -1,0 +1,18 @@
+from pcapi.models import VenueProvider
+from pcapi.models import VenueSQLEntity
+from pcapi.repository.provider_queries import get_provider_by_local_class
+
+from . import synchronize_fnac_stocks
+
+
+def synchronize_fnac_venues_stocks() -> None:
+    fnac_provider_id = get_provider_by_local_class("FnacStocks").id
+    venues = (
+        VenueSQLEntity.query.join(VenueProvider)
+        .filter(VenueProvider.providerId == fnac_provider_id)
+        .filter(VenueProvider.isActive == True)
+        .all()
+    )
+
+    for venue in venues:
+        synchronize_fnac_stocks.synchronize_venue_stocks_from_fnac(venue)

--- a/src/pcapi/local_providers/fnac/synchronize_fnac_stocks.py
+++ b/src/pcapi/local_providers/fnac/synchronize_fnac_stocks.py
@@ -1,0 +1,188 @@
+from datetime import datetime
+from typing import Dict
+from typing import Generator
+from typing import List
+from typing import Tuple
+from typing import Union
+
+from pcapi import settings
+from pcapi.core.offers.models import Offer
+from pcapi.core.offers.models import Stock
+from pcapi.core.offers.repository import get_offers_map_by_id_at_providers
+from pcapi.core.offers.repository import get_products_map_by_id_at_providers
+from pcapi.core.offers.repository import get_stocks_by_id_at_providers
+from pcapi.infrastructure.repository.stock_provider.provider_api import ProviderAPI
+from pcapi.models import Product
+from pcapi.models import VenueSQLEntity
+from pcapi.models.db import db
+from pcapi.utils.logger import logger
+from pcapi.validation.models.entity_validator import validate
+
+
+def synchronize_venue_stocks_from_fnac(venue: VenueSQLEntity) -> None:
+    logger.info("Starting synchronization of venue=%s provider=fnac", venue.id)
+    fnac_api = ProviderAPI(
+        api_url=settings.FNAC_API_URL,
+        name="Fnac",
+        authentication_token=settings.FNAC_API_TOKEN,
+    )
+
+    for raw_stocks in _get_stocks_by_batch(venue.siret, fnac_api):
+        stock_details = _build_stock_details_from_raw_stocks(raw_stocks, venue.siret)
+
+        products_fnac_references = [stock_detail["products_fnac_reference"] for stock_detail in stock_details]
+        products_by_fnac_reference = get_products_map_by_id_at_providers(products_fnac_references)
+
+        stock_details = [
+            stock for stock in stock_details if stock["products_fnac_reference"] in products_by_fnac_reference
+        ]
+
+        offers_fnac_references = [stock_detail["offers_fnac_reference"] for stock_detail in stock_details]
+        offers_by_fnac_reference = get_offers_map_by_id_at_providers(offers_fnac_references)
+
+        new_offers = _build_new_offers_from_stock_details(
+            stock_details, offers_by_fnac_reference, products_by_fnac_reference, venue
+        )
+        new_offers_references = [new_offer.idAtProviders for new_offer in new_offers]
+
+        db.session.bulk_save_objects(new_offers)
+
+        new_offers_by_fnac_reference = get_offers_map_by_id_at_providers(new_offers_references)
+        offers_by_fnac_reference = {**offers_by_fnac_reference, **new_offers_by_fnac_reference}
+
+        stocks_fnac_references = [stock["stocks_fnac_reference"] for stock in stock_details]
+        stocks_by_fnac_reference = get_stocks_by_id_at_providers(stocks_fnac_references)
+
+        update_stock_mapping, new_stocks = _get_stocks_to_upsert(
+            stock_details, stocks_by_fnac_reference, offers_by_fnac_reference
+        )
+
+        db.session.bulk_save_objects(new_stocks)
+        db.session.bulk_update_mappings(Stock, update_stock_mapping)
+
+        db.session.commit()
+
+    logger.info("Ending synchronization of venue=%s provider=fnac", venue.id)
+
+
+def _get_stocks_by_batch(siret: str, fnac_api: ProviderAPI) -> Generator:
+    last_processed_fnac_reference = ""
+
+    while True:
+        fnac_responses = fnac_api.validated_stocks(
+            siret=siret,
+            last_processed_reference=last_processed_fnac_reference,
+            modified_since="",  # Fnac API does not handle this parameter
+        )
+        raw_stocks = fnac_responses.get("stocks", [])
+
+        if not raw_stocks:
+            break
+
+        yield raw_stocks
+
+        last_processed_fnac_reference = raw_stocks[-1]["ref"]
+
+
+def _build_stock_details_from_raw_stocks(raw_stocks: List[Dict], venue_siret: str) -> List[Dict]:
+    stock_details = []
+    for stock in raw_stocks:
+        stock_details.append(
+            {
+                "products_fnac_reference": stock["ref"],
+                "offers_fnac_reference": stock["ref"] + "@" + venue_siret,
+                "stocks_fnac_reference": stock["ref"] + "@" + venue_siret,
+                "available_quantity": stock["available"],
+                "price": stock["price"],
+            }
+        )
+
+    return stock_details
+
+
+def _build_new_offers_from_stock_details(
+    stock_details: List,
+    existing_offers_by_fnac_reference: Dict[str, int],
+    products_by_fnac_reference: Dict[str, Product],
+    venue: VenueSQLEntity,
+) -> List[Offer]:
+    new_offers = []
+    for stock_detail in stock_details:
+        if stock_detail["offers_fnac_reference"] in existing_offers_by_fnac_reference:
+            continue
+
+        product = products_by_fnac_reference[stock_detail["products_fnac_reference"]]
+        offer = _build_new_offer(venue, product, id_at_providers=stock_detail["offers_fnac_reference"])
+
+        if not _validate_stock_or_offer(offer):
+            continue
+
+        new_offers.append(offer)
+
+    return new_offers
+
+
+def _get_stocks_to_upsert(
+    stock_details: List[Dict], stocks_by_fnac_reference: Dict[str, Dict], offers_by_fnac_reference: Dict[str, int]
+) -> Tuple[List, List[Stock]]:
+    update_stock_mapping = []
+    new_stocks = []
+
+    for stock_detail in stock_details:
+        if stock_detail["stocks_fnac_reference"] in stocks_by_fnac_reference:
+            stock = stocks_by_fnac_reference[stock_detail["stocks_fnac_reference"]]
+            update_stock_mapping.append(
+                {
+                    "id": stock["id"],
+                    "quantity": stock_detail["available_quantity"] + stock["booking_quantity"],
+                    "price": stock_detail["price"],
+                }
+            )
+
+        else:
+            stock = _build_stock_from_stock_detail(
+                stock_detail, offers_by_fnac_reference[stock_detail["offers_fnac_reference"]]
+            )
+            if not _validate_stock_or_offer(stock):
+                continue
+
+            new_stocks.append(stock)
+
+    return update_stock_mapping, new_stocks
+
+
+def _build_stock_from_stock_detail(stock_detail: Dict, offers_id: int) -> Stock:
+    return Stock(
+        quantity=stock_detail["available_quantity"],
+        bookingLimitDatetime=None,
+        offerId=offers_id,
+        price=stock_detail["price"],
+        dateModified=datetime.now(),
+        idAtProviders=stock_detail["stocks_fnac_reference"],
+    )
+
+
+def _validate_stock_or_offer(model: Union[Offer, Stock]) -> bool:
+    model_api_errors = validate(model)
+    if model_api_errors.errors.keys():
+        logger.exception(
+            "[FNAC SYNC] errors while trying to add stock or offer with ref %s: %s",
+            model.idAtProviders,
+            model_api_errors.errors,
+        )
+        return False
+
+    return True
+
+
+def _build_new_offer(venue: VenueSQLEntity, product: Product, id_at_providers: str) -> Offer:
+    return Offer(
+        bookingEmail=venue.bookingEmail,
+        description=product.description,
+        extraData=product.extraData,
+        idAtProviders=id_at_providers,
+        name=product.name,
+        productId=product.id,
+        venueId=venue.id,
+        type=product.type,
+    )

--- a/src/pcapi/scheduled_tasks/clock.py
+++ b/src/pcapi/scheduled_tasks/clock.py
@@ -1,6 +1,7 @@
 from apscheduler.schedulers.blocking import BlockingScheduler
 
 from pcapi import settings
+from pcapi.local_providers.fnac.fnac_stocks_provider import synchronize_fnac_venues_stocks
 from pcapi.local_providers.provider_manager import synchronize_venue_providers_for_provider
 from pcapi.models.beneficiary_import import BeneficiaryImportSources
 from pcapi.models.feature import FeatureToggle
@@ -42,8 +43,7 @@ def synchronize_libraires_stocks(app) -> None:
 @log_cron
 @cron_context
 def synchronize_fnac_stocks(app) -> None:
-    fnac_stocks_provider_id = get_provider_by_local_class("FnacStocks").id
-    synchronize_venue_providers_for_provider(fnac_stocks_provider_id)
+    synchronize_fnac_venues_stocks()
 
 
 @log_cron

--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -164,6 +164,7 @@ STAGING_TEST_USER_PASSWORD = os.environ.get("STAGING_TEST_USER_PASSWORD", "")
 # PROVIDERS
 ALLOCINE_API_KEY = os.environ.get("ALLOCINE_API_KEY")
 FNAC_API_TOKEN = os.environ.get("PROVIDER_FNAC_BASIC_AUTHENTICATION_TOKEN")
+FNAC_API_URL = "https://passculture-fr.ws.fnac.com/api/v1/pass-culture/stocks"
 PROVIDERS_SYNC_WORKERS_POOL_SIZE = int(os.environ.get("SYNC_WORKERS_POOL_SIZE", 5))
 
 

--- a/tests/local_providers/synchronize_fnac_stocks_test.py
+++ b/tests/local_providers/synchronize_fnac_stocks_test.py
@@ -1,0 +1,200 @@
+import pytest
+import requests_mock
+
+from pcapi.core.bookings.factories import BookingFactory
+import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.offers import factories
+from pcapi.core.offers.factories import VenueFactory
+from pcapi.core.offers.models import Offer
+from pcapi.core.testing import override_settings
+from pcapi.local_providers.fnac import synchronize_fnac_stocks
+from pcapi.models import ThingType
+from pcapi.models.product import Product
+
+
+ISBNs = [
+    "3010000101789",
+    "3010000101797",
+    "3010000103769",
+    "3010000107163",
+    "3010000108123",
+    "3010000108124",
+    "3010000108125",
+    "3010000108126",
+]
+fnac_responses = [
+    {
+        "total": len(ISBNs),
+        "limit": 4,
+        "offset": 0,
+        "stocks": [
+            {"ref": ISBNs[0], "available": 6, "price": 35.000},
+            {"ref": ISBNs[1], "available": 4, "price": 30.000},
+            {"ref": ISBNs[2], "available": 18, "price": 17.905},
+            {"ref": ISBNs[3], "available": 12, "price": 26.989},
+        ],
+    },
+    {
+        "total": len(ISBNs),
+        "limit": 4,
+        "offset": 4,
+        "stocks": [
+            {"ref": ISBNs[4], "available": 17, "price": 23.989},
+            {"ref": ISBNs[5], "available": 17, "price": 28.989},
+            {"ref": ISBNs[6], "available": 17, "price": 28.989},
+            {"ref": ISBNs[7], "price": 28.989},
+        ],
+    },
+    {"total": 3, "limit": 3, "offset": 4, "stocks": []},
+]
+
+
+def create_product(isbn, **kwargs):
+    return factories.ProductFactory(idAtProviders=isbn, type=str(ThingType.LIVRE_EDITION), **kwargs)
+
+
+def create_offer(isbn, siret):
+    return factories.OfferFactory(product=create_product(isbn), idAtProviders=f"{isbn}@{siret}")
+
+
+def create_stock(isbn, siret, **kwargs):
+    return factories.StockFactory(offer=create_offer(isbn, siret), idAtProviders=f"{isbn}@{siret}", **kwargs)
+
+
+class FnacCronTest:
+    @pytest.mark.usefixtures("db_session")
+    @override_settings(FNAC_API_URL="https://fnac_url", FNAC_API_TOKEN="fake_token")
+    def test_execution(self):
+        # Given
+        venue_provider = offerers_factories.VenueProviderFactory(isActive=True)
+        siret = venue_provider.venue.siret
+
+        stock = create_stock(ISBNs[0], siret, quantity=20)
+        offer = create_offer(ISBNs[1], siret)
+        product = create_product(ISBNs[2])
+        create_product(ISBNs[4])
+        create_product(ISBNs[6], isGcuCompatible=False)
+
+        stock_with_booking = create_stock(ISBNs[5], siret, quantity=20)
+        BookingFactory(stock=stock_with_booking)
+        BookingFactory(stock=stock_with_booking, quantity=2)
+
+        # When
+        with requests_mock.Mocker() as request_mock:
+            request_mock.get(
+                f"https://fnac_url/{siret}?limit=1000",
+                [{"json": r, "headers": {"content-type": "application/json"}} for r in fnac_responses],
+                request_headers={
+                    "Authorization": "Basic fake_token",
+                },
+            )
+            synchronize_fnac_stocks.synchronize_venue_stocks_from_fnac(venue_provider.venue)
+
+        # Then
+        # Test updates stock if already exists
+        assert stock.quantity == 6
+
+        # Test creates stock if does not exist
+        assert len(offer.stocks) == 1
+        created_stock = offer.stocks[0]
+        assert created_stock.quantity == 4
+
+        # Test creates offer if does not exist
+        created_offer = Offer.query.filter_by(idAtProviders=f"{ISBNs[2]}@{siret}").one()
+        assert created_offer.stocks[0].quantity == 18
+
+        # Test doesn't create offer if product does not exist or not gcu compatible
+        assert Offer.query.filter_by(idAtProviders=f"{ISBNs[3]}@{siret}").count() == 0
+        assert Offer.query.filter_by(idAtProviders=f"{ISBNs[6]}@{siret}").count() == 0
+
+        # Test second page is actually processed
+        assert Offer.query.filter_by(idAtProviders=f"{ISBNs[4]}@{siret}").count() == 1
+
+        # Test existing bookings are added to quantity
+        assert stock_with_booking.quantity == 17 + 1 + 2
+
+        # Test fill stock attributes
+        assert created_stock.price == 30
+        assert created_stock.idAtProviders == f"{ISBNs[1]}@{siret}"
+
+        # Test override stock price attribute
+        assert stock.price == 35
+
+        # Test fill offers attributes
+        assert created_offer.bookingEmail == venue_provider.venue.bookingEmail
+        assert created_offer.description == product.description
+        assert created_offer.extraData == product.extraData
+        assert created_offer.name == product.name
+        assert created_offer.productId == product.id
+        assert created_offer.venueId == venue_provider.venue.id
+        assert created_offer.type == product.type
+        assert created_offer.idAtProviders == f"{ISBNs[2]}@{siret}"
+
+    def test_build_stock_details_from_raw_stocks(self):
+        # Given
+        raw_stocks = [
+            {"ref": ISBNs[4], "available": 17, "price": 23.989},
+            {"ref": ISBNs[5], "available": 17, "price": 28.989},
+        ]
+
+        # When
+        result = synchronize_fnac_stocks._build_stock_details_from_raw_stocks(raw_stocks, "siret")
+
+        # Then
+        assert result == [
+            {
+                "available_quantity": 17,
+                "offers_fnac_reference": "3010000108123@siret",
+                "price": 23.989,
+                "products_fnac_reference": "3010000108123",
+                "stocks_fnac_reference": "3010000108123@siret",
+            },
+            {
+                "available_quantity": 17,
+                "offers_fnac_reference": "3010000108124@siret",
+                "price": 28.989,
+                "products_fnac_reference": "3010000108124",
+                "stocks_fnac_reference": "3010000108124@siret",
+            },
+        ]
+
+    def test_build_new_offers_from_stock_details(self, db_session):
+        # Given
+        stock_details = [
+            {
+                "offers_fnac_reference": "offer_ref1",
+            },
+            {
+                "available_quantity": 17,
+                "offers_fnac_reference": "offer_ref_2",
+                "price": 28.989,
+                "products_fnac_reference": "product_ref",
+                "stocks_fnac_reference": "stock_ref",
+            },
+        ]
+
+        existing_offers_by_fnac_reference = {"offer_ref1"}
+        venue = VenueFactory(bookingEmail="booking_email")
+        product = Product(
+            id=456, name="product_name", description="product_desc", extraData="extra", type="product_type"
+        )
+        products_by_fnac_reference = {"product_ref": product}
+
+        # When
+        new_offers = synchronize_fnac_stocks._build_new_offers_from_stock_details(
+            stock_details, existing_offers_by_fnac_reference, products_by_fnac_reference, venue
+        )
+
+        # Then
+        assert new_offers == [
+            Offer(
+                bookingEmail="booking_email",
+                description="product_desc",
+                extraData="extra",
+                idAtProviders="offer_ref_2",
+                name="product_name",
+                productId=456,
+                venueId=venue.id,
+                type="product_type",
+            )
+        ]


### PR DESCRIPTION
- [x] Test end to end complet pour valider le métier

- [x] Test IRL pour valider le gain en temps
      - Précédent script : lancé en staging, connexion perdu au bout de 3h15, la synchro dure 3h50 en prod d'après kibana
      - Script proposé : 6min20s en staging, lancé en deuxième peut être que ça va plus vite
      => **Test concluant**
      

Remarques (à challenger ?) : 
- Les dateModifiedAtLastProvider ne sont pas implémentées ni utilisées => à quel besoin elles correspondent ?
- Les attributs suivants ne sont pas implémentés ni utilisés, ils ne semblent pas avoir d'impact sur la synchronisation, est-ce normal : 
     - Stock : dateModifiedAtLastProvider, lastProviderId, fieldsUpdated
     - Offer : dateModifiedAtLastProvider, lastProviderId, fieldsUpdated
     - Product : dateModifiedAtLastProvider, lastProviderId, fieldsUpdated
     - Venue : idAtProviders, dateModifiedAtLastProvider, lastProviderId, fieldsUpdated
- Les attributs des offres existantes ne sont pas actualisées (en fonction de venue et product)
- Les erreurs de create et update ne sont pas catchées

🔺Attention : 
Code non organisé/refacto pour l'instant