### PR TITLE
(PC-5508) Add unique constraint on venue.validationToken

### DIFF
--- a/src/pcapi/alembic/versions/9a2cd2388d90_create_unique_index_venue_token.py
+++ b/src/pcapi/alembic/versions/9a2cd2388d90_create_unique_index_venue_token.py
@@ -1,0 +1,29 @@
+"""Add unique constraint on venue.validationToken (Step 1/2)
+
+Revision ID: 9a2cd2388d90
+Revises: e7b46b06f6dd
+Create Date: 2021-01-25 17:03:24.375376
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "9a2cd2388d90"
+down_revision = "e7b46b06f6dd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("COMMIT;")
+    op.execute(
+        """
+        CREATE UNIQUE INDEX CONCURRENTLY idx_venue_validation_token ON venue ("validationToken");
+        """
+    )
+
+
+def downgrade():
+    # when the step_2 validation_token_unique_key is dropped, there is no more index
+    pass


### PR DESCRIPTION
Doc psql : 
> Adding a constraint using an existing index can be helpful in situations where a new constraint needs to be added without blocking table updates for a long time. To do that, create the index using CREATE INDEX CONCURRENTLY, and then install it as an official constraint using this syntax. See the example below.

Testé sur staging : la migration en 2 étapes est immédiate, alors que `"ALTER TABLE venue ADD UNIQUE CONSTRAINT venue (validationToken)"` prenait plus de 3 minutes...

`CONCURRENTLY` est incompatible avec une migration lancée dans une transaction.

Mais le `CREATE INDEX` est très rapide sur staging (peut-être parce qu'il n'y a que 3 token `not nulls`, et 9400 `null`).