### PR TITLE
(PC-5508) Add not null constraint to mediation.offerId

### DIFF
--- a/src/pcapi/alembic/versions/06a7f387d996_drop_the_mediation_without_offer_step_0.py
+++ b/src/pcapi/alembic/versions/06a7f387d996_drop_the_mediation_without_offer_step_0.py
@@ -1,0 +1,23 @@
+"""Drop the mediation without offer (Step 0/4)
+
+Revision ID: 06a7f387d996
+Revises: bce80c4f574f
+Create Date: 2021-01-22 10:07:29.071338
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "06a7f387d996"
+down_revision = "bce80c4f574f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""DELETE FROM "mediation" WHERE "offerId" IS NULL;""")
+
+
+def downgrade() -> None:
+    pass

--- a/src/pcapi/alembic/versions/0e2e82aa2d40_remove_check_constraint_on_mediation_offerid_step_4.py
+++ b/src/pcapi/alembic/versions/0e2e82aa2d40_remove_check_constraint_on_mediation_offerid_step_4.py
@@ -1,0 +1,27 @@
+"""Remove check constraint on mediation.offerId (Step 4/4 to add not null constraint)
+
+Revision ID: 0e2e82aa2d40
+Revises: 7a89c0773774
+Create Date: 2021-01-22 10:18:22.695050
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "0e2e82aa2d40"
+down_revision = "7a89c0773774"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("mediation_offerid_not_null_constraint", table_name="mediation")
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+            ALTER TABLE mediation ADD CONSTRAINT mediation_offerid_not_null_constraint CHECK ("offerId" IS NOT NULL) NOT VALID;
+        """
+    )

--- a/src/pcapi/alembic/versions/7a89c0773774_add_not_null_constraint_on_mediation_step_3.py
+++ b/src/pcapi/alembic/versions/7a89c0773774_add_not_null_constraint_on_mediation_step_3.py
@@ -1,0 +1,23 @@
+"""Add not null constraint on mediation.offerId (Step 3/4 to add not null constraint)
+
+Revision ID: 7a89c0773774
+Revises: b27d6c71fc9d
+Create Date: 2021-01-22 10:14:03.844534
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "7a89c0773774"
+down_revision = "b27d6c71fc9d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("mediation", "offerId", nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("mediation", "offerId", nullable=True)

--- a/src/pcapi/alembic/versions/b27d6c71fc9d_validate_check_constraint_on_mediation_step_2.py
+++ b/src/pcapi/alembic/versions/b27d6c71fc9d_validate_check_constraint_on_mediation_step_2.py
@@ -1,0 +1,23 @@
+"""Validate check_constraint on mediation.offerId (Step 2/4 to add not null constraint)
+
+Revision ID: b27d6c71fc9d
+Revises: b295261d5da0
+Create Date: 2021-01-22 10:12:32.939250
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "b27d6c71fc9d"
+down_revision = "b295261d5da0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE mediation VALIDATE CONSTRAINT mediation_offerid_not_null_constraint;")
+
+
+def downgrade() -> None:
+    pass

--- a/src/pcapi/alembic/versions/b295261d5da0_add_check_constraint_on_mediation_step_1.py
+++ b/src/pcapi/alembic/versions/b295261d5da0_add_check_constraint_on_mediation_step_1.py
@@ -1,0 +1,27 @@
+"""Add check_constraint on mediation.offerId (Step 1/4 to add not null constraint)
+
+Revision ID: b295261d5da0
+Revises: 06a7f387d996
+Create Date: 2021-01-22 10:09:41.533226
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "b295261d5da0"
+down_revision = "06a7f387d996"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+             ALTER TABLE mediation ADD CONSTRAINT mediation_offerid_not_null_constraint CHECK ("offerId" IS NOT NULL) NOT VALID;
+         """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("mediation_offerid_not_null_constraint", table_name="mediation")


### PR DESCRIPTION
Step 0: Drop the two mediations without offer. They were used in earlier version for the first connection cards.

Step 1: Add a validation constraint not valid not to lock the table - see doc https://www.postgresql.org/docs/12/sql-altertable.html#SQL-ALTERTABLE-NOTES:
"The main purpose of the NOT VALID constraint option is to reduce the impact of adding a constraint on concurrent updates. With NOT VALID, the ADD CONSTRAINT command does not scan the table and can be committed immediately."

Step 2: Validate constraint - see doc https://www.postgresql.org/docs/12/sql-altertable.html#SQL-ALTERTABLE-NOTES
"After that, a VALIDATE CONSTRAINT command can be issued to verify that existing rows satisfy the constraint. The validation step does not need to lock out concurrent updates, since it knows that other transactions will be enforcing the constraint for rows that they insert or update; only pre-existing rows need to be checked. Hence, validation acquires only a SHARE UPDATE EXCLUSIVE lock on the table being altered"

Step 3: Add not null constraint on column - see doc: https://www.postgresql.org/docs/12/sql-altertable.html# - 'SET/DROP NOT NULL' section
"SET NOT NULL may only be applied to a column provided none of the records in the table contain a NULL value for the column. Ordinarily this is checked during the ALTER TABLE by scanning the entire table; however, if a valid CHECK constraint is found which proves no NULL can exist, then the table scan is skipped."

Step 4: Drop check constraint