### PR TITLE
(PC-6975) : cache feature values when within a request context

### DIFF
--- a/src/pcapi/core/testing.py
+++ b/src/pcapi/core/testing.py
@@ -257,7 +257,15 @@ class override_features(TestContextDecorator):
             if status != state[name]:
                 self.apply_to_revert[name] = not status
                 Feature.query.filter_by(name=name).update({"isActive": status})
+        # Clear the feature cache on request if any
+        if flask.has_request_context():
+            if hasattr(flask.request, "_cached_features"):
+                flask.request._cached_features = {}
 
     def disable(self):
         for name, status in self.apply_to_revert.items():
             Feature.query.filter_by(name=name).update({"isActive": status})
+        # Clear the feature cache on request if any
+        if flask.has_request_context():
+            if hasattr(flask.request, "_cached_features"):
+                flask.request._cached_features = {}

--- a/src/pcapi/repository/feature_queries.py
+++ b/src/pcapi/repository/feature_queries.py
@@ -1,3 +1,6 @@
+from flask import has_request_context
+from flask import request
+
 from pcapi.models.api_errors import ResourceNotFoundError
 from pcapi.models.feature import Feature
 from pcapi.models.feature import FeatureToggle
@@ -10,4 +13,18 @@ def find_all():
 def is_active(feature_toggle: FeatureToggle) -> bool:
     if not isinstance(feature_toggle, FeatureToggle):
         raise ResourceNotFoundError
-    return Feature.query.filter_by(name=feature_toggle.name).first().isActive
+
+    if has_request_context():
+        if not hasattr(request, "_cached_features"):
+            setattr(request, "_cached_features", {})
+
+        cached_value = request._cached_features.get(feature_toggle.name)
+        if cached_value is not None:
+            return cached_value
+
+    value = Feature.query.filter_by(name=feature_toggle.name).first().isActive
+
+    if has_request_context():
+        request._cached_features[feature_toggle.name] = value
+
+    return value

--- a/tests/repository/feature_queries_test.py
+++ b/tests/repository/feature_queries_test.py
@@ -1,5 +1,7 @@
+import flask
 import pytest
 
+from pcapi.core.testing import assert_num_queries
 from pcapi.models.api_errors import ResourceNotFoundError
 from pcapi.models.feature import Feature
 from pcapi.models.feature import FeatureToggle
@@ -26,7 +28,33 @@ class FeatureToggleTest:
         # When / Then
         assert not is_active(FeatureToggle.WEBAPP_SIGNUP)
 
-    def test_is_active_returns_false_when_feature_unknown(self):
+    def test_is_active_raises_exception_when_feature_is_unknown(self):
         # When / Then
         with pytest.raises(ResourceNotFoundError):
             is_active("some_random_value")
+
+    def test_is_active_query_count_inside_request_context(self):
+        feature = Feature.query.filter_by(name=FeatureToggle.WEBAPP_SIGNUP.name).first()
+        feature.isActive = True
+        repository.save(feature)
+
+        # we should only have a single DB query here thanks to the cache
+        with assert_num_queries(1):
+            is_active(FeatureToggle.WEBAPP_SIGNUP)
+            is_active(FeatureToggle.WEBAPP_SIGNUP)
+            is_active(FeatureToggle.WEBAPP_SIGNUP)
+
+    def test_is_active_query_count_outside_request_context(self, app):
+        feature = Feature.query.filter_by(name=FeatureToggle.WEBAPP_SIGNUP.name).first()
+        feature.isActive = True
+        repository.save(feature)
+        context = flask._request_ctx_stack.pop()
+
+        # we don't cache yet outside the scope of a request so it'll be 3 DB queries
+        try:
+            with assert_num_queries(3):
+                is_active(FeatureToggle.WEBAPP_SIGNUP)
+                is_active(FeatureToggle.WEBAPP_SIGNUP)
+                is_active(FeatureToggle.WEBAPP_SIGNUP)
+        finally:
+            flask._request_ctx_stack.push(context)


### PR DESCRIPTION
We noticed the expense computation did query several times the
feature APPLY_BOOKING_LIMITS_V2. This is done though calls to
BaseLimitConfiguration.physical_cap_applies for every user's
booking.
A quick and easy fix here is to cache the feature value inside
the request context to avoid unintended extra db queries.

Note that feature will still work outside the request context -
ie in scripts, crons, workers - but will not benefit caching.