### PR TITLE
(FIX) : Return werkzeug HTTP exception as correct HTTP response

### DIFF
--- a/src/pcapi/routes/error_handlers/generic_error_handlers.py
+++ b/src/pcapi/routes/error_handlers/generic_error_handlers.py
@@ -1,10 +1,12 @@
 from typing import Dict
 from typing import Tuple
+from typing import Union
 
 from flask import current_app as app
 from flask import jsonify
 from flask import request
 import simplejson as json
+from werkzeug.exceptions import HTTPException
 from werkzeug.exceptions import MethodNotAllowed
 from werkzeug.exceptions import NotFound
 
@@ -33,7 +35,10 @@ def restize_too_late_to_delete_stock(error: offers_exceptions.TooLateToDeleteSto
 
 
 @app.errorhandler(Exception)
-def internal_error(error: Exception) -> Tuple[Dict, int]:
+def internal_error(error: Exception) -> Union[Tuple[Dict, int], HTTPException]:
+    # pass through HTTP errors
+    if isinstance(error, HTTPException):
+        return error
     app.logger.exception("Unexpected error on method=%s url=%s: %s", request.method, request.url, error)
     errors = ApiErrors()
     errors.add_error("global", "Il semble que nous ayons des problèmes techniques :(" + " On répare ça au plus vite.")


### PR DESCRIPTION
The catchall exception handler `internal_error` also catches
werkzeug valid exceptions that should be passed as it instead of
returning them as 500.

According to the documentation:
An error handler for Exception might seem useful for changing
how all errors, even unhandled ones, are presented to the user.
However, this is similar to doing except Exception: in Python,
it will capture all otherwise unhandled errors, including all
HTTP status codes. In most cases it will be safer to register
handlers for more specific exceptions. Since HTTPException
instances are valid WSGI responses, you could also pass them
through directly.

https://flask.palletsprojects.com/en/1.1.x/errorhandling/#generic-exception-handlers