### PR TITLE
(PC-7426) admin: Do not list partner accounts in beneficiary list view

### DIFF
--- a/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -110,7 +110,9 @@ class BeneficiaryUserView(SuspensionMixin, BaseAdminView):
         super().after_model_change(form, model, is_created)
 
     def get_query(self) -> query:
-        return User.query.outerjoin(UserOfferer).filter(UserOfferer.userId.is_(None)).filter(User.isAdmin.is_(False))
+        return (
+            User.query.outerjoin(UserOfferer).filter(UserOfferer.userId.is_(None)).filter(User.isBeneficiary.is_(True))
+        )
 
     def get_count_query(self) -> query:
         return (
@@ -118,5 +120,5 @@ class BeneficiaryUserView(SuspensionMixin, BaseAdminView):
             .select_from(self.model)
             .outerjoin(UserOfferer)
             .filter(UserOfferer.userId.is_(None))
-            .filter(User.isAdmin.is_(False))
+            .filter(User.isBeneficiary.is_(True))
         )

--- a/src/pcapi/admin/install.py
+++ b/src/pcapi/admin/install.py
@@ -75,7 +75,7 @@ def install_admin_views(admin: Admin, session: Session) -> None:
         BeneficiaryUserView(
             User,
             session,
-            name="Comptes Jeunes/Grand Public",
+            name="Comptes Jeunes",
             category=Category.USERS,
             endpoint="/beneficiary_users",
         )


### PR DESCRIPTION
Partner accounts are neither admin nor beneficiary, which is why they
were listed. If we specifically filter on `isBeneficiary=True`, we'll
only get beneficiaries, without partner accounts.