### PR TITLE
(PC-7528) add a mock offer validation

### DIFF
--- a/src/pcapi/alembic/versions/20210322_bd142e43ea07_add_feature_flag_offer_validation_.py
+++ b/src/pcapi/alembic/versions/20210322_bd142e43ea07_add_feature_flag_offer_validation_.py
@@ -1,0 +1,32 @@
+"""add_feature_flag_offer_validation_computation
+
+Revision ID: bd142e43ea07
+Revises: 069e6621725a
+Create Date: 2021-03-22 12:07:13.888217
+
+"""
+from alembic import op
+from sqlalchemy import text
+
+from pcapi.models.feature import FeatureToggle
+
+
+# revision identifiers, used by Alembic.
+revision = "bd142e43ea07"
+down_revision = "069e6621725a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    feature = FeatureToggle.OFFER_VALIDATION_MOCK_COMPUTATION
+    op.execute(
+        text("""INSERT INTO feature (name, description, "isActive") VALUES (:name, :value, true)""").bindparams(
+            name=feature.name, value=feature.value
+        )
+    )
+
+
+def downgrade() -> None:
+    feature = FeatureToggle.OFFER_VALIDATION_MOCK_COMPUTATION
+    op.execute(text("""DELETE FROM feature WHERE name = :name""").bindparams(name=feature.name))

--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -7,6 +7,7 @@ from flask import current_app as app
 import pytz
 from sqlalchemy.sql.functions import func
 
+from pcapi import settings
 from pcapi.connectors import redis
 from pcapi.connectors.thumb_storage import create_thumb
 from pcapi.connectors.thumb_storage import remove_thumb
@@ -15,6 +16,7 @@ from pcapi.core.bookings.api import update_confirmation_dates
 from pcapi.core.bookings.conf import LIMIT_CONFIGURATIONS
 from pcapi.core.bookings.models import Booking
 import pcapi.core.bookings.repository as bookings_repository
+from pcapi.core.offers.models import OfferValidationStatus
 import pcapi.core.offers.repository as offers_repository
 from pcapi.core.users.models import ExpenseDomain
 from pcapi.core.users.models import User
@@ -52,6 +54,11 @@ from .models import Mediation
 DEFAULT_OFFERS_PER_PAGE = 10
 DEFAULT_PAGE = 1
 UNCHANGED = object()
+VALIDATION_KEYWORDS_MAPPING = {
+    "APPROVED": OfferValidationStatus.APPROVED,
+    "AWAITING": OfferValidationStatus.AWAITING,
+    "REJECTED": OfferValidationStatus.REJECTED,
+}
 
 
 def list_offers_for_pro_user(
@@ -125,6 +132,9 @@ def create_offer(offer_data: PostOfferBodyModel, user: User) -> Offer:
     offer.mentalDisabilityCompliant = offer_data.mental_disability_compliant
     offer.motorDisabilityCompliant = offer_data.motor_disability_compliant
     offer.visualDisabilityCompliant = offer_data.visual_disability_compliant
+    # TODO(fseguin): remove after the real implementation is added
+    offer.validation = compute_offer_validation_from_name(offer)
+
     repository.save(offer)
     admin_emails.send_offer_creation_notification_to_administration(offer, user)
 
@@ -541,3 +551,12 @@ def deactivate_inappropriate_product(isbn: str) -> bool:
             redis.add_offer_id(client=app.redis_client, offer_id=offer_id)
 
     return True
+
+
+def compute_offer_validation_from_name(offer: Offer) -> OfferValidationStatus:
+    """This is temporary logic, before real business rules are implemented"""
+    if not settings.IS_PROD and feature_queries.is_active(FeatureToggle.OFFER_VALIDATION_MOCK_COMPUTATION):
+        for keyword, validation_status in VALIDATION_KEYWORDS_MAPPING.items():
+            if keyword in offer.name:
+                return validation_status
+    return OfferValidationStatus.APPROVED

--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -10,7 +10,10 @@ from sqlalchemy.sql.functions import func
 from pcapi.connectors import redis
 from pcapi.connectors.thumb_storage import create_thumb
 from pcapi.connectors.thumb_storage import remove_thumb
+from pcapi.core.bookings.api import mark_as_unused
+from pcapi.core.bookings.api import update_confirmation_dates
 from pcapi.core.bookings.conf import LIMIT_CONFIGURATIONS
+from pcapi.core.bookings.models import Booking
 import pcapi.core.bookings.repository as bookings_repository
 import pcapi.core.offers.repository as offers_repository
 from pcapi.core.users.models import ExpenseDomain
@@ -42,9 +45,6 @@ from pcapi.utils.rest import load_or_raise_error
 from pcapi.workers.push_notification_job import send_transactional_notification_job
 
 from . import validation
-from ..bookings.api import mark_as_unused
-from ..bookings.api import update_confirmation_dates
-from ..bookings.models import Booking
 from .exceptions import ThumbnailStorageError
 from .models import Mediation
 

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -42,6 +42,7 @@ class FeatureToggle(enum.Enum):
     SYNCHRONIZE_VENUE_PROVIDER_IN_WORKER = "Effectue la première synchronisation des venue_provider dans le worker"
     ENABLE_NATIVE_APP_RECAPTCHA = "Active le reCaptacha sur l'API native"
     FNAC_SYNCHRONIZATION_V2 = "Active la synchronisation FNAC v2 : synchronisation par batch"
+    OFFER_VALIDATION_MOCK_COMPUTATION = "Active le calcul automatique de validation d'offre depuis le nom de l'offre"
 
 
 class Feature(PcObject, Model, DeactivableMixin):


### PR DESCRIPTION
##  Objectif

Calculer et enregistrer le statut de validation d'une Offre lors de sa création

##  Implémentation

- Ajout d'une nouvelle fonction `compute_offer_validation()` qui vérifie le nom de l'Offre pour déterminer son statut de validation. Ce mécanisme est _feature flagged_, et désactivé en Production
- Mise à jour de l'`OfferFactory` pour y ajouter un _post-génération hook_ qui calcule ce statut
- Ajout d'une migration pour ce _feature flag_

##  Informations supplémentaires

Nouveau _feature flag_: `OFFER_VALIDATION_MOCK_COMPUTATION`
