### PR TITLE
(PC-6976) : fix password reset link in email for native app

### DIFF
--- a/src/pcapi/emails/user_reset_password.py
+++ b/src/pcapi/emails/user_reset_password.py
@@ -27,7 +27,7 @@ def retrieve_data_for_reset_password_native_app_email(
             "email": user_email,
         }
     )
-    reset_password_link = f"{settings.NATIVE_APP_URL}/native/v1/redirect_to_native/mot-de-passe-perdu?{query_string}"
+    reset_password_link = f"{settings.NATIVE_APP_URL}/mot-de-passe-perdu?{query_string}"
 
     return {
         "MJ-TemplateID": 1838526,

--- a/tests/emails/user_reset_password_test.py
+++ b/tests/emails/user_reset_password_test.py
@@ -46,7 +46,7 @@ class NativeAppUserResetPasswordEmailDataTest:
             "MJ-TemplateLanguage": True,
             "Vars": {
                 "native_app_link": (
-                    "https://app.passculture-testing.beta.gouv.fr/native/v1/redirect_to_native/mot-de-passe-perdu"
+                    "https://app.passculture-testing.beta.gouv.fr/mot-de-passe-perdu"
                     "?token=abc&expiration_timestamp=1577836800&email=ewing%2Bdemo%40example.com"
                 )
             },


### PR DESCRIPTION
when switching to the universal links, the part that was used to
detect the url redirection should have been removed but was not :(