### PR TITLE
(PC-7034) : add isExhausted to favorite's offers

### DIFF
--- a/src/pcapi/routes/native/v1/serialization/favorites.py
+++ b/src/pcapi/routes/native/v1/serialization/favorites.py
@@ -43,7 +43,8 @@ class FavoriteOfferResponse(BaseModel):
     startPrice: Optional[int] = None
     date: Optional[datetime] = None
     startDate: Optional[datetime] = None
-    isExpired: bool = True
+    isExpired: bool = False
+    isExhausted: bool = False
 
     _convert_price = validator("price", pre=True, allow_reuse=True)(convert_to_cent)
     _convert_start_price = validator("startPrice", pre=True, allow_reuse=True)(convert_to_cent)


### PR DESCRIPTION
Flag offers that don't have any stock left as `isExhausted`.
Currently it's a pity in performance as it does a query for
each stock to get the bookings.
We'll improve that later.