### PR TITLE
(PC-5206) emails: Use offer name instead of product name in offerer notifications

### DIFF
--- a/src/pcapi/emails/offerer_booking_recap.py
+++ b/src/pcapi/emails/offerer_booking_recap.py
@@ -16,7 +16,7 @@ from pcapi.utils.mailing import format_environment_for_email
 def retrieve_data_for_offerer_booking_recap_email(booking: Booking, recipients: List[str]) -> Dict:
     offer = booking.stock.offer
     venue_name = offer.venue.name
-    offer_name = offer.product.name
+    offer_name = offer.name
     price = "Gratuit" if booking.stock.price == 0 else str(booking.stock.price)
     quantity = booking.quantity
     user_email = booking.user.email

--- a/src/pcapi/utils/mailing.py
+++ b/src/pcapi/utils/mailing.py
@@ -159,7 +159,7 @@ def make_validation_email_object(
 
 
 def make_offerer_driven_cancellation_email_for_offerer(booking: Booking) -> Dict:
-    stock_name = booking.stock.offer.product.name
+    stock_name = booking.stock.offer.name
     venue = booking.stock.offer.venue
     user_name = booking.user.publicName
     user_email = booking.user.email

--- a/tests/emails/offerer_booking_recap_test.py
+++ b/tests/emails/offerer_booking_recap_test.py
@@ -86,6 +86,7 @@ def test_with_event():
 @pytest.mark.usefixtures("db_session")
 def test_with_book():
     booking = make_booking(
+        stock__offer__name="Le récit de voyage",
         stock__offer__product__extraData={"isbn": "123456789"},
         stock__offer__product__name="Le récit de voyage",
         stock__offer__product__type=str(models.ThingType.LIVRE_EDITION),
@@ -114,6 +115,7 @@ def test_with_book():
 @pytest.mark.usefixtures("db_session")
 def test_with_book_with_missing_isbn():
     booking = make_booking(
+        stock__offer__name="Le récit de voyage",
         stock__offer__product__extraData={},  # no ISBN
         stock__offer__product__name="Le récit de voyage",
         stock__offer__product__type=str(models.ThingType.LIVRE_EDITION),


### PR DESCRIPTION
When created, the offer name is the same as the product name. However,
the name of the offer can be customized by the offerer. It thus makes
sense to use the (possibly customized) *offer* name in these offerer's
e-mail notifications. We already do so in other e-mail notifications.