### PR TITLE
(PC-6015) Isolate booking.recommandationId drop migration

### DIFF
--- a/src/pcapi/alembic/versions/acbee9d1615b_drop_booking_recommandation_id_column.py
+++ b/src/pcapi/alembic/versions/acbee9d1615b_drop_booking_recommandation_id_column.py
@@ -1,0 +1,23 @@
+"""drop_booking_recommandation_id_column
+
+Revision ID: acbee9d1615b
+Revises: 1196c69e1385
+Create Date: 2021-01-15 14:09:43.264333
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "acbee9d1615b"
+down_revision = "1196c69e1385"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("booking", "recommendationId")
+
+
+def downgrade():
+    op.create_foreign_key(None, "booking", "recommendation", ["recommendationId"], ["id"])

--- a/src/pcapi/alembic/versions/b757109d4694_drop_recommendation_table.py
+++ b/src/pcapi/alembic/versions/b757109d4694_drop_recommendation_table.py
@@ -1,7 +1,7 @@
 """drop_recommendation_table
 
 Revision ID: b757109d4694
-Revises: 1196c69e1385
+Revises: acbee9d1615b
 Create Date: 2021-01-08 14:30:11.459680
 
 """
@@ -11,13 +11,12 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "b757109d4694"
-down_revision = "1196c69e1385"
+down_revision = "acbee9d1615b"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.drop_column("booking", "recommendationId")
     op.drop_table("recommendation")
 
 
@@ -55,5 +54,4 @@ def downgrade():
     op.create_index(op.f("ix_recommendation_userId"), "recommendation", ["userId"], unique=False)
     op.add_column("booking", sa.Column("recommendationId", sa.BigInteger(), nullable=True))
     op.create_index(op.f("ix_booking_recommendationId"), "booking", ["recommendationId"], unique=False)
-    op.create_foreign_key(None, "booking", "recommendation", ["recommendationId"], ["id"])
     # ### end Alembic commands ###


### PR DESCRIPTION
Le fait de ne pas commiter la transaction `alter table booking drop recommandationId` crée un deadlock si une transaction (comme ici sur user ()) demande un AccessShareLock sur booking.
![image](https://user-images.githubusercontent.com/22373097/104737510-9ee2fa00-5744-11eb-972b-2dec1a1032ea.png)
(“relation 106809768” correspond à `user` et "106809562" à `booking`)
