### PR TITLE
(PC-6915) : Delete expired tokens

### DIFF
--- a/src/pcapi/alembic/versions/021d3f2434f0_add_on_cascade_delete_on_tokens.py
+++ b/src/pcapi/alembic/versions/021d3f2434f0_add_on_cascade_delete_on_tokens.py
@@ -1,0 +1,35 @@
+"""Add on cascade delete on tokens
+
+Revision ID: 021d3f2434f0
+Revises: b00c0a0dec8f
+Create Date: 2021-02-24 16:37:59.422400
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "021d3f2434f0"
+down_revision = "b00c0a0dec8f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+    ALTER TABLE ONLY public.token
+    DROP CONSTRAINT "token_userId_fkey",
+    ADD CONSTRAINT "token_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."user"(id) ON DELETE CASCADE;
+    """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+    ALTER TABLE ONLY public.token
+    DROP CONSTRAINT "token_userId_fkey",
+    ADD CONSTRAINT "token_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."user"(id);
+    """
+    )

--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -80,6 +80,10 @@ def generate_and_save_token(user: User, token_type: TokenType, life_time: Option
     return token
 
 
+def delete_expired_tokens() -> None:
+    Token.query.filter(Token.expirationDate < datetime.now()).delete()
+
+
 def create_account(
     email: str,
     password: str,

--- a/src/pcapi/core/users/models.py
+++ b/src/pcapi/core/users/models.py
@@ -20,6 +20,7 @@ from sqlalchemy import String
 from sqlalchemy import Text
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import backref
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
@@ -54,9 +55,9 @@ class Token(PcObject, Model):
 
     id = Column(BigInteger, primary_key=True, autoincrement=True)
 
-    userId = Column(BigInteger, ForeignKey("user.id"), index=True, nullable=False)
+    userId = Column(BigInteger, ForeignKey("user.id", ondelete="CASCADE"), index=True, nullable=False)
 
-    user = relationship("User", foreign_keys=[userId], backref="tokens")
+    user = relationship("User", foreign_keys=[userId], backref=backref("tokens", passive_deletes=True))
 
     value = Column(String, index=True, unique=True, nullable=False)
 


### PR DESCRIPTION
Clean the token table from expired ones.
We have no need to keep unused tokens.

Also adds a on cascade delete so that whenever a user is deleted, its tokens also are.