### PR TITLE
(PC-5630) Revert "Add an input base model that contains the right configuration and use it in offer serialization"

### DIFF
--- a/src/pcapi/routes/serialization/offers_serialize.py
+++ b/src/pcapi/routes/serialization/offers_serialize.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel
 from pydantic import HttpUrl
 from pydantic import validator
 
-from pcapi.serialization.utils import InputBaseModel
 from pcapi.serialization.utils import cast_optional_field_str_to_int
 from pcapi.serialization.utils import dehumanize_field
 from pcapi.serialization.utils import dehumanize_list_field
@@ -20,7 +19,7 @@ from pcapi.validation.routes.offers import check_offer_name_length_is_valid
 from pcapi.validation.routes.offers import check_offer_type_is_valid
 
 
-class PostOfferBodyModel(InputBaseModel):
+class PostOfferBodyModel(BaseModel):
     venue_id: str
     product_id: Optional[str]
     type: Optional[str]
@@ -54,8 +53,12 @@ class PostOfferBodyModel(InputBaseModel):
             check_offer_type_is_valid(type_field)
         return type_field
 
+    class Config:
+        alias_generator = to_camel
+        extra = "forbid"
 
-class PatchOfferBodyModel(InputBaseModel):
+
+class PatchOfferBodyModel(BaseModel):
     bookingEmail: Optional[str]
     description: Optional[str]
     isNational: Optional[bool]
@@ -80,6 +83,10 @@ class PatchOfferBodyModel(InputBaseModel):
             check_offer_name_length_is_valid(name)
         return name
 
+    class Config:
+        alias_generator = to_camel
+        extra = "forbid"
+
 
 class OfferResponseIdModel(BaseModel):
     id: str
@@ -92,14 +99,17 @@ class OfferResponseIdModel(BaseModel):
         arbitrary_types_allowed = True
 
 
-class PatchOfferActiveStatusBodyModel(InputBaseModel):
+class PatchOfferActiveStatusBodyModel(BaseModel):
     is_active: bool
     ids: List[int]
 
     _dehumanize_ids = dehumanize_list_field("ids")
 
+    class Config:
+        alias_generator = to_camel
 
-class PatchAllOffersActiveStatusBodyModel(InputBaseModel):
+
+class PatchAllOffersActiveStatusBodyModel(BaseModel):
     is_active: bool
     offerer_id: Optional[int]
     venue_id: Optional[int]
@@ -112,6 +122,9 @@ class PatchAllOffersActiveStatusBodyModel(InputBaseModel):
 
     _dehumanize_offerer_id = dehumanize_field("offerer_id")
     _dehumanize_venue_id = dehumanize_field("venue_id")
+
+    class Config:
+        alias_generator = to_camel
 
 
 class ListOffersVenueResponseModel(BaseModel):

--- a/src/pcapi/serialization/utils.py
+++ b/src/pcapi/serialization/utils.py
@@ -4,7 +4,6 @@ from typing import Union
 
 from flask import Request
 from flask import Response
-from pydantic import BaseModel
 from pydantic import ValidationError
 from pydantic import validator
 
@@ -90,9 +89,3 @@ def dehumanize_list_field(field_name: str) -> classmethod:
 
 def cast_optional_field_str_to_int(field_name: str) -> classmethod:
     return validator(field_name, pre=True, allow_reuse=True)(cast_optional_str_to_int)
-
-
-class InputBaseModel(BaseModel):
-    class Config:
-        alias_generator = to_camel
-        extra = "forbid"

--- a/tests/routes/pro/patch_all_offers_active_status_test.py
+++ b/tests/routes/pro/patch_all_offers_active_status_test.py
@@ -21,7 +21,7 @@ class Returns204:
 
         # When
         client = TestClient(app.test_client()).with_auth("pro@example.com")
-        data = {"isActive": True}
+        data = {"isActive": True, "page": 1, "venueId": humanize(venue.id)}
         response = client.patch("/offers/all-active-status", json=data)
 
         # Then


### PR DESCRIPTION
This reverts commit 18264761ec525ca0ca0c1ecca8b15e0806c77515.

We cannot safely apply this commit because some routes may send more
data than pydantic models accept. For example,
`patch_all_offers_active_status` sends a "page" field which does not
appear in the body model. The request is hence rejected by pydantic
with a 400 error code.

This field is useless and the frontend should stop sending it... But
there may be other fields and other routes with the same issue, so
let's play it safe.