### PR TITLE
___ wip (DO NOT MERGE): build and push Docker image

### DIFF
--- a/src/pcapi/core/logging.py
+++ b/src/pcapi/core/logging.py
@@ -44,7 +44,14 @@ def get_or_set_correlation_id():
 def get_logged_in_user_id():
     if not _is_within_app_context():
         return None
-    if not current_user:
+    try:
+        if not current_user:
+            return None
+    except AttributeError:
+        # For some reason, we may get an AttributeError if this
+        # function is called very soon (before some initialization is
+        # done, I guess):
+        #     'Flask' object has no attribute 'login_manager'
         return None
     try:
         return current_user.id

--- a/src/pcapi/core/logging.py
+++ b/src/pcapi/core/logging.py
@@ -152,6 +152,7 @@ def install_logging():
 
 
 def _silence_noisy_loggers():
+    logging.getLogger("spectree.config").setLevel(logging.WARNING)
     # FIXME (dbaty, 2021-03-17): these log levels are historical.
     # Perhaps we should set them to WARNING instead?
     logging.getLogger("werkzeug").setLevel(logging.ERROR)


### PR DESCRIPTION
(PC-7668) logging: Fix detection of logged-in user

I am not sure why, but we get an indirect AttributeError when trying
to access `current_request` on some log that is emitted very soon,
probably before Flask is properly initialized.


logging: Set log level of spectree logger.

It logs INFO messages that are not very useful to us:

    [✓] Attribute "PATH" has been updated to "/"
    [✓] Attribute "MODE" has been updated to "strict"