### PR TITLE
(PC-6986) mails: Monkey patch `mailjet_rest` library to use our `requests` wrapper

### DIFF
--- a/src/pcapi/core/mails/backends/mailjet.py
+++ b/src/pcapi/core/mails/backends/mailjet.py
@@ -11,6 +11,19 @@ from ..models import MailResult
 from .base import BaseBackend
 
 
+def monkey_patch_mailjet_requests():
+    # We want the `mailjet_rest` library to use our wrapper around
+    # `requests` to have automatic logging.
+    import mailjet_rest.client  # pylint: disable=redefined-outer-name
+
+    import pcapi.utils.requests
+
+    mailjet_rest.client.requests = pcapi.utils.requests
+
+
+monkey_patch_mailjet_requests()
+
+
 def _add_template_debugging(message_data: dict) -> None:
     message_data["TemplateErrorReporting"] = {
         "Email": settings.DEV_EMAIL_ADDRESS,

--- a/src/pcapi/utils/requests.py
+++ b/src/pcapi/utils/requests.py
@@ -39,6 +39,11 @@ def post(url: str, **kwargs: Any) -> Response:
         return session.request(method="POST", url=url, **kwargs)
 
 
+def put(url: str, **kwargs: Any) -> Response:
+    with Session() as session:
+        return session.request(method="PUT", url=url, **kwargs)
+
+
 class _SessionMixin:
     def request(self, method: str, url: str, *args: Any, **kwargs: Any) -> Response:
         return _wrapper(super().request, method, url, *args, **kwargs)

--- a/tests/core/mails/tests.py
+++ b/tests/core/mails/tests.py
@@ -148,7 +148,6 @@ class MailjetBackendTest:
         assert response.status_code == 200
         assert posted.last_request.json() == {"Email": "contact@example.com"}
 
-    @override_settings(EMAIL_BACKEND="pcapi.core.mails.backends.mailjet.MailjetBackend")
     def test_update_contact(self):
         backend = self._get_backend()
         dt = datetime.date(2000, 1, 1)
@@ -164,7 +163,6 @@ class MailjetBackendTest:
             ],
         }
 
-    @override_settings(EMAIL_BACKEND="pcapi.core.mails.backends.mailjet.MailjetBackend")
     def test_add_contact_to_list(self):
         backend = self._get_backend()
         with requests_mock.Mocker() as mock:
@@ -254,7 +252,6 @@ class ToDevMailjetBackendTest:
             ],
         }
 
-    @override_settings(EMAIL_BACKEND="pcapi.core.mails.backends.mailjet.MailjetBackend")
     def test_add_contact_to_list(self):
         backend = self._get_backend()
         with requests_mock.Mocker() as mock:

--- a/tests/core/mails/tests.py
+++ b/tests/core/mails/tests.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+from unittest.mock import patch
 
 import pytest
 import requests.exceptions
@@ -175,6 +176,16 @@ class MailjetBackendTest:
             "ContactAlt": "contact@example.com",
             "ListID": "12345",
         }
+
+    @patch("pcapi.utils.requests.json_logger.info")
+    def test_use_our_requests_wrapper_that_logs(self, mocked_logger):
+        backend = self._get_backend()
+        with requests_mock.Mocker() as mock:
+            posted = mock.post("https://api.eu.mailjet.com/v3/send")
+            backend.send_mail(recipients=self.recipients, data=self.data)
+
+        assert posted.last_request.json() == self.expected_sent_data
+        mocked_logger.assert_called_once()
 
 
 class ToDevMailjetBackendTest:


### PR DESCRIPTION
Pourquoi un monkey patch ? Cf. #1975.

---

Currently, HTTP requests to the Mailjet HTTP API are not logged. We
have no idea how much time these requests take. Having logs would be a
good first step before potentially making e-mail sending asynchronous.

I chose to monkey patch `mailjet_rest` because... we don't have much
choice. The code in `mailjet_rest` is not pluggable, we would have to
copy and paste a lot of code to inject our `requests` wrapper, by
redefining `Client`, `Endpoint` and `api_call`. In the end, monkey
patching is less fragile.