### PR TITLE
scripts: Make sure that `update_booking_used_after_stock_occurrence` is not called by mistake

### DIFF
--- a/src/pcapi/scripts/update_booking_used.py
+++ b/src/pcapi/scripts/update_booking_used.py
@@ -1,10 +1,15 @@
 from datetime import datetime
 
 import pcapi.core.bookings.repository as booking_repository
+from pcapi.models.feature import FeatureToggle
+from pcapi.repository import feature_queries
 from pcapi.repository import repository
 
 
 def update_booking_used_after_stock_occurrence():
+    if not feature_queries.is_active(FeatureToggle.UPDATE_BOOKING_USED):
+        raise ValueError("This function is behind a deactivated feature flag.")
+
     bookings_to_process = booking_repository.find_not_used_and_not_cancelled()
     bookings_id_errors = []
 

--- a/tests/scripts/update_booking_used_test.py
+++ b/tests/scripts/update_booking_used_test.py
@@ -5,6 +5,7 @@ import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.offers.factories as offers_factories
+from pcapi.core.testing import override_features
 from pcapi.models import Booking
 from pcapi.scripts.update_booking_used import update_booking_used_after_stock_occurrence
 
@@ -72,3 +73,9 @@ class UpdateBookingUsedTest:
         booking = Booking.query.first()
         assert not booking.isUsed
         assert booking.dateUsed is None
+
+    @pytest.mark.usefixtures("db_session")
+    @override_features(UPDATE_BOOKING_USED=False)
+    def test_raise_if_feature_flag_is_deactivated(self):
+        with pytest.raises(ValueError):
+            update_booking_used_after_stock_occurrence()


### PR DESCRIPTION
This function is usually called by a cron that is "protected" by a
feature flag. But it may be called manually (and it has). And we
really don't want to call it if the feature flag is deactivated.
See PC-7403 for an example.