### PR TITLE
(PC-5752) : fix OpenAPI 3.0.3 schema

### DIFF
--- a/src/pcapi/routes/native/v1/blueprint.py
+++ b/src/pcapi/routes/native/v1/blueprint.py
@@ -1,4 +1,5 @@
 from flask import Blueprint
+import pydantic.schema
 from spectree import SpecTree
 
 from pcapi.serialization.utils import before_handler
@@ -6,5 +7,18 @@ from pcapi.serialization.utils import before_handler
 
 native_v1 = Blueprint("native_v1", __name__)
 
-api = SpecTree("flask", MODE="strict", before=before_handler, PATH="/")
+
+# TODO: Remove PassSpecTree and pydantic patch whenever
+# https://github.com/0b01001001/spectree/pull/91 is released
+class PassSpecTree(SpecTree):
+    def _generate_spec(self) -> dict:
+        spec = super()._generate_spec()
+        spec["components"]["schemas"].update(spec.pop("definitions", {}))
+        return spec
+
+
+pydantic.schema.default_prefix = "#/components/schemas/"
+
+
+api = PassSpecTree("flask", MODE="strict", before=before_handler, PATH="/")
 api.register(native_v1)


### PR DESCRIPTION
Spectree has a small imcompatibility with the OpenAPI 3.0.3:
Nested models are generated as `/definitions/{model}` while
no such path exists within OpenAPI 3.0.x
All models should be under `/components/schemas/`.
While this has been reported and fixed upstream with PR:
https://github.com/0b01001001/spectree/pull/91
we need to fix it while waiting the proper solution.