### PR TITLE
redis: Fix add_offer_ids_in_error

### DIFF
--- a/src/pcapi/connectors/redis.py
+++ b/src/pcapi/connectors/redis.py
@@ -170,7 +170,7 @@ def get_number_of_venue_providers_currently_in_sync(client: Redis) -> int:
 
 def add_offer_ids_in_error(client: Redis, offer_ids: List[int]) -> None:
     try:
-        client.rpush(RedisBucket.REDIS_LIST_OFFER_IDS_IN_ERROR_NAME.value, offer_ids)
+        client.rpush(RedisBucket.REDIS_LIST_OFFER_IDS_IN_ERROR_NAME.value, *offer_ids)
     except redis.exceptions.RedisError as error:
         logger.exception("[REDIS] %s", error)
 

--- a/tests/connectors/redis_test.py
+++ b/tests/connectors/redis_test.py
@@ -447,7 +447,7 @@ class AddOfferIdInErrorTest:
         add_offer_ids_in_error(client=client, offer_ids=[1, 2])
 
         # Then
-        client.rpush.assert_called_once_with("offer_ids_in_error", [1, 2])
+        client.rpush.assert_called_once_with("offer_ids_in_error", 1, 2)
 
 
 class GetOfferIdsInErrorTest:


### PR DESCRIPTION
Vu dans Sentry : https://logs.passculture.app/organizations/sentry/issues/2192/

----

`rpush()` takes star arguments:

```python
    def rpush(self, name, *values):
        "Push ``values`` onto the tail of the list ``name``"
        return self.execute_command('RPUSH', name, *values)
```

This is the kind of bug that happens when we mock too much...

Manual validation of the fix:

```pycon
    >>> import redis
    >>> client = redis.from_url(url=settings.REDIS_URL, decode_responses=True)

    >>> # previous version, shows the bug
    >>> client.rpush("offer_ids_in_error", ["1", "2"])
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/home/damien/env/pcapi/lib/python3.7/site-packages/redis/client.py", line 2016, in rpush
        return self.execute_command('RPUSH', name, *values)
      File "/home/damien/env/pcapi/lib/python3.7/site-packages/redis/client.py", line 900, in execute_command
        conn.send_command(*args)
      File "/home/damien/env/pcapi/lib/python3.7/site-packages/redis/connection.py", line 725, in send_command
        self.send_packed_command(self.pack_command(*args),
      File "/home/damien/env/pcapi/lib/python3.7/site-packages/redis/connection.py", line 775, in pack_command
        for arg in imap(self.encoder.encode, args):
      File "/home/damien/env/pcapi/lib/python3.7/site-packages/redis/connection.py", line 120, in encode
        "bytes, string, int or float first." % typename)
    redis.exceptions.DataError: Invalid input of type: 'list'. Convert
    to a bytes, string, int or float first.

    >>> # Now with a star:
    >>> client.rpush("offer_ids_in_error", *["1", "2"])
    2
    >>> client.lrange("offer_ids_in_error",0,2)
    ['1', '2']
```

The proper way to fix this would be to stop mocking these calls and
let the code call Redis. I don't think that it would make the tests
much slower. If it did, we could introduce backends (like we do for
emails): a real backend that talks to Redis (and is properly tested
against a real testing Redis instance), and a testing backend that
stores things in memory.