### PR TITLE
(PC-5541) : beneficiary rejection mail takes more simple inputs

### DIFF
--- a/src/pcapi/domain/user_emails.py
+++ b/src/pcapi/domain/user_emails.py
@@ -194,9 +194,9 @@ def send_rejection_email_to_beneficiary_pre_subscription(
     send_email: Callable[..., bool],
 ) -> None:
     if isinstance(error, BeneficiaryIsNotEligible):
-        data = make_not_eligible_beneficiary_pre_subscription_rejected_data(beneficiary_pre_subscription)
+        data = make_not_eligible_beneficiary_pre_subscription_rejected_data(beneficiary_pre_subscription.email)
     else:
-        data = make_duplicate_beneficiary_pre_subscription_rejected_data(beneficiary_pre_subscription)
+        data = make_duplicate_beneficiary_pre_subscription_rejected_data(beneficiary_pre_subscription.email)
 
     send_email(data=data)
 

--- a/src/pcapi/emails/beneficiary_pre_subscription_rejected.py
+++ b/src/pcapi/emails/beneficiary_pre_subscription_rejected.py
@@ -1,17 +1,13 @@
 import os
 from typing import Dict
 
-from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription import BeneficiaryPreSubscription
-
 
 SUPPORT_EMAIL_ADDRESS = os.environ.get("SUPPORT_EMAIL_ADDRESS")
 
 
 def make_duplicate_beneficiary_pre_subscription_rejected_data(
-    beneficiary_pre_subscription: BeneficiaryPreSubscription,
+    beneficiary_email: str,
 ) -> Dict:
-    beneficiary_email = beneficiary_pre_subscription.email
-
     return {
         "FromEmail": SUPPORT_EMAIL_ADDRESS,
         "Mj-TemplateID": 1530996,
@@ -21,10 +17,8 @@ def make_duplicate_beneficiary_pre_subscription_rejected_data(
 
 
 def make_not_eligible_beneficiary_pre_subscription_rejected_data(
-    beneficiary_pre_subscription: BeneficiaryPreSubscription,
+    beneficiary_email: str,
 ) -> Dict:
-    beneficiary_email = beneficiary_pre_subscription.email
-
     return {
         "FromEmail": SUPPORT_EMAIL_ADDRESS,
         "Mj-TemplateID": 1619528,

--- a/tests/domain/user_emails_test.py
+++ b/tests/domain/user_emails_test.py
@@ -528,7 +528,7 @@ class SendRejectionEmailToBeneficiaryPreSubscriptionTest:
         send_rejection_email_to_beneficiary_pre_subscription(beneficiary_pre_subscription, error, mocked_send_email)
 
         # then
-        mocked_make_data.assert_called_once_with(beneficiary_pre_subscription)
+        mocked_make_data.assert_called_once_with(beneficiary_pre_subscription.email)
         mocked_send_email.assert_called_once_with(data={"MJ-TemplateID": 1530996})
 
     @patch(
@@ -545,5 +545,5 @@ class SendRejectionEmailToBeneficiaryPreSubscriptionTest:
         send_rejection_email_to_beneficiary_pre_subscription(beneficiary_pre_subscription, error, mocked_send_email)
 
         # then
-        mocked_make_data.assert_called_once_with(beneficiary_pre_subscription)
+        mocked_make_data.assert_called_once_with(beneficiary_pre_subscription.email)
         mocked_send_email.assert_called_once_with(data={"MJ-TemplateID": 1619528})

--- a/tests/emails/beneficiary_pre_subscription_rejected_test.py
+++ b/tests/emails/beneficiary_pre_subscription_rejected_test.py
@@ -3,16 +3,13 @@ from pcapi.emails.beneficiary_pre_subscription_rejected import (
 )
 from pcapi.emails.beneficiary_pre_subscription_rejected import make_duplicate_beneficiary_pre_subscription_rejected_data
 
-from tests.domain_creators.generic_creators import create_domain_beneficiary_pre_subcription
-
 
 def test_make_duplicate_beneficiary_pre_subscription_rejected_data():
     # Given
     email = "test@example.org"
-    beneficiary_pre_subscription = create_domain_beneficiary_pre_subcription(email=email)
 
     # When
-    data = make_duplicate_beneficiary_pre_subscription_rejected_data(beneficiary_pre_subscription)
+    data = make_duplicate_beneficiary_pre_subscription_rejected_data(email)
 
     # Then
     assert data == {
@@ -26,10 +23,9 @@ def test_make_duplicate_beneficiary_pre_subscription_rejected_data():
 def test_make_not_eligible_beneficiary_pre_subscription_rejected_data():
     # Given
     email = "test@example.org"
-    beneficiary_pre_subscription = create_domain_beneficiary_pre_subcription(email=email)
 
     # When
-    data = make_not_eligible_beneficiary_pre_subscription_rejected_data(beneficiary_pre_subscription)
+    data = make_not_eligible_beneficiary_pre_subscription_rejected_data(email)
 
     # Then
     assert data == {


### PR DESCRIPTION
Directly use the email instead of passing the entire User structure
in the beneficiary rejection emails context building functions.