### PR TITLE
(PC-6629) : temporarily remove the beneficiary age check

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -116,8 +116,6 @@ def create_account(
 
 
 def activate_beneficiary(user: User, deposit_source: str) -> User:
-    if not user.is_eligible:
-        raise exceptions.NotEligible()
     user.isBeneficiary = True
     deposit = payment_api.create_deposit(user, deposit_source=deposit_source)
     db.session.add_all((user, deposit))

--- a/tests/core/users/test_api.py
+++ b/tests/core/users/test_api.py
@@ -10,7 +10,6 @@ import pytest
 
 from pcapi.core.users import api as users_api
 from pcapi.core.users import constants as users_constants
-from pcapi.core.users import exceptions as users_exceptions
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users.api import _set_offerer_departement_code
 from pcapi.core.users.api import create_id_check_token
@@ -329,11 +328,6 @@ class ChangeUserEmailTest:
 
 
 class CreateBeneficiaryTest:
-    def test_with_ineligible_user_raises_exception(self):
-        user = users_factories.UserFactory.build(isBeneficiary=False)
-        with pytest.raises(users_exceptions.NotEligible):
-            users_api.activate_beneficiary(user, "test")
-
     def test_with_eligible_user(self):
         eligible_date = date.today() - relativedelta(years=18, days=30)
         user = users_factories.UserFactory(isBeneficiary=False, dateOfBirth=eligible_date)


### PR DESCRIPTION
This is performed by the IDCheck upfront as explained in
https://www.notion.so/Cr-ation-du-compte-ID-Check-5f04139e78f7457eb86e17ac609960ca

No need for now to rush on that check.