### PR TITLE
(FIX) : Configure sentry for the RQ worker

### DIFF
--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -40,11 +40,11 @@ from pcapi.utils.mailing import MAILJET_API_SECRET
 
 if settings.IS_DEV is False:
     sentry_sdk.init(
-        dsn="https://0470142cf8d44893be88ecded2a14e42@logs.passculture.app/5",
+        dsn=settings.SENTRY_DSN,
         integrations=[FlaskIntegration(), RqIntegration()],
         release=read_version_from_file(),
         environment=settings.ENV,
-        traces_sample_rate=float(os.environ.get("SENTRY_SAMPLE_RATE", 0)),
+        traces_sample_rate=settings.SENTRY_SAMPLE_RATE,
     )
 
 app = Flask(__name__, static_url_path="/static")

--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -68,6 +68,10 @@ REDIS_VENUE_IDS_CHUNK_SIZE = int(os.environ.get("REDIS_VENUE_IDS_CHUNK_SIZE", 10
 REDIS_VENUE_PROVIDERS_CHUNK_SIZE = int(os.environ.get("REDIS_VENUE_PROVIDERS_LRANGE_END", 1))
 
 
+# SENTRY
+SENTRY_DSN = "https://0470142cf8d44893be88ecded2a14e42@logs.passculture.app/5"
+SENTRY_SAMPLE_RATE = float(os.environ.get("SENTRY_SAMPLE_RATE", 0))
+
 # MAILS
 # Temporary setting to allow load tests to disable sending email
 # Possible values:


### PR DESCRIPTION
It should work out of the box by import pcapi.flask_app but I'm
quite unsure about the side effects of opening connections to
redis or others from inside the flask_app.