### PR TITLE
(Pc-5508) Add not null constraint in booking.isCancelled column

### DIFF
--- a/src/pcapi/alembic/versions/15f7a576bd85_validate_is_cancelled_not_null_.py
+++ b/src/pcapi/alembic/versions/15f7a576bd85_validate_is_cancelled_not_null_.py
@@ -1,0 +1,23 @@
+"""validate_is_cancelled_not_null_constraint (Add not null constraint to booking.isCancelled: Step 2/4)
+
+Revision ID: 15f7a576bd85
+Revises: 1739553e1d3c
+Create Date: 2020-12-11 10:54:27.118535
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "15f7a576bd85"
+down_revision = "1739553e1d3c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TABLE booking VALIDATE CONSTRAINT is_cancelled_not_null_constraint;")
+
+
+def downgrade():
+    pass

--- a/src/pcapi/alembic/versions/1739553e1d3c_add_not_null_booking_is_cancelled.py
+++ b/src/pcapi/alembic/versions/1739553e1d3c_add_not_null_booking_is_cancelled.py
@@ -1,0 +1,27 @@
+"""add_not_null_booking_is_cancelled (Add not null constraint to booking.isCancelled: Step 1/4)
+
+Revision ID: 1739553e1d3c
+Revises: 1efe2b3cb31c
+Create Date: 2020-12-11 10:37:09.017934
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "1739553e1d3c"
+down_revision = "1efe2b3cb31c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+            ALTER TABLE booking ADD CONSTRAINT is_cancelled_not_null_constraint CHECK ("isCancelled" IS NOT NULL) NOT VALID;
+        """
+    )
+
+
+def downgrade():
+    op.drop_constraint("is_cancelled_not_null_constraint", table_name="booking")

--- a/src/pcapi/alembic/versions/3d08d5ba9f11_drop_is_cancelled_not_null_constraint.py
+++ b/src/pcapi/alembic/versions/3d08d5ba9f11_drop_is_cancelled_not_null_constraint.py
@@ -1,0 +1,27 @@
+"""drop_is_cancelled_not_null_constraint (Add not null constraint to booking.isCancelled: Step 4/4)
+
+Revision ID: 3d08d5ba9f11
+Revises: 525b32ead72d
+Create Date: 2020-12-11 11:12:28.993957
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "3d08d5ba9f11"
+down_revision = "525b32ead72d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint("is_cancelled_not_null_constraint", table_name="booking")
+
+
+def downgrade():
+    op.execute(
+        """
+            ALTER TABLE booking ADD CONSTRAINT is_cancelled_not_null_constraint CHECK ("isCancelled" IS NOT NULL) NOT VALID;
+        """
+    )

--- a/src/pcapi/alembic/versions/525b32ead72d_add_not_null_constraint_on_booking.py
+++ b/src/pcapi/alembic/versions/525b32ead72d_add_not_null_constraint_on_booking.py
@@ -1,0 +1,23 @@
+"""add_not_null_constraint_on_booking (Add not null constraint to booking.isCancelled: Step 3/4)
+
+Revision ID: 525b32ead72d
+Revises: 15f7a576bd85
+Create Date: 2020-12-11 11:08:53.524881
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "525b32ead72d"
+down_revision = "15f7a576bd85"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("booking", "isCancelled", nullable=False)
+
+
+def downgrade():
+    op.alter_column("booking", "isCancelled", nullable=True)


### PR DESCRIPTION
Step 1: 
Add a validation constraint not valid not to lock the table - see doc https://www.postgresql.org/docs/12/sql-altertable.html#SQL-ALTERTABLE-NOTES:
> The main purpose of the NOT VALID constraint option is to reduce the impact of adding a constraint on concurrent updates. With NOT VALID, the ADD CONSTRAINT command does not scan the table and can be committed immediately.

Step 2:
Validate constraint - see doc https://www.postgresql.org/docs/12/sql-altertable.html#SQL-ALTERTABLE-NOTES
> After that, a VALIDATE CONSTRAINT command can be issued to verify that existing rows satisfy the constraint. The validation step does not need to lock out concurrent updates, since it knows that other transactions will be enforcing the constraint for rows that they insert or update; only pre-existing rows need to be checked. Hence, validation acquires only a SHARE UPDATE EXCLUSIVE lock on the table being altered

Step 3:
Add not null constraint on column isCancelled - see doc: https://www.postgresql.org/docs/12/sql-altertable.html# - 'SET/DROP NOT NULL' section
> SET NOT NULL may only be applied to a column provided none of the records in the table contain a NULL value for the column. Ordinarily this is checked during the ALTER TABLE by scanning the entire table; however, if a valid CHECK constraint is found which proves no NULL can exist, then the table scan is skipped.

Step 4:
Drop check constraint