### PR TITLE
feature: Turn Feature.name from an enum into a simpler text column

### DIFF
--- a/src/pcapi/alembic/versions/f17831b0a62a_remove_enum_on_feature_name.py
+++ b/src/pcapi/alembic/versions/f17831b0a62a_remove_enum_on_feature_name.py
@@ -1,0 +1,24 @@
+"""Change feature.name from an enum to a text column
+
+Revision ID: f17831b0a62a
+Revises: 1e81fd76a908
+Create Date: 2021-01-05 18:05:06.971798
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f17831b0a62a"
+down_revision = "1e81fd76a908"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("feature", "name", type_=sa.Text())
+
+
+def downgrade():
+    op.execute("ALTER TABLE feature ALTER COLUMN name TYPE featuretoggle USING name::text::featuretoggle")

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -3,8 +3,8 @@ import enum
 from typing import Generator
 
 from sqlalchemy import Column
-from sqlalchemy import Enum
 from sqlalchemy import String
+from sqlalchemy import Text
 
 from pcapi.models.db import Model
 from pcapi.models.deactivable_mixin import DeactivableMixin
@@ -38,7 +38,7 @@ class FeatureToggle(enum.Enum):
 
 
 class Feature(PcObject, Model, DeactivableMixin):
-    name = Column(Enum(FeatureToggle), unique=True, nullable=False)
+    name = Column(Text, unique=True, nullable=False)
     description = Column(String(300), nullable=False)
 
     @property
@@ -64,12 +64,7 @@ def override_features(**overrides) -> Generator:
         def test_something():
             pass  # [...]
     """
-    state = {
-        feature.name: is_active
-        for feature, is_active in (
-            Feature.query.filter(Feature.name.in_(overrides)).with_entities(Feature.name, Feature.isActive).all()
-        )
-    }
+    state = dict(Feature.query.filter(Feature.name.in_(overrides)).with_entities(Feature.name, Feature.isActive).all())
     # Yes, the following may perform multiple SQL queries. It's fine,
     # we will probably not toggle thousands of features in each call.
     apply_to_revert = {}

--- a/src/pcapi/models/install.py
+++ b/src/pcapi/models/install.py
@@ -22,7 +22,7 @@ def install_features() -> None:
     for toggle in FeatureToggle:
         feature = Feature()
         feature.populate_from_dict(
-            {"description": toggle.value, "name": toggle, "is_active": toggle != "APPLY_BOOKING_LIMITS_V2"}
+            {"description": toggle.value, "name": toggle.name, "is_active": toggle != "APPLY_BOOKING_LIMITS_V2"}
         )
         features.append(feature)
     repository.save(*features)

--- a/src/pcapi/repository/feature_queries.py
+++ b/src/pcapi/repository/feature_queries.py
@@ -11,7 +11,7 @@ def find_all():
 def is_active(feature_toggle: FeatureToggle) -> bool:
     if not isinstance(feature_toggle, FeatureToggle):
         raise ResourceNotFoundError
-    return Feature.query.filter_by(name=feature_toggle).first().isActive
+    return Feature.query.filter_by(name=feature_toggle.name).first().isActive
 
 
 def feature_send_mail_to_users_enabled() -> bool:

--- a/tests/models/install_test.py
+++ b/tests/models/install_test.py
@@ -16,7 +16,7 @@ class InstallFeaturesTest:
 
         # Then
         for feature_toggle in FeatureToggle:
-            feature = Feature.query.filter_by(name=feature_toggle).one()
+            feature = Feature.query.filter_by(name=feature_toggle.name).one()
             assert feature.description == feature_toggle.value
             if feature_toggle != "APPLY_BOOKING_LIMITS_V2":
                 assert feature.isActive

--- a/tests/repository/feature_queries_test.py
+++ b/tests/repository/feature_queries_test.py
@@ -7,28 +7,26 @@ from pcapi.repository import repository
 from pcapi.repository.feature_queries import is_active
 
 
+@pytest.mark.usefixtures("db_session")
 class FeatureToggleTest:
-    @pytest.mark.usefixtures("db_session")
-    def test_is_active_returns_true_when_feature_is_active(self, app):
+    def test_is_active_returns_true_when_feature_is_active(self):
         # Given
-        feature = Feature.query.filter_by(name=FeatureToggle.WEBAPP_SIGNUP).first()
+        feature = Feature.query.filter_by(name=FeatureToggle.WEBAPP_SIGNUP.name).first()
         feature.isActive = True
         repository.save(feature)
 
         # When / Then
         assert is_active(FeatureToggle.WEBAPP_SIGNUP)
 
-    @pytest.mark.usefixtures("db_session")
-    def test_is_active_returns_false_when_feature_is_inactive(self, app):
+    def test_is_active_returns_false_when_feature_is_inactive(self):
         # Given
-        feature = Feature.query.filter_by(name=FeatureToggle.WEBAPP_SIGNUP).first()
+        feature = Feature.query.filter_by(name=FeatureToggle.WEBAPP_SIGNUP.name).first()
         feature.isActive = False
         repository.save(feature)
         # When / Then
         assert not is_active(FeatureToggle.WEBAPP_SIGNUP)
 
-    @pytest.mark.usefixtures("db_session")
-    def test_is_active_returns_false_when_feature_unknown(self, app):
+    def test_is_active_returns_false_when_feature_unknown(self):
         # When / Then
         with pytest.raises(ResourceNotFoundError):
             is_active("some_random_value")

--- a/tests/routes/serialization/reimbursement_csv_test.py
+++ b/tests/routes/serialization/reimbursement_csv_test.py
@@ -11,7 +11,7 @@ from pcapi.model_creators.generic_creators import create_user_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
 from pcapi.model_creators.specific_creators import create_stock_with_thing_offer
-from pcapi.models.feature import FeatureToggle
+from pcapi.models.feature import override_features
 from pcapi.models.payment_status import TransactionStatus
 from pcapi.repository import repository
 from pcapi.repository.reimbursement_queries import find_all_offerer_payments
@@ -19,8 +19,6 @@ from pcapi.routes.serialization.reimbursement_csv_serialize import Reimbursement
 from pcapi.routes.serialization.reimbursement_csv_serialize import find_all_offerer_reimbursement_details
 from pcapi.routes.serialization.reimbursement_csv_serialize import generate_reimbursement_details_csv
 from pcapi.scripts.payment.batch_steps import generate_new_payments
-
-from tests.test_utils import deactivate_feature
 
 
 class FindReimbursementDetailsTest:
@@ -70,9 +68,9 @@ class ReimbursementDetailsCSVTest:
 
     @freeze_time("2019-07-05 12:00:00")
     @pytest.mark.usefixtures("db_session")
+    @override_features(DEGRESSIVE_REIMBURSEMENT_RATE=False)
     def test_generate_payment_details_csv_with_right_values(self, app):
         # given
-        deactivate_feature(FeatureToggle.DEGRESSIVE_REIMBURSEMENT_RATE)
         user = create_user(first_name="John", last_name="Doe")
         deposit = create_deposit(user, amount=500, source="public")
         offerer1 = create_offerer(siren="123456789", address="123 rue de Paris")

--- a/tests/routes/webapp/signup_webapp_test.py
+++ b/tests/routes/webapp/signup_webapp_test.py
@@ -4,10 +4,8 @@ from unittest.mock import patch
 from freezegun import freeze_time
 import pytest
 
-from pcapi.models.feature import Feature
-from pcapi.models.feature import FeatureToggle
+from pcapi.models.feature import override_features
 from pcapi.models.user_sql_entity import UserSQLEntity
-from pcapi.repository import repository
 from pcapi.routes.serialization import serialize
 
 from tests.conftest import TestClient
@@ -300,16 +298,11 @@ class Post:
 
     class Returns403:
         @pytest.mark.usefixtures("db_session")
+        @override_features(WEBAPP_SIGNUP=False)
         def when_feature_is_not_active(self, app):
-            # Given
-            data = BASE_DATA.copy()
-            feature = Feature.query.filter_by(name=FeatureToggle.WEBAPP_SIGNUP).first()
-            feature.isActive = False
-            repository.save(feature)
-
             # When
             response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
+                "/users/signup/webapp", json=BASE_DATA, headers={"origin": "http://localhost:3000"}
             )
 
             # Then

--- a/tests/scripts/payment/batch_test.py
+++ b/tests/scripts/payment/batch_test.py
@@ -2,12 +2,8 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.models import Feature
-from pcapi.models.feature import FeatureToggle
-from pcapi.repository import repository
+from pcapi.models.feature import override_features
 from pcapi.scripts.payment.batch import generate_and_send_payments
-
-from tests.test_utils import deactivate_feature
 
 
 class GenerateAndSendPaymentsTest:
@@ -20,6 +16,7 @@ class GenerateAndSendPaymentsTest:
     @patch("pcapi.scripts.payment.batch.send_payments_report", return_value=[])
     @patch("pcapi.scripts.payment.batch.send_payments_details", return_value=[])
     @patch("pcapi.scripts.payment.batch.send_wallet_balances", return_value=[])
+    @override_features(DEGRESSIVE_REIMBURSEMENT_RATE=False)
     @pytest.mark.usefixtures("db_session")
     def test_should_retrieve_all_steps_except_1_bis_when_message_id_is_none(
         self,
@@ -34,11 +31,6 @@ class GenerateAndSendPaymentsTest:
         update_booking_used_after_stock_occurrence,
         app,
     ):
-        # Given
-        feature = Feature.query.filter_by(name=FeatureToggle.DEGRESSIVE_REIMBURSEMENT_RATE).first()
-        feature.isActive = False
-        repository.save(feature)
-
         # When
         generate_and_send_payments(None)
 
@@ -100,6 +92,7 @@ class GenerateAndSendPaymentsTest:
     @patch("pcapi.scripts.payment.batch.send_payments_details", return_value=[])
     @patch("pcapi.scripts.payment.batch.send_wallet_balances", return_value=[])
     @pytest.mark.usefixtures("db_session")
+    @override_features(UPDATE_BOOKING_USED=False)
     def test_should_not_update_booking_usage_if_corresponding_feature_is_disabled(
         self,
         send_wallet_balances,
@@ -113,9 +106,6 @@ class GenerateAndSendPaymentsTest:
         update_booking_used_after_stock_occurrence,
         app,
     ):
-        # Given
-        deactivate_feature(FeatureToggle.UPDATE_BOOKING_USED)
-
         # When
         generate_and_send_payments("ar5y65dtre45")
 

--- a/tests/scripts/payment/generate_new_payments_test.py
+++ b/tests/scripts/payment/generate_new_payments_test.py
@@ -10,20 +10,18 @@ from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
 from pcapi.model_creators.specific_creators import create_stock_from_offer
 from pcapi.models import ThingType
-from pcapi.models.feature import FeatureToggle
+from pcapi.models.feature import override_features
 from pcapi.models.payment import Payment
 from pcapi.repository import repository
 from pcapi.scripts.payment.batch_steps import generate_new_payments
 
-from tests.test_utils import deactivate_feature
-
 
 class GenerateNewPaymentsTest:
+    @override_features(DEGRESSIVE_REIMBURSEMENT_RATE=False)
     class WithCurrentRulesTest:
         @pytest.mark.usefixtures("db_session")
         def test_records_new_payment_lines_in_database(self, app):
             # Given
-            deactivate_feature(FeatureToggle.DEGRESSIVE_REIMBURSEMENT_RATE)
             offerer = create_offerer()
             venue = create_venue(offerer)
             offer = create_offer_with_thing_product(venue)
@@ -51,7 +49,6 @@ class GenerateNewPaymentsTest:
         @pytest.mark.usefixtures("db_session")
         def test_returns_a_tuple_of_pending_and_not_processable_payments(self, app):
             # Given
-            deactivate_feature(FeatureToggle.DEGRESSIVE_REIMBURSEMENT_RATE)
             offerer1 = create_offerer(siren="123456789")
             offerer2 = create_offerer(siren="987654321")
             repository.save(offerer1)
@@ -83,7 +80,6 @@ class GenerateNewPaymentsTest:
         @pytest.mark.usefixtures("db_session")
         def test_should_not_reimburse_offerer_if_he_has_more_than_20000_euros_in_bookings_on_several_venues(self, app):
             # Given
-            deactivate_feature(FeatureToggle.DEGRESSIVE_REIMBURSEMENT_RATE)
             offerer1 = create_offerer(siren="123456789")
             repository.save(offerer1)
             bank_information = create_bank_information(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,15 +4,6 @@ from unittest.mock import Mock
 from shapely.geometry import Polygon
 
 from pcapi.models import Booking
-from pcapi.models.feature import Feature
-from pcapi.models.feature import FeatureToggle
-from pcapi.repository import repository
-
-
-def deactivate_feature(feature_toggle: FeatureToggle):
-    feature = Feature.query.filter_by(name=feature_toggle.name).one()
-    feature.isActive = False
-    repository.save(feature)
 
 
 def create_mocked_bookings(num_bookings: int, venue_email: str, name: str = "Offer name") -> List[Booking]:


### PR DESCRIPTION
**Pour le déploiement :** passer la commande SQL suivante **AVANT** le déploiement en staging et en prod :

```sql
ALTER TABLE feature ALTER COLUMN "name" TYPE TEXT;
```

----

Having `Feature.name` as an SQL ENUM column makes it hard to add and
remove feature flags:

- adding one requires a lot of boilerplate code, see
  a5fa86ada028d11354a73ae15f09a63e76c65431 for example.

- removing one is complex: we need to update the code before removing
  the table row in the database, otherwise the previous version of the
  code (that requires the feature to be there) fails. And when we
  update the code (which does not have the feature flag anymore in the
  Python enum), SQLAlchemy complains that the database returns a value
  that is not part of the enum.

Since we rarely manipulate (write) features, the safety provided by
the SQL ENUM constraint is not needed.
