### PR TITLE
(PC-5929) add stock price and booking quantity to favorites route

### DIFF
--- a/src/pcapi/domain/favorite/favorite.py
+++ b/src/pcapi/domain/favorite/favorite.py
@@ -11,6 +11,7 @@ class Favorite:
         self.offer = offer
         self.booking_identifier = booking["id"] if booking else None
         self.booked_stock_identifier = booking["stock_id"] if booking else None
+        self.booking_quantity = booking["quantity"] if booking else None
 
     @property
     def is_booked(self) -> bool:

--- a/src/pcapi/infrastructure/repository/favorite/favorite_sql_repository.py
+++ b/src/pcapi/infrastructure/repository/favorite/favorite_sql_repository.py
@@ -34,12 +34,18 @@ class FavoriteSQLRepository(FavoriteRepository):
             .join(Booking)
             .filter(Booking.userId == beneficiary_identifier)
             .filter(Booking.isCancelled == False)
-            .with_entities(Booking.id.label("booking_id"), Offer.id.label("offer_id"), Stock.id.label("stock_id"))
+            .with_entities(
+                Booking.id.label("booking_id"),
+                Booking.quantity,
+                Offer.id.label("offer_id"),
+                Stock.id.label("stock_id"),
+            )
             .all()
         )
 
         bookings_by_offer_id = {
-            booking.offer_id: {"id": booking.booking_id, "stock_id": booking.stock_id} for booking in bookings
+            booking.offer_id: {"id": booking.booking_id, "stock_id": booking.stock_id, "quantity": booking.quantity}
+            for booking in bookings
         }
 
         return [

--- a/src/pcapi/routes/serialization/favorites_serialize.py
+++ b/src/pcapi/routes/serialization/favorites_serialize.py
@@ -1,6 +1,7 @@
 from typing import Dict
 from typing import List
 
+from pcapi.core.bookings.models import Booking
 from pcapi.domain.favorite.favorite import Favorite
 from pcapi.routes.serialization.serializer import serialize
 from pcapi.utils.human_ids import humanize
@@ -17,7 +18,12 @@ def serialize_favorite(favorite: Favorite) -> Dict:
     humanized_venue_id = humanize(venue.id)
 
     stocks = [
-        {"beginningDatetime": stock.beginningDatetime, "id": humanize(stock.id), "offerId": humanized_offer_id}
+        {
+            "beginningDatetime": stock.beginningDatetime,
+            "id": humanize(stock.id),
+            "offerId": humanized_offer_id,
+            "price": stock.price,
+        }
         for stock in offer.stocks
     ]
 
@@ -40,9 +46,11 @@ def serialize_favorite(favorite: Favorite) -> Dict:
     }
 
     if favorite.is_booked:
+        booking = Booking.query.filter_by(id=favorite.booking_identifier).first_or_404()
         serialized_favorite["booking"] = {
             "id": humanize(favorite.booking_identifier),
             "stockId": humanize(favorite.booked_stock_identifier),
+            "quantity": booking.quantity,
         }
 
     return serialized_favorite

--- a/src/pcapi/routes/serialization/favorites_serialize.py
+++ b/src/pcapi/routes/serialization/favorites_serialize.py
@@ -1,7 +1,6 @@
 from typing import Dict
 from typing import List
 
-from pcapi.core.bookings.models import Booking
 from pcapi.domain.favorite.favorite import Favorite
 from pcapi.routes.serialization.serializer import serialize
 from pcapi.utils.human_ids import humanize
@@ -46,11 +45,10 @@ def serialize_favorite(favorite: Favorite) -> Dict:
     }
 
     if favorite.is_booked:
-        booking = Booking.query.filter_by(id=favorite.booking_identifier).first_or_404()
         serialized_favorite["booking"] = {
             "id": humanize(favorite.booking_identifier),
             "stockId": humanize(favorite.booked_stock_identifier),
-            "quantity": booking.quantity,
+            "quantity": favorite.booking_quantity,
         }
 
     return serialized_favorite

--- a/tests/infrastructure/repository/favorite/favorite_sql_repository_test.py
+++ b/tests/infrastructure/repository/favorite/favorite_sql_repository_test.py
@@ -78,6 +78,7 @@ class FindByBeneficiaryTest:
         assert favorite.is_booked is True
         assert favorite.booking_identifier == booking.id
         assert favorite.booked_stock_identifier == stock.id
+        assert favorite.booking_quantity == booking.quantity
 
     @pytest.mark.usefixtures("db_session")
     def test_should_not_return_booking_when_favorite_offer_booking_is_cancelled(self, app):

--- a/tests/routes/webapp/get_favorites_test.py
+++ b/tests/routes/webapp/get_favorites_test.py
@@ -76,6 +76,9 @@ class Get:
             favorite = response.json[0]
             assert "offer" in favorite
             assert "venue" in favorite["offer"]
+            assert "stocks" in favorite["offer"]
+            assert stock.price == favorite["offer"]["stocks"][0]["price"]
+            assert booking.quantity == favorite["booking"]["quantity"]
             assert humanize(booking.id) in favorite["booking"]["id"]
             assert "validationToken" not in favorite["offer"]["venue"]
 


### PR DESCRIPTION
## Contexte 

[Ce ticket de bug](https://passculture.atlassian.net/secure/RapidBoard.jspa?rapidView=16&modal=detail&selectedIssue=PC-5929) "**ETQU** connecté sur l'onglet favoris, **quand** je clique sur un de mes favoris dont j'ai réservé un ticket, **je suis** redirigé sur la page détails de cette offre, et le prix n'apparaît pas **alors qu'il** devrait apparaître."
<img width="300"  src="https://user-images.githubusercontent.com/66383742/103348081-43084800-4a99-11eb-9ece-7ada91c897dd.png"/>

## La source du bug

Lors de l'appel à la route `/favorites` un résultat contenant notamment cela est renvoyé:
```json
{
    "booking": {
      "id": "WQ", 
      "stockId": "AHSA"
    }, 
    ...
    "offer":{
      ...
      "stocks": [
        {
          "beginningDatetime": null, 
          "id": "AHSA", 
          "offerId": "AHVQ"
        }
      ],
    },
    ...
  }
```
Hors sur les pages détails d'une offre (qu'on vienne de l'onglet Accueil, Recherche, Réservations ou Favoris...), on évalue le prix avec les données suivantes:
* `booking.quantity`
* `stocks.findStockById.price`

Ainsi les 2 champs `booking.quantity` et `booking.price` n'étant pas renvoyés par l'API seulement lorsque l'on est sur l'onglet Favoris, ce prix ne peut pas être calculé et donc ne peut pas être affiché.

## Après ces changements

| Screenshot | api response |
|--|--|
||<div></div>|
<table>
<tr>
<th>
Status
</th>
<th>
Response
</th>
</tr>

<tr>

<td width="40%">
<img  src="https://user-images.githubusercontent.com/66383742/103350698-240db400-4aa1-11eb-83b6-44dc09ae8d1f.png">
</td>

<td>
<pre>
  {
    "booking": {
      "id": "WQ", 
      "stockId": "AHSA"
      "quantity": 1, 
    }, 
    ...
    "offer":{
      ...
      "stocks": [
        {
          "beginningDatetime": null, 
          "id": "AHSA", 
          "offerId": "AHVQ"
          "price": 4.00,
        }
      ],
    },
    ...
  }
</pre>
</td>
</tr>
</table>

## Noter que

Si la solution proposée ici semble fonctionner en local, n'ayant pas l'habitude de contribuer au code de l'API, je suis impatient de voir vos retours sur cette PR.