### PR TITLE
(PC-7158): Log to stdout

### DIFF
--- a/src/pcapi/utils/logger.py
+++ b/src/pcapi/utils/logger.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import logging
+import sys
 
 from pythonjsonlogger import jsonlogger
 
@@ -27,12 +28,13 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
     level=LOG_LEVEL,
     datefmt="%Y-%m-%d %H:%M:%S",
+    stream=sys.stdout,
 )
 json_logger = logging.getLogger(__name__)
 
 
 def configure_json_logger() -> None:
-    log_handler = logging.StreamHandler()
+    log_handler = logging.StreamHandler(sys.stdout)
     formatter = CustomJsonFormatter("%(timestamp) %(level) %(message)")
     log_handler.setFormatter(formatter)
     json_logger.addHandler(log_handler)


### PR DESCRIPTION
D'après la doc de StreamHandler il log sur stderr par défault, ici on met stdout

MAIS
- ça ne concerne que le jsonlogger
- pas réussit à reproduire en local, les logs étaient déjà tous dans stdout