### PR TITLE
(PC-5408) : Allow load tests to turn off emails delivery

### DIFF
--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -66,3 +66,11 @@ REDIS_OFFER_IDS_CHUNK_SIZE = int(os.environ.get("REDIS_OFFER_IDS_CHUNK_SIZE", 10
 REDIS_OFFER_IDS_IN_ERROR_CHUNK_SIZE = int(os.environ.get("REDIS_OFFER_IDS_IN_ERROR_CHUNK_SIZE", 1000))
 REDIS_VENUE_IDS_CHUNK_SIZE = int(os.environ.get("REDIS_VENUE_IDS_CHUNK_SIZE", 1000))
 REDIS_VENUE_PROVIDERS_CHUNK_SIZE = int(os.environ.get("REDIS_VENUE_PROVIDERS_LRANGE_END", 1))
+
+
+# MAILS
+# Temporary setting to allow load tests to disable sending email
+# Possible values:
+#   - mailjet
+#   - log
+SEND_RAW_EMAIL_BACKEND = os.environ.get("SEND_RAW_EMAIL_BACKEND", "mailjet").lower()

--- a/src/pcapi/utils/mailing.py
+++ b/src/pcapi/utils/mailing.py
@@ -45,7 +45,10 @@ class MailServiceException(Exception):
 def send_raw_email(data: Dict) -> bool:
     successfully_sent_email = False
     try:
-        response = app.mailjet_client.send.create(data=data)
+        if settings.SEND_RAW_EMAIL_BACKEND == "log":
+            logger.info("[EMAIL] Sending email %s", data)
+        else:
+            response = app.mailjet_client.send.create(data=data)
         successfully_sent_email = response.status_code == 200
         status = EmailStatus.SENT if successfully_sent_email else EmailStatus.ERROR
         save(data, status)


### PR DESCRIPTION
Load tests are sending massive amount of emails through mailjet
to the dev mailing list (I think I deleted around 10K yesterday).
As we don't want to test load on Mailjet, let's just skip
the email delivery to Mailjet when `SEND_RAW_EMAIL_BACKEND` is set
to `log`.