### PR TITLE
(PC- 7460) prevent Offer and Stock edition when Offer is not validated

### DIFF
--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -171,6 +171,7 @@ def update_offer(  # pylint: disable=redefined-builtin
     motorDisabilityCompliant: bool = UNCHANGED,
     visualDisabilityCompliant: bool = UNCHANGED,
 ) -> Offer:
+    validation.check_validation_status(offer)
     # fmt: off
     modifications = {
         field: new_value
@@ -209,6 +210,7 @@ def update_offer(  # pylint: disable=redefined-builtin
 
 
 def update_offers_active_status(query, is_active):
+    query = query.filter(Offer.validation == OfferValidationStatus.APPROVED)
     # We cannot just call `query.update()` because `distinct()` may
     # already have been called on `query`.
     query_to_update = Offer.query.filter(Offer.id.in_(query.with_entities(Offer.id)))
@@ -229,8 +231,7 @@ def _create_stock(
     booking_limit_datetime: datetime.datetime = None,
 ) -> Stock:
     validation.check_required_dates_for_stock(offer, beginning, booking_limit_datetime)
-    validation.check_offer_is_editable(offer)
-    validation.check_stocks_are_editable_for_offer(offer)
+    validation.check_stock_can_be_created_for_offer(offer)
     validation.check_stock_price(price)
     validation.check_stock_quantity(quantity)
 

--- a/src/pcapi/core/offers/models.py
+++ b/src/pcapi/core/offers/models.py
@@ -410,6 +410,7 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin, ProvidableMixin, 
 
     @property
     def isEditable(self) -> bool:
+        """This property is used by the pro frontend, to display the Edit button in the Offers list"""
         if not self.isFromProvider:
             return True
         return self.isFromAllocine


### PR DESCRIPTION
##  Objectif

Tant qu'une offre n'a pas été validée, elle ne doit pas pouvoir être éditée, et on ne doit pas pouvoir lui créer ou ajouter de Stock.
Cela concerne également le statut Active/Inactive, dans la liste des Offres.

##  Implémentation

- Le statut de validation de l'Offre est désormais vérifié dans les différentes méthodes d'API interne d'édition d'Offre, et de création, édition et suppression de Stock.
