### PR TITLE
(PC-5580) local_providers: Fix creation of thumbnails

### DIFF
--- a/src/pcapi/local_providers/local_provider.py
+++ b/src/pcapi/local_providers/local_provider.py
@@ -234,5 +234,5 @@ def _save_same_thumb_from_thumb_count_to_index(pc_object: Model, thumb_index: in
     else:
         # add new thumb
         for index in range(pc_object.thumbCount, thumb_index):
-            create_thumb(pc_object, image_as_bytes, thumb_index)
+            create_thumb(pc_object, image_as_bytes, index)
             pc_object.thumbCount += 1


### PR DESCRIPTION
Bug introduced in fbe15ae.

The previous version of the code would write the image to a single
location only. For example, if `thumbCount` equaled 1 and `thumbIndex`
equaled 3, we would write only to "/ABC_3" on the file storage instead
of writing to both "/ABC_2" and "/ABC_3".

Detected by pylint.