### PR TITLE
(QA) : refactor a bit redefined BookingRecap's booking_token

### DIFF
--- a/src/pcapi/domain/booking_recap/booking_recap.py
+++ b/src/pcapi/domain/booking_recap/booking_recap.py
@@ -72,13 +72,16 @@ class BookingRecap:
             raise TypeError("BookingRecap may not be instantiated")
         return object.__new__(cls)
 
-    @property
-    def booking_token(self) -> str:
+    def _get_booking_token(self) -> Optional[str]:
         return self._booking_token
 
-    @booking_token.setter
-    def booking_token(self, booking_token) -> str:
+    def _set_booking_token(self, booking_token: str) -> None:
         self._booking_token = booking_token
+
+    booking_token = property(
+        lambda self: self._get_booking_token(),
+        lambda self, booking_token: self._set_booking_token(booking_token),
+    )
 
     @property
     def booking_status(self) -> BookingRecapStatus:
@@ -122,8 +125,7 @@ class BookingRecap:
 
 
 class ThingBookingRecap(BookingRecap):
-    @BookingRecap.booking_token.getter
-    def booking_token(self) -> Optional[str]:  # pylint: disable=invalid-overridden-method
+    def _get_booking_token(self) -> Optional[str]:
         if not self.booking_is_used and not self.booking_is_cancelled:
             return None
         return self._booking_token


### PR DESCRIPTION
The `booking_token` property was redefined in a way pylint lost
the track.
Refactor the property to use `_get_booking_token()` and
`_set_booking_token()`. Lambda are used here so we don't need to
redefine the property for every class that changes its behavior.