### PR TITLE
(PC-6627) providers: Do not spawn Scalingo containers when importing TiteLive stock

### DIFF
--- a/src/pcapi/alembic/versions/c5dbd02f35f4_add_feature_flag_parallel_.py
+++ b/src/pcapi/alembic/versions/c5dbd02f35f4_add_feature_flag_parallel_.py
@@ -1,0 +1,31 @@
+"""add_feature_flag_parallel_synchronization_of_venue_provider
+
+Revision ID: c5dbd02f35f4
+Revises: 6e99e0e5834d
+Create Date: 2021-02-05 17:20:05.483125
+
+"""
+from alembic import op
+
+from pcapi.models.feature import FeatureToggle
+
+
+# revision identifiers, used by Alembic.
+revision = "c5dbd02f35f4"
+down_revision = "6e99e0e5834d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    feature = FeatureToggle.PARALLEL_SYNCHRONIZATION_OF_VENUE_PROVIDER
+    op.execute(
+        f"""INSERT INTO feature (name, description, "isActive")
+        VALUES ('{feature.name}', '{feature.value}', False)
+        """
+    )
+
+
+def downgrade():
+    feature = FeatureToggle.PARALLEL_SYNCHRONIZATION_OF_VENUE_PROVIDER
+    op.execute(f"DELETE FROM feature WHERE name = '{feature.name}'")

--- a/src/pcapi/local_providers/provider_manager.py
+++ b/src/pcapi/local_providers/provider_manager.py
@@ -47,8 +47,18 @@ def get_local_provider_class_by_name(class_name: str) -> Callable:
 
 def synchronize_venue_provider(venue_provider: VenueProvider, limit: Optional[int] = None):
     provider_class = get_local_provider_class_by_name(venue_provider.provider.localClass)
+    logger.info(
+        "Starting synchronization of venue_provider=%s with provider=%s",
+        venue_provider.id,
+        venue_provider.provider.localClass,
+    )
     try:
         provider = provider_class(venue_provider)
         do_update(provider, limit)
     except Exception:  # pylint: disable=broad-except
         logger.exception(build_cron_log_message(name=provider_class.__name__, status=CronStatus.FAILED))
+    logger.info(
+        "Ended synchronization of venue_provider=%s with provider=%s",
+        venue_provider.id,
+        venue_provider.provider.localClass,
+    )

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -39,6 +39,9 @@ class FeatureToggle(enum.Enum):
     WHOLE_FRANCE_OPENING = "Ouvre le service à la France entière"
     PRO_HOMEPAGE = "Permettre l affichage de la nouvelle page d accueil du portail pro"
     PRO_TUTO = "Permettre l affichage des cartes tuto du portail pro"
+    PARALLEL_SYNCHRONIZATION_OF_VENUE_PROVIDER = (
+        "Active la parallèlisation des opérations de synchronisation pour les VenueProvider"
+    )
 
 
 class Feature(PcObject, Model, DeactivableMixin):

--- a/src/pcapi/scripts/stock/fully_sync_library.py
+++ b/src/pcapi/scripts/stock/fully_sync_library.py
@@ -1,6 +1,6 @@
 from pcapi.core.bookings.repository import count_not_cancelled_bookings_quantity_by_stock_id
 from pcapi.core.offers.models import Offer
-from pcapi.local_providers.venue_provider_worker import do_sync_venue_provider
+from pcapi.local_providers.provider_manager import synchronize_venue_provider
 from pcapi.models import Stock
 from pcapi.models import VenueProvider
 from pcapi.repository import repository
@@ -26,4 +26,4 @@ def fully_sync_library(venue_id: int) -> None:
     venue_provider_to_sync.lastSyncDate = None
     repository.save(venue_provider_to_sync)
 
-    do_sync_venue_provider(venue_provider_to_sync)
+    synchronize_venue_provider(venue_provider_to_sync)

--- a/tests/scripts/stock/fully_sync_library_test.py
+++ b/tests/scripts/stock/fully_sync_library_test.py
@@ -14,8 +14,8 @@ from pcapi.scripts.stock.fully_sync_library import fully_sync_library
 
 class FullySyncLibraryTest:
     @pytest.mark.usefixtures("db_session")
-    @patch("pcapi.scripts.stock.fully_sync_library.do_sync_venue_provider")
-    def should_call_synchronize_on_expected_venue_provider(self, mock_do_sync_venue_provider, app):
+    @patch("pcapi.scripts.stock.fully_sync_library.synchronize_venue_provider")
+    def should_call_synchronize_on_expected_venue_provider(self, mock_synchronize_venue_provider):
         # Given
         venue = VenueFactory()
         offer = OfferFactory(venue=venue)
@@ -29,12 +29,12 @@ class FullySyncLibraryTest:
         fully_sync_library(venue_id=venue.id)
 
         # Then
-        mock_do_sync_venue_provider.assert_called_once_with(venue_provider)
+        mock_synchronize_venue_provider.assert_called_once_with(venue_provider)
 
     @pytest.mark.usefixtures("db_session")
-    @patch("pcapi.scripts.stock.fully_sync_library.do_sync_venue_provider")
+    @patch("pcapi.scripts.stock.fully_sync_library.synchronize_venue_provider")
     def should_update_quantity_to_booking_amount_for_each_synchronized_stock_on_venue(
-        self, mock_do_sync_venue_provider, app
+        self, mock_synchronize_venue_provider
     ):
         # Given
         titelive = activate_provider(provider_classname="TiteLiveStocks")


### PR DESCRIPTION
J'ai créé un _feature flag_ pour pouvoir facilement activer ou désactiver le nouveau comportement, et j'ai essayé de limiter le diff pour faciliter le cherry-pick.

----

We used to spawn Scalingo containers to parallelize operations.
Obviously, that won't work too well on Google Cloud Platform.

Spawning containers did not dramatically reduce the overall time spent
synchronizing stock. According to logs from 2021-02-02, cumulative
time spent is around 97 minutes and spawning containers only gain 20
minutes.

Thus, we now run the synchronization of TiteLive stock in a standard
way, one venue at a time.

I am a coward, so the new behaviour requires a feature flag to be
disabled: `PARALLEL_SYNCHRONIZATION_OF_VENUE_PROVIDER`. In other
words, by default the *old* behaviour is the default one.

(We'll have to tackle performance issues, though, because 90 minutes
is too long. We can probably do better.)