### PR TITLE
Corrections dans override_settings / override_features

### DIFF
--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -13,9 +13,9 @@ from pcapi.core.bookings.models import BookingCancellationReasons
 import pcapi.core.mails.testing as mails_testing
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
+from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
 from pcapi.models import api_errors
-from pcapi.models.feature import override_features
 from pcapi.utils.token import random_token
 
 

--- a/tests/core/bookings/test_validation.py
+++ b/tests/core/bookings/test_validation.py
@@ -9,10 +9,10 @@ from pcapi.core.bookings import factories
 from pcapi.core.bookings import validation
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
+from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
 from pcapi.models import ThingType
 from pcapi.models import api_errors
-from pcapi.models.feature import override_features
 
 
 @pytest.mark.usefixtures("db_session")
@@ -112,11 +112,11 @@ class CheckStockIsBookableTest:
 
 
 @pytest.mark.usefixtures("db_session")
-@override_features(APPLY_BOOKING_LIMITS_V2=False)
 class CheckExpenseLimitsDepositVersion1BeforeSwitchTest:
     def _get_beneficiary(self):
         return users_factories.UserFactory(deposit__version=1)
 
+    @override_features(APPLY_BOOKING_LIMITS_V2=False)
     def test_physical_limit(self):
         beneficiary = self._get_beneficiary()
         offer = offers_factories.OfferFactory(product__type=str(ThingType.INSTRUMENT))
@@ -130,6 +130,7 @@ class CheckExpenseLimitsDepositVersion1BeforeSwitchTest:
             "Le plafond de 200 € pour les biens culturels ne vous permet pas de réserver cette offre."
         ]
 
+    @override_features(APPLY_BOOKING_LIMITS_V2=False)
     def test_physical_limit_on_uncapped_type(self):
         beneficiary = self._get_beneficiary()
         offer = offers_factories.OfferFactory(product__type=str(ThingType.CINEMA_ABO))
@@ -138,6 +139,7 @@ class CheckExpenseLimitsDepositVersion1BeforeSwitchTest:
         # should not raise because CINEMA_ABO is not capped
         validation.check_expenses_limits(beneficiary, 11, offer)
 
+    @override_features(APPLY_BOOKING_LIMITS_V2=False)
     def test_digital_limit(self):
         beneficiary = self._get_beneficiary()
         product = offers_factories.DigitalProductFactory(type=str(ThingType.AUDIOVISUEL))
@@ -156,6 +158,7 @@ class CheckExpenseLimitsDepositVersion1BeforeSwitchTest:
             "Le plafond de 200 € pour les offres numériques ne vous permet pas de réserver cette offre."
         ]
 
+    @override_features(APPLY_BOOKING_LIMITS_V2=False)
     def test_digital_limit_on_uncapped_type(self):
         beneficiary = self._get_beneficiary()
         product = offers_factories.DigitalProductFactory(type=str(ThingType.OEUVRE_ART))
@@ -165,6 +168,7 @@ class CheckExpenseLimitsDepositVersion1BeforeSwitchTest:
         # should not raise because OEUVRE_ART is not capped
         validation.check_expenses_limits(beneficiary, 11, offer)
 
+    @override_features(APPLY_BOOKING_LIMITS_V2=False)
     def test_global_limit(self):
         beneficiary = self._get_beneficiary()
         factories.BookingFactory(user=beneficiary, stock__price=490)
@@ -180,7 +184,6 @@ class CheckExpenseLimitsDepositVersion1BeforeSwitchTest:
 
 
 @pytest.mark.usefixtures("db_session")
-@override_features(APPLY_BOOKING_LIMITS_V2=True)
 class CheckExpenseLimitsDepositVersion1AfterSwitchTest:
     def _get_beneficiary(self, **kwargs):
         return users_factories.UserFactory(deposit__version=1, **kwargs)
@@ -192,6 +195,7 @@ class CheckExpenseLimitsDepositVersion1AfterSwitchTest:
         with pytest.raises(exceptions.UserHasInsufficientFunds):
             validation.check_expenses_limits(beneficiary, 10, offer)
 
+    @override_features(APPLY_BOOKING_LIMITS_V2=True)
     def test_physical_limit(self):
         beneficiary = self._get_beneficiary()
         offer = offers_factories.OfferFactory(product__type=str(ThingType.INSTRUMENT))
@@ -205,6 +209,7 @@ class CheckExpenseLimitsDepositVersion1AfterSwitchTest:
             "Le plafond de 300 € pour les biens culturels ne vous permet pas de réserver cette offre."
         ]
 
+    @override_features(APPLY_BOOKING_LIMITS_V2=True)
     def test_physical_limit_on_uncapped_type(self):
         beneficiary = self._get_beneficiary()
         offer = offers_factories.OfferFactory(product__type=str(ThingType.CINEMA_ABO))
@@ -213,6 +218,7 @@ class CheckExpenseLimitsDepositVersion1AfterSwitchTest:
         # should not raise because CINEMA_ABO is not capped
         validation.check_expenses_limits(beneficiary, 11, offer)
 
+    @override_features(APPLY_BOOKING_LIMITS_V2=True)
     def test_digital_limit(self):
         beneficiary = self._get_beneficiary()
         product = offers_factories.DigitalProductFactory(type=str(ThingType.AUDIOVISUEL))
@@ -231,6 +237,7 @@ class CheckExpenseLimitsDepositVersion1AfterSwitchTest:
             "Le plafond de 200 € pour les offres numériques ne vous permet pas de réserver cette offre."
         ]
 
+    @override_features(APPLY_BOOKING_LIMITS_V2=True)
     def test_digital_limit_on_uncapped_type(self):
         beneficiary = self._get_beneficiary()
         product = offers_factories.DigitalProductFactory(type=str(ThingType.OEUVRE_ART))
@@ -240,6 +247,7 @@ class CheckExpenseLimitsDepositVersion1AfterSwitchTest:
         # should not raise because OEUVRE_ART is not capped
         validation.check_expenses_limits(beneficiary, 11, offer)
 
+    @override_features(APPLY_BOOKING_LIMITS_V2=True)
     def test_global_limit(self):
         beneficiary = self._get_beneficiary()
         factories.BookingFactory(user=beneficiary, stock__price=490)

--- a/tests/core/offers/test_api.py
+++ b/tests/core/offers/test_api.py
@@ -18,10 +18,10 @@ from pcapi.core.offers import exceptions
 from pcapi.core.offers import factories
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
+from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
 from pcapi.models import api_errors
 from pcapi.models import offer_type
-from pcapi.models.feature import override_features
 from pcapi.routes.serialization import offers_serialize
 from pcapi.routes.serialization.stock_serialize import StockCreationBodyModel
 from pcapi.routes.serialization.stock_serialize import StockEditionBodyModel

--- a/tests/core/testing/tests.py
+++ b/tests/core/testing/tests.py
@@ -1,5 +1,10 @@
+import pytest
+
 from pcapi import settings
+from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
+from pcapi.models.feature import FeatureToggle
+from pcapi.repository import feature_queries
 
 
 @override_settings(IS_RUNNING_TESTS=2)
@@ -22,3 +27,24 @@ class OverrideSettingsOnClassTest:
     @override_settings(IS_RUNNING_TESTS=3)
     def test_method_level_override(self):
         assert settings.IS_RUNNING_TESTS == 3
+
+
+@pytest.mark.usefixtures("db_session")
+@override_features(SEARCH_ALGOLIA=False)
+def test_override_features_on_function():
+    assert not feature_queries.is_active(FeatureToggle.SEARCH_ALGOLIA)
+
+
+@pytest.mark.usefixtures("db_session")
+def test_override_features_as_context_manager():
+    assert feature_queries.is_active(FeatureToggle.SEARCH_ALGOLIA)
+    with override_features(SEARCH_ALGOLIA=False):
+        assert not feature_queries.is_active(FeatureToggle.SEARCH_ALGOLIA)
+    assert feature_queries.is_active(FeatureToggle.SEARCH_ALGOLIA)
+
+
+@pytest.mark.usefixtures("db_session")
+class OverrideFeaturesOnClassTest:
+    @override_features(SEARCH_ALGOLIA=False)
+    def test_method_level_override(self):
+        assert not feature_queries.is_active(FeatureToggle.SEARCH_ALGOLIA)

--- a/tests/core/testing/tests.py
+++ b/tests/core/testing/tests.py
@@ -1,0 +1,24 @@
+from pcapi import settings
+from pcapi.core.testing import override_settings
+
+
+@override_settings(IS_RUNNING_TESTS=2)
+def test_override_settings_on_function():
+    assert settings.IS_RUNNING_TESTS == 2
+
+
+def test_override_settings_as_context_manager():
+    assert settings.IS_RUNNING_TESTS is True
+    with override_settings(IS_RUNNING_TESTS=2):
+        assert settings.IS_RUNNING_TESTS == 2
+    assert settings.IS_RUNNING_TESTS is True
+
+
+@override_settings(IS_RUNNING_TESTS=2)
+class OverrideSettingsOnClassTest:
+    def test_class_level_override(self):
+        assert settings.IS_RUNNING_TESTS == 2
+
+    @override_settings(IS_RUNNING_TESTS=3)
+    def test_method_level_override(self):
+        assert settings.IS_RUNNING_TESTS == 3

--- a/tests/domain/beneficiary/beneficiary_pre_subscription_validator_test.py
+++ b/tests/domain/beneficiary/beneficiary_pre_subscription_validator_test.py
@@ -2,12 +2,12 @@ from datetime import datetime
 
 import pytest
 
+from pcapi.core.testing import override_features
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_exceptions import BeneficiaryIsADuplicate
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_exceptions import BeneficiaryIsNotEligible
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_exceptions import CantRegisterBeneficiary
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_validator import validate
 from pcapi.model_creators.generic_creators import create_user
-from pcapi.models.feature import override_features
 from pcapi.repository import repository
 
 from tests.domain_creators.generic_creators import create_domain_beneficiary_pre_subcription

--- a/tests/local_providers/titelive_stocks_test.py
+++ b/tests/local_providers/titelive_stocks_test.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from freezegun import freeze_time
 import pytest
 
+from pcapi.core.testing import override_features
 from pcapi.local_providers import TiteLiveStocks
 from pcapi.model_creators.generic_creators import create_booking
 from pcapi.model_creators.generic_creators import create_offerer
@@ -20,7 +21,6 @@ from pcapi.model_creators.specific_creators import create_offer_with_thing_produ
 from pcapi.model_creators.specific_creators import create_product_with_thing_type
 from pcapi.models import Offer
 from pcapi.models import Stock
-from pcapi.models.feature import override_features
 from pcapi.repository import repository
 
 

--- a/tests/local_providers/venue_provider_worker_test.py
+++ b/tests/local_providers/venue_provider_worker_test.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.testing import override_features
 from pcapi.local_providers.venue_provider_worker import do_sync_venue_provider
 from pcapi.local_providers.venue_provider_worker import update_venues_for_specific_provider
 from pcapi.model_creators.generic_creators import create_offerer
@@ -10,7 +11,6 @@ from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.generic_creators import create_venue_provider
 from pcapi.model_creators.provider_creators import activate_provider
 from pcapi.models import VenueProvider
-from pcapi.models.feature import override_features
 from pcapi.repository import repository
 
 

--- a/tests/routes/webapp/signup_webapp_test.py
+++ b/tests/routes/webapp/signup_webapp_test.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 from freezegun import freeze_time
 import pytest
 
+from pcapi.core.testing import override_features
 from pcapi.core.users.models import User
-from pcapi.models.feature import override_features
 from pcapi.routes.serialization import serialize
 
 from tests.conftest import TestClient

--- a/tests/scripts/payment/batch_test.py
+++ b/tests/scripts/payment/batch_test.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.models.feature import override_features
+from pcapi.core.testing import override_features
 from pcapi.scripts.payment.batch import generate_and_send_payments
 
 

--- a/tests/use_cases/create_beneficiary_from_application_test.py
+++ b/tests/use_cases/create_beneficiary_from_application_test.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from freezegun import freeze_time
 import pytest
 
+from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 from pcapi.core.users import api as users_api
 from pcapi.core.users.models import User
@@ -13,7 +14,6 @@ from pcapi.model_creators.generic_creators import create_user
 from pcapi.models import BeneficiaryImport
 from pcapi.models.beneficiary_import_status import ImportStatus
 from pcapi.models.deposit import Deposit
-from pcapi.models.feature import override_features
 from pcapi.repository import repository
 from pcapi.use_cases.create_beneficiary_from_application import create_beneficiary_from_application
 


### PR DESCRIPTION
2 classes de test décorées avec `override_features` n'étaient pas
détectées par pytest, donc des tests n'étaient pas exécutés.

Commits à relire séparément.