### PR TITLE
(PC-6129) : Add universal links description

### DIFF
--- a/src/pcapi/routes/native/v1/__init__.py
+++ b/src/pcapi/routes/native/v1/__init__.py
@@ -7,3 +7,4 @@ def install_routes(app: Flask) -> None:
     from . import authentication
     from . import offers
     from . import redirection
+    from . import universal_links

--- a/src/pcapi/routes/native/v1/universal_links.py
+++ b/src/pcapi/routes/native/v1/universal_links.py
@@ -1,0 +1,55 @@
+from flask import jsonify
+from flask.wrappers import Response
+
+from pcapi.flask_app import public_api
+
+
+# WARNING: those routes are required for universal links - ie links to the
+# native application - to work.
+# They are not attached to the native_v1 blueprint because they must be at
+# the server's root.
+
+
+@public_api.route("/.well-known/apple-app-site-association", methods=["GET"])
+def apple_app_site_association() -> Response:
+    response = jsonify(
+        {
+            "applinks": {
+                "appIDs": [
+                    "WBC4X3LRTS.app.passculture.test",
+                    "WBC4X3LRTS.app.passculture.staging",
+                    "WBC4X3LRTS.app.passculture",
+                ],
+                "components": [{"/": "*", "comment": "Matchs every routes and lets app decides which accept"}],
+            },
+            "webcredentials": {
+                "appIDs": [
+                    "WBC4X3LRTS.app.passculture.test",
+                    "WBC4X3LRTS.app.passculture.staging",
+                    "WBC4X3LRTS.app.passculture",
+                ]
+            },
+        }
+    )
+    response.content_type = "application/pkcs7-mime"
+    return response
+
+
+@public_api.route("/.well-knwon/assetlinks.json", methods=["GET"])
+def asset_links() -> Response:
+    response = jsonify(
+        [
+            {
+                "relation": ["delegate_permission/common.handle_all_urls"],
+                "target": {
+                    "namespace": "PassCulture T",
+                    "package_name": "com.passculture",
+                    "sha256_cert_fingerprints": [
+                        "F2:59:8C:3F:07:B3:8E:6D:D0:20:A8:1B:A1:02:7B:82:41:53:88:D8:84:0E:CB:22:87:CC:CD:12:F0:8E:32:7F"
+                    ],
+                },
+            }
+        ]
+    )
+    response.content_type = "application/pkcs7-mime"
+    return response

--- a/tests/routes/native/v1/universal_links_test.py
+++ b/tests/routes/native/v1/universal_links_test.py
@@ -1,0 +1,19 @@
+import json
+
+from tests.conftest import TestClient
+
+
+class UniversalLinksTest:
+    def test_apple_app_site_asso(self, app):
+        test_client = TestClient(app.test_client())
+        response = test_client.get("/.well-known/apple-app-site-association")
+        assert response.status_code == 200
+        assert response.content_type == "application/pkcs7-mime"
+        assert "applinks" in json.loads(response.data.decode("utf8"))
+
+    def test_asset_links(self, app):
+        test_client = TestClient(app.test_client())
+        response = test_client.get("/.well-knwon/assetlinks.json")
+        assert response.status_code == 200
+        assert response.content_type == "application/pkcs7-mime"
+        assert json.loads(response.data.decode("utf8"))[0]["target"]["package_name"] == "com.passculture"


### PR DESCRIPTION
Universal links are links to the native application instead of
links to a website.
In order to make them work, the server has to provide a description
of the links and how to interprete the scheme to the native application