### PR TITLE
(PC-5567) Fix loading of PC_GOOGLE_KEY for webapp signup

### DIFF
--- a/src/pcapi/connectors/google_spreadsheet.py
+++ b/src/pcapi/connectors/google_spreadsheet.py
@@ -18,11 +18,13 @@ def get_credentials():
     google_key = os.environ.get("PC_GOOGLE_KEY")
     if not google_key:
         raise MissingGoogleKeyException()
-    scopes = ["https://spreadsheets.google.com/feeds", "https://www.googleapis.com/auth/drive"]
+    # Newline characters must be escaped in JSON.
+    google_key = google_key.replace("\n", "\\n")
     # FIXME(cgaunet, 2020-11-24): We need to do this because parsing env variables yml
     # to give it to terraform, replaces double quotes with single quotes making it not json friendly
     google_key = google_key.replace("'", '"')
     account_info = json.loads(google_key)
+    scopes = ["https://spreadsheets.google.com/feeds", "https://www.googleapis.com/auth/drive"]
     return Credentials.from_service_account_info(account_info, scopes=scopes)
 
 

--- a/tests/connectors/google_spreadsheet_test.py
+++ b/tests/connectors/google_spreadsheet_test.py
@@ -10,27 +10,38 @@ from pcapi.connectors.google_spreadsheet import get_credentials
 class GetCredentialsTest:
     @patch("pcapi.connectors.google_spreadsheet.os.environ.get")
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
-    def test_calls_service_account_credentials_from_temp_file_created_from_environ_variable_when_exists(
+    def test_calls_from_service_account_info(
         self,
         from_service_account_info,
         get_environment,
     ):
         # Given
-        account_info = {
-            "type": "service_account",
-            "project_id": "pass-culture",
-            "client_email": "a@example.com",
-            "client_id": "1",
-            "token_uri": "https://www.example.com/",
-        }
+        account_info_as_json = (
+            "{"
+            '"type": "service_account",'
+            '"project_id": "pass-culture",'
+            '"client_email": "a@example.com",'
+            '"client_id": "1",'
+            '"token_uri": "https://www.example.com/",'
+            '"private_key": "the\nprivate\nkey\nwith\nmultiple\nlines"'
+            "}"
+        )
         # FIXME(cgaunet, 2020-11-24): see `get_credentials` as for why we replace double quotes.
-        get_environment.return_value = json.dumps(account_info).replace('"', "'")
+        get_environment.return_value = account_info_as_json.replace('"', "'")
 
         # When
         get_credentials()
 
         # Then
-        assert from_service_account_info.call_args[0][0] == account_info
+        expected_account_info = {
+            "type": "service_account",
+            "project_id": "pass-culture",
+            "client_email": "a@example.com",
+            "client_id": "1",
+            "token_uri": "https://www.example.com/",
+            "private_key": "the\nprivate\nkey\nwith\nmultiple\nlines",
+        }
+        assert from_service_account_info.call_args[0][0] == expected_account_info
         expected_scopes = ["https://spreadsheets.google.com/feeds", "https://www.googleapis.com/auth/drive"]
         assert from_service_account_info.call_args[1] == {"scopes": expected_scopes}
 


### PR DESCRIPTION
The current version of the code fails with:

    Invalid control character at: line 1 column 176 (char 175)

... when calling `json.loads()`. This is because the private key
contains newline characters, and they should be escaped in JSON.

The bug was introduced by 6a656fc05050f9a3a1e076eaf08cfa4193250246 when I removed `strict=False`.