### PR TITLE
(PC-5649) local_providers: Ignore NUL caracters in description from TiteLiveThingDescriptions

### DIFF
--- a/src/pcapi/local_providers/titelive_thing_descriptions/titelive_thing_descriptions.py
+++ b/src/pcapi/local_providers/titelive_thing_descriptions/titelive_thing_descriptions.py
@@ -49,7 +49,8 @@ class TiteLiveThingDescriptions(LocalProvider):
 
     def fill_object_attributes(self, product: Product):
         with self.zip_file.open(self.description_zip_info) as f:
-            product.description = f.read().decode("iso-8859-1")
+            description = f.read().decode("iso-8859-1")
+        product.description = description.replace("\x00", "")
 
     def open_next_file(self):
         if self.zip_file:


### PR DESCRIPTION
They break the creation/update of products with the following
exception when SQLAlchemy prepares the SQL query:

    A string literal cannot contain NUL (0x00) characters.


---

Cette fonction n'est pas testée. Je ne vois pas trop l'intérêt
d'ajouter un test unitaire de cette fonction : il serait plutôt
préférable d'écrire un test d'intégration de TiteLiveThingDescriptions,
mais c'est une tâche non négligeable pour qui ne connaît pas le code actuel.