### PR TITLE
(FIX) : only set sentry when worker is started directly

### DIFF
--- a/src/pcapi/workers/worker.py
+++ b/src/pcapi/workers/worker.py
@@ -30,15 +30,6 @@ conn = redis.from_url(settings.REDIS_URL)
 redis_queue = Queue(connection=conn)
 logging.getLogger("rq.worker").setLevel(logging.CRITICAL)
 
-if settings.IS_DEV is False:
-    sentry_sdk.init(
-        dsn=settings.SENTRY_DSN,
-        integrations=[RedisIntegration(), RqIntegration(), SqlalchemyIntegration()],
-        release=read_version_from_file(),
-        environment=settings.ENV,
-        traces_sample_rate=settings.SENTRY_SAMPLE_RATE,
-    )
-
 
 def log_worker_error(job: Job, exception_type: Type, exception_value: Exception) -> None:
     # This handler is called by `rq.Worker.handle_exception()` from an
@@ -47,6 +38,14 @@ def log_worker_error(job: Job, exception_type: Type, exception_value: Exception)
 
 
 if __name__ == "__main__":
+    if settings.IS_DEV is False:
+        sentry_sdk.init(
+            dsn=settings.SENTRY_DSN,
+            integrations=[RedisIntegration(), RqIntegration(), SqlalchemyIntegration()],
+            release=read_version_from_file(),
+            environment=settings.ENV,
+            traces_sample_rate=settings.SENTRY_SAMPLE_RATE,
+        )
     while True:
         try:
             with Connection(conn):


### PR DESCRIPTION
It previously overrode the flask_app sentry initialization through
an import chain:
<img width="847" alt="Capture d’écran 2020-12-17 à 14 17 30" src="https://user-images.githubusercontent.com/2340654/102492943-b27e4080-4072-11eb-82b2-2afaba40db43.png">
<img width="1090" alt="Capture d’écran 2020-12-17 à 14 17 38" src="https://user-images.githubusercontent.com/2340654/102492947-b5793100-4072-11eb-993f-1bea0c7e072c.png">
