### PR TITLE
(PC-6752) Fixes on `check_booking` after introduction of Deposit.expirationDate

### DIFF
--- a/src/pcapi/alembic/versions/0867450b4c30_update_check_booking_function.py
+++ b/src/pcapi/alembic/versions/0867450b4c30_update_check_booking_function.py
@@ -1,0 +1,93 @@
+"""Update `check_booking`
+
+Revision ID: 0867450b4c30
+Revises: 2b860ecd3072
+Create Date: 2021-02-08 10:58:14.217608
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "0867450b4c30"
+down_revision = "2b860ecd3072"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+    CREATE OR REPLACE FUNCTION check_booking()
+    RETURNS TRIGGER AS $$
+    DECLARE
+        lastStockUpdate date := (SELECT "dateModified" FROM stock WHERE id=NEW."stockId");
+    BEGIN
+      IF EXISTS (SELECT "quantity" FROM stock WHERE id=NEW."stockId" AND "quantity" IS NOT NULL)
+         AND (
+             (SELECT "quantity" FROM stock WHERE id=NEW."stockId")
+              <
+              (SELECT SUM(quantity) FROM booking WHERE "stockId"=NEW."stockId" AND NOT "isCancelled")
+              )
+         THEN RAISE EXCEPTION 'tooManyBookings'
+                    USING HINT = 'Number of bookings cannot exceed "stock.quantity"';
+      END IF;
+
+      IF (
+        (
+          -- If this is a new booking, we probably want to check the wallet.
+          OLD IS NULL
+          -- If we're updating an existing booking...
+          OR (
+            -- Check the wallet if we are changing the quantity or the amount
+            -- The backend should never do that, but let's be defensive.
+            (NEW."quantity" != OLD."quantity" OR NEW."amount" != OLD."amount")
+            -- If amount and quantity are unchanged, we want to check the wallet
+            -- only if we are UNcancelling a booking (which the backend should never
+            -- do, but let's be defensive). Users with no credits left should
+            -- be able to cancel their booking. Also, their booking can
+            -- be marked as used or not used.
+            OR (NEW."isCancelled" != OLD."isCancelled" AND NOT NEW."isCancelled")
+          )
+        )
+        -- Allow to book free offers even with no credit left (or expired deposits)
+        AND (NEW."amount" != 0)
+        AND (get_wallet_balance(NEW."userId", false) < 0)
+      )
+      THEN RAISE EXCEPTION 'insufficientFunds'
+                 USING HINT = 'The user does not have enough credit to book';
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+    CREATE OR REPLACE FUNCTION check_booking()
+    RETURNS TRIGGER AS $$
+    DECLARE
+        lastStockUpdate date := (SELECT "dateModified" FROM stock WHERE id=NEW."stockId");
+    BEGIN
+      IF EXISTS (SELECT "quantity" FROM stock WHERE id=NEW."stockId" AND "quantity" IS NOT NULL)
+         AND (
+             (SELECT "quantity" FROM stock WHERE id=NEW."stockId")
+              <
+              (SELECT SUM(quantity) FROM booking WHERE "stockId"=NEW."stockId" AND NOT "isCancelled")
+              )
+         THEN RAISE EXCEPTION 'tooManyBookings'
+                    USING HINT = 'Number of bookings cannot exceed "stock.quantity"';
+      END IF;
+      IF (SELECT get_wallet_balance(NEW."userId", false) < 0)
+      THEN RAISE EXCEPTION 'insufficientFunds'
+                 USING HINT = 'The user does not have enough credit to book';
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+        """
+    )

--- a/src/pcapi/core/bookings/validation.py
+++ b/src/pcapi/core/bookings/validation.py
@@ -61,7 +61,8 @@ def check_expenses_limits(user: User, requested_amount: Decimal, offer: Offer):
     if not deposit:
         raise exceptions.UserHasInsufficientFunds()
     if deposit.expirationDate and deposit.expirationDate < datetime.datetime.now():
-        raise exceptions.UserHasInsufficientFunds()
+        if requested_amount:
+            raise exceptions.UserHasInsufficientFunds()
 
     config = conf.LIMIT_CONFIGURATIONS[deposit.version]
     for expense in user.expenses:


### PR DESCRIPTION
There were multiple bugs:

- a booking can be cancelled even if its user's deposit has
expired (i.e. even if the wallet balance is negative);

- a user whose deposit has expired (i.e. with a wallet balance that is
negative) should still be able to book free offers.