### PR TITLE
recommendations: Fix Recommendation.thumbUrl

### DIFF
--- a/src/pcapi/models/recommendation.py
+++ b/src/pcapi/models/recommendation.py
@@ -46,4 +46,6 @@ class Recommendation(PcObject, Model):
 
     @property
     def thumbUrl(self) -> str:
-        return self.offer.thumbUrl
+        if self.offer:
+            return self.offer.thumbUrl
+        return self.mediation.thumbUrl


### PR DESCRIPTION
A recommendation is linked to an offer or a mediation. If it is not
linked to an offer, use the mediation thumbnail URL.

----

Pas de test, pas de ticket, j'ai fait ça vite fait après avoir vu une erreur dans Sentry : https://logs.passculture.app/organizations/sentry/issues/1233. (Je ne suis pas sûr de comprendre comment on peut avoir une recommendation avec offre et sans médiation, en sachant qu'une médiation est de toute façon liée à une offre...)