### PR TITLE
(PC-5314) scheduled_tasks: notify users and offerers of daily expired bookings

### DIFF
--- a/src/pcapi/scheduled_tasks/clock.py
+++ b/src/pcapi/scheduled_tasks/clock.py
@@ -25,6 +25,7 @@ from pcapi.scheduled_tasks.decorators import cron_require_feature
 from pcapi.scheduled_tasks.decorators import log_cron
 from pcapi.scripts.beneficiary import old_remote_import
 from pcapi.scripts.beneficiary import remote_import
+from pcapi.scripts.booking import expiry_notifications
 from pcapi.scripts.booking.cancel_expired_bookings import cancel_expired_bookings
 from pcapi.scripts.update_booking_used import update_booking_used_after_stock_occurrence
 
@@ -134,6 +135,18 @@ def pc_cancel_expired_bookings(app) -> None:
     cancel_expired_bookings()
 
 
+@log_cron
+@cron_context
+def pc_notify_users_of_expired_bookings(app) -> None:
+    expiry_notifications.notify_users_of_expired_bookings()
+
+
+@log_cron
+@cron_context
+def pc_notify_offerers_of_expired_bookings(app) -> None:
+    expiry_notifications.notify_offerers_of_expired_bookings()
+
+
 def main():
     from pcapi.flask_app import app
 
@@ -175,6 +188,24 @@ def main():
         [app],
         day="*",
         hour="2",
+        start_date=CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE.strftime("%Y-%m-%d"),
+    )
+
+    scheduler.add_job(
+        pc_notify_offerers_of_expired_bookings,
+        "cron",
+        [app],
+        day="*",
+        hour="5",
+        start_date=CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE.strftime("%Y-%m-%d"),
+    )
+
+    scheduler.add_job(
+        pc_notify_users_of_expired_bookings,
+        "cron",
+        [app],
+        day="*",
+        hour="6",
         start_date=CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE.strftime("%Y-%m-%d"),
     )
 

--- a/src/pcapi/scripts/booking/expiry_notifications.py
+++ b/src/pcapi/scripts/booking/expiry_notifications.py
@@ -1,0 +1,81 @@
+import datetime
+from itertools import groupby
+from operator import attrgetter
+
+from pcapi.core.bookings import conf
+import pcapi.core.bookings.repository as bookings_repository
+from pcapi.utils.logger import logger
+
+
+def notify_users_of_expired_bookings(expired_on: datetime.date = datetime.date.today()) -> None:
+    """
+    This script will be scheduled to begin after CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE, but can be called before that
+    date manually in order to check the number of emails that would be sent.
+    """
+
+    logger.info("[notify_users_of_expired_bookings] Start")
+    expired_bookings_ordered_by_user = bookings_repository.find_expired_bookings_ordered_by_user(expired_on)
+
+    expired_bookings_grouped_by_user = dict()
+    for user, booking in groupby(expired_bookings_ordered_by_user, attrgetter("user")):
+        expired_bookings_grouped_by_user[user] = list(booking)
+
+    is_after_start_date = datetime.datetime.utcnow() >= conf.CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE
+    notified_users = []
+
+    if is_after_start_date:
+        for user, _bookings in expired_bookings_grouped_by_user.items():
+            notified_users.append(user)
+
+        logger.info(
+            "%d Users have been notified: %s",
+            len(notified_users),
+            notified_users,
+        )
+
+    else:
+        logger.info(
+            "%d Users would have been notified of expired booking cancellation: %s",
+            len(notified_users),
+            notified_users,
+        )
+
+    logger.info("[notify_users_of_expired_bookings] End")
+
+
+def notify_offerers_of_expired_bookings(expired_on: datetime.date = datetime.date.today()) -> None:
+    """
+    This script will be scheduled to begin after CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE, but can be called before that
+    date manually in order to check the number of emails that would be sent.
+    """
+
+    logger.info("[notify_offerers_of_expired_bookings] Start")
+
+    expired_bookings_ordered_by_offerer = bookings_repository.find_expired_bookings_ordered_by_offerer(expired_on)
+    expired_bookings_grouped_by_offerer = dict()
+    for offerer, booking in groupby(
+        expired_bookings_ordered_by_offerer, attrgetter("stock.offer.venue.managingOfferer")
+    ):
+        expired_bookings_grouped_by_offerer[offerer] = list(booking)
+
+    is_after_start_date = datetime.datetime.utcnow() >= conf.CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE
+    notified_offerers = []
+
+    if is_after_start_date:
+        for offerer, _bookings in expired_bookings_grouped_by_offerer.items():
+            notified_offerers.append(offerer)
+
+        logger.info(
+            "%d Offerers have been notified: %s",
+            len(notified_offerers),
+            notified_offerers,
+        )
+
+    else:
+        logger.info(
+            "%d Offerers would have been notified of expired booking cancellation: %s",
+            len(notified_offerers),
+            notified_offerers,
+        )
+
+    logger.info("[notify_offerers_of_expired_bookings] End")

--- a/tests/scripts/booking/expiry_notifications_test.py
+++ b/tests/scripts/booking/expiry_notifications_test.py
@@ -1,0 +1,99 @@
+from datetime import datetime
+from datetime import timedelta
+import logging
+from unittest import mock
+
+import pytest
+
+from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.models import BookingCancellationReasons
+from pcapi.core.offers.factories import ProductFactory
+from pcapi.models import offer_type
+from pcapi.repository import repository
+from pcapi.scripts.booking.expiry_notifications import notify_offerers_of_expired_bookings
+from pcapi.scripts.booking.expiry_notifications import notify_users_of_expired_bookings
+
+
+@pytest.mark.usefixtures("db_session")
+class NotifyUsersOfExpiredBookingsTest:
+    @mock.patch("pcapi.core.bookings.conf.CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE", datetime.utcnow())
+    def should_log_notifications_of_todays_expired_bookings(self, app, caplog) -> None:
+        caplog.set_level(logging.INFO)
+        now = datetime.utcnow()
+        yesterday = now - timedelta(days=1)
+        long_ago = now - timedelta(days=31)
+        very_long_ago = now - timedelta(days=32)
+        dvd = ProductFactory(type=str(offer_type.ThingType.AUDIOVISUEL))
+        expired_today_dvd_booking = BookingFactory(
+            stock__offer__product=dvd,
+            dateCreated=long_ago,
+            isCancelled=True,
+            cancellationReason=BookingCancellationReasons.EXPIRED,
+        )
+        cd = ProductFactory(type=str(offer_type.ThingType.MUSIQUE))
+        expired_today_cd_booking = BookingFactory(
+            stock__offer__product=cd,
+            dateCreated=long_ago,
+            isCancelled=True,
+            cancellationReason=BookingCancellationReasons.EXPIRED,
+        )
+        painting = ProductFactory(type=str(offer_type.ThingType.OEUVRE_ART))
+        expired_yesterday_painting_booking = BookingFactory(
+            stock__offer__product=painting,
+            dateCreated=very_long_ago,
+            isCancelled=True,
+            cancellationReason=BookingCancellationReasons.EXPIRED,
+        )
+        expired_yesterday_painting_booking.cancellationDate = yesterday
+        repository.save(expired_yesterday_painting_booking)
+
+        notify_users_of_expired_bookings()
+
+        assert (
+            caplog.records[1].message
+            == f"2 Users have been notified: [{expired_today_dvd_booking.user}, {expired_today_cd_booking.user}]"
+        )
+        assert str(expired_yesterday_painting_booking) not in caplog.text
+
+
+@pytest.mark.usefixtures("db_session")
+class NotifyOfferersOfExpiredBookingsTest:
+    @mock.patch("pcapi.core.bookings.conf.CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE", datetime.utcnow())
+    def should_log_notifications_of_todays_expired_bookings(self, app, caplog) -> None:
+        caplog.set_level(logging.INFO)
+        now = datetime.utcnow()
+        yesterday = now - timedelta(days=1)
+        long_ago = now - timedelta(days=31)
+        very_long_ago = now - timedelta(days=32)
+        dvd = ProductFactory(type=str(offer_type.ThingType.AUDIOVISUEL))
+        expired_today_dvd_booking = BookingFactory(
+            stock__offer__product=dvd,
+            dateCreated=long_ago,
+            isCancelled=True,
+            cancellationReason=BookingCancellationReasons.EXPIRED,
+        )
+        cd = ProductFactory(type=str(offer_type.ThingType.MUSIQUE))
+        expired_today_cd_booking = BookingFactory(
+            stock__offer__product=cd,
+            dateCreated=long_ago,
+            isCancelled=True,
+            cancellationReason=BookingCancellationReasons.EXPIRED,
+        )
+        painting = ProductFactory(type=str(offer_type.ThingType.OEUVRE_ART))
+        expired_yesterday_painting_booking = BookingFactory(
+            stock__offer__product=painting,
+            dateCreated=very_long_ago,
+            isCancelled=True,
+            cancellationReason=BookingCancellationReasons.EXPIRED,
+        )
+        expired_yesterday_painting_booking.cancellationDate = yesterday
+        repository.save(expired_yesterday_painting_booking)
+
+        notify_offerers_of_expired_bookings()
+
+        assert (
+            caplog.records[1].message
+            == f"2 Offerers have been notified: [{expired_today_dvd_booking.stock.offer.venue.managingOfferer},"
+            f" {expired_today_cd_booking.stock.offer.venue.managingOfferer}]"
+        )
+        assert str(expired_yesterday_painting_booking) not in caplog.text


### PR DESCRIPTION
Cette PR ajoute 2 tâches programmées qui pour l'instant ne font pas d'envoi de mails aux bénéficiaires et offreurs, car cela sera ajouté dans une seconde PR.
On pourra néanmoins récupérer (dans les logs) le nombre de bénéficiaires/offreurs qui seraient contactés.