### PR TITLE
(PC-7668) Inclusion dans les logs d'un "correlation id" et du user_id

### DIFF
--- a/src/pcapi/core/logging.py
+++ b/src/pcapi/core/logging.py
@@ -4,6 +4,7 @@ import sys
 import uuid
 
 import flask
+from flask_login import current_user
 
 from pcapi import settings
 
@@ -40,6 +41,15 @@ def get_or_set_correlation_id():
         return flask.g.correlation_id
 
 
+def get_logged_in_user_id():
+    if not _is_within_app_context():
+        return None
+    if not current_user:
+        return None
+    try:
+        return current_user.id
+    except AttributeError:  # anonymous use
+        return None
 
 
 class Logger(logging.Logger):
@@ -66,6 +76,7 @@ class JsonFormatter(logging.Formatter):
             "logging.googleapis.com/trace": get_or_set_correlation_id(),
             "module": record.name,
             "severity": record.levelname,
+            "user_id": get_logged_in_user_id(),
             "message": record.msg % record.args,
             # `getattr()` is necessary for log records that have not
             # been created by our `Logger.makeRecord()` defined above.

--- a/tests/core/logging/tests.py
+++ b/tests/core/logging/tests.py
@@ -1,6 +1,10 @@
 import uuid
 
+import pytest
+from requests.auth import _basic_auth_str
+
 from pcapi.core import logging
+import pcapi.core.users.factories as users_factories
 
 
 class GetOrSetCorrelationIdTest:
@@ -14,3 +18,18 @@ class GetOrSetCorrelationIdTest:
         with app.test_request_context(headers=headers):
             correlation_id = logging.get_or_set_correlation_id()
             assert correlation_id == headers["X-Request-Id"]
+
+
+@pytest.mark.usefixtures("db_session")
+class GetLoggedInUserIdTest:
+    def test_request_from_anonymous_user(self, app):
+        with app.test_request_context():
+            user_id = logging.get_logged_in_user_id()
+            assert user_id is None
+
+    def test_request_from_authenticated_user(self, app):
+        user = users_factories.UserFactory()
+        headers = {"Authorization": _basic_auth_str(user.email, users_factories.DEFAULT_PASSWORD)}
+        with app.test_request_context(headers=headers):
+            user_id = logging.get_logged_in_user_id()
+            assert user_id == user.id

--- a/tests/core/logging/tests.py
+++ b/tests/core/logging/tests.py
@@ -1,0 +1,16 @@
+import uuid
+
+from pcapi.core import logging
+
+
+class GetOrSetCorrelationIdTest:
+    def test_request_with_no_header(self, app):
+        with app.test_request_context():
+            correlation_id = logging.get_or_set_correlation_id()
+            assert correlation_id == ""
+
+    def test_request_with_header(self, app):
+        headers = {"X-Request-Id": uuid.uuid4().hex}
+        with app.test_request_context(headers=headers):
+            correlation_id = logging.get_or_set_correlation_id()
+            assert correlation_id == headers["X-Request-Id"]


### PR DESCRIPTION
Commits à relire séparément.

Ci-dessous, visualisation dans Google Cloud Logging. (Un clic sur le bouton gris clair avec des traits horizontaux gris foncés permet d'"afficher tous les journaux de cette trace", c'est-à-dire tous les logs ayant le même _correlation id_.)

![correlation-id-dans-google-cloud-logging](https://user-images.githubusercontent.com/471321/111759629-1563bb80-889e-11eb-89a1-e75f612eb014.png)

Je n'arrive pas écrire des tests permettant une couverture totale du code. Il faudra ce contenter de ça.
