### PR TITLE
(PC-6408) : urlencode the password reset url query arguments

### DIFF
--- a/src/pcapi/emails/user_reset_password.py
+++ b/src/pcapi/emails/user_reset_password.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Dict
+from urllib.parse import urlencode
 
 from pcapi import settings
 from pcapi.core.users.models import User
@@ -25,11 +26,14 @@ def retrieve_data_for_reset_password_user_email(user: User) -> Dict:
 def retrieve_data_for_reset_password_native_app_email(
     user_email: str, token_value: str, expiration_date: datetime
 ) -> Dict:
-    reset_password_link = (
-        f"{settings.API_URL}/native/v1/redirect_to_native/mot-de-passe-perdu?token={token_value}"
-        f"&expiration_timestamp={int(expiration_date.timestamp())}"
-        f"&email={user_email}"
+    query_string = urlencode(
+        {
+            "token": token_value,
+            "expiration_timestamp": int(expiration_date.timestamp()),
+            "email": user_email,
+        }
     )
+    reset_password_link = f"{settings.API_URL}/native/v1/redirect_to_native/mot-de-passe-perdu?{query_string}"
 
     return {
         "FromEmail": settings.SUPPORT_EMAIL_ADDRESS,

--- a/tests/emails/user_reset_password_test.py
+++ b/tests/emails/user_reset_password_test.py
@@ -1,7 +1,9 @@
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
 
+from pcapi.emails.user_reset_password import retrieve_data_for_reset_password_native_app_email
 from pcapi.emails.user_reset_password import retrieve_data_for_reset_password_user_email
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_user
@@ -58,4 +60,28 @@ class MakeUserResetPasswordEmailDataTest:
             "MJ-TemplateLanguage": True,
             "To": "ewing@example.com",
             "Vars": {"prenom_user": "Bobby", "token": user.resetPasswordToken, "env": ""},
+        }
+
+
+class NativeAppUserResetPasswordEmailDataTest:
+    def test_email_is_encoded_in_(self, app):
+        # When
+        reset_password_email_data = retrieve_data_for_reset_password_native_app_email(
+            user_email="ewing+demo@example.com",
+            token_value="abc",
+            expiration_date=datetime(2020, 1, 1),
+        )
+
+        # Then
+        assert reset_password_email_data == {
+            "FromEmail": "support@example.com",
+            "MJ-TemplateID": 1838526,
+            "MJ-TemplateLanguage": True,
+            "To": "dev@example.com",
+            "Vars": {
+                "native_app_link": (
+                    "http://localhost/native/v1/redirect_to_native/mot-de-passe-perdu"
+                    "?token=abc&expiration_timestamp=1577836800&email=ewing%2Bdemo%40example.com"
+                )
+            },
         }


### PR DESCRIPTION
Because we are good web citizens we encode the query arguments in
the urls.