### PR TITLE
(PC-5891) pro: Remove special handling of "activation" offer bookings

### DIFF
--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -125,7 +125,6 @@ def mark_as_used(booking: Booking) -> None:
 
 
 def mark_as_unused(booking: Booking) -> None:
-    validation.check_is_not_activation_booking(booking)
     validation.check_can_be_mark_as_unused(booking)
     booking.isUsed = False
     booking.dateUsed = None

--- a/src/pcapi/core/bookings/validation.py
+++ b/src/pcapi/core/bookings/validation.py
@@ -8,7 +8,6 @@ from pcapi.core.bookings import exceptions
 from pcapi.core.bookings.models import Booking
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
-from pcapi.domain import user_activation
 import pcapi.domain.expenses as payments_api
 from pcapi.models import UserSQLEntity
 from pcapi.models import api_errors
@@ -144,14 +143,6 @@ def check_is_usable(booking: Booking) -> None:
             f"Cette réservation a été effectuée le {booking_date}. "
             f"Veuillez attendre jusqu’au {max_cancellation_date} pour valider la contremarque.",
         )
-        raise forbidden
-
-
-# FIXME: should not raise exceptions from `api_errors` (see above for details).
-def check_is_not_activation_booking(booking: Booking) -> None:
-    if user_activation.is_activation_booking(booking):
-        forbidden = api_errors.ForbiddenError()
-        forbidden.add_error("booking", "Impossible d'annuler une offre d'activation")
         raise forbidden
 
 

--- a/src/pcapi/domain/user_activation.py
+++ b/src/pcapi/domain/user_activation.py
@@ -7,8 +7,6 @@ from pcapi.domain.password import random_password
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.beneficiary_import_status import ImportStatus
 from pcapi.models.deposit import Deposit
-from pcapi.models.offer_type import EventType
-from pcapi.models.offer_type import ThingType
 from pcapi.models.user_sql_entity import UserSQLEntity
 from pcapi.scripts.beneficiary import THIRTY_DAYS_IN_HOURS
 
@@ -57,10 +55,6 @@ def generate_activation_users_csv(activation_users: Iterable[ActivationUser]) ->
     writer.writerow(ActivationUser.CSV_HEADER)
     writer.writerows(csv_lines)
     return output.getvalue()
-
-
-def is_activation_booking(booking):
-    return booking.stock.offer.type in [str(EventType.ACTIVATION), str(ThingType.ACTIVATION)]
 
 
 def create_beneficiary_from_application(application_detail: dict) -> UserSQLEntity:

--- a/src/pcapi/routes/pro/bookings.py
+++ b/src/pcapi/routes/pro/bookings.py
@@ -10,8 +10,6 @@ from pcapi.core.bookings.models import Booking
 import pcapi.core.bookings.repository as booking_repository
 import pcapi.core.bookings.validation as bookings_validation
 from pcapi.domain.user_activation import create_initial_deposit
-from pcapi.domain.user_activation import is_activation_booking
-from pcapi.domain.user_emails import send_activation_email
 from pcapi.domain.users import check_is_authorized_to_access_bookings_recap
 from pcapi.flask_app import private_api
 from pcapi.flask_app import public_api
@@ -27,7 +25,6 @@ from pcapi.routes.serialization import serialize_booking
 from pcapi.routes.serialization.bookings_recap_serialize import serialize_bookings_recap_paginated
 from pcapi.utils.human_ids import dehumanize
 from pcapi.utils.human_ids import humanize
-from pcapi.utils.mailing import send_raw_email
 from pcapi.utils.rest import ensure_current_user_has_rights
 from pcapi.validation.routes.bookings import check_email_and_offer_id_for_anonymous_user
 from pcapi.validation.routes.bookings import check_page_format_is_number
@@ -73,10 +70,6 @@ def patch_booking_by_token(token: str):
         check_email_and_offer_id_for_anonymous_user(email, offer_id)
 
     bookings_api.mark_as_used(booking)
-
-    if is_activation_booking(booking):
-        _activate_user(booking.user)
-        send_activation_email(booking.user, send_raw_email)
 
     return "", 204
 
@@ -137,10 +130,6 @@ def patch_booking_use_by_token(token: str):
 
     if valid_api_key:
         check_api_key_allows_to_validate_booking(valid_api_key, offerer_id)
-
-    if is_activation_booking(booking):
-        _activate_user(booking.user)
-        send_activation_email(booking.user, send_raw_email)
 
     bookings_api.mark_as_used(booking)
 

--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -16,7 +16,6 @@ import pcapi.core.payments.factories as payments_factories
 import pcapi.core.recommendations.factories as recommendations_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.models import api_errors
-from pcapi.models import offer_type
 from pcapi.models.feature import override_features
 from pcapi.utils.token import random_token
 
@@ -292,15 +291,6 @@ class MarkAsUnusedTest:
         booking = factories.BookingFactory(isUsed=True)
         api.mark_as_unused(booking)
         assert not booking.isUsed
-
-    def test_raise_if_activation_booking(self):
-        booking = factories.BookingFactory(
-            isUsed=True,
-            stock__offer__type=str(offer_type.EventType.ACTIVATION),
-        )
-        with pytest.raises(api_errors.ForbiddenError):
-            api.mark_as_unused(booking)
-        assert booking.isUsed  # unchanged
 
     def test_raise_if_not_yet_used(self):
         booking = factories.BookingFactory(isUsed=False)

--- a/tests/core/bookings/test_validation.py
+++ b/tests/core/bookings/test_validation.py
@@ -10,8 +10,6 @@ from pcapi.core.bookings import validation
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
 import pcapi.core.users.factories as users_factories
-from pcapi.models import ApiErrors
-from pcapi.models import EventType
 from pcapi.models import ThingType
 from pcapi.models import api_errors
 
@@ -302,25 +300,6 @@ class CheckOffererCanCancelBookingTest:
         with pytest.raises(api_errors.ForbiddenError) as exc:
             validation.check_offerer_can_cancel_booking(booking)
         assert exc.value.errors["global"] == ["Impossible d'annuler une réservation consommée"]
-
-
-@pytest.mark.usefixtures("db_session")
-class CheckActivationBookingCanBeKeptTest:
-    def test_should_raise_an_error_when_booking_has_an_event_activation_type(self):
-        booking = factories.BookingFactory(stock__offer__type=str(EventType.ACTIVATION))
-        with pytest.raises(ApiErrors) as exc:
-            validation.check_is_not_activation_booking(booking)
-        assert exc.value.errors["booking"] == ["Impossible d'annuler une offre d'activation"]
-
-    def test_should_raise_an_error_when_booking_has_a_thing_activation_type(self):
-        booking = factories.BookingFactory(stock__offer__type=str(EventType.ACTIVATION))
-        with pytest.raises(ApiErrors) as exc:
-            validation.check_is_not_activation_booking(booking)
-        assert exc.value.errors["booking"] == ["Impossible d'annuler une offre d'activation"]
-
-    def test_should_not_raise_when_booking_is_not_an_activation(self):
-        booking = factories.BookingFactory(stock__offer__type=str(EventType.JEUX))
-        validation.check_is_not_activation_booking(booking)  # should not raise
 
 
 @pytest.mark.usefixtures("db_session")

--- a/tests/domain/user_activation_test.py
+++ b/tests/domain/user_activation_test.py
@@ -6,20 +6,15 @@ import pytest
 
 from pcapi.domain.user_activation import ActivationUser
 from pcapi.domain.user_activation import generate_activation_users_csv
-from pcapi.domain.user_activation import is_activation_booking
 from pcapi.domain.user_activation import is_import_status_change_allowed
 from pcapi.model_creators.generic_creators import create_booking
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_stock
 from pcapi.model_creators.generic_creators import create_user
 from pcapi.model_creators.generic_creators import create_venue
-from pcapi.model_creators.specific_creators import create_offer_with_event_product
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.model_creators.specific_creators import create_product_with_event_type
-from pcapi.models import EventType
 from pcapi.models import ImportStatus
 from pcapi.models import ThingType
-from pcapi.models import UserSQLEntity
 from pcapi.scripts.beneficiary.old_remote_import import create_beneficiary_from_application
 
 
@@ -149,36 +144,3 @@ class CreateBeneficiaryFromApplicationTest:
         assert len(beneficiary.deposits) == 1
         assert beneficiary.deposits[0].amount == Decimal(500)
         assert beneficiary.deposits[0].source == "démarches simplifiées dossier [123]"
-
-
-class IsActivationBookingTest:
-    def test_returns_true_when_offer_is_event_type_activation(self):
-        # Given
-        product = create_product_with_event_type(event_type=EventType.ACTIVATION)
-        offer = create_offer_with_event_product(product=product)
-        stock = create_stock(offer=offer)
-        booking = create_booking(user=UserSQLEntity(), stock=stock)
-
-        # Then
-        assert is_activation_booking(booking)
-
-    def test_returns_true_when_offer_is_thing_type_activation(self):
-        # Given
-        product = create_product_with_event_type(event_type=ThingType.ACTIVATION)
-        offer = create_offer_with_event_product(product=product)
-        stock = create_stock(offer=offer)
-        booking = create_booking(user=UserSQLEntity(), stock=stock)
-
-        # Then
-        assert is_activation_booking(booking)
-
-    def test_returns_false_with_type_of_offer_is_not_an_activation(self):
-        # Given
-        product = create_product_with_event_type(event_type=EventType.SPECTACLE_VIVANT)
-        offer = create_offer_with_event_product(product=product)
-        offer.type = "EventType.SPECTACLE_VIVANT"
-        stock = create_stock(offer=offer)
-        booking = create_booking(user=UserSQLEntity(), stock=stock)
-
-        # Then
-        assert is_activation_booking(booking) is False

--- a/tests/routes/pro/get_booking_by_token_test.py
+++ b/tests/routes/pro/get_booking_by_token_test.py
@@ -91,40 +91,6 @@ class Get:
             }
 
         @pytest.mark.usefixtures("db_session")
-        def when_user_has_rights_and_activation_event(self, app):
-            # Given
-            user = create_user(date_of_birth=datetime(2001, 2, 1), email="user@example.com", phone_number="0698765432")
-            admin_user = create_user(is_beneficiary=False, email="admin@example.com", is_admin=True)
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(
-                venue, event_name="Offre d'activation", event_type=EventType.ACTIVATION
-            )
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(admin_user, booking)
-            url = f"/bookings/token/{booking.token}"
-
-            # When
-            response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
-
-            # Then
-            assert response.status_code == 200
-            response_json = response.json
-            assert response_json == {
-                "bookingId": humanize(booking.id),
-                "date": serialize(booking.stock.beginningDatetime),
-                "dateOfBirth": "2001-02-01T00:00:00Z",
-                "email": "user@example.com",
-                "isUsed": False,
-                "offerName": "Offre d'activation",
-                "phoneNumber": "0698765432",
-                "userName": "John Doe",
-                "venueDepartementCode": "93",
-            }
-
-        @pytest.mark.usefixtures("db_session")
         def when_user_has_rights_and_email_with_special_characters_url_encoded(self, app):
             # Given
             user = create_user(email="user+plus@example.com")

--- a/tests/routes/pro/get_booking_by_token_v2_test.py
+++ b/tests/routes/pro/get_booking_by_token_v2_test.py
@@ -160,28 +160,6 @@ class Get:
             # Then
             assert response.status_code == 200
 
-        @pytest.mark.usefixtures("db_session")
-        def when_activation_event_and_user_has_rights(self, app):
-            # Given
-            user = create_user(date_of_birth=datetime(2001, 2, 1), email="user@example.com", phone_number="0698765432")
-            admin_user = create_user(is_beneficiary=False, email="admin@example.com", is_admin=True)
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(
-                venue, event_name="Offre d'activation", event_type=EventType.ACTIVATION
-            )
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(admin_user, booking)
-            url = f"/v2/bookings/token/{booking.token}"
-
-            # When
-            response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
-
-            # Then
-            assert response.status_code == 200
-
     class Returns401:
         def when_user_not_logged_in_and_doesnt_give_api_key(self, app):
             # Given

--- a/tests/routes/pro/patch_booking_keep_by_token_test.py
+++ b/tests/routes/pro/patch_booking_keep_by_token_test.py
@@ -17,7 +17,6 @@ from pcapi.model_creators.specific_creators import create_offer_with_event_produ
 from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence
 from pcapi.model_creators.specific_creators import create_stock_with_event_offer
 from pcapi.models import Booking
-from pcapi.models import EventType
 from pcapi.repository import repository
 from pcapi.utils.token import random_token
 
@@ -242,32 +241,6 @@ class Returns403:
             assert response.status_code == 403
             assert response.json["user"] == ["Vous n'avez pas les droits suffisants pour valider cette contremarque."]
             assert Booking.query.get(booking.id).isUsed is False
-
-        @pytest.mark.usefixtures("db_session")
-        def when_user_tries_to_patch_activation_offer(self, app):
-            # Given
-            user = create_user()
-
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(user, offerer)
-            venue = create_venue(offerer)
-
-            activation_offer = create_offer_with_event_product(venue, event_type=EventType.ACTIVATION)
-            activation_event_occurrence = create_event_occurrence(activation_offer)
-            stock = create_stock_from_event_occurrence(activation_event_occurrence, price=0)
-
-            booking = create_booking(user=user, stock=stock, venue=venue)
-
-            repository.save(booking, user_offerer)
-
-            # When
-            url = "/v2/bookings/keep/token/{}".format(booking.token)
-            response = TestClient(app.test_client()).with_auth(user.email).patch(url)
-
-            # Then
-            assert response.status_code == 403
-            assert Booking.query.get(booking.id).isUsed is False
-            assert response.json["booking"] == ["Impossible d'annuler une offre d'activation"]
 
         @pytest.mark.usefixtures("db_session")
         def when_user_is_logged_in_and_booking_has_been_cancelled_already(self, app):

--- a/tests/routes/pro/validate_bookings_test.py
+++ b/tests/routes/pro/validate_bookings_test.py
@@ -11,21 +11,15 @@ import pcapi.core.offers.factories as offers_factories
 from pcapi.core.payments.factories import PaymentFactory
 from pcapi.core.users.factories import UserFactory
 from pcapi.model_creators.generic_creators import create_booking
-from pcapi.model_creators.generic_creators import create_deposit
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_user
 from pcapi.model_creators.generic_creators import create_user_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_event_occurrence
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
-from pcapi.model_creators.specific_creators import create_offer_with_thing_product
 from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence
 from pcapi.model_creators.specific_creators import create_stock_with_event_offer
 from pcapi.models import Booking
-from pcapi.models import Deposit
-from pcapi.models import EventType
-from pcapi.models import ThingType
-from pcapi.models import UserSQLEntity
 from pcapi.models import api_errors
 from pcapi.repository import repository
 from pcapi.utils.human_ids import humanize
@@ -87,64 +81,6 @@ class Returns204:  # No Content
         booking = bookings_models.Booking.query.one()
         assert booking.isUsed
 
-    def when_user_patching_is_global_admin_is_activation_event_and_no_deposit_for_booking_user(self, app):
-        # Given
-        user = create_user(is_beneficiary=False, is_admin=False, first_name="John")
-        pro_user = create_user(is_beneficiary=False, email="pro@email.fr", is_admin=True)
-        offerer = create_offerer()
-        user_offerer = create_user_offerer(pro_user, offerer)
-        venue = create_venue(offerer)
-        activation_offer = create_offer_with_event_product(venue, event_type=EventType.ACTIVATION)
-        activation_event_occurrence = create_event_occurrence(activation_offer, beginning_datetime=tomorrow)
-        stock = create_stock_from_event_occurrence(
-            activation_event_occurrence, price=0, booking_limit_date=tomorrow_minus_one_hour
-        )
-        booking = create_booking(user=user, stock=stock, venue=venue)
-        repository.save(booking, user_offerer)
-        user_id = user.id
-        url = "/bookings/token/{}".format(booking.token)
-
-        # When
-        response = TestClient(app.test_client()).with_auth("pro@email.fr").patch(url)
-
-        # Then
-        user = UserSQLEntity.query.get(user_id)
-        assert response.status_code == 204
-        assert user.isBeneficiary
-        deposits_for_user = Deposit.query.filter_by(userId=user.id).all()
-        assert len(deposits_for_user) == 1
-        assert deposits_for_user[0].amount == 500
-        assert user.isBeneficiary
-
-    def when_user_patching_is_global_admin_is_activation_thing_and_no_deposit_for_booking_user(self, app):
-        # Given
-        user = create_user(is_beneficiary=False, is_admin=False, first_name="John")
-        pro_user = create_user(is_beneficiary=False, email="pro@email.fr", is_admin=True)
-        offerer = create_offerer()
-        user_offerer = create_user_offerer(pro_user, offerer)
-        venue = create_venue(offerer)
-        activation_offer = create_offer_with_thing_product(venue, thing_type=ThingType.ACTIVATION)
-        activation_event_occurrence = create_event_occurrence(activation_offer, beginning_datetime=tomorrow)
-        stock = create_stock_from_event_occurrence(
-            activation_event_occurrence, price=0, booking_limit_date=tomorrow_minus_one_hour
-        )
-        booking = create_booking(user=user, stock=stock, venue=venue)
-        repository.save(booking, user_offerer)
-        user_id = user.id
-        url = "/bookings/token/{}".format(booking.token)
-
-        # When
-        response = TestClient(app.test_client()).with_auth("pro@email.fr").patch(url)
-
-        # Then
-        user = UserSQLEntity.query.get(user_id)
-        assert response.status_code == 204
-        assert user.isBeneficiary
-        deposits_for_user = Deposit.query.filter_by(userId=user.id).all()
-        assert len(deposits_for_user) == 1
-        assert deposits_for_user[0].amount == 500
-        assert user.isBeneficiary
-
 
 class Returns403:
     @pytest.mark.usefixtures("db_session")
@@ -190,32 +126,6 @@ class Returns403:
         # Then
         assert response.status_code == 403
         assert response.json["booking"] == ["Not confirmed"]
-
-    @pytest.mark.usefixtures("db_session")
-    def when_it_is_an_offer_on_an_activation_event_and_user_patching_is_not_global_admin(self, app):
-        # Given
-        user = create_user()
-        pro_user = create_user(email="pro@email.fr", is_admin=False)
-        offerer = create_offerer()
-        user_offerer = create_user_offerer(pro_user, offerer)
-        venue = create_venue(offerer)
-        activation_offer = create_offer_with_event_product(venue, event_type=EventType.ACTIVATION)
-        activation_event_occurrence = create_event_occurrence(activation_offer)
-        stock = create_stock_from_event_occurrence(activation_event_occurrence, price=0)
-        activation_offer = create_offer_with_event_product(venue, event_type=EventType.ACTIVATION)
-        activation_event_occurrence = create_event_occurrence(activation_offer, beginning_datetime=tomorrow)
-        stock = create_stock_from_event_occurrence(
-            activation_event_occurrence, price=0, booking_limit_date=tomorrow_minus_one_hour
-        )
-        booking = create_booking(user=user, stock=stock, venue=venue)
-        repository.save(booking, user_offerer)
-        url = "/bookings/token/{}".format(booking.token)
-
-        # When
-        response = TestClient(app.test_client()).with_auth("pro@email.fr").patch(url)
-
-        # Then
-        assert response.status_code == 403
 
     @pytest.mark.usefixtures("db_session")
     def when_booking_is_cancelled(self, app):
@@ -316,36 +226,6 @@ class Returns404:
         # Then
         assert response.status_code == 404
         assert not Booking.query.get(booking_id).isUsed
-
-
-class Returns405:  # Method Not Allowed
-    @pytest.mark.usefixtures("db_session")
-    def when_user_patching_is_global_admin_is_activation_offer_and_existing_deposit_for_booking_user(self, app):
-        # Given
-        user = create_user(is_beneficiary=False, is_admin=False)
-        pro_user = create_user(is_beneficiary=False, email="pro@email.fr", is_admin=True)
-        offerer = create_offerer()
-        user_offerer = create_user_offerer(pro_user, offerer)
-        venue = create_venue(offerer)
-        activation_offer = create_offer_with_event_product(venue, event_type=EventType.ACTIVATION)
-        activation_event_occurrence = create_event_occurrence(activation_offer, beginning_datetime=tomorrow)
-        stock = create_stock_from_event_occurrence(
-            activation_event_occurrence, price=0, booking_limit_date=tomorrow_minus_one_hour
-        )
-        booking = create_booking(user=user, stock=stock, venue=venue)
-        deposit = create_deposit(user, amount=500)
-        repository.save(booking, user_offerer, deposit)
-        user_id = user.id
-        url = "/bookings/token/{}".format(booking.token)
-
-        # When
-        response = TestClient(app.test_client()).with_auth("pro@email.fr").patch(url)
-
-        # Then
-        deposits_for_user = Deposit.query.filter_by(userId=user_id).all()
-        assert response.status_code == 405
-        assert len(deposits_for_user) == 1
-        assert deposits_for_user[0].amount == 500
 
 
 class Returns410:  # Gone

--- a/tests/validation/routes/offers_test.py
+++ b/tests/validation/routes/offers_test.py
@@ -20,7 +20,7 @@ class CheckOfferTypeIsValidTest:
         check_offer_type_is_valid(str(ThingType.JEUX_VIDEO))
 
     def test_does_not_raise_exception_when_EventType_is_given(self):
-        check_offer_type_is_valid(str(EventType.ACTIVATION))
+        check_offer_type_is_valid(str(EventType.CINEMA))
 
 
 class CheckOfferNameIsValidTest:


### PR DESCRIPTION
"Activation" offers are not used anymore to create users. We now use
the admin interface instead. As such, we can remove the special
handling of such bookings in the pro-related endpoints.