### PR TITLE
(PC-6036) improve cancel_expired_bookings performance

### DIFF
--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import joinedload
 
 from pcapi.connectors import redis
 from pcapi.core.bookings import conf
-import pcapi.core.bookings.exceptions as bookings_exceptions
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.repository import generate_booking_token
@@ -183,26 +182,6 @@ def update_confirmation_dates(
         booking.confirmationDate = compute_confirmation_date(beginning_datetime, booking.dateCreated)
     repository.save(*bookings)
     return bookings
-
-
-def cancel_expired_bookings(
-    expired_bookings: typing.List[Booking],
-) -> typing.Tuple[typing.List[Booking], typing.List[bookings_exceptions.BookingCancellationError]]:
-    cancelled_bookings = []
-    errors = []
-
-    for booking in expired_bookings:
-        try:
-            validation.check_system_can_cancel_expired_booking(booking)
-            booking.isCancelled = True
-            booking.cancellationReason = BookingCancellationReasons.EXPIRED
-            cancelled_bookings.append(booking)
-        except bookings_exceptions.BookingCancellationError as exc:
-            errors.append(exc)
-
-    repository.save(*cancelled_bookings)
-
-    return cancelled_bookings, errors
 
 
 def get_expenses_limits(user: UserSQLEntity, version: int) -> typing.Iterable:

--- a/src/pcapi/core/bookings/conf.py
+++ b/src/pcapi/core/bookings/conf.py
@@ -8,7 +8,6 @@ CONFIRM_BOOKING_AFTER_CREATION_DELAY = datetime.timedelta(hours=48)
 CONFIRM_BOOKING_BEFORE_EVENT_DELAY = datetime.timedelta(hours=48)
 BOOKINGS_AUTO_EXPIRY_DELAY = datetime.timedelta(days=30)
 BOOKINGS_EXPIRY_NOTIFICATION_DELAY = datetime.timedelta(days=7)
-CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE = datetime.datetime(2021, 1, 4)
 
 
 def _get_hours_from_timedelta(td: datetime.timedelta) -> float:

--- a/src/pcapi/core/bookings/exceptions.py
+++ b/src/pcapi/core/bookings/exceptions.py
@@ -56,19 +56,3 @@ class CannotCancelConfirmedBooking(ClientError):
 class BookingDoesntExist(ClientError):
     def __init__(self):
         super().__init__("bookingId", "bookingId ne correspond à aucune réservation")
-
-
-class BookingCancellationError(Exception):
-    pass
-
-
-class AlreadyCancelled(BookingCancellationError):
-    """Raised when trying to cancel a cancelled Booking"""
-
-
-class AlreadyUsed(BookingCancellationError):
-    """Raised when trying to cancel a used Booking"""
-
-
-class DoesNotExpire(BookingCancellationError):
-    """Raised when trying to cancel a Booking Offer type that does not expire"""

--- a/src/pcapi/core/bookings/repository.py
+++ b/src/pcapi/core/bookings/repository.py
@@ -150,6 +150,10 @@ def find_expiring_bookings() -> Query:
     )
 
 
+def find_expiring_bookings_ids() -> Query:
+    return find_expiring_bookings().order_by(Booking.id).with_entities(Booking.id)
+
+
 def find_soon_to_be_expiring_booking_ordered_by_user(given_date: date = None) -> Query:
     given_date = given_date or date.today()
     given_date = (

--- a/src/pcapi/core/bookings/validation.py
+++ b/src/pcapi/core/bookings/validation.py
@@ -101,13 +101,6 @@ def check_offerer_can_cancel_booking(booking: Booking) -> None:
         raise forbidden
 
 
-def check_system_can_cancel_expired_booking(booking: Booking) -> None:
-    if booking.isCancelled:
-        raise exceptions.AlreadyCancelled("Booking %s is already cancelled" % booking)
-    if booking.isUsed:
-        raise exceptions.AlreadyUsed("Booking %s has been used" % booking)
-
-
 # FIXME (dbaty, 2020-10-19): I moved this function from validation/routes/bookings.py. It
 # should not raise HTTP-related exceptions. It should rather raise
 # generic exceptions such as `BookingIsAlreadyUsed` and the calling

--- a/src/pcapi/core/bookings/validation.py
+++ b/src/pcapi/core/bookings/validation.py
@@ -102,10 +102,6 @@ def check_offerer_can_cancel_booking(booking: Booking) -> None:
 
 
 def check_system_can_cancel_expired_booking(booking: Booking) -> None:
-    if not booking.stock.offer.offerType["canExpire"]:
-        raise exceptions.DoesNotExpire(
-            "Booking %s is of type %s, which does not expire" % (booking, booking.stock.offer.type)
-        )
     if booking.isCancelled:
         raise exceptions.AlreadyCancelled("Booking %s is already cancelled" % booking)
     if booking.isUsed:

--- a/src/pcapi/scheduled_tasks/clock.py
+++ b/src/pcapi/scheduled_tasks/clock.py
@@ -1,7 +1,6 @@
 from apscheduler.schedulers.blocking import BlockingScheduler
 
 from pcapi import settings
-from pcapi.core.bookings.conf import CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE
 from pcapi.local_providers.provider_manager import synchronize_venue_providers_for_provider
 from pcapi.models.beneficiary_import import BeneficiaryImportSources
 from pcapi.models.feature import FeatureToggle
@@ -114,7 +113,6 @@ def main():
         [app],
         day="*",
         hour="5",
-        start_date=CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE.strftime("%Y-%m-%d"),
     )
 
     scheduler.add_job(
@@ -124,7 +122,6 @@ def main():
         day="*",
         hour="5",
         minute="30",
-        start_date=CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE.strftime("%Y-%m-%d"),
     )
 
     scheduler.start()

--- a/src/pcapi/scripts/booking/notify_soon_to_be_expired_bookings.py
+++ b/src/pcapi/scripts/booking/notify_soon_to_be_expired_bookings.py
@@ -2,7 +2,6 @@ import datetime
 from itertools import groupby
 from operator import attrgetter
 
-from pcapi.core.bookings import conf
 import pcapi.core.bookings.repository as bookings_repository
 from pcapi.domain.user_emails import send_soon_to_be_expired_bookings_recap_email_to_beneficiary
 from pcapi.utils.logger import logger
@@ -25,25 +24,16 @@ def notify_users_of_soon_to_be_expired_bookings(given_date: datetime.date = None
     for user, booking in groupby(bookings_ordered_by_user, attrgetter("user")):
         expired_bookings_grouped_by_user[user] = list(booking)
 
-    is_after_start_date = datetime.datetime.utcnow() >= conf.CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE
     notified_users = []
 
-    if is_after_start_date:
-        for user, bookings in expired_bookings_grouped_by_user.items():
-            send_soon_to_be_expired_bookings_recap_email_to_beneficiary(user, bookings, send_raw_email)
-            notified_users.append(user)
+    for user, bookings in expired_bookings_grouped_by_user.items():
+        send_soon_to_be_expired_bookings_recap_email_to_beneficiary(user, bookings, send_raw_email)
+        notified_users.append(user)
 
-        logger.info(
-            "[notify_users_of_soon_to_be_expired_bookings] %d Users have been notified: %s",
-            len(notified_users),
-            notified_users,
-        )
-
-    else:
-        logger.info(
-            "[notify_users_of_soon_to_be_expired_bookings] %d Users would have been notified of expired booking cancellation: %s",
-            len(expired_bookings_grouped_by_user),
-            expired_bookings_grouped_by_user,
-        )
+    logger.info(
+        "[notify_users_of_soon_to_be_expired_bookings] %d Users have been notified: %s",
+        len(notified_users),
+        notified_users,
+    )
 
     logger.info("[notify_users_of_soon_to_be_expired_bookings] End")

--- a/tests/scripts/booking/notify_soon_to_be_expired_bookings_test.py
+++ b/tests/scripts/booking/notify_soon_to_be_expired_bookings_test.py
@@ -16,7 +16,6 @@ from pcapi.scripts.booking.notify_soon_to_be_expired_bookings import notify_user
 
 @pytest.mark.usefixtures("db_session")
 class NotifyUsersOfSoonToBeExpiredBookingsTest:
-    @mock.patch("pcapi.core.bookings.conf.CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE", datetime.utcnow())
     @mock.patch(
         "pcapi.scripts.booking.notify_soon_to_be_expired_bookings.send_soon_to_be_expired_bookings_recap_email_to_beneficiary"
     )
@@ -54,7 +53,6 @@ class NotifyUsersOfSoonToBeExpiredBookingsTest:
         )
         assert str(dont_expire_in_7_days_cd_booking) not in caplog.text
 
-    @mock.patch("pcapi.core.bookings.conf.CANCEL_EXPIRED_BOOKINGS_CRON_START_DATE", datetime.utcnow())
     @mock.patch("pcapi.scripts.booking.notify_soon_to_be_expired_bookings.send_raw_email")
     @mock.patch(
         "pcapi.scripts.booking.notify_soon_to_be_expired_bookings.send_soon_to_be_expired_bookings_recap_email_to_beneficiary"


### PR DESCRIPTION
When cancelling several thousands of expiring Bookings, performance tanked so we investigated and improved the script.

Note the use of the flask-sqlalchemy function `get_debug_queries` in tests cf https://flask-sqlalchemy.palletsprojects.com/en/2.x/api/#flask_sqlalchemy.get_debug_queries