### PR TITLE
(PC-7823): Use venueIdAtOfferProvider instead of SIRET

### DIFF
--- a/src/pcapi/core/offerers/factories.py
+++ b/src/pcapi/core/offerers/factories.py
@@ -28,3 +28,5 @@ class VenueProviderFactory(BaseFactory):
 
     venue = factory.SubFactory(VenueFactory)
     provider = factory.SubFactory(ProviderFactory)
+
+    venueIdAtOfferProvider = factory.SelfAttribute("venue.siret")

--- a/src/pcapi/local_providers/generic_provider/generic_stocks.py
+++ b/src/pcapi/local_providers/generic_provider/generic_stocks.py
@@ -29,7 +29,7 @@ class GenericStocks(LocalProvider):
     ):
         super().__init__(venue_provider, **options)
         self.venue = venue_provider.venue
-        self.venueIdAtProvider = self.venue_provider.venueIdAtOfferProvider
+        self.id_at_provider = self.venue_provider.venueIdAtOfferProvider
         self.last_processed_isbn = ""
         self.stock_data = iter([])
         self.modified_since = venue_provider.lastSyncDate
@@ -41,7 +41,7 @@ class GenericStocks(LocalProvider):
             self.provider_stocks = next(self.stock_data)
         except StopIteration:
             self.stock_data = self.get_provider_stock_information(  # pylint: disable=not-callable
-                self.venueIdAtProvider, self.last_processed_isbn, self.modified_since
+                self.id_at_provider, self.last_processed_isbn, self.modified_since
             )
             self.provider_stocks = next(self.stock_data)
 
@@ -52,10 +52,10 @@ class GenericStocks(LocalProvider):
             return []
 
         providable_info_offer = self.create_providable_info(
-            Offer, f"{self.provider_stocks['ref']}@{self.venueIdAtProvider}", datetime.utcnow()
+            Offer, f"{self.provider_stocks['ref']}@{self.id_at_provider}", datetime.utcnow()
         )
         providable_info_stock = self.create_providable_info(
-            Stock, f"{self.provider_stocks['ref']}@{self.venueIdAtProvider}", datetime.utcnow()
+            Stock, f"{self.provider_stocks['ref']}@{self.id_at_provider}", datetime.utcnow()
         )
 
         return [providable_info_offer, providable_info_stock]

--- a/src/pcapi/local_providers/generic_provider/generic_stocks.py
+++ b/src/pcapi/local_providers/generic_provider/generic_stocks.py
@@ -29,7 +29,7 @@ class GenericStocks(LocalProvider):
     ):
         super().__init__(venue_provider, **options)
         self.venue = venue_provider.venue
-        self.siret = self.venue.siret
+        self.venueIdAtProvider = self.venue_provider.venueIdAtOfferProvider
         self.last_processed_isbn = ""
         self.stock_data = iter([])
         self.modified_since = venue_provider.lastSyncDate
@@ -41,7 +41,7 @@ class GenericStocks(LocalProvider):
             self.provider_stocks = next(self.stock_data)
         except StopIteration:
             self.stock_data = self.get_provider_stock_information(  # pylint: disable=not-callable
-                self.siret, self.last_processed_isbn, self.modified_since
+                self.venueIdAtProvider, self.last_processed_isbn, self.modified_since
             )
             self.provider_stocks = next(self.stock_data)
 
@@ -52,10 +52,10 @@ class GenericStocks(LocalProvider):
             return []
 
         providable_info_offer = self.create_providable_info(
-            Offer, f"{self.provider_stocks['ref']}@{self.siret}", datetime.utcnow()
+            Offer, f"{self.provider_stocks['ref']}@{self.venueIdAtProvider}", datetime.utcnow()
         )
         providable_info_stock = self.create_providable_info(
-            Stock, f"{self.provider_stocks['ref']}@{self.siret}", datetime.utcnow()
+            Stock, f"{self.provider_stocks['ref']}@{self.venueIdAtProvider}", datetime.utcnow()
         )
 
         return [providable_info_offer, providable_info_stock]

--- a/src/pcapi/local_providers/provider_api/synchronize_provider_api.py
+++ b/src/pcapi/local_providers/provider_api/synchronize_provider_api.py
@@ -47,8 +47,10 @@ def synchronize_venue_provider(venue_provider: VenueProvider) -> None:
     provider_api = provider.getProviderAPI()
 
     stats = {"new_offers": 0, "new_stocks": 0, "updated_stocks": 0}
-    for raw_stocks in _get_stocks_by_batch(venue.siret, provider_api, venue_provider.lastSyncDate):
-        stock_details = _build_stock_details_from_raw_stocks(raw_stocks, venue.siret)
+    for raw_stocks in _get_stocks_by_batch(
+        venue_provider.venueIdAtOfferProvider, provider_api, venue_provider.lastSyncDate
+    ):
+        stock_details = _build_stock_details_from_raw_stocks(raw_stocks, venue_provider.venueIdAtOfferProvider)
 
         products_provider_references = [stock_detail["products_provider_reference"] for stock_detail in stock_details]
         products_by_provider_reference = get_products_map_by_id_at_providers(products_provider_references)

--- a/src/pcapi/model_creators/generic_creators.py
+++ b/src/pcapi/model_creators/generic_creators.py
@@ -521,7 +521,7 @@ def create_venue_provider(
     is_active: bool = True,
     last_provider_id: int = None,
     last_sync_date: datetime = None,
-    venue_id_at_offer_provider: str = "123456789",
+    venue_id_at_offer_provider: str = None,
     sync_worker_id: str = None,
 ) -> VenueProvider:
     venue_provider = VenueProvider()
@@ -533,7 +533,7 @@ def create_venue_provider(
     venue_provider.lastSyncDate = last_sync_date
     venue_provider.provider = provider
     venue_provider.venue = venue
-    venue_provider.venueIdAtOfferProvider = venue_id_at_offer_provider
+    venue_provider.venueIdAtOfferProvider = venue_id_at_offer_provider or venue.siret
     venue_provider.syncWorkerId = sync_worker_id
 
     return venue_provider

--- a/tests/scripts/stock/fully_sync_venue_test.py
+++ b/tests/scripts/stock/fully_sync_venue_test.py
@@ -28,7 +28,7 @@ def test_fully_sync_venue():
             "total": 1,
             "stocks": [{"ref": "1234", "available": 5}],
         }
-        mock.get(f"{api_url}/{venue.siret}", [{"json": response}, {"json": {"stocks": []}}])
+        mock.get(f"{api_url}/{venue_provider.venueIdAtOfferProvider}", [{"json": response}, {"json": {"stocks": []}}])
         fully_sync_venue.fully_sync_venue(venue)
 
     # Check that the quantity of existing stocks has been reset.


### PR DESCRIPTION
Un rattrapage des données est nécessaire pour que la synchro fonctionne à partir de venueIdAtOfferProvider.
Voir le ticket pour les requetes SQL.