### PR TITLE
(PC-6974) users/webapp: Remove User.wallet_date_created

### DIFF
--- a/src/pcapi/core/users/models.py
+++ b/src/pcapi/core/users/models.py
@@ -265,13 +265,6 @@ class User(PcObject, Model, NeedsValidationMixin, VersionedMixin):
         return len(self.deposits) > 0
 
     @property
-    def wallet_date_created(self):
-        result = Deposit.query.filter_by(userId=self.id).first()
-        if result is not None:
-            return result.dateCreated
-        return None
-
-    @property
     def hasPhysicalVenues(self):
         for offerer in self.offerers:
             if any(not venue.isVirtual for venue in offerer.managedVenues):

--- a/src/pcapi/routes/serialization/beneficiaries.py
+++ b/src/pcapi/routes/serialization/beneficiaries.py
@@ -80,7 +80,6 @@ class BeneficiaryAccountResponse(BaseModel):
     publicName: str
     suspensionReason: Optional[str]
     wallet_balance: float
-    wallet_date_created: Optional[datetime]
     deposit_expiration_date: Optional[datetime]
     wallet_is_activated: bool
 

--- a/src/pcapi/utils/includes.py
+++ b/src/pcapi/utils/includes.py
@@ -13,7 +13,6 @@ BENEFICIARY_INCLUDES = [
     "expenses",
     "wallet_balance",
     "wallet_is_activated",
-    "wallet_date_created",
     "deposit_expiration_date",
     "needsToSeeTutorials",
 ]

--- a/tests/routes/webapp/get_beneficiary_profile_test.py
+++ b/tests/routes/webapp/get_beneficiary_profile_test.py
@@ -54,7 +54,6 @@ class Get:
 
             # Then
             assert response.json["wallet_is_activated"] == True
-            assert response.json["wallet_date_created"] == "2000-01-01T02:02:00Z"
             assert response.json["deposit_expiration_date"] == "2002-01-01T02:02:00Z"
 
         @pytest.mark.usefixtures("db_session")

--- a/tests/routes/webapp/patch_beneficiary_test.py
+++ b/tests/routes/webapp/patch_beneficiary_test.py
@@ -96,7 +96,6 @@ class Patch:
                 "publicName": "Anne",
                 "suspensionReason": "",
                 "wallet_balance": 500.0,
-                "wallet_date_created": format_into_utc_date(user.wallet_date_created),
                 "deposit_expiration_date": format_into_utc_date(user.deposit_expiration_date),
                 "wallet_is_activated": True,
             }


### PR DESCRIPTION
This property was used by the frontend to calculate the expiration
date of the deposit. But the frontend does not do that anymore and
just uses `User.deposit_expiration` instead. As such, we don't need to
expose `User.wallet_date_created` anymore and can remove it.