### PR TITLE
(FIX) : remove the migration content

### DIFF
--- a/src/pcapi/alembic/versions/bc4ad3f45b5c_fill_isemailvalidated.py
+++ b/src/pcapi/alembic/versions/bc4ad3f45b5c_fill_isemailvalidated.py
@@ -5,8 +5,6 @@ Revises: faa02accb1c4
 Create Date: 2020-11-17 20:47:32.588635
 
 """
-from alembic import op
-
 
 # revision identifiers, used by Alembic.
 revision = "bc4ad3f45b5c"
@@ -16,8 +14,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute("""UPDATE "user" SET "isEmailValidated"=false WHERE "password" IS NULL""")
-    op.execute("""UPDATE "user" SET "isEmailValidated"=true WHERE "password" IS NOT NULL""")
+    pass
 
 
 def downgrade() -> None:


### PR DESCRIPTION
Since it appears to be taking way too long because of the related
triggers and times out during deploy, let's just empty it to get
a smooth migration and update the fields through a script.