### PR TITLE
[PC-7809] Add serializer for routes.pro.venues.get_venue(venue_id)

### DIFF
--- a/src/pcapi/routes/serialization/venues_serialize.py
+++ b/src/pcapi/routes/serialization/venues_serialize.py
@@ -1,14 +1,17 @@
+from datetime import datetime
 from typing import Dict
 from typing import List
+from typing import Optional
 
-from flask import json
 from pydantic import BaseModel
 
 from pcapi.domain.venue.venue_with_offerer_name.venue_with_offerer_name import VenueWithOffererName
+from pcapi.serialization.utils import humanize_field
+from pcapi.utils.date import format_into_utc_date
 from pcapi.utils.human_ids import humanize
 
 
-def serialize_venues_with_offerer_name(venues: List[VenueWithOffererName]) -> json:
+def serialize_venues_with_offerer_name(venues: List[VenueWithOffererName]) -> List[Dict]:
     return [serialize_venue_with_offerer_name(venue) for venue in venues]
 
 
@@ -29,3 +32,66 @@ class VenueStatsResponseModel(BaseModel):
     validatedBookingsQuantity: int
     activeOffersCount: int
     soldOutOffersCount: int
+
+
+class GetVenueManagingOffererResponseModel(BaseModel):
+    address: Optional[str]
+    bic: Optional[str]
+    city: str
+    dateCreated: datetime
+    dateModifiedAtLastProvider: Optional[datetime]
+    demarchesSimplifieesApplicationId: Optional[str]
+    fieldsUpdated: List[str]
+    iban: Optional[str]
+    id: str
+    idAtProviders: Optional[str]
+    isValidated: bool
+    lastProviderId: Optional[str]
+    name: str
+    postalCode: str
+    # FIXME (dbaty, 2020-11-09): optional until we populate the database (PC-5693)
+    siren: Optional[str]
+
+    _humanize_id = humanize_field("id")
+
+    class Config:
+        orm_mode = True
+        json_encoders = {datetime: format_into_utc_date}
+
+
+class GetVenueResponseModel(BaseModel):
+    address: Optional[str]
+    bic: Optional[str]
+    bookingEmail: Optional[str]
+    city: Optional[str]
+    comment: Optional[str]
+    dateCreated: datetime
+    dateModifiedAtLastProvider: Optional[datetime]
+    demarchesSimplifieesApplicationId: Optional[str]
+    departementCode: Optional[str]
+    fieldsUpdated: List[str]
+    iban: Optional[str]
+    id: str
+    idAtProviders: Optional[str]
+    isValidated: bool
+    isVirtual: bool
+    lastProviderId: Optional[str]
+    latitude: Optional[float]
+    longitude: Optional[float]
+    managingOfferer: GetVenueManagingOffererResponseModel
+    managingOffererId: str
+    name: str
+    postalCode: Optional[str]
+    publicName: Optional[str]
+    siret: Optional[str]
+    venueLabelId: Optional[str]
+    venueTypeId: Optional[str]
+
+    _humanize_id = humanize_field("id")
+    _humanize_managing_offerer_id = humanize_field("managingOffererId")
+    _humanize_venue_label_id = humanize_field("venueLabelId")
+    _humanize_venue_type_id = humanize_field("venueTypeId")
+
+    class Config:
+        orm_mode = True
+        json_encoders = {datetime: format_into_utc_date}


### PR DESCRIPTION
Jira: https://passculture.atlassian.net/browse/PC-7809

Cette route est utilisé à deux endroit:
* dans le formulaire de preview de l'offre afin d'afficher l'adresse du lieux. (champs utilisées : isVirtual, adresse, city, postalCode, name, publicName)
* dans la création et édition de lieu via requestData. J'ai l'impression que tout les champs sont utilisées.

