### PR TITLE
(Pc-5915)  Specify when request/response field is nullable for openapi schema

### DIFF
--- a/src/pcapi/routes/native/v1/blueprint.py
+++ b/src/pcapi/routes/native/v1/blueprint.py
@@ -6,5 +6,4 @@ from pcapi.serialization.utils import before_handler
 
 native_v1 = Blueprint("native_v1", __name__)
 
-api = SpecTree("flask", MODE="strict", before=before_handler, PATH="/")
-api.register(native_v1)
+api = SpecTree("flask", MODE="strict", before=before_handler, PATH="/", app=native_v1)

--- a/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/src/pcapi/routes/native/v1/serialization/offers.py
@@ -19,14 +19,14 @@ from pcapi.utils.logger import logger
 
 
 class Coordinates(BaseModel):
-    latitude: Optional[Decimal]
-    longitude: Optional[Decimal]
+    latitude: Optional[Decimal] = Field(..., nullable=True)
+    longitude: Optional[Decimal] = Field(..., nullable=True)
 
 
 class OfferCategoryResponse(BaseModel):
     categoryType: CategoryType
     label: str
-    name: Optional[CategoryNameEnum]
+    name: Optional[CategoryNameEnum] = Field(..., nullable=True)
 
 
 class OfferOffererResponse(BaseModel):
@@ -38,8 +38,8 @@ class OfferOffererResponse(BaseModel):
 
 class OfferStockResponse(BaseModel):
     id: int
-    beginningDatetime: Optional[datetime]
-    bookingLimitDatetime: Optional[datetime]
+    beginningDatetime: Optional[datetime] = Field(..., nullable=True)
+    bookingLimitDatetime: Optional[datetime] = Field(..., nullable=True)
     isBookable: bool
     price: Decimal
 
@@ -54,12 +54,12 @@ class OfferVenueResponse(BaseModel):
         return super().from_orm(venue)
 
     id: int
-    address: Optional[str]
-    city: Optional[str]
+    address: Optional[str] = Field(..., nullable=True)
+    city: Optional[str] = Field(..., nullable=True)
     managingOfferer: OfferOffererResponse = Field(..., alias="offerer")
     name: str
-    postalCode: Optional[str]
-    publicName: Optional[str]
+    postalCode: Optional[str] = Field(..., nullable=True)
+    publicName: Optional[str] = Field(..., nullable=True)
     coordinates: Coordinates
 
     class Config:
@@ -85,7 +85,7 @@ def get_id_converter(labels_by_id: Dict, field_name: str) -> Callable[[Optional[
 
 class OfferExtraData(BaseModel):
     author: Optional[str]
-    durationMinutes: Optional[int]
+    durationMinutes: Optional[int] = Field(..., nullable=True)
     isbn: Optional[str]
     musicSubType: Optional[str]
     musicType: Optional[str]
@@ -111,15 +111,15 @@ class OfferExtraData(BaseModel):
 
 
 class OfferAccessibilityResponse(BaseModel):
-    audioDisability: Optional[bool]
-    mentalDisability: Optional[bool]
-    motorDisability: Optional[bool]
-    visualDisability: Optional[bool]
+    audioDisability: Optional[bool] = Field(..., nullable=True)
+    mentalDisability: Optional[bool] = Field(..., nullable=True)
+    motorDisability: Optional[bool] = Field(..., nullable=True)
+    visualDisability: Optional[bool] = Field(..., nullable=True)
 
 
 class OfferImageResponse(BaseModel):
     url: str
-    credit: Optional[str]
+    credit: Optional[str] = Field(..., nullable=True)
 
     class Config:
         orm_mode = True
@@ -149,18 +149,18 @@ class OfferResponse(BaseModel):
 
     id: int
     accessibility: OfferAccessibilityResponse
-    description: Optional[str]
-    externalTicketOfficeUrl: Optional[str]
-    extraData: Optional[OfferExtraData]
+    description: Optional[str] = Field(..., nullable=True)
+    externalTicketOfficeUrl: Optional[str] = Field(..., nullable=True)
+    extraData: OfferExtraData
     isActive: bool
     isDigital: bool
     isDuo: bool
     name: str
     category: OfferCategoryResponse
     stocks: List[OfferStockResponse]
-    image: Optional[OfferImageResponse]
+    image: Optional[OfferImageResponse] = Field(..., nullable=True)
     venue: OfferVenueResponse
-    withdrawalDetails: Optional[str]
+    withdrawalDetails: Optional[str] = Field(..., nullable=True)
 
     class Config:
         orm_mode = True

--- a/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/src/pcapi/routes/native/v1/serialization/offers.py
@@ -67,9 +67,6 @@ class OfferVenueResponse(BaseModel):
         allow_population_by_field_name = True
 
 
-LABELS_BY_DICT_MAPPING = {"musicSubType": ""}
-
-
 def get_id_converter(labels_by_id: Dict, field_name: str) -> Callable[[Optional[str]], Optional[str]]:
     def convert_id_into_label(value_id: Optional[str]) -> Optional[str]:
         try:


### PR DESCRIPTION
## Problème : 

lorsque l'API renvoie (ou accepte) un body avec un champ `Optional` alors le schéma openapi généré considère le champ comme optionnel (la clé peut ne pas être présente), alors que dans la plupart des cas, le champ est présent mais nullable.

Ex : 
```
Offer(BaseModel):
    description: Optional[str]
```

Va générer le schéma typescript `Offer: { description?: string }` alors que ce qu'on veut c'est : `Offer: { description: string | null }`

**(Vu la lourdeur de la solution : est-ce que le front a vraiment besoin de faire cette distinction.. ?)**

## Solution
Solution trouvée ici : https://github.com/samuelcolvin/pydantic/issues/1270#issuecomment-734467055 :

Ajouter `Field(..., nullable=True)` => le "..." fait que le champ est considéré `required`. `nullable=True` permet d'avoir l'info dans le schéma openapi.

## Toujours un problème :

Il reste un problème concernant les champs qui ne sont pas forcément présents sur le modèle. Exemple : `offer.extraData` est stocké sous la forme d'un json en bdd. Donc `offer.extraData["author"]` n'est parfois pas défini. 

- Si on ne met pas : `... = Field(..., nullable=True)` alors le champ n’est pas dans les clés required , alors qu’il apparait tout le temps dans la réponse :/ 
- Si on met  `... = Field(..., nullable=True)` alors pydantic jette une erreur quand le champ n’est pas présent sur le modèle.

## Résultat

Voici le rendu `openapi` . On a "latitude", "longitude" dans la liste `required`, et l'info : `nullable: true` dans les properties

```
{
    "components": {
        "schemas": {
            "Coordinates": {
                "properties": {
                    "latitude": {
                        "nullable": true,
                        "title": "Latitude",
                        "type": "number"
                    },
                    "longitude": {
                        "nullable": true,
                        "title": "Longitude",
                        "type": "number"
                    }
                },
                "required": [
                    "latitude",
                    "longitude"
                ],
                "title": "Coordinates",
                "type": "object"
            },
           
     ....
}
```