### PR TITLE
script: Work around import loop in `import_users`

### DIFF
--- a/src/pcapi/scripts/beneficiary/import_users.py
+++ b/src/pcapi/scripts/beneficiary/import_users.py
@@ -1,9 +1,11 @@
+# isort: skip_file
 import csv
 from datetime import datetime
 import sys
 from typing import Iterable
 from typing import List
 
+import pcapi.models  # pylint: disable=unused-import
 from pcapi import settings
 import pcapi.core.payments.api as payments_api
 import pcapi.core.users.api as users_api


### PR DESCRIPTION
Otherwise, we get an import loop when running the script:

    $ python src/pcapi/scripts/beneficiary/import_users.py
    Traceback (most recent call last):
      File "src/pcapi/scripts/beneficiary/import_users.py", line 8, in <module>
        import pcapi.core.payments.api as payments_api
      File "/path/api/src/pcapi/core/payments/api.py", line 1, in <module>
        import pcapi.core.bookings.conf as bookings_conf
      File "/path/api/src/pcapi/core/bookings/conf.py", line 4, in <module>
        from pcapi.models.feature import FeatureToggle
      File "/path/api/src/pcapi/models/__init__.py", line 5, in <module>
        from pcapi.core.users.models import Token
      File "/path/api/src/pcapi/core/users/models.py", line 28, in <module>
        from pcapi.core.bookings.conf import LIMIT_CONFIGURATIONS
    ImportError: cannot import name 'LIMIT_CONFIGURATIONS' from 'pcapi.core.bookings.conf' (/path/api/src/pcapi/core/bookings/conf.py

Enough! Next week I will remove all imports from `models/__init__.py`.
We spend too much time and energy on these import loops.