### PR TITLE
(PC-5508) : Realign models and database - step 2

### DIFF
--- a/src/pcapi/alembic/versions/ad5e76920552_rename_indexes.py
+++ b/src/pcapi/alembic/versions/ad5e76920552_rename_indexes.py
@@ -1,0 +1,37 @@
+"""Rename indexes
+
+Revision ID: ad5e76920552
+Revises: df15599370fd
+Create Date: 2020-12-04 09:30:19.933353
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "ad5e76920552"
+down_revision = "df15599370fd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+ALTER INDEX "idx_api_key_offererId" RENAME TO "ix_api_key_offererId";
+ALTER INDEX "idx_api_key_value" RENAME TO "ix_api_key_value";
+ALTER INDEX "idx_bank_information_applicationId" RENAME TO "ix_bank_information_applicationId";
+ALTER INDEX "ix_status" RENAME TO "ix_email_status";
+    """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+ALTER INDEX "ix_email_status" RENAME TO "ix_status";
+ALTER INDEX "ix_bank_information_applicationId" RENAME TO "idx_bank_information_applicationId";
+ALTER INDEX "ix_api_key_value" RENAME TO "idx_api_key_value";
+ALTER INDEX "ix_api_key_offererId" RENAME TO "idx_api_key_offererId";
+    """
+    )

--- a/src/pcapi/core/offers/models.py
+++ b/src/pcapi/core/offers/models.py
@@ -12,6 +12,7 @@ from sqlalchemy import Column
 from sqlalchemy import DDL
 from sqlalchemy import DateTime
 from sqlalchemy import ForeignKey
+from sqlalchemy import Index
 from sqlalchemy import Integer
 from sqlalchemy import Numeric
 from sqlalchemy import String
@@ -231,6 +232,7 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin, ProvidableMixin, 
     type = Column(String(50), CheckConstraint("type != 'None'"), index=True, nullable=False)
 
     name = Column(String(140), nullable=False)
+    Index("idx_offer_trgm_name", name, postgresql_using="gin")
 
     description = Column(Text, nullable=True)
 

--- a/src/pcapi/models/beneficiary_import.py
+++ b/src/pcapi/models/beneficiary_import.py
@@ -4,6 +4,7 @@ from enum import Enum
 from sqlalchemy import BigInteger
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
+from sqlalchemy import Index
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import desc
@@ -33,6 +34,14 @@ class BeneficiaryImport(PcObject, Model):
     source = Column(String(255), nullable=False)
 
     beneficiary = relationship("UserSQLEntity", foreign_keys=[beneficiaryId], backref="beneficiaryImports")
+
+    Index(
+        "idx_beneficiary_import_application",
+        applicationId,
+        sourceId,
+        source,
+        unique=True,
+    )
 
     def setStatus(self, status: ImportStatus, detail: str = None, author: UserSQLEntity = None):
         new_status = BeneficiaryImportStatus()

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -40,7 +40,7 @@ class FeatureToggle(enum.Enum):
 
 
 class Feature(PcObject, Model, DeactivableMixin):
-    name = Column(Enum(FeatureToggle), index=True, unique=True, nullable=False)
+    name = Column(Enum(FeatureToggle), unique=True, nullable=False)
     description = Column(String(300), nullable=False)
 
     @property

--- a/src/pcapi/models/iris_france.py
+++ b/src/pcapi/models/iris_france.py
@@ -1,5 +1,6 @@
 from geoalchemy2 import Geometry
 from sqlalchemy import Column
+from sqlalchemy import Index
 from sqlalchemy import VARCHAR
 
 from pcapi.models import PcObject
@@ -10,3 +11,6 @@ class IrisFrance(PcObject, Model):
     irisCode = Column(VARCHAR(9), nullable=False)
     centroid = Column(Geometry(geometry_type="POINT"), nullable=False)
     shape = Column("shape", Geometry(srid=4326), nullable=False)
+
+    Index("idx_iris_france_centroid", centroid, postgresql_using="gist")
+    Index("idx_iris_france_shape", shape, postgresql_using="gist")


### PR DESCRIPTION
Suite à cette PR, il restera à traiter:
- 7 colonnes à passer en `NOT NULL` (attention, c'est compliqué)
- une clef étrangère sur le propriétaire d'un produit
- une contrainte d'unicité sur `validationToken` dans `venue`

SQL généré par la migration:

```SQL
BEGIN;

INFO  [alembic.runtime.migration] Running upgrade df15599370fd -> ad5e76920552, Rename indexes
-- Running upgrade df15599370fd -> ad5e76920552

ALTER INDEX "idx_api_key_offererId" RENAME TO "ix_api_key_offererId";
ALTER INDEX "idx_api_key_value" RENAME TO "ix_api_key_value";
ALTER INDEX "idx_bank_information_applicationId" RENAME TO "ix_bank_information_applicationId";
ALTER INDEX "ix_status" RENAME TO "ix_email_status";;

UPDATE alembic_version SET version_num='ad5e76920552' WHERE alembic_version.version_num = 'df15599370fd';

COMMIT;
```