### PR TITLE
(PC-7001) Add user credits

### DIFF
--- a/src/pcapi/core/users/models.py
+++ b/src/pcapi/core/users/models.py
@@ -241,6 +241,7 @@ class User(PcObject, Model, NeedsValidationMixin, VersionedMixin):
 
         return relativedelta(date.today(), self.dateOfBirth.date()).years
 
+    # TODO(viconnex) Remove expenses once the webapp and app native use api.get_domains_credit
     @property
     def expenses(self):
         from pcapi.core.users.api import user_expenses

--- a/src/pcapi/core/users/models.py
+++ b/src/pcapi/core/users/models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from decimal import Decimal
 import enum
 from hashlib import md5
+from typing import List
 from typing import Optional
 
 import bcrypt
@@ -225,7 +226,7 @@ class User(PcObject, Model, NeedsValidationMixin, VersionedMixin):
         self.resetPasswordToken = None
         self.resetPasswordTokenValidityLimit = None
 
-    def get_not_cancelled_bookings(self) -> Booking:
+    def get_not_cancelled_bookings(self) -> List[Booking]:
         return (
             db.session.query(Booking)
             .with_parent(self)
@@ -257,6 +258,10 @@ class User(PcObject, Model, NeedsValidationMixin, VersionedMixin):
     @property
     def deposit_version(self) -> Optional[int]:
         return self.deposit.version if self.deposit else None
+
+    @property
+    def has_active_deposit(self):
+        return self.deposit_expiration_date and self.deposit_expiration_date > datetime.now()
 
     @property
     def real_wallet_balance(self):
@@ -311,3 +316,16 @@ class Expense:
     domain: ExpenseDomain
     current: Decimal
     limit: Decimal
+
+
+@dataclass
+class Credit:
+    initial: Decimal
+    remaining: Decimal
+
+
+@dataclass
+class DomainsCredit:
+    all: Credit
+    digital: Optional[Credit] = None
+    physical: Optional[Credit] = None

--- a/src/pcapi/routes/serialization/beneficiaries.py
+++ b/src/pcapi/routes/serialization/beneficiaries.py
@@ -63,7 +63,6 @@ class BeneficiaryAccountResponse(BaseModel):
     deposit_version: Optional[int]
     email: str
     expenses: List[Expense]
-    # @debt api-data "asaunier: Seuls quelques comptes n'ont pas cette information. Elle devrait être rendue obligatoire"
     firstName: Optional[str]
     hasAllowedRecommendations: bool
     hasPhysicalVenues: bool
@@ -72,7 +71,6 @@ class BeneficiaryAccountResponse(BaseModel):
     isAdmin: bool
     isBeneficiary: bool
     isEmailValidated: bool
-    # @debt api-data "asaunier: Seuls quelques comptes n'ont pas cette information. Elle devrait être rendue obligatoire"
     lastName: Optional[str]
     needsToFillCulturalSurvey: bool
     needsToSeeTutorials: bool

--- a/tests/core/users/test_expenses.py
+++ b/tests/core/users/test_expenses.py
@@ -560,9 +560,9 @@ class ExpensesTest:
 
                 # Then
                 assert expenses == [
-                    Expense(domain=ExpenseDomain.ALL, current=Decimal(210.0), limit=Decimal(500)),
+                    Expense(domain=ExpenseDomain.ALL, current=Decimal(210), limit=Decimal(500)),
                     Expense(domain=ExpenseDomain.DIGITAL, current=Decimal(0.0), limit=Decimal(200)),
-                    Expense(domain=ExpenseDomain.PHYSICAL, current=Decimal(210.0), limit=Decimal(200)),
+                    Expense(domain=ExpenseDomain.PHYSICAL, current=Decimal(200.00), limit=Decimal(200)),
                 ]
 
             def test_returns_max_500_and_actual_0(self):

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -90,6 +90,11 @@ class AccountTest:
 
         EXPECTED_DATA = {
             "id": user.id,
+            "domainsCredit": {
+                "all": {"initial": 50000, "remaining": 37655},
+                "digital": {"initial": 20000, "remaining": 20000},
+                "physical": {"initial": 20000, "remaining": 7655},
+            },
             "dateOfBirth": "2000-01-01T00:00:00",
             "depositVersion": 1,
             "depositExpirationDate": "2040-01-01T00:00:00",
@@ -108,6 +113,18 @@ class AccountTest:
 
         assert response.status_code == 200
         assert response.json == EXPECTED_DATA
+
+    def test_get_user_not_beneficiary(self, app):
+        users_factories.UserFactory(email=self.identifier, deposit=None, isBeneficiary=False)
+
+        access_token = create_access_token(identity=self.identifier)
+        test_client = TestClient(app.test_client())
+        test_client.auth_header = {"Authorization": f"Bearer {access_token}"}
+
+        response = test_client.get("/native/v1/me")
+
+        assert response.status_code == 200
+        assert not response.json["domainsCredit"]
 
     def test_get_user_profile_empty_first_name(self, app):
         users_factories.UserFactory(

--- a/tests/routes/webapp/get_beneficiary_profile_test.py
+++ b/tests/routes/webapp/get_beneficiary_profile_test.py
@@ -32,6 +32,7 @@ class Get:
             assert response.status_code == 200
             json = response.json
             assert json["email"] == "toto@example.com"
+            assert not json["domainsCredit"]
             assert json["expenses"] == []
             assert "password" not in json
             assert "clearTextPassword" not in json
@@ -79,6 +80,11 @@ class Get:
 
             # Then
             assert response.json["wallet_balance"] == 495.0
+            assert response.json["domainsCredit"] == {
+                "all": {"initial": 500.0, "remaining": 495.0},
+                "digital": {"initial": 200.0, "remaining": 200.0},
+                "physical": {"initial": 200.0, "remaining": 195.0},
+            }
             assert response.json["expenses"] == [
                 {"domain": "all", "current": 5.0, "limit": 500.0},
                 {"domain": "digital", "current": 0.0, "limit": 200.0},
@@ -95,6 +101,11 @@ class Get:
 
             # Then
             assert response.json["wallet_balance"] == 500.0
+            assert response.json["domainsCredit"] == {
+                "all": {"initial": 500.0, "remaining": 500.0},
+                "digital": {"initial": 200.0, "remaining": 200.0},
+                "physical": {"initial": 200.0, "remaining": 200.0},
+            }
             assert response.json["expenses"] == [
                 {"domain": "all", "current": 0.0, "limit": 500.0},
                 {"domain": "digital", "current": 0.0, "limit": 200.0},

--- a/tests/routes/webapp/patch_beneficiary_test.py
+++ b/tests/routes/webapp/patch_beneficiary_test.py
@@ -71,6 +71,11 @@ class Patch:
                 "address": "1 rue des machines",
                 "city": "Paris",
                 "civility": None,
+                "domainsCredit": {
+                    "all": {"initial": 500.0, "remaining": 500.0},
+                    "digital": {"initial": 200.0, "remaining": 200.0},
+                    "physical": {"initial": 200.0, "remaining": 200.0},
+                },
                 "dateCreated": format_into_utc_date(user.dateCreated),
                 "dateOfBirth": "2000-01-01T00:00:00Z",
                 "departementCode": "97",


### PR DESCRIPTION
Add a more solid and domain-like model of the credit : replace user.expenses: List[Expense] by get_domains_credit(user)->DomainsCredit.

This will moreover help the frontends that currently have to deal with a list instead of an object, and prevent it from repeating logics like _"is deposit exired?"_  or _"if `all`  credit is lower than `physical` credit then `physical` credit is `all`"_.

Refacto steps :
1.  add `domainsCredit` aside to `user.expenses` (this PR)
2. user `domainsCredit` in App Native and Webapp
3. remove user.expenses