### PR TITLE
(PC-6807) : Fix null prices for existing stocks

### DIFF
--- a/src/pcapi/local_providers/local_provider.py
+++ b/src/pcapi/local_providers/local_provider.py
@@ -112,6 +112,9 @@ class LocalProvider(Iterator):
 
         errors = entity_validator.validate(pc_object)
         if errors and len(errors.errors) > 0:
+            # expire pc_object because we may have modified it during fill_object_attributes
+            # and we don't want it to be pushed to the DB if there is any error
+            db.session.expire(pc_object)
             self.log_provider_event(LocalProviderEventType.SyncError, "ApiErrors")
             self.erroredObjects += 1
             raise errors


### PR DESCRIPTION
This issue was tricky. Null prices were fixed BUT for existing stocks
there was some strange integrity error risen when the error log was
added in the DB.
It turns out that the stock is being modified then validated.
The validation fails and the backend inserts a message in the DB
about the failure.
HOWEVER when inserting the message a commit happens and since the
stock was modified SQLAlchemy assumes the stock is meant to be
commited.
Because the stock did not meet the validation requirements it also
fails the DB constraints (null price is not allowed) and thus an
integrity is risen.

I HATE implicit actions with SQLAlchemy

So in order to prevent thos cases, I need to EXPLICITLY remove the
stock from the session by expiring it.

Associated Sentry:
https://logs.passculture.app/organizations/sentry/issues/2583/
https://logs.passculture.app/organizations/sentry/issues/2584/