### PR TITLE
(PC-6525) : validate email when user resets its password

### DIFF
--- a/src/pcapi/routes/native/v1/authentication.py
+++ b/src/pcapi/routes/native/v1/authentication.py
@@ -90,6 +90,7 @@ def reset_password(body: ResetPasswordRequest) -> None:
     check_password_strength("newPassword", body.new_password)
 
     user.setPassword(body.new_password)
+    user.isEmailValidated = True
     repository.save(user)
 
 


### PR DESCRIPTION
Whenever the user follows a link with an expired account creation
token, it would receive a mail for a password reset in return.
If the user follows the email's link and successfully reset its
password, we should consider the email has indeed been validated.