### PR TITLE
ci: Do not cache requirements on "master" builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,18 +125,26 @@ jobs:
           password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
-      - restore_cache:
-          key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+      - unless:
+          condition:
+            equal: [ "master", << pipeline.git.branch >> ]
+          steps:
+            - restore_cache:
+                key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - run:
           name: Install requirements
           command: |
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
-      - save_cache:
-          key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
-          paths:
-            - "venv"
+      - unless:
+          condition:
+            equal: [ "master", << pipeline.git.branch >> ]
+          steps:
+            - save_cache:
+                key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+                paths:
+                  - "venv"
       - run:
           name: Install pcapi Python package
           command: |


### PR DESCRIPTION
Caching the whole virtual environment directory is not a good idea for
the "master" branch. When a new version of an unpinned dependency is
released (such as pylint), the requirements file does not change, so
CircleCI reuses the cache and the old version. This is wrong. The
build should really pick up the latest version.

This commit is only a quick fix. We should think about a better
solution. An alternative might be to use a cache on master, but use
`pip --upgrade-strategy eager` to be sure to fetch the latest version
of unpinned requirements.