### PR TITLE
(PC-7904) admin: Fix inclusion of first/last name in beneficiary creation/edition

### DIFF
--- a/src/pcapi/admin/base_configuration.py
+++ b/src/pcapi/admin/base_configuration.py
@@ -45,6 +45,9 @@ class BaseAdminView(ModelView):
 
     def check_super_admins(self) -> bool:
         if settings.IS_PROD:
+            # `current_user` may be None, here, because this function
+            # is (also) called when admin views are registered and
+            # Flask-Admin populates its form cache.
             return current_user and current_user.email in settings.SUPER_ADMIN_EMAIL_ADDRESSES
 
         return True


### PR DESCRIPTION
Super-admins should be able to see form fields for the first name and
last name when creating or editing a beneficiary (see 48883f3594e603).

It did not work because the form class (and its fields) was cached by
Flask-Admin when the admin view was registered, i.e. when there was no
logged-in user.

Not populating the form cache seemed hard (as other things in
Flask-Admin expected the cache to be there), so here we simply
override a couple of functions to avoid using the cache.