### PR TITLE
mails: Use our requests wrapper when using the Mailjet HTTP API

### DIFF
--- a/src/pcapi/core/mails/backends/mailjet.py
+++ b/src/pcapi/core/mails/backends/mailjet.py
@@ -197,8 +197,11 @@ class _CustomEndpoint(mailjet_rest.client.Endpoint):
         )
 
 
-# This is an exact copy of the original `mailjet_rest.client.api_call`,
-# but here `requests` is our wrapper, not the original `requests` package.
+# This is a copy of the original `mailjet_rest.client.api_call`, except:
+# - here `requests` is our wrapper, not the original `requests` package.
+# - the default value for `timeout` is None (instead of 60, which is
+#   too high), which means that we use the default timeout set by our
+#   `requests` wrapper.
 def _custom_api_call(
     auth,
     method,
@@ -207,7 +210,7 @@ def _custom_api_call(
     data=None,
     filters=None,
     resource_id=None,
-    timeout=60,
+    timeout=None,
     debug=False,
     action=None,
     action_id=None,

--- a/src/pcapi/core/mails/backends/mailjet.py
+++ b/src/pcapi/core/mails/backends/mailjet.py
@@ -1,10 +1,12 @@
 import datetime
+import json
 from typing import Iterable
 
-import mailjet_rest
+import mailjet_rest.client
 from requests import Response
 
 from pcapi import settings
+from pcapi.utils import requests
 from pcapi.utils.logger import logger
 
 from ..models import MailResult
@@ -22,7 +24,7 @@ class MailjetBackend(BaseBackend):
     def __init__(self):
         super().__init__()
         auth = (settings.MAILJET_API_KEY, settings.MAILJET_API_SECRET)
-        self.mailjet_client = mailjet_rest.Client(auth=auth, version="v3")
+        self.mailjet_client = MailjetClient(auth=auth, version="v3")
 
     def _send(self, recipients: Iterable[str], data: dict) -> MailResult:
         data["To"] = ", ".join(recipients)
@@ -109,3 +111,118 @@ class ToDevMailjetBackend(MailjetBackend):
     def add_contact_to_list(self, email: str, *args, **kwargs) -> Response:
         email = settings.DEV_EMAIL_ADDRESS
         return super().add_contact_to_list(email, *args, **kwargs)
+
+
+# Here below we define a custom client for Mailjet that uses our
+# `requests` wrapper. This allows automatic logging and a sane default
+# timeout. Because Mailjet client code is not very pluggable, this is
+# a bit verbose and we need to copy and paste a lot of upstream code.
+#  Fortunately, it rarely changes.
+class MailjetClient(mailjet_rest.client.Client):
+    def __getattr__(self, name):
+        # Start of original code.
+        # --- 8-> ---
+        split = name.split("_")
+        # identify the resource
+        fname = split[0]
+        action = None
+        if len(split) > 1:
+            # identify the sub resource (action)
+            action = split[1]
+            if action == "csvdata":
+                action = "csvdata/text:plain"
+            if action == "csverror":
+                action = "csverror/text:csv"
+        url, headers = self.config[name]
+        # --- 8-> ---
+        # Use our `_CustomEndpoint` instead of the original
+        # `Endpoint`. This is the only change.
+        return type(fname, (_CustomEndpoint,), {})(url=url, headers=headers, action=action, auth=self.auth)
+
+
+# Here we redefine all methods of the original `Endpoint` class to use
+# our `_custom_api_call` instead of the original `api_call`. This is
+# the only change.
+class _CustomEndpoint(mailjet_rest.client.Endpoint):
+    # The original code uses `id` as an argument, which pylint does not like.
+    # pylint: disable=redefined-builtin
+    def _get(self, filters=None, action_id=None, id=None, **kwargs):
+        return _custom_api_call(
+            self._auth,
+            "get",
+            self._url,
+            headers=self.headers,
+            action=self.action,
+            action_id=action_id,
+            filters=filters,
+            resource_id=id,
+            **kwargs,
+        )
+
+    def create(self, data=None, filters=None, id=None, action_id=None, **kwargs):
+        if self.headers["Content-type"] == "application/json":
+            data = json.dumps(data)
+        return _custom_api_call(
+            self._auth,
+            "post",
+            self._url,
+            headers=self.headers,
+            resource_id=id,
+            data=data,
+            action=self.action,
+            action_id=action_id,
+            filters=filters,
+            **kwargs,
+        )
+
+    def update(self, id, data, filters=None, action_id=None, **kwargs):
+        if self.headers["Content-type"] == "application/json":
+            data = json.dumps(data)
+        return _custom_api_call(
+            self._auth,
+            "put",
+            self._url,
+            resource_id=id,
+            headers=self.headers,
+            data=data,
+            action=self.action,
+            action_id=action_id,
+            filters=filters,
+            **kwargs,
+        )
+
+    def delete(self, id, **kwargs):
+        return _custom_api_call(
+            self._auth, "delete", self._url, action=self.action, headers=self.headers, resource_id=id, **kwargs
+        )
+
+
+# This is an exact copy of the original `mailjet_rest.client.api_call`,
+# but here `requests` is our wrapper, not the original `requests` package.
+def _custom_api_call(
+    auth,
+    method,
+    url,
+    headers,
+    data=None,
+    filters=None,
+    resource_id=None,
+    timeout=60,
+    debug=False,
+    action=None,
+    action_id=None,
+    **kwargs,
+):
+    url = mailjet_rest.client.build_url(url, method=method, action=action, resource_id=resource_id, action_id=action_id)
+    req_method = getattr(requests, method)
+
+    try:
+        response = req_method(
+            url, data=data, params=filters, headers=headers, auth=auth, timeout=timeout, verify=True, stream=False
+        )
+        return response
+
+    except requests.exceptions.Timeout:
+        raise mailjet_rest.client.TimeoutError
+    except requests.RequestException as e:
+        raise mailjet_rest.client.ApiError(e)

--- a/src/pcapi/utils/requests.py
+++ b/src/pcapi/utils/requests.py
@@ -39,6 +39,16 @@ def post(url: str, **kwargs: Any) -> Response:
         return session.request(method="POST", url=url, **kwargs)
 
 
+def put(url: str, **kwargs: Any) -> Response:
+    with Session() as session:
+        return session.request(method="PUT", url=url, **kwargs)
+
+
+def delete(url: str, **kwargs: Any) -> Response:
+    with Session() as session:
+        return session.request(method="DELETE", url=url, **kwargs)
+
+
 class _SessionMixin:
     def request(self, method: str, url: str, *args: Any, **kwargs: Any) -> Response:
         return _wrapper(super().request, method, url, *args, **kwargs)

--- a/tests/scripts/beneficiary/remote_import_test.py
+++ b/tests/scripts/beneficiary/remote_import_test.py
@@ -5,7 +5,6 @@ from unittest.mock import ANY
 from unittest.mock import Mock
 from unittest.mock import patch
 
-from mailjet_rest import Client
 import pytest
 
 import pcapi.core.mails.testing as mails_testing
@@ -250,8 +249,6 @@ class ProcessBeneficiaryApplicationTest:
     @pytest.mark.usefixtures("db_session")
     def test_new_beneficiaries_are_recorded_with_deposit(self, app):
         # given
-        app.mailjet_client = Mock(spec=Client)
-        app.mailjet_client.send = Mock()
         information = {
             "department": "93",
             "last_name": "Doe",
@@ -280,8 +277,6 @@ class ProcessBeneficiaryApplicationTest:
     @pytest.mark.usefixtures("db_session")
     def test_an_import_status_is_saved_if_beneficiary_is_created(self, app):
         # given
-        app.mailjet_client = Mock(spec=Client)
-        app.mailjet_client.send = Mock()
         information = {
             "department": "93",
             "last_name": "Doe",


### PR DESCRIPTION
Mise à jour (18/02) : finalement, je pense qu'un monkey patch serait moins invasif et plus sûr. C'est implémenté ici : #1999

---

HTTP requests to the Mailjet API were not logged. We don't know if
they are slow... That would be a good first step before potentially
making e-mail sending asynchronous.

I chose to define a subclass of the original Mailjet client class. It
is a bit verbose because the original code is not really pluggable.
The alternative would be to monkey-patch the `requests` imported in
`mailjet_rest.client` but I find that even more unpleasant.

-- 

J'ai fait un autre commit de nettoyage à côté, qui est indépendant de l'utilisation de notre wrapper à `requests`.