### PR TITLE
(PC-7191) admin: Allow to mark a cancelled booking as used

### DIFF
--- a/src/pcapi/admin/custom_views/booking_view.py
+++ b/src/pcapi/admin/custom_views/booking_view.py
@@ -1,0 +1,90 @@
+from flask import redirect
+from flask import request
+from flask.helpers import flash
+from flask.helpers import url_for
+from flask_admin import expose
+from flask_admin.form import SecureForm
+from sqlalchemy.orm import joinedload
+from wtforms import HiddenField
+from wtforms import StringField
+from wtforms import validators
+
+from pcapi.admin.base_configuration import BaseCustomAdminView
+import pcapi.core.bookings.api as bookings_api
+from pcapi.core.bookings.models import Booking
+from pcapi.core.offers.models import Stock
+from pcapi.domain.client_exceptions import ClientError
+from pcapi.models.api_errors import ApiErrors
+
+
+class SearchForm(SecureForm):
+    token = StringField(
+        "Code de contremarque",
+        validators=[validators.DataRequired()],
+        description='Par exemple "ABC123"',
+    )
+
+
+class MarkAsUsedForm(SecureForm):
+    booking_id = HiddenField()
+
+
+class BookingView(BaseCustomAdminView):
+    @expose("/", methods=["GET", "POST"])
+    def search(self):
+        search_form = SearchForm(request.form)
+        mark_as_used_form = None
+
+        # Get booking by token from POSTed search; or by id from GET
+        # on redirect (because we'd rather not see the token in the
+        # URL).
+        booking = None
+        if request.method == "POST":
+            if search_form.validate():
+                booking = (
+                    Booking.query.filter_by(token=search_form.token.data)
+                    .options(joinedload(Booking.user))
+                    .options(joinedload(Booking.stock).joinedload(Stock.offer))
+                    .first()
+                )
+                if not booking:
+                    flash("Aucune réservation n'existe avec ce code de contremarque.", "error")
+                elif booking.isCancelled:
+                    mark_as_used_form = MarkAsUsedForm(booking_id=booking.id)
+        elif "id" in request.args:
+            booking = (
+                Booking.query.filter_by(id=request.args["id"])
+                .options(joinedload(Booking.user))
+                .options(joinedload(Booking.stock).joinedload(Stock.offer))
+                .first()
+            )
+
+        return self.render(
+            "admin/booking.html", search_form=search_form, mark_as_used_form=mark_as_used_form, booking=booking
+        )
+
+    @expose("/mark-as-used", methods=["POST"])
+    def uncancel_and_mark_as_used(self):
+        form = MarkAsUsedForm(request.form)
+        if not form.validate():
+            flash(f"Une erreur est survenue : {form.errors}", "error")
+            return redirect(url_for(".search"))
+
+        booking = Booking.query.get(form.booking_id.data)
+        booking_url = f"{url_for('.search')}?id={booking.id}"
+
+        if not booking.isCancelled:
+            flash("Cette réservation n'est pas annulée, elle ne peut pas être validée via ce formulaire.", "error")
+            return redirect(booking_url)
+
+        try:
+            bookings_api.mark_as_used(booking, uncancel=True)
+        except Exception as exc:  # pylint: disable=broad-except
+            if isinstance(exc, (ClientError, ApiErrors)):
+                err = list(exc.errors.values())[0][0]
+            else:
+                err = str(exc)
+            flash(f"L'opération a échoué : {err}", "error")
+        else:
+            flash("La réservation a été dés-annulée et marquée comme utilisée.", "info")
+        return redirect(booking_url)

--- a/src/pcapi/admin/install.py
+++ b/src/pcapi/admin/install.py
@@ -7,6 +7,7 @@ from pcapi.admin.custom_views.admin_user_view import AdminUserView
 from pcapi.admin.custom_views.allocine_pivot_view import AllocinePivotView
 from pcapi.admin.custom_views.beneficiary_import_view import BeneficiaryImportView
 from pcapi.admin.custom_views.beneficiary_user_view import BeneficiaryUserView
+from pcapi.admin.custom_views.booking_view import BookingView
 from pcapi.admin.custom_views.criteria_view import CriteriaView
 from pcapi.admin.custom_views.feature_view import FeatureView
 from pcapi.admin.custom_views.many_offers_operations_view import ManyOffersOperationsView
@@ -94,6 +95,13 @@ def install_admin_views(admin: Admin, session: Session) -> None:
         ManyOffersOperationsView(
             name="Opérations sur plusieurs offres",
             endpoint="/many_offers_operations",
+            category=Category.CUSTOM_OPERATIONS,
+        )
+    )
+    admin.add_view(
+        BookingView(
+            name="Réservations",
+            endpoint="/bookings",
             category=Category.CUSTOM_OPERATIONS,
         )
     )

--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -116,7 +116,18 @@ def cancel_booking_by_offerer(booking: Booking) -> None:
         redis.add_offer_id(client=app.redis_client, offer_id=booking.stock.offerId)
 
 
-def mark_as_used(booking: Booking) -> None:
+def mark_as_used(booking: Booking, uncancel=False) -> None:
+    """Mark a booking as used.
+
+    The ``uncancel`` argument should be provided only if the booking
+    has been cancelled by mistake or fraudulently after the offer was
+    retrieved (for example, when a beneficiary retrieved a book from a
+    library and then cancelled their booking before the library marked
+    it as used).
+    """
+    if uncancel:
+        booking.isCancelled = False
+        booking.cancellationReason = None
     validation.check_is_usable(booking)
     booking.isUsed = True
     booking.dateUsed = datetime.datetime.utcnow()

--- a/src/pcapi/core/bookings/validation.py
+++ b/src/pcapi/core/bookings/validation.py
@@ -110,8 +110,7 @@ def check_offerer_can_cancel_booking(booking: Booking) -> None:
 # desired HTTP-related exception (such as ResourceGone and Forbidden)
 # See also functions below.
 def check_is_usable(booking: Booking) -> None:
-    booking_payment = payment_queries.find_by_booking_id(booking.id)
-    if booking_payment is not None:
+    if payment_queries.has_payment(booking):
         forbidden = api_errors.ForbiddenError()
         forbidden.add_error("payment", "Cette réservation a été remboursée")
         raise forbidden
@@ -154,8 +153,7 @@ def check_can_be_mark_as_unused(booking: Booking) -> None:
         forbidden.add_error("booking", "Cette réservation a été annulée")
         raise forbidden
 
-    booking_payment = payment_queries.find_by_booking_id(booking.id)
-    if booking_payment is not None:
+    if payment_queries.has_payment(booking):
         gone = api_errors.ResourceGoneError()
         gone.add_error("payment", "Le remboursement est en cours de traitement")
         raise gone

--- a/src/pcapi/repository/payment_queries.py
+++ b/src/pcapi/repository/payment_queries.py
@@ -39,8 +39,8 @@ def get_payments_by_message_id(payment_message_id: str) -> List[Payment]:
     return Payment.query.join(PaymentMessage).filter(PaymentMessage.name == payment_message_id).all()
 
 
-def find_by_booking_id(booking_id: int) -> Optional[Payment]:
-    return Payment.query.filter_by(bookingId=booking_id).first()
+def has_payment(booking: Booking) -> Optional[Payment]:
+    return db.session.query(Payment.query.filter_by(bookingId=booking.id).exists()).scalar()
 
 
 def find_not_processable_with_bank_information() -> List[Payment]:

--- a/src/pcapi/scripts/booking/canceling_token_validation.py
+++ b/src/pcapi/scripts/booking/canceling_token_validation.py
@@ -7,9 +7,7 @@ def canceling_token_validation(token: str) -> None:
     booking = booking_repository.find_used_by_token(token)
 
     if booking:
-        payment = payment_queries.find_by_booking_id(booking_id=booking.id)
-
-        if payment is None:
+        if not payment_queries.has_payment(booking):
             booking.isUsed = False
             booking.dateUsed = None
             repository.save(booking)

--- a/src/pcapi/templates/admin/booking.html
+++ b/src/pcapi/templates/admin/booking.html
@@ -1,0 +1,42 @@
+{% extends 'admin/master.html' %}
+{% import 'admin/forms.html' as forms %}
+
+{% block body %}
+<h2>Réservations</h2>
+
+<form action="" method="POST">
+  {{ forms.display_form(search_form, "Rechercher la réservation") }}
+</form>
+
+{% if booking %}
+  <hr>
+  <p>
+    <div><b>Code :</b> {{ booking.token }}</div>
+    <div><b>Bénéficiaire :</b> {{ booking.user.email }} ({{ booking.user.id }})</div>
+    <div><b>Offre :</b> {{ booking.stock.offer.name }}</div>
+    <div><b>Date d'annulation :</b>
+      {% if booking.isCancelled %}
+        {{ booking.cancellationDate.strftime('%d/%m/%Y %H:%M') }}
+      {% else %}
+        non annulée
+      {% endif %}
+    </div>
+  </p>
+
+  {% if mark_as_used_form %}
+    <p>
+      Si cette réservation a été annulée par erreur (ou
+      frauduleusement) alors qu'elle a en fait été utilisée, il est
+      possible de la marquer comme utilisée.
+      <br>
+      <b>Attention : cette opération est irréversible.</b>
+    </p>
+    <form action="mark-as-used" method="POST">
+      {{ forms.display_form(mark_as_used_form) }}
+      <input class="btn btn-danger" type="submit" value="Marquer comme utilisée">
+    </form>
+  {% endif %}
+
+{% endif %} {# if booking #}
+
+{% endblock %}

--- a/src/pcapi/templates/admin/forms.html
+++ b/src/pcapi/templates/admin/forms.html
@@ -1,0 +1,23 @@
+{% macro display_form(form, submit_button=None) %}
+  {% for field in form %}
+    {% if 'hidden' in field.widget.field_flags %}
+      {{ field }}
+    {% else %}
+      <div class="row form-group">
+        <div class="col-md-3"></div>
+        <div class="col-md-6">
+          <label>{{ field.label }} {% if field.flags.required %}*{% endif %}</label>
+          {{ field(class_="form-control") }}
+        </div>
+        <div class="col-md-3"></div>
+      </div>
+    {% endif %}
+  {% endfor %}
+  {% if submit_button %}
+    <div class="row">
+      <div class="col-md-3"></div>
+      <input class="btn btn-default col-md-6" type="submit" value="{{ submit_button }} ">
+      <div class="col-md-3"></div>
+    </div>
+  {% endif %}
+{% endmacro %}

--- a/src/pcapi/templates/admin/search_many_offers.html
+++ b/src/pcapi/templates/admin/search_many_offers.html
@@ -1,26 +1,11 @@
 {% extends 'admin/master.html' %}
+{% import 'admin/forms.html' as forms %}
 
 {% block body %}
 <h2>Je cherche des offres par :</h2>
+
 <form action="{{ action }}" method="POST">
-  {% for field in form %}
-    {% if field.name == "csrf_token" %}
-      {{ field }}
-    {% else %}
-    <div class="row form-group">
-      <div class="col-md-3"></div>
-        <div class="col-md-6">
-          <label>{{ field.label }} {% if field.flags.required %}*{% endif %}</label>
-          {{ field(class_="form-control") }}
-        </div>
-      <div class="col-md-3"></div>
-    </div>
-    {% endif %}
-  {% endfor %}
-  <div class="row">
-    <div class="col-md-3"></div>
-    <input class="btn btn-default col-md-6" type="submit" value="Rechercher les offres associées à cet ISBN">
-    <div class="col-md-3"></div>
-  </div>
+  {{ forms.display_form(form, "Rechercher les offres associées à cet ISBN") }}
 </form>
+
 {% endblock %}

--- a/tests/admin/custom_views/booking_view_test.py
+++ b/tests/admin/custom_views/booking_view_test.py
@@ -1,0 +1,67 @@
+from unittest import mock
+
+import pytest
+
+import pcapi.core.bookings.factories as bookings_factories
+from pcapi.core.bookings.models import Booking
+import pcapi.core.users.factories as users_factories
+
+from tests.conftest import TestClient
+
+
+@pytest.mark.usefixtures("db_session")
+@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token", lambda *args, **kwargs: True)
+class BookingViewTest:
+    def test_search_booking(self, app):
+        users_factories.UserFactory(email="admin@example.com", isAdmin=True)
+        booking = bookings_factories.BookingFactory()
+
+        client = TestClient(app.test_client()).with_auth("admin@example.com")
+        response = client.post(f"/pc/back-office/bookings/", form={"token": booking.token})
+
+        assert response.status_code == 200
+        content = response.data.decode(response.charset)
+        assert booking.user.email in content
+        assert "Marquer comme utilisée" not in content
+
+    def test_show_mark_as_used_button(self, app):
+        users_factories.UserFactory(email="admin@example.com", isAdmin=True)
+        booking = bookings_factories.BookingFactory(isCancelled=True)
+
+        client = TestClient(app.test_client()).with_auth("admin@example.com")
+        response = client.post(f"/pc/back-office/bookings/", form={"token": booking.token})
+
+        assert response.status_code == 200
+        content = response.data.decode(response.charset)
+        assert "Marquer comme utilisée" in content
+
+    def test_uncancel_and_mark_as_used(self, app):
+        users_factories.UserFactory(email="admin@example.com", isAdmin=True)
+        booking = bookings_factories.BookingFactory(isCancelled=True)
+
+        client = TestClient(app.test_client()).with_auth("admin@example.com")
+        response = client.post(f"/pc/back-office/bookings/mark-as-used", form={"booking_id": booking.id})
+
+        assert response.status_code == 302
+        assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
+        response = client.get(response.location)
+        content = response.data.decode(response.charset)
+        assert "La réservation a été dés-annulée et marquée comme utilisée." in content
+        booking = Booking.query.get(booking.id)
+        assert not booking.isCancelled
+        assert booking.isUsed
+
+    def test_fail_to_uncancel_and_mark_as_used(self, app):
+        users_factories.UserFactory(email="admin@example.com", isAdmin=True)
+        booking = bookings_factories.BookingFactory()
+
+        client = TestClient(app.test_client()).with_auth("admin@example.com")
+        response = client.post(f"/pc/back-office/bookings/mark-as-used", form={"booking_id": booking.id})
+
+        assert response.status_code == 302
+        assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
+        response = client.get(response.location)
+        content = response.data.decode(response.charset)
+        assert "ne peut pas être validée via ce formulaire." in content
+        booking = Booking.query.get(booking.id)
+        assert not booking.isUsed

--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -251,6 +251,13 @@ class MarkAsUsedTest:
         api.mark_as_used(booking)
         assert booking.isUsed
 
+    def test_mark_as_used_with_uncancel(self):
+        booking = factories.BookingFactory(isCancelled=True, cancellationReason="BENEFICIARY")
+        api.mark_as_used(booking, uncancel=True)
+        assert booking.isUsed
+        assert not booking.isCancelled
+        assert not booking.cancellationReason
+
     def test_mark_as_used_when_stock_starts_soon(self):
         booking = factories.BookingFactory(stock__beginningDatetime=datetime.now() + timedelta(days=1))
         api.mark_as_used(booking)

--- a/tests/repository/payment_queries_test.py
+++ b/tests/repository/payment_queries_test.py
@@ -2,6 +2,8 @@ import uuid
 
 import pytest
 
+import pcapi.core.bookings.factories as bookings_factories
+import pcapi.core.payments.factories as payments_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.model_creators.generic_creators import create_bank_information
 from pcapi.model_creators.generic_creators import create_booking
@@ -291,34 +293,10 @@ class FindNotProcessableWithBankInformationTest:
         assert not_processable_payment in payments_to_retry
 
 
-class FindByBookingIdTest:
-    @pytest.mark.usefixtures("db_session")
-    def test_should_return_a_payment_when_one_linked_to_booking(self, app):
-        # Given
-        beneficiary = users_factories.UserFactory()
-        offerer = create_offerer()
-        booking = create_booking(user=beneficiary)
-        valid_payment = create_payment(booking=booking, offerer=offerer)
-        repository.save(valid_payment)
+@pytest.mark.usefixtures("db_session")
+def test_has_payment():
+    booking = bookings_factories.BookingFactory()
+    assert not payment_queries.has_payment(booking)
 
-        # When
-        payment = payment_queries.find_by_booking_id(booking_id=booking.id)
-
-        # Then
-        assert payment == valid_payment
-
-    @pytest.mark.usefixtures("db_session")
-    def test_should_return_nothing_when_no_payment_linked_to_booking(self, app):
-        # Given
-        invalid_booking_id = "99999"
-        beneficiary = users_factories.UserFactory()
-        offerer = create_offerer()
-        booking = create_booking(user=beneficiary)
-        valid_payment = create_payment(booking=booking, offerer=offerer)
-        repository.save(valid_payment)
-
-        # When
-        payment = payment_queries.find_by_booking_id(booking_id=invalid_booking_id)
-
-        # Then
-        assert payment is None
+    payments_factories.PaymentFactory(booking=booking)
+    assert payment_queries.has_payment(booking)


### PR DESCRIPTION
Sometimes a booking is cancelled by mistake or fraudulently, but it
really should be mark as used (because the offer has been retrieved
from the offerer). It cannot be done by the offerer, but we should be
able to do it from the admin.

### Accueil de la rubrique "réservations" / formulaire de recherche

![réservations-accueil-recherche](https://user-images.githubusercontent.com/471321/110765448-78c56c00-8254-11eb-9bee-8bc497805a80.png)

### Vue d'une réservation pour action

![réservations-vue-d-une-réservation](https://user-images.githubusercontent.com/471321/110765443-76fba880-8254-11eb-977a-97a186414b3e.png)
