### PR TITLE
(PC-7924) logging: Introduce a StructureMessage class for our logs

### DIFF
--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -24,6 +24,7 @@ from sqlalchemy import orm
 from werkzeug.middleware.profiler import ProfilerMiddleware
 
 from pcapi import settings
+from pcapi.core.logging import M
 from pcapi.core.logging import install_logging
 from pcapi.models.db import db
 from pcapi.serialization.utils import before_handler
@@ -111,7 +112,7 @@ def log_request_details(response: flask.wrappers.Response) -> flask.wrappers.Res
         "size": response.headers.get("Content-Length", type=int),
     }
 
-    logger.info("HTTP request at %s", request.path, extra=extra)
+    logger.info(M("HTTP request at %s", request.path, **extra))
 
     return response
 

--- a/src/pcapi/routes/internal/health_check.py
+++ b/src/pcapi/routes/internal/health_check.py
@@ -1,6 +1,20 @@
+import logging
+
 from pcapi.flask_app import public_api
+from pcapi.utils import requests
 from pcapi.utils.health_checker import check_database_connection
 from pcapi.utils.health_checker import read_version_from_file
+
+
+print("creating logger for route")
+logger = logging.getLogger(__name__)
+
+
+@public_api.route("/selftest/log", methods=["GET"])
+def selftest_log():
+    response = requests.get("https://example.com")
+    logger.info("Log without M object")
+    return str(response.status_code), 200
 
 
 @public_api.route("/health/api", methods=["GET"])

--- a/src/pcapi/utils/requests.py
+++ b/src/pcapi/utils/requests.py
@@ -18,6 +18,10 @@ import requests.exceptions as exceptions
 # isort: on
 # fmt: on
 
+print("creating logger in utils.requests")
+from pcapi.core.logging import M
+
+
 logger = logging.getLogger(__name__)
 
 REQUEST_TIMEOUT_IN_SECOND = 10
@@ -28,15 +32,15 @@ def _wrapper(request_func: Callable, method: str, url: str, **kwargs: Any) -> Re
         timeout = kwargs.pop("timeout", REQUEST_TIMEOUT_IN_SECOND)
         response = request_func(method=method, url=url, timeout=timeout, **kwargs)
         logger.info(
-            "External service called",
-            extra={
-                "url": response.url,
-                "statusCode": response.status_code,
-                "duration": response.elapsed.total_seconds(),
-            },
+            M(
+                "External service called",
+                url=response.url,
+                statusCode=response.status_code,
+                duration=response.elapsed.total_seconds(),
+            )
         )
     except Exception as exc:
-        logger.exception("Call to external service failed with %s", exc, extra={"method": method, "url": url})
+        logger.exception(M("Call to external service failed with %s", exc, method=method, url=url))
         raise exc
 
     return response


### PR DESCRIPTION
The previous implementation did not work if a logger was defined
before we had called `install_logging()`. The `extra` argument
was always empty in generated JSON logs.

The new approach uses the (standard) log record factory, but it's not
enough because the `Logger.makeRecord()` does not pass extra arguments
to this factory. So we need to introduce a special class to use in our
own logs, like this:

    from pcapi.core.logging import M

    logger.info(M("Frobulated a blob", blob=blob.id, reason=reason))

External logs are still generated as JSON with context information
such as the current user and correlation id (thanks to the formatter).
But they will always have an empty `extra` attribute. That's fine.