### PR TITLE
(PC-5900) admin: Restrict account suspension/reactivation to super admins

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,9 +107,12 @@ def mocked_mail(f):
 def clean_database(f: object) -> object:
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        return_value = f(*args, **kwargs)
-        db.session.rollback()
         clean_all_database()
+        try:
+            return_value = f(*args, **kwargs)
+        finally:
+            db.session.rollback()
+            clean_all_database()
         return return_value
 
     return decorated_function


### PR DESCRIPTION
Plus un petit commit en bonus pour que clean_database fonctionne aussi
pour les tests qui échouent.