### PR TITLE
[PC-6840] route.offerers: add missing field "demarchesSimplifieesApplicationId"

### DIFF
--- a/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/src/pcapi/routes/serialization/offerers_serialize.py
@@ -50,6 +50,7 @@ class GetOffererResponseModel(BaseModel):
     city: str
     dateCreated: datetime
     dateModifiedAtLastProvider: Optional[datetime]
+    demarchesSimplifieesApplicationId: Optional[str]
     fieldsUpdated: List[str]
     iban: Optional[str]
     id: str


### PR DESCRIPTION
Ajout d'un champs qui avait disparut suite au switch entre "as_dict" et le serializer de la reponse.
cf: https://github.com/pass-culture/pass-culture-api/commit/347316604d31814382eda42ab98795e8c1f222ab