### PR TITLE
[PC-5511] Do not index offer stocks when they're not bookable

### DIFF
--- a/src/pcapi/algolia/usecase/orchestrator.py
+++ b/src/pcapi/algolia/usecase/orchestrator.py
@@ -69,7 +69,7 @@ def delete_expired_offers(client: Redis, offer_ids: List[int]) -> None:
 
 
 def _build_offer_details_to_be_indexed(offer: Offer) -> dict:
-    stocks = offer.activeStocks
+    stocks = offer.bookableStocks
     event_dates = []
     prices = list(map(lambda stock: float(stock.price), stocks))
 


### PR DESCRIPTION
jira : https://passculture.atlassian.net/browse/PC-5511

Je ne sais pas trop si ça fixe le cas de bug exact défini dans le jira.
Mais il me semble qu'il est bon de ne pas indexer les dates non réservable, le front recherche sur `offer.date`, si on ne veux que le offre réservable à une date donnée, il ne faut pas indexer les autres.  

* Ajout d'un test qui casse avant le changement.