### PR TITLE
(pytest) mark classes so that they are not collected by pytest

### DIFF
--- a/src/pcapi/domain/postal_code/postal_code.py
+++ b/src/pcapi/domain/postal_code/postal_code.py
@@ -4,6 +4,7 @@ OVERSEAS_DEPARTEMENT_IDENTIFIER = "97"
 
 
 class PostalCode:
+    __test__ = False
     postalCode: str
 
     def __init__(self, postalCode: str):

--- a/src/pcapi/models/pc_object.py
+++ b/src/pcapi/models/pc_object.py
@@ -34,6 +34,7 @@ OBLIGATORY_FIELD_ERROR_CODE = "23502"
 
 
 class DeletedRecordException(Exception):
+    __test__ = False
     pass
 
 

--- a/src/pcapi/use_cases/get_bookings_for_beneficiary.py
+++ b/src/pcapi/use_cases/get_bookings_for_beneficiary.py
@@ -3,6 +3,8 @@ from pcapi.domain.beneficiary_bookings.beneficiary_bookings_with_stocks import B
 
 
 class GetBookingsForBeneficiary:
+    __test__ = False
+
     def __init__(self, beneficiary_bookings_repository: BeneficiaryBookingsRepository):
         self.beneficiary_bookings_repository = beneficiary_bookings_repository
 

--- a/src/pcapi/use_cases/get_venue_labels.py
+++ b/src/pcapi/use_cases/get_venue_labels.py
@@ -5,6 +5,8 @@ from pcapi.domain.venue.venue_label.venue_label_repository import VenueLabelRepo
 
 
 class GetVenueLabels:
+    __test__ = False
+
     def __init__(self, venue_label_repository: VenueLabelRepository):
         self.venue_label_repository = venue_label_repository
 


### PR DESCRIPTION
Our specific collection keywords in `pytest.ini` has Pytest try to collect classes whose names start with `Get`, `Post`, `Delete`