### PR TITLE
[PC-5337] OfferCriterion: add startDate and endDate

### DIFF
--- a/src/pcapi/admin/custom_views/criteria_view.py
+++ b/src/pcapi/admin/custom_views/criteria_view.py
@@ -7,8 +7,14 @@ class CriteriaView(BaseAdminView):
     can_create = True
     can_edit = True
     can_delete = True
-    column_list = ["id", "name", "description", "scoreDelta"]
-    column_labels = dict(name="Nom", description="Description", scoreDelta="Score")
-    column_searchable_list = ["name", "description"]
+    column_list = ["id", "name", "description", "scoreDelta", "startDateTime", "endDateTime"]
+    column_labels = dict(
+        name="Nom",
+        description="Description",
+        scoreDelta="Score",
+        startDateTime="Date de début",
+        endDateTime="Date de fin",
+    )
+    column_searchable_list = ["name", "description", "startDateTime", "endDateTime"]
     column_filters: List[str] = []
-    form_columns = ["name", "description", "scoreDelta"]
+    form_columns = ["name", "description", "scoreDelta", "startDateTime", "endDateTime"]

--- a/src/pcapi/alembic/versions/1efe2b3cb31c_offer_citerion_add_startdate_and_enddate.py
+++ b/src/pcapi/alembic/versions/1efe2b3cb31c_offer_citerion_add_startdate_and_enddate.py
@@ -1,0 +1,28 @@
+"""offer_citerion_add_startDate_and_endDate
+
+Revision ID: 1efe2b3cb31c
+Revises: 6846a3873abb
+Create Date: 2021-01-19 13:16:55.260365
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "1efe2b3cb31c"
+down_revision = "6846a3873abb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("criterion", sa.Column("endDateTime", sa.DateTime, nullable=True))
+    op.execute("COMMIT")
+    op.add_column("criterion", sa.Column("startDateTime", sa.DateTime, nullable=True))
+    op.execute("COMMIT")
+
+
+def downgrade():
+    op.drop_column("criterion", "endDateTime")
+    op.drop_column("criterion", "startDateTime")

--- a/src/pcapi/models/criterion.py
+++ b/src/pcapi/models/criterion.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Column
+from sqlalchemy import DateTime
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import Text
@@ -13,6 +14,10 @@ class Criterion(PcObject, Model):
     description = Column(Text, nullable=True)
 
     scoreDelta = Column(Integer, nullable=False)
+
+    startDateTime = Column(DateTime, nullable=True)
+
+    endDateTime = Column(DateTime, nullable=True)
 
     def __repr__(self):
         return "%s" % self.name


### PR DESCRIPTION
  These informations will be use to track relation between home playlist
offers and booking.

======

jira https://passculture.atlassian.net/browse/PC-5337

-> ajouter des date de début et de fin au criterions afin que la data puisse faire le lien entre les offres mis en avant sur une periode de temps et leurs reservations.

=====

Note, j'ai pu verifier que les champs s'affichaient sur flaskAdmin.
Parcontre je n'ai pas reussi à faire tourné metabase en local pour verifier que les champs y étaient bien.