### PR TITLE
(PC-4964) : Add settings to disable repatcha on the account creation

### DIFF
--- a/src/pcapi/routes/native/v1/account.py
+++ b/src/pcapi/routes/native/v1/account.py
@@ -2,6 +2,7 @@ from flask import current_app as app
 from flask_jwt_extended import get_jwt_identity
 from flask_jwt_extended import jwt_required
 
+from pcapi import settings
 from pcapi.core.users import api
 from pcapi.core.users.models import VOID_FIRST_NAME
 from pcapi.domain.beneficiary import beneficiary_licence
@@ -36,7 +37,9 @@ def get_user_profile() -> serializers.UserProfileResponse:
 @blueprint.native_v1.route("/account", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.api, on_error_statuses=[400])
 def create_account(body: serializers.AccountRequest) -> None:
-    if not beneficiary_licence.is_licence_token_valid(body.token):
+    if settings.NATIVE_ACCOUNT_CREATION_REQUIRES_RECAPTCHA and not beneficiary_licence.is_licence_token_valid(
+        body.token
+    ):
         raise ApiErrors(
             {"token": ["Le token est invalide"]},
             status_code=400,

--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -74,3 +74,9 @@ REDIS_VENUE_PROVIDERS_CHUNK_SIZE = int(os.environ.get("REDIS_VENUE_PROVIDERS_LRA
 #   - mailjet
 #   - log
 SEND_RAW_EMAIL_BACKEND = os.environ.get("SEND_RAW_EMAIL_BACKEND", "mailjet").lower()
+
+
+# NATIVE APP
+NATIVE_ACCOUNT_CREATION_REQUIRES_RECAPTCHA = bool(
+    os.environ.get("NATIVE_ACCOUNT_CREATION_REQUIRES_RECAPTCHA", ENV != "testing")
+)


### PR DESCRIPTION
Required for the validation and tests, we need to be able to create
an account with an invalide recaptacha in testing.
Let's keep the other env protected, we don't want to be spammed
with account creations elsewhere.