### PR TITLE
(PC-5613) alembic: Restore event_is_in_less_than_10_days SQL function

### DIFF
--- a/src/pcapi/alembic/versions/df15599370fd_restore_event_is_in_less_than_10_days_.py
+++ b/src/pcapi/alembic/versions/df15599370fd_restore_event_is_in_less_than_10_days_.py
@@ -1,0 +1,40 @@
+"""Restore event_is_in_less_than_10_days function
+
+Revision ID: df15599370fd
+Revises: 87eba0d86e80
+Create Date: 2020-12-03 16:38:14.198175
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "df15599370fd"
+down_revision = "87eba0d86e80"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION event_is_in_less_than_10_days(offer_id BIGINT)
+        RETURNS SETOF INTEGER AS
+        $body$
+        BEGIN
+           RETURN QUERY
+           SELECT 1
+            FROM stock
+            WHERE stock."offerId" = offer_id
+              AND (stock."beginningDatetime" IS NULL
+                    OR stock."beginningDatetime" > NOW()
+                   AND stock."beginningDatetime" < NOW() + INTERVAL '10 DAY');
+        END
+        $body$
+        LANGUAGE plpgsql;
+        """
+    )
+
+
+def downgrade():
+    op.execute("DROP FUNCTION event_is_in_less_than_10_days;")


### PR DESCRIPTION
The function was deleted in 94861d27719c776cac31b099883e9c6cc1b04b8e.

... but it is still used in staging and prod because the definition of
the `get_offer_score` SQL function has not been updated on these
environments. In other words, on staging and prod, we still need the
`event_is_in_less_than_10_days` SQL function.

We should create a new migration that updates `get_offer_score` on
staging and prod, but that warrants a thorough validation, and I am
not willing to change recommendation-related code in a patch release.