### PR TITLE
(PC-7415) : return newly created favorite

### DIFF
--- a/tests/routes/native/v1/favorites_test.py
+++ b/tests/routes/native/v1/favorites_test.py
@@ -104,7 +104,7 @@ class Get:
 
 
 class Post:
-    class Returns204:
+    class Returns200:
         def when_user_creates_a_favorite(self, app):
             # Given
             user, test_client = utils.create_user_and_test_client(app)
@@ -118,11 +118,13 @@ class Post:
             response = test_client.post(FAVORITES_URL, json={"offerId": offer1.id})
 
             # Then
-            assert response.status_code == 204, response.data
+            assert response.status_code == 200, response.data
             assert FavoriteSQLEntity.query.count() == 1
             favorite = FavoriteSQLEntity.query.first()
             assert favorite.dateCreated
             assert favorite.userId == user.id
+            assert response.json["id"] == favorite.id
+            assert response.json["offer"]
 
 
 class Delete:


### PR DESCRIPTION
Returns the favorite structure whenever one is created.
This allows the client to cache it and flag the offer as favorite
without the need to refresh the offer from the backend.