### PR TITLE
(PC-7924) Make sure that all loggers use our custom record factory

### DIFF
--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -32,13 +32,9 @@ from pcapi.utils.json_encoder import EnumJSONEncoder
 from pcapi.utils.rate_limiting import rate_limiter
 
 
-# This must be called BEFORE creating `logger` below. Otherwise this
-# logger won't work with our JSON formatter.
-install_logging()
-
-
 logger = logging.getLogger(__name__)
 
+install_logging()
 
 if settings.IS_DEV is False:
     sentry_sdk.init(


### PR DESCRIPTION
With the previous implementation, loggers that were created before we
called `install_logging()` would not use our custom record factory. As
such, the `extra` property in the JSON log was empty. It occurred on
some (but not all) of our own loggers, and depended on the order in
which modules were imported.

An alternative would be to call `install_logging()` first on each
entry point module of the app (`flask_app.app`, `workers.worker`, each
cron module, etc.) but it's tedious.

The easy solution seems to be a monkey patch. Will I regret it?