### PR TITLE
(PC-6752) Let get_wallet_balance SQL function return a negative number

### DIFF
--- a/src/pcapi/alembic/versions/2b860ecd3072_update_get_wallet_balance_function.py
+++ b/src/pcapi/alembic/versions/2b860ecd3072_update_get_wallet_balance_function.py
@@ -44,7 +44,7 @@ def upgrade():
             WHERE "userId"=user_id AND NOT "isCancelled";
         END CASE;
 
-        RETURN GREATEST(0, (sum_deposits - sum_bookings));
+        RETURN (sum_deposits - sum_bookings);
     END; $$
     LANGUAGE plpgsql;
         """

--- a/src/pcapi/core/bookings/models.py
+++ b/src/pcapi/core/bookings/models.py
@@ -159,7 +159,7 @@ Booking.trig_ddl = """
             WHERE "userId"=user_id AND NOT "isCancelled";
         END CASE;
 
-        RETURN GREATEST(0, (sum_deposits - sum_bookings));
+        RETURN (sum_deposits - sum_bookings);
     END; $$
     LANGUAGE plpgsql;
 

--- a/src/pcapi/core/payments/api.py
+++ b/src/pcapi/core/payments/api.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from dateutil.relativedelta import relativedelta
+
 import pcapi.core.bookings.conf as bookings_conf
 from pcapi.core.users.models import User
 from pcapi.models.deposit import Deposit
@@ -14,7 +16,7 @@ DEPOSIT_VALIDITY_IN_YEARS = 2
 
 def _get_expiration_date(start=None):
     start = start or datetime.utcnow()
-    return start.replace(year=start.year + DEPOSIT_VALIDITY_IN_YEARS)
+    return start + relativedelta(years=DEPOSIT_VALIDITY_IN_YEARS)
 
 
 def create_deposit(beneficiary: User, deposit_source: str, version: int = None) -> Deposit:

--- a/src/pcapi/core/users/models.py
+++ b/src/pcapi/core/users/models.py
@@ -249,11 +249,16 @@ class User(PcObject, Model, NeedsValidationMixin, VersionedMixin):
 
     @property
     def real_wallet_balance(self):
-        return db.session.query(func.get_wallet_balance(self.id, True)).scalar()
+        balance = db.session.query(func.get_wallet_balance(self.id, True)).scalar()
+        # Balance can be negative if the user has booked in the past
+        # but their deposit has expired. We don't want to expose a
+        # negative number.
+        return max(0, balance)
 
     @property
     def wallet_balance(self):
-        return db.session.query(func.get_wallet_balance(self.id, False)).scalar()
+        balance = db.session.query(func.get_wallet_balance(self.id, False)).scalar()
+        return max(0, balance)
 
     @property
     def wallet_is_activated(self):


### PR DESCRIPTION
The `check_booking` SQL function raises the `insufficientFunds` error
when `get_wallet_balance() < 0`. This never happens if we use
`GREATEST(0, xxx)`. As such, it would not prevent a user to book again
with an expired deposit if they had booked something in the past.

What we really want is to avoid exposing a negative deposit value, so
we'd rather do it in `User` properties.