### PR TITLE
(PC-5799) Rationalisation de la suspension des comptes

### DIFF
--- a/src/pcapi/alembic/versions/55bf0bb6c53b_add_user_isactive.py
+++ b/src/pcapi/alembic/versions/55bf0bb6c53b_add_user_isactive.py
@@ -1,0 +1,24 @@
+"""add_user_isActive
+
+Revision ID: 55bf0bb6c53b
+Revises: ef6ec02387a3
+Create Date: 2020-12-14 09:55:46.642156
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "55bf0bb6c53b"
+down_revision = "ef6ec02387a3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("user", sa.Column("isActive", sa.BOOLEAN(), server_default=sa.text("true"), nullable=True))
+
+
+def downgrade():
+    op.drop_column("user", "isActive")

--- a/src/pcapi/alembic/versions/ef6ec02387a3_add_user_suspensionreason.py
+++ b/src/pcapi/alembic/versions/ef6ec02387a3_add_user_suspensionreason.py
@@ -1,0 +1,25 @@
+"""Add user.suspensionReason
+
+Revision ID: ef6ec02387a3
+Revises: ad5e76920552
+Create Date: 2020-12-14 09:29:45.052541
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "ef6ec02387a3"
+down_revision = "ad5e76920552"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("user", sa.Column("suspensionReason", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("user", "suspensionReason")

--- a/src/pcapi/core/users/constants.py
+++ b/src/pcapi/core/users/constants.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from enum import Enum
 
 
 RESET_PASSWORD_TOKEN_LIFE_TIME = timedelta(hours=24)
@@ -6,3 +7,13 @@ EMAIL_VALIDATION_TOKEN_LIFE_TIME = timedelta(hours=24)
 ID_CHECK_TOKEN_LIFE_TIME = timedelta(days=1)
 
 ELIGIBILITY_AGE = 18
+
+
+class SuspensionReason(Enum):
+    def __str__(self) -> str:
+        return str(self.value)
+
+    END_OF_CONTRACT = "end of contract"
+    END_OF_ELIGIBILITY = "end of eligibility"
+    FRAUD = "fraud"
+    UPON_USER_REQUEST = "upon user request"

--- a/src/pcapi/core/users/factories.py
+++ b/src/pcapi/core/users/factories.py
@@ -1,8 +1,10 @@
 import datetime
+import uuid
 
 import factory
 
 from pcapi.core.testing import BaseFactory
+from pcapi.models import user_session
 from pcapi.models import user_sql_entity
 
 from . import constants
@@ -64,3 +66,19 @@ class ResetPasswordToken(TokenFactory):
 class EmailValidationToken(TokenFactory):
     type = models.TokenType.EMAIL_VALIDATION
     expirationDate = factory.LazyFunction(lambda: datetime.datetime.now() + constants.EMAIL_VALIDATION_TOKEN_LIFE_TIME)
+
+
+class UserSessionFactory(BaseFactory):
+    class Meta:
+        model = user_session.UserSession
+
+    uuid = factory.LazyFunction(uuid.uuid4)
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        try:
+            user = kwargs.pop("user")
+        except KeyError:
+            raise ValueError('UserSessionFactory requires a "user" argument.')
+        kwargs["userId"] = user.id
+        return super()._create(model_class, *args, **kwargs)

--- a/src/pcapi/core/users/repository.py
+++ b/src/pcapi/core/users/repository.py
@@ -13,6 +13,8 @@ def get_user_with_credentials(identifier: str, password: str) -> UserSQLEntity:
     user = find_user_by_email(identifier)
     if not user:
         raise exceptions.InvalidIdentifier()
+    if not user.isActive:
+        raise exceptions.InvalidIdentifier()
     if not user.isValidated:
         raise exceptions.UnvalidatedAccount()
     if not user.checkPassword(password):

--- a/src/pcapi/models/user_sql_entity.py
+++ b/src/pcapi/models/user_sql_entity.py
@@ -134,6 +134,12 @@ class UserSQLEntity(PcObject, Model, NeedsValidationMixin, VersionedMixin):
     # existing rows with the empty string and add NOT NULL constraint.
     suspensionReason = Column(Text, nullable=True, default="")
 
+    # FIXME (dbaty, 2020-12-14): once v114 has been deployed, populate
+    # existing rows, remove this field and let the UserSQLEntity model
+    # use DeactivableMixin. We'll need to add a migration that adds a
+    # NOT NULL constraint.
+    isActive = Column(Boolean, nullable=True, server_default=expression.true(), default=True)
+
     def checkPassword(self, passwordToCheck):
         return check_password(passwordToCheck, self.password)
 

--- a/src/pcapi/models/user_sql_entity.py
+++ b/src/pcapi/models/user_sql_entity.py
@@ -130,6 +130,10 @@ class UserSQLEntity(PcObject, Model, NeedsValidationMixin, VersionedMixin):
 
     hasAllowedRecommendations = Column(Boolean, nullable=False, server_default=expression.false())
 
+    # FIXME (dbaty, 2020-12-14): once v114 has been deployed, populate
+    # existing rows with the empty string and add NOT NULL constraint.
+    suspensionReason = Column(Text, nullable=True, default="")
+
     def checkPassword(self, passwordToCheck):
         return check_password(passwordToCheck, self.password)
 

--- a/src/pcapi/routes/native/v1/authentication.py
+++ b/src/pcapi/routes/native/v1/authentication.py
@@ -63,7 +63,7 @@ def refresh() -> authentication.RefreshResponse:
 def request_password_reset(body: RequestPasswordResetRequest) -> None:
     user = find_user_by_email(body.email)
 
-    if not user:
+    if not user or not user.isActive:
         return
 
     reset_password_token = users_api.create_reset_password_token(user)

--- a/src/pcapi/routes/shared/passwords.py
+++ b/src/pcapi/routes/shared/passwords.py
@@ -49,7 +49,7 @@ def post_for_password_token(body: ResetPasswordBodyModel) -> None:
     check_recaptcha_token_is_valid(body.token, "resetPassword", settings.RECAPTCHA_RESET_PASSWORD_MINIMAL_SCORE)
     user = find_user_by_email(body.email)
 
-    if not user:
+    if not user or not user.isActive:
         # Here we also return a 204 to prevent attacker from discovering which email exists in db
         return
 

--- a/src/pcapi/utils/includes.py
+++ b/src/pcapi/utils/includes.py
@@ -89,6 +89,7 @@ USER_INCLUDES = [
     "-password",
     "-resetPasswordToken",
     "-resetPasswordTokenValidityLimit",
+    "-suspensionReason",
     "-validationToken",
     "hasPhysicalVenues",
     "hasOffers",

--- a/src/pcapi/utils/includes.py
+++ b/src/pcapi/utils/includes.py
@@ -86,6 +86,7 @@ USER_INCLUDES = [
     "-culturalSurveyId",
     "-culturalSurveyFilledDate",
     "-hasSeenTutorials",
+    "-isActive",
     "-password",
     "-resetPasswordToken",
     "-resetPasswordTokenValidityLimit",

--- a/tests/routes/native/v1/authentication_test.py
+++ b/tests/routes/native/v1/authentication_test.py
@@ -118,6 +118,18 @@ def test_request_reset_password_for_existing_email(mock_send_reset_password_emai
     assert saved_token.type.value == "reset-password"
 
 
+@patch("pcapi.routes.native.v1.authentication.send_reset_password_email_to_native_app_user")
+def test_request_reset_password_for_inactive_account(mock_send_reset_password_email_to_native_app_user, app):
+    email = "existing_user@example.com"
+    data = {"email": email}
+    users_factories.UserFactory(email=email, isActive=False)
+
+    response = TestClient(app.test_client()).post("/native/v1/request_password_reset", json=data)
+
+    assert response.status_code == 204
+    mock_send_reset_password_email_to_native_app_user.assert_not_called()
+
+
 @pytest.mark.usefixtures("db_session")
 @patch("pcapi.routes.native.v1.authentication.send_reset_password_email_to_native_app_user")
 def test_request_reset_password_with_mail_service_exception(mock_send_reset_password_email_to_native_app_user, app):

--- a/tests/routes/shared/post_reset_password_test.py
+++ b/tests/routes/shared/post_reset_password_test.py
@@ -84,6 +84,20 @@ class Returns204:
         assert response.status_code == 204
 
     @patch("pcapi.routes.shared.passwords.check_recaptcha_token_is_valid", return_value=True)
+    def when_account_is_not_valid(self, check_recaptcha_token_is_valid_mock, app, db_session):
+        # given
+        user = users_factories.UserFactory(isActive=False)
+        data = {"token": "dumbToken", "email": user.email}
+
+        # when
+        response = TestClient(app.test_client()).post("/users/reset-password", json=data)
+
+        # then
+        assert response.status_code == 204
+        user = UserSQLEntity.query.get(user.id)
+        assert not user.resetPasswordToken
+
+    @patch("pcapi.routes.shared.passwords.check_recaptcha_token_is_valid", return_value=True)
     def when_email_is_known(self, check_recaptcha_token_is_valid_mock, app, db_session):
         # given
         user = users_factories.UserFactory()

--- a/tests/routes/webapp/post_signin_beneficiary_test.py
+++ b/tests/routes/webapp/post_signin_beneficiary_test.py
@@ -1,139 +1,119 @@
 import pytest
 
-from pcapi.model_creators.generic_creators import create_user
+import pcapi.core.users.factories as users_factories
 from pcapi.models import UserSession
-from pcapi.repository import repository
 
 from tests.conftest import TestClient
 
 
-class Post:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_account_is_known(self, app):
-            # given
-            user = create_user(email="user@example.com")
-            repository.save(user)
-            data = {"identifier": user.email, "password": user.clearTextPassword}
+@pytest.mark.usefixtures("db_session")
+class Returns200:
+    def when_account_is_known(self, app):
+        # given
+        user = users_factories.UserFactory(password="secret")
+        data = {"identifier": user.email, "password": "secret"}
 
-            # when
-            response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
+        # when
+        response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
 
-            # then
-            assert response.status_code == 200
+        # then
+        assert response.status_code == 200
 
-        @pytest.mark.usefixtures("db_session")
-        def when_account_is_known_with_mixed_case_email(self, app):
-            # given
-            user = create_user(email="USER@example.COM")
-            repository.save(user)
-            data = {"identifier": "uSeR@EXAmplE.cOm", "password": user.clearTextPassword}
+    def when_account_is_known_with_mixed_case_email(self, app):
+        # given
+        users_factories.UserFactory(email="USER@example.COM", password="secret")
+        data = {"identifier": "uSeR@EXAmplE.cOm", "password": "secret"}
 
-            # when
-            response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
+        # when
+        response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
 
-            # then
-            assert response.status_code == 200
+        # then
+        assert response.status_code == 200
 
-        @pytest.mark.usefixtures("db_session")
-        def when_account_is_known_with_trailing_spaces_in_email(self, app):
-            # given
-            user = create_user(email="user@example.com")
-            repository.save(user)
-            data = {"identifier": "  user@example.com  ", "password": user.clearTextPassword}
+    def when_account_is_known_with_trailing_spaces_in_email(self, app):
+        # given
+        users_factories.UserFactory(email="user@example.com", password="secret")
+        data = {"identifier": "  user@example.com  ", "password": "secret"}
 
-            # when
-            response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
+        # when
+        response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
 
-            # then
-            assert response.status_code == 200
+        # then
+        assert response.status_code == 200
 
-        @pytest.mark.usefixtures("db_session")
-        def expect_a_new_user_session_to_be_recorded(self, app):
-            # given
-            user = create_user(email="user@example.com")
-            repository.save(user)
-            data = {"identifier": user.email, "password": user.clearTextPassword}
+    def expect_a_new_user_session_to_be_recorded(self, app):
+        # given
+        user = users_factories.UserFactory(password="secret")
+        data = {"identifier": user.email, "password": "secret"}
 
-            # when
-            response = TestClient(app.test_client()).post(
-                "/beneficiaries/signin", json=data, headers={"origin": "http://localhost:3000"}
-            )
+        # when
+        response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
 
-            # then
-            assert response.status_code == 200
+        # then
+        assert response.status_code == 200
+        session = UserSession.query.filter_by(userId=user.id).first()
+        assert session is not None
 
-            session = UserSession.query.filter_by(userId=user.id).first()
-            assert session is not None
 
-    class Returns401:
-        @pytest.mark.usefixtures("db_session")
-        def when_identifier_is_missing(self, app):
-            # Given
-            user = create_user()
-            repository.save(user)
-            data = {"identifier": None, "password": user.clearTextPassword}
+@pytest.mark.usefixtures("db_session")
+class Returns401:
+    def when_identifier_is_missing(self, app):
+        # Given
+        users_factories.UserFactory()
+        data = {"identifier": None, "password": "secret"}
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
 
-            # Then
-            assert response.status_code == 401
-            assert response.json["identifier"] == ["Identifiant manquant"]
+        # Then
+        assert response.status_code == 401
+        assert response.json["identifier"] == ["Identifiant manquant"]
 
-        @pytest.mark.usefixtures("db_session")
-        def when_identifier_is_incorrect(self, app):
-            # Given
-            user = create_user()
-            repository.save(user)
-            data = {"identifier": "random.email@test.com", "password": user.clearTextPassword}
+    def when_identifier_is_unknown(self, app):
+        # Given
+        users_factories.UserFactory()
+        data = {"identifier": "unknown@example.com", "password": "password"}
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
 
-            # Then
-            assert response.status_code == 401
-            assert response.json["identifier"] == ["Identifiant incorrect"]
+        # Then
+        assert response.status_code == 401
+        assert response.json["identifier"] == ["Identifiant incorrect"]
 
-        @pytest.mark.usefixtures("db_session")
-        def when_password_is_missing(self, app):
-            # Given
-            user = create_user()
-            repository.save(user)
-            data = {"identifier": user.email, "password": None}
+    def when_password_is_missing(self, app):
+        # Given
+        user = users_factories.UserFactory()
+        data = {"identifier": user.email, "password": None}
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
 
-            # Then
-            assert response.status_code == 401
-            assert response.json["password"] == ["Mot de passe manquant"]
+        # Then
+        assert response.status_code == 401
+        assert response.json["password"] == ["Mot de passe manquant"]
 
-        @pytest.mark.usefixtures("db_session")
-        def when_password_is_incorrect(self, app):
-            # Given
-            user = create_user()
-            repository.save(user)
-            data = {"identifier": user.email, "password": "wr0ng_p455w0rd"}
+    def when_password_is_incorrect(self, app):
+        # Given
+        user = users_factories.UserFactory()
+        data = {"identifier": user.email, "password": "wrong password"}
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
 
-            # Then
-            assert response.status_code == 401
-            assert response.json["password"] == ["Mot de passe incorrect"]
+        # Then
+        assert response.status_code == 401
+        assert response.json["password"] == ["Mot de passe incorrect"]
 
-        @pytest.mark.usefixtures("db_session")
-        def when_account_is_not_validated(self, app):
-            # Given
-            user = create_user()
-            user.generate_validation_token()
-            repository.save(user)
-            data = {"identifier": user.email, "password": user.clearTextPassword}
+    def when_account_is_not_validated(self, app):
+        # Given
+        user = users_factories.UserFactory(password="secret")
+        user.generate_validation_token()
+        data = {"identifier": user.email, "password": "secret"}
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
 
-            # Then
-            assert response.status_code == 401
-            assert response.json["identifier"] == ["Ce compte n'est pas validé."]
+        # Then
+        assert response.status_code == 401
+        assert response.json["identifier"] == ["Ce compte n'est pas validé."]

--- a/tests/routes/webapp/post_signin_beneficiary_test.py
+++ b/tests/routes/webapp/post_signin_beneficiary_test.py
@@ -105,6 +105,18 @@ class Returns401:
         assert response.status_code == 401
         assert response.json["password"] == ["Mot de passe incorrect"]
 
+    def when_account_is_not_active(self, app):
+        # Given
+        user = users_factories.UserFactory(isActive=False, password="secret")
+        data = {"identifier": user.email, "password": "secret"}
+
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/signin", json=data)
+
+        # Then
+        assert response.status_code == 401
+        assert response.json["identifier"] == ["Identifiant incorrect"]
+
     def when_account_is_not_validated(self, app):
         # Given
         user = users_factories.UserFactory(password="secret")


### PR DESCRIPTION
Commits à relire séparément. Au menu :

- ajout de `User.isActive` et prise en compte lors du login et de la
  demande de réinitialisation du mot de passe;

- ajout de `suspend_account()` et `unsuspend_account()` et remplissage
  du nouveau champ `suspensionReason`.

---

**Important : suggestion pour la migration** : puisqu'on n'a pas encore de mécanisme de migration pré-deploiement, je propose la procédure suivante (sur staging et production) :

1. **Avant** le déploiement, créer manuellement les 2 nouvelles colonnes, et simuler (_fake_) les 2 migrations :

   ```sql
   ALTER TABLE "user" ADD COLUMN "suspensionReason" TEXT;
   ALTER TABLE "user" ADD COLUMN "isActive" BOOLEAN DEFAULT true;
   UPDATE alembic_version SET version_num='55bf0bb6c53b' WHERE alembic_version.version_num = 'ad5e76920552';
   ```

2. Déployer comme d'habitude.

3. **Après** le déploiement, remplir les données (procéder par batch si besoin) :

    ```sql
    UPDATE "user" SET "isActive" = true;
    UPDATE "user" SET "suspensionReason" = '';
    -- FIXME : marquer les comptes déjà suspendus avec  `"isActive" = false`, `"isAdmin" = false` et `"suspensionReason" = 'XXX'.
    ```