### PR TITLE
.pylintrc: use multiple processes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
       - run:
           name: Run pylint
           when: always
-          command: venv/bin/pylint src tests
+          command: venv/bin/pylint src tests --jobs=4
 
   build-container:
     machine:


### PR DESCRIPTION
Afin d'accélérer les tests de qualité, nous pouvons paralléliser l'exécution de pylint via la config ou la ligne de commande.
Ce changement passe de 1 à 4 _jobs_, et l'amélioration, bien que non-linéaire, est notable (environ 3 fois plus rapide).

Comparatif de l'exécution du step `Run pylint` dans CircleCI:
* `jobs=1` : 3min41s
* `jobs=2 `: 2min4s
* `jobs=4` : 1min17s

Cela permet d'avoir une durée de _quality check_ inférieure à la durée des tests _python_.