### PR TITLE
(PC-6111) fix mailjet template

### DIFF
--- a/src/pcapi/emails/beneficiary_activation.py
+++ b/src/pcapi/emails/beneficiary_activation.py
@@ -38,7 +38,7 @@ def get_activation_email_data_for_native(user: users_models.User, token: users_m
         "To": user.email if feature_send_mail_to_users_enabled() else settings.DEV_EMAIL_ADDRESS,
         "Vars": {
             "nativeAppLink": email_confirmation_link,
-            "isEligible": users_api.is_user_eligible(user),
-            "isMinor": user.dateOfBirth + relativedelta(years=18) > datetime.today(),
+            "isEligible": int(users_api.is_user_eligible(user)),
+            "isMinor": int(user.dateOfBirth + relativedelta(years=18) > datetime.today()),
         },
     }

--- a/tests/emails/beneficiary_activation_test.py
+++ b/tests/emails/beneficiary_activation_test.py
@@ -56,8 +56,10 @@ class GetActivationEmailTest:
         # Then
         assert activation_email_data["Vars"]["nativeAppLink"]
         assert "email=fabien%2Btest%40example.net" in activation_email_data["Vars"]["nativeAppLink"]
-        assert activation_email_data["Vars"]["isEligible"] is True
-        assert activation_email_data["Vars"]["isMinor"] is False
+        assert activation_email_data["Vars"]["isEligible"]
+        assert not activation_email_data["Vars"]["isMinor"]
+        assert isinstance(activation_email_data["Vars"]["isEligible"], int)
+        assert isinstance(activation_email_data["Vars"]["isMinor"], int)
 
     @freeze_time("2011-05-15 09:00:00")
     def test_return_dict_for_native_under_age_user(self):
@@ -71,5 +73,5 @@ class GetActivationEmailTest:
         # Then
         assert activation_email_data["Vars"]["nativeAppLink"]
         assert "email=fabien%2Btest%40example.net" in activation_email_data["Vars"]["nativeAppLink"]
-        assert activation_email_data["Vars"]["isEligible"] is False
-        assert activation_email_data["Vars"]["isMinor"] is True
+        assert not activation_email_data["Vars"]["isEligible"]
+        assert activation_email_data["Vars"]["isMinor"]


### PR DESCRIPTION
Mailjet templating language does not work with booleans.
It will allow integers and strings.
Cast booleans into integers so 1 is true and 0 is false.