### PR TITLE
(PC-6861): Deuxième worker pour les synchronisations

### DIFF
--- a/src/pcapi/alembic/versions/877b67c234f9_add_feature_flag_synchronize_venue_provider_in_worker.py
+++ b/src/pcapi/alembic/versions/877b67c234f9_add_feature_flag_synchronize_venue_provider_in_worker.py
@@ -1,0 +1,31 @@
+"""add_feature_flag_synchronize_venue_provider_in_worker
+
+Revision ID: 877b67c234f9
+Revises: 7c8fc9aed6e7
+Create Date: 2021-02-15 10:46:05.320883
+
+"""
+from alembic import op
+
+from pcapi.models.feature import FeatureToggle
+
+
+# revision identifiers, used by Alembic.
+revision = "877b67c234f9"
+down_revision = "7c8fc9aed6e7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    feature = FeatureToggle.SYNCHRONIZE_VENUE_PROVIDER_IN_WORKER
+    op.execute(
+        f"""INSERT INTO feature (name, description, "isActive")
+        VALUES ('{feature.name}', '{feature.value}', False)
+        """
+    )
+
+
+def downgrade():
+    feature = FeatureToggle.SYNCHRONIZE_VENUE_PROVIDER_IN_WORKER
+    op.execute(f"DELETE FROM feature WHERE name = '{feature.name}'")

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -40,6 +40,7 @@ class FeatureToggle(enum.Enum):
         "Active la parallèlisation des opérations de synchronisation pour les VenueProvider"
     )
     ENABLE_WHOLE_VENUE_PROVIDER_ALGOLIA_INDEXATION = "Active la réindexation globale sur Algolia des VenueProvider"
+    SYNCHRONIZE_VENUE_PROVIDER_IN_WORKER = "Effectue la première synchronisation des venue_provider dans le worker"
 
 
 class Feature(PcObject, Model, DeactivableMixin):

--- a/src/pcapi/routes/pro/venue_providers.py
+++ b/src/pcapi/routes/pro/venue_providers.py
@@ -87,7 +87,7 @@ def _get_stock_provider_repository(provider_class) -> StockProviderRepository:
 
 
 def _run_first_synchronization(new_venue_provider: VenueProvider):
-    if feature_queries.is_active(FeatureToggle.PARALLEL_SYNCHRONIZATION_OF_VENUE_PROVIDER):
+    if not feature_queries.is_active(FeatureToggle.SYNCHRONIZE_VENUE_PROVIDER_IN_WORKER):
         subprocess.Popen(
             [
                 "python",

--- a/src/pcapi/workers/bank_information_job.py
+++ b/src/pcapi/workers/bank_information_job.py
@@ -7,7 +7,7 @@ from pcapi.workers.decorators import job_context
 from pcapi.workers.decorators import log_job
 
 
-@job(worker.redis_queue, connection=worker.conn)
+@job(worker.default_queue, connection=worker.conn)
 @job_context
 @log_job
 def bank_information_job(application_id: str, refferer_type: str):

--- a/src/pcapi/workers/beneficiary_job.py
+++ b/src/pcapi/workers/beneficiary_job.py
@@ -6,7 +6,7 @@ from pcapi.workers.decorators import job_context
 from pcapi.workers.decorators import log_job
 
 
-@job(worker.redis_queue, connection=worker.conn)
+@job(worker.default_queue, connection=worker.conn)
 @job_context
 @log_job
 def beneficiary_job(application_id: int) -> None:

--- a/src/pcapi/workers/mailing_contacts_job.py
+++ b/src/pcapi/workers/mailing_contacts_job.py
@@ -9,7 +9,7 @@ from pcapi.workers.decorators import job_context
 from pcapi.workers.decorators import log_job
 
 
-@job(worker.redis_queue, connection=worker.conn)
+@job(worker.default_queue, connection=worker.conn)
 @job_context
 @log_job
 def mailing_contacts_job(contact_email: str, contact_date_of_birth: str, contact_department_code: str) -> None:

--- a/src/pcapi/workers/venue_provider_job.py
+++ b/src/pcapi/workers/venue_provider_job.py
@@ -7,7 +7,7 @@ from pcapi.workers.decorators import job_context
 from pcapi.workers.decorators import log_job
 
 
-@job(worker.redis_queue, connection=worker.conn)
+@job(worker.default_queue, connection=worker.conn)
 @job_context
 @log_job
 def venue_provider_job(venue_provider_id: int) -> None:

--- a/src/pcapi/workers/venue_provider_job.py
+++ b/src/pcapi/workers/venue_provider_job.py
@@ -7,7 +7,7 @@ from pcapi.workers.decorators import job_context
 from pcapi.workers.decorators import log_job
 
 
-@job(worker.default_queue, connection=worker.conn)
+@job(worker.low_queue, connection=worker.conn)
 @job_context
 @log_job
 def venue_provider_job(venue_provider_id: int) -> None:

--- a/tests/routes/pro/post_venue_provider_test.py
+++ b/tests/routes/pro/post_venue_provider_test.py
@@ -24,7 +24,7 @@ from tests.conftest import clean_database
 class Post:
     class Returns201:
         @pytest.mark.usefixtures("db_session")
-        @override_features(PARALLEL_SYNCHRONIZATION_OF_VENUE_PROVIDER=True)
+        @override_features(SYNCHRONIZE_VENUE_PROVIDER_IN_WORKER=False)
         @patch("pcapi.routes.pro.venue_providers.subprocess.Popen")
         @patch("pcapi.use_cases.connect_venue_to_provider._check_venue_can_be_synchronized_with_provider")
         @patch("pcapi.routes.pro.venue_providers.find_by_id")
@@ -71,7 +71,7 @@ class Post:
             )
 
         @pytest.mark.usefixtures("db_session")
-        @override_features(PARALLEL_SYNCHRONIZATION_OF_VENUE_PROVIDER=False)
+        @override_features(SYNCHRONIZE_VENUE_PROVIDER_IN_WORKER=True)
         @patch("pcapi.workers.venue_provider_job.venue_provider_job.delay")
         @patch("pcapi.use_cases.connect_venue_to_provider._check_venue_can_be_synchronized_with_provider")
         @patch("pcapi.routes.pro.venue_providers.find_by_id")


### PR DESCRIPTION
The worker is not ready to accept long running jobs like the synchronization of venue_providers.
The delegation of this task to the worker now has its own feature flip, so we can postpone

When the feature flip will be activated, the job will run on a new "low priority" worker.
This worker has to be instanciated by the ops team.
Meaning as long as this second worker is not up and running, **we shouldn't change the feature flip**