### PR TITLE
(PC-6845) Add can_book_again to cancellation emails data

### DIFF
--- a/src/pcapi/emails/beneficiary_booking_cancellation.py
+++ b/src/pcapi/emails/beneficiary_booking_cancellation.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Dict
 
 from pcapi.models import Booking
@@ -19,6 +20,7 @@ def make_beneficiary_booking_cancellation_email_data(booking: Booking) -> Dict:
     offer_name = offer.name
     price = str(stock.price * booking.quantity)
     is_free_offer = 1 if stock.price == 0 else 0
+    can_book_again = int(beneficiary.deposit.expirationDate > datetime.datetime.now())
 
     if is_event:
         beginning_date_time_in_tz = utc_datetime_to_department_timezone(
@@ -39,5 +41,6 @@ def make_beneficiary_booking_cancellation_email_data(booking: Booking) -> Dict:
             "offer_name": offer_name,
             "offer_price": price,
             "user_first_name": first_name,
+            "can_book_again": can_book_again,
         },
     }

--- a/src/pcapi/emails/beneficiary_warning_after_pro_booking_cancellation.py
+++ b/src/pcapi/emails/beneficiary_warning_after_pro_booking_cancellation.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Dict
 
 from babel.dates import format_date
@@ -27,6 +28,7 @@ def retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation(booking: Bo
     offer_price = str(stock.price * booking.quantity)
     user_first_name = booking.user.firstName
     venue_name = offer.venue.publicName if offer.venue.publicName else offer.venue.name
+    can_book_again = int(booking.user.deposit.expirationDate > datetime.datetime.now())
 
     return {
         "MJ-TemplateID": 1116690,
@@ -42,6 +44,7 @@ def retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation(booking: Bo
             "offer_price": offer_price,
             "offerer_name": offerer_name,
             "user_first_name": user_first_name,
+            "can_book_again": can_book_again,
             "venue_name": venue_name,
         },
     }

--- a/tests/domain/user_emails_test.py
+++ b/tests/domain/user_emails_test.py
@@ -153,8 +153,7 @@ class SendBeneficiaryUserDrivenCancellationEmailToOffererTest:
 class SendWarningToBeneficiaryAfterProBookingCancellationTest:
     def test_should_sends_email_to_beneficiary_when_pro_cancels_booking(self):
         # Given
-        user = create_user(email="user@example.com")
-        booking = create_booking(user=user)
+        booking = BookingFactory(user__email="user@example.com", user__firstName="Jeanne")
 
         # When
         send_warning_to_beneficiary_after_pro_booking_cancellation(booking)
@@ -173,9 +172,10 @@ class SendWarningToBeneficiaryAfterProBookingCancellationTest:
                 "is_thing": 1,
                 "is_online": 0,
                 "offer_name": booking.stock.offer.name,
-                "offer_price": "10",
+                "offer_price": "10.00",
                 "offerer_name": booking.stock.offer.venue.managingOfferer.name,
-                "user_first_name": user.firstName,
+                "user_first_name": "Jeanne",
+                "can_book_again": True,
                 "venue_name": booking.stock.offer.venue.name,
                 "env": "-development",
             },

--- a/tests/emails/beneficiary_booking_cancellation_test.py
+++ b/tests/emails/beneficiary_booking_cancellation_test.py
@@ -34,6 +34,7 @@ class MakeBeneficiaryBookingCancellationEmailDataTest:
             "Mj-TemplateID": 1091464,
             "Mj-TemplateLanguage": True,
             "Vars": {
+                "can_book_again": 1,
                 "event_date": "",
                 "event_hour": "",
                 "is_event": 0,
@@ -67,6 +68,7 @@ class MakeBeneficiaryBookingCancellationEmailDataTest:
             "Mj-TemplateID": 1091464,
             "Mj-TemplateLanguage": True,
             "Vars": {
+                "can_book_again": 1,
                 "event_date": "26 novembre",
                 "event_hour": "19h29",
                 "is_event": 1,


### PR DESCRIPTION
These cancellation e-mails indicate whether the offer is "reimbursed"
and whether the user can book it again if it was cancelled by mistake.
This depends on whether the beneficiary is allowed to book again (i.e.
whether their deposit is still valid).