### PR TITLE
(PC-6627) providers: Reindex offers within offer/stock synchronization

### DIFF
--- a/src/pcapi/alembic/versions/85adf538245f_add_feature_flag_enable_whole_venue_.py
+++ b/src/pcapi/alembic/versions/85adf538245f_add_feature_flag_enable_whole_venue_.py
@@ -1,0 +1,31 @@
+"""add_feature_flag_enable_whole_venue_provider_algolia_indexation
+
+Revision ID: 85adf538245f
+Revises: c5dbd02f35f4
+Create Date: 2021-02-05 17:41:56.500901
+
+"""
+from alembic import op
+
+from pcapi.models.feature import FeatureToggle
+
+
+# revision identifiers, used by Alembic.
+revision = "85adf538245f"
+down_revision = "c5dbd02f35f4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    feature = FeatureToggle.ENABLE_WHOLE_VENUE_PROVIDER_ALGOLIA_INDEXATION
+    op.execute(
+        f"""INSERT INTO feature (name, description, "isActive")
+        VALUES ('{feature.name}', '{feature.value}', False)
+        """
+    )
+
+
+def downgrade():
+    feature = FeatureToggle.ENABLE_WHOLE_VENUE_PROVIDER_ALGOLIA_INDEXATION
+    op.execute(f"DELETE FROM feature WHERE name = '{feature.name}'")

--- a/src/pcapi/local_providers/local_provider.py
+++ b/src/pcapi/local_providers/local_provider.py
@@ -2,8 +2,13 @@ from abc import abstractmethod
 from collections.abc import Iterator
 from datetime import datetime
 
+from flask import current_app as app
+
+from pcapi.connectors import redis
 from pcapi.connectors.redis import send_venue_provider_data_to_redis
 from pcapi.connectors.thumb_storage import create_thumb
+from pcapi.core.offers.models import Offer
+from pcapi.core.offers.models import Stock
 from pcapi.local_providers.chunk_manager import get_existing_pc_obj
 from pcapi.local_providers.chunk_manager import save_chunks
 from pcapi.local_providers.providable_info import ProvidableInfo
@@ -148,6 +153,10 @@ class LocalProvider(Iterator):
         chunk_to_insert = {}
         chunk_to_update = {}
 
+        reindex_whole_venue_provider_later = feature_queries.is_active(
+            FeatureToggle.ENABLE_WHOLE_VENUE_PROVIDER_ALGOLIA_INDEXATION
+        )
+
         for providable_infos in self:
             objects_limit_reached = limit and self.checkedObjects >= limit
             if objects_limit_reached:
@@ -209,11 +218,15 @@ class LocalProvider(Iterator):
 
                 if len(chunk_to_insert) + len(chunk_to_update) >= CHUNK_MAX_SIZE:
                     save_chunks(chunk_to_insert, chunk_to_update)
+                    if not reindex_whole_venue_provider_later:
+                        _reindex_offers(list(chunk_to_insert.values()) + list(chunk_to_update.values()))
                     chunk_to_insert = {}
                     chunk_to_update = {}
 
         if len(chunk_to_insert) + len(chunk_to_update) > 0:
             save_chunks(chunk_to_insert, chunk_to_update)
+            if not reindex_whole_venue_provider_later:
+                _reindex_offers(list(chunk_to_insert.values()) + list(chunk_to_update.values()))
 
         self._print_objects_summary()
         self.log_provider_event(LocalProviderEventType.SyncEnd)
@@ -222,8 +235,9 @@ class LocalProvider(Iterator):
             self.venue_provider.lastSyncDate = datetime.utcnow()
             self.venue_provider.syncWorkerId = None
             repository.save(self.venue_provider)
-            if feature_queries.is_active(FeatureToggle.SYNCHRONIZE_ALGOLIA):
-                send_venue_provider_data_to_redis(self.venue_provider)
+            if reindex_whole_venue_provider_later:
+                if feature_queries.is_active(FeatureToggle.SYNCHRONIZE_ALGOLIA):
+                    send_venue_provider_data_to_redis(self.venue_provider)
 
 
 def _save_same_thumb_from_thumb_count_to_index(pc_object: Model, thumb_index: int, image_as_bytes: bytes):
@@ -237,3 +251,16 @@ def _save_same_thumb_from_thumb_count_to_index(pc_object: Model, thumb_index: in
         for index in range(pc_object.thumbCount, thumb_index):
             create_thumb(pc_object, image_as_bytes, index)
             pc_object.thumbCount += 1
+
+
+def _reindex_offers(created_or_updated_objects):
+    if not feature_queries.is_active(FeatureToggle.SYNCHRONIZE_ALGOLIA):
+        return
+    offer_ids = set()
+    for obj in created_or_updated_objects:
+        if isinstance(obj, Stock):
+            offer_ids.add(obj.offerId)
+        elif isinstance(obj, Offer):
+            offer_ids.add(obj.id)
+    for offer_id in offer_ids:
+        redis.add_offer_id(client=app.redis_client, offer_id=offer_id)

--- a/src/pcapi/local_providers/local_provider.py
+++ b/src/pcapi/local_providers/local_provider.py
@@ -127,15 +127,26 @@ class LocalProvider(Iterator):
         db.session.commit()
 
     def _print_objects_summary(self):
-        logger.info("  Checked %d objects", self.checkedObjects)
-        logger.info("  Created %d objects", self.createdObjects)
-        logger.info("  Updated %d objects", self.updatedObjects)
-        logger.info("  %d errors in creations/updates", self.erroredObjects)
-
-        logger.info("  Checked %d thumbs", self.checkedThumbs)
-        logger.info("  Created %d thumbs", self.createdThumbs)
-        logger.info("  Updated %d thumbs", self.updatedThumbs)
-        logger.info("  %d errors in thumb creations/updates", self.erroredThumbs)
+        # FIXME (dbaty, 2020-02-05): I don't know how we could end up
+        # here with no venue_provider, but there are checks elsewhere
+        # so I do the same here.
+        venue_id = self.venue_provider.venueId if self.venue_provider else "none"
+        logger.info(
+            "Synchronization of objects of venue=%s, checked=%d, created=%d, updated=%d, errors=%s",
+            venue_id,
+            self.checkedObjects,
+            self.createdObjects,
+            self.updatedObjects,
+            self.erroredObjects,
+        )
+        logger.info(
+            "Synchronization of thumbs of venue=%s, checked=%d, created=%d, updated=%d, errors=%s",
+            venue_id,
+            self.checkedThumbs,
+            self.createdThumbs,
+            self.updatedThumbs,
+            self.erroredThumbs,
+        )
 
     def updateObjects(self, limit=None):
         # pylint: disable=too-many-nested-blocks

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -42,6 +42,7 @@ class FeatureToggle(enum.Enum):
     PARALLEL_SYNCHRONIZATION_OF_VENUE_PROVIDER = (
         "Active la parallèlisation des opérations de synchronisation pour les VenueProvider"
     )
+    ENABLE_WHOLE_VENUE_PROVIDER_ALGOLIA_INDEXATION = "Active la réindexation globale sur Algolia des VenueProvider"
 
 
 class Feature(PcObject, Model, DeactivableMixin):

--- a/src/pcapi/scheduled_tasks/algolia_clock.py
+++ b/src/pcapi/scheduled_tasks/algolia_clock.py
@@ -30,6 +30,7 @@ def index_offers_in_algolia_by_venue(app):
 @log_cron
 @cron_context
 @cron_require_feature(FeatureToggle.SYNCHRONIZE_ALGOLIA)
+@cron_require_feature(FeatureToggle.ENABLE_WHOLE_VENUE_PROVIDER_ALGOLIA_INDEXATION)
 def index_offers_in_algolia_by_venue_provider(app):
     process_multi_indexing(client=app.redis_client)
 


### PR DESCRIPTION
J'ai créé un feature flag pour pouvoir facilement activer ou désactiver le nouveau comportement, et j'ai essayé de limiter le diff pour faciliter le cherry-pick.

---

Previously, when synchronizing offers and stock against a provider, we
enqueued the reindexation of the *whole* venue. This is very long and
too expensive when only a few offers have been created or updated and
thus need to be reindexed.

We now ask for the reindexation of offers that have been created or
updated only.

I am a coward, so the new behaviour requires a feature flag to be
disabled: `ENABLE_WHOLE_VENUE_PROVIDER_ALGOLIA_INDEXATION`. In other
words, by default the *old* behaviour is the default one.