### PR TITLE
(PC-7221) : links to the native app should not be rewritten by Mailjet

### DIFF
--- a/src/pcapi/emails/beneficiary_activation.py
+++ b/src/pcapi/emails/beneficiary_activation.py
@@ -32,6 +32,7 @@ def get_activation_email_data_for_native(user: users_models.User, token: users_m
     return {
         "Mj-TemplateID": 2015423,
         "Mj-TemplateLanguage": True,
+        "Mj-trackclick": 1,
         "Vars": {
             "nativeAppLink": email_confirmation_link,
             "isEligible": int(user.is_eligible),
@@ -57,6 +58,7 @@ def get_newly_eligible_user_email_data(user: users_models.User, token: users_mod
     return {
         "Mj-TemplateID": 2030056,
         "Mj-TemplateLanguage": True,
+        "Mj-trackclick": 1,
         "Vars": {
             "nativeAppLink": email_link,
         },

--- a/src/pcapi/emails/user_reset_password.py
+++ b/src/pcapi/emails/user_reset_password.py
@@ -32,6 +32,6 @@ def retrieve_data_for_reset_password_native_app_email(
     return {
         "MJ-TemplateID": 1838526,
         "MJ-TemplateLanguage": True,
-        "Mj-trackopen": 1,
+        "Mj-trackclick": 1,
         "Vars": {"native_app_link": reset_password_link},
     }

--- a/tests/emails/user_reset_password_test.py
+++ b/tests/emails/user_reset_password_test.py
@@ -44,7 +44,7 @@ class NativeAppUserResetPasswordEmailDataTest:
         assert reset_password_email_data == {
             "MJ-TemplateID": 1838526,
             "MJ-TemplateLanguage": True,
-            "Mj-trackopen": 1,
+            "Mj-trackclick": 1,
             "Vars": {
                 "native_app_link": (
                     "https://app.passculture-testing.beta.gouv.fr/mot-de-passe-perdu"


### PR DESCRIPTION
Mailjet rewrites the http/https links in order to track who's clicked
the mail. However, this breaks universal links to the native application.
It is still possible to deactivate that url rewriting by sending
`Mj-trackclick` set to 1 along with the other Mailjet's headers.