### PR TITLE
(PC-7171) Use new PC_GOOGLE_KEY_64 environment variable

### DIFF
--- a/src/pcapi/connectors/google_spreadsheet.py
+++ b/src/pcapi/connectors/google_spreadsheet.py
@@ -1,3 +1,4 @@
+import base64
 import json
 
 from google.oauth2.service_account import Credentials
@@ -19,12 +20,7 @@ def get_credentials():
     google_key = settings.GOOGLE_KEY
     if not google_key:
         raise MissingGoogleKeyException()
-    # Newline characters must be escaped in JSON.
-    google_key = google_key.replace("\n", "\\n")
-    # FIXME(cgaunet, 2020-11-24): We need to do this because parsing env variables yml
-    # to give it to terraform, replaces double quotes with single quotes making it not json friendly
-    google_key = google_key.replace("'", '"')
-    account_info = json.loads(google_key)
+    account_info = json.loads(base64.b64decode(google_key))
     scopes = ["https://spreadsheets.google.com/feeds", "https://www.googleapis.com/auth/drive"]
     return Credentials.from_service_account_info(account_info, scopes=scopes)
 

--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -211,6 +211,6 @@ PASS_CULTURE_REMITTANCE_CODE = os.environ.get("PASS_CULTURE_REMITTANCE_CODE")
 
 
 # GOOGLE
-GOOGLE_KEY = os.environ.get("PC_GOOGLE_KEY")
+GOOGLE_KEY = os.environ.get("PC_GOOGLE_KEY_64")
 GCP_BUCKET_CREDENTIALS = json.loads(base64.b64decode(os.environ.get("GCP_BUCKET_CREDENTIALS", "")) or "{}")
 GCP_BUCKET_NAME = os.environ.get("GCP_BUCKET_NAME", "")

--- a/tests/connectors/google_spreadsheet_test.py
+++ b/tests/connectors/google_spreadsheet_test.py
@@ -1,38 +1,33 @@
+import base64
+import json
 from unittest.mock import patch
 
 import pytest
 
 from pcapi.connectors.google_spreadsheet import MissingGoogleKeyException
 from pcapi.connectors.google_spreadsheet import get_credentials
+from pcapi.core.testing import override_settings
+
+
+TEST_ACCOUNT_INFO = {
+    "type": "service_account",
+    "project_id": "pass-culture",
+    "client_email": "a@example.com",
+    "client_id": "1",
+    "token_uri": "https://www.example.com/",
+    "private_key": "the\nprivate\nkey\nwith\nmultiple\nlines",
+}
 
 
 class GetCredentialsTest:
-    @patch(
-        "pcapi.settings.GOOGLE_KEY",
-        (
-            "{'type': 'service_account','project_id': 'pass-culture', 'client_email': 'a@example.com', "
-            "'client_id': '1', 'token_uri': 'https://www.example.com/', "
-            "'private_key': 'the\nprivate\nkey\nwith\nmultiple\nlines'}"
-        ),
-    )
+    @override_settings(GOOGLE_KEY=base64.b64encode(json.dumps(TEST_ACCOUNT_INFO).encode("utf-8")))
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
-    def test_calls_from_service_account_info(
-        self,
-        from_service_account_info,
-    ):
+    def test_calls_from_service_account_info(self, from_service_account_info):
         # When
         get_credentials()
 
         # Then
-        expected_account_info = {
-            "type": "service_account",
-            "project_id": "pass-culture",
-            "client_email": "a@example.com",
-            "client_id": "1",
-            "token_uri": "https://www.example.com/",
-            "private_key": "the\nprivate\nkey\nwith\nmultiple\nlines",
-        }
-        assert from_service_account_info.call_args[0][0] == expected_account_info
+        assert from_service_account_info.call_args[0][0] == TEST_ACCOUNT_INFO
         expected_scopes = ["https://spreadsheets.google.com/feeds", "https://www.googleapis.com/auth/drive"]
         assert from_service_account_info.call_args[1] == {"scopes": expected_scopes}
 


### PR DESCRIPTION
This one is base64-encoded, which is easier to work with in
configuration files.