### PR TITLE
(PC-5915) : Native app OpenAPI schema with nullable fields

### DIFF
--- a/src/pcapi/routes/native/v1/serialization/__init__.py
+++ b/src/pcapi/routes/native/v1/serialization/__init__.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel as PydanticBaseModel
+
+
+class BaseModel(PydanticBaseModel):
+    class Config:
+        @staticmethod
+        def schema_extra(schema, model):
+            for prop, value in schema.get("properties", {}).items():
+                # retrieve right field from alias or name
+                field = [x for x in model.__fields__.values() if x.alias == prop][0]
+                if field.allow_none:
+                    if "$ref" in value:
+                        if issubclass(field.type_, PydanticBaseModel):
+                            # add 'title' in schema to have the exact same behaviour as the rest
+                            value["title"] = field.type_.__config__.title or field.type_.__name__
+                        value["anyOf"] = [{"$ref": value.pop("$ref")}]
+                    value["nullable"] = True

--- a/src/pcapi/routes/native/v1/serialization/account.py
+++ b/src/pcapi/routes/native/v1/serialization/account.py
@@ -4,7 +4,6 @@ from decimal import Decimal
 from typing import List
 from typing import Optional
 
-from pydantic import BaseModel
 from pydantic.class_validators import validator
 from pydantic.fields import Field
 
@@ -12,6 +11,8 @@ from pcapi.core.users.models import ExpenseDomain
 from pcapi.core.users.models import VOID_FIRST_NAME
 from pcapi.core.users.models import VOID_PUBLIC_NAME
 from pcapi.serialization.utils import to_camel
+
+from . import BaseModel
 
 
 class AccountRequest(BaseModel):

--- a/src/pcapi/routes/native/v1/serialization/authentication.py
+++ b/src/pcapi/routes/native/v1/serialization/authentication.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
-from pydantic import BaseModel
-
 from pcapi.serialization.utils import to_camel
+
+from . import BaseModel
 
 
 class SigninRequest(BaseModel):

--- a/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/src/pcapi/routes/native/v1/serialization/offers.py
@@ -5,7 +5,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from pydantic import BaseModel
 from pydantic.class_validators import validator
 from pydantic.fields import Field
 
@@ -16,6 +15,8 @@ from pcapi.domain.show_types import SHOW_TYPES_DICT
 from pcapi.models.offer_type import CategoryNameEnum
 from pcapi.models.offer_type import CategoryType
 from pcapi.utils.logger import logger
+
+from . import BaseModel
 
 
 class Coordinates(BaseModel):


### PR DESCRIPTION
The default OpenAPI schema generation does not adds nullable property
to the fields defined as `Optional[...]`. This commit adds a post
schema step to insert the nullable properties to such fields.

PS: meant to replace #1819