### PR TITLE
(PC-7625) : include offer `isReleased` to favorites

### DIFF
--- a/src/pcapi/routes/native/v1/favorites.py
+++ b/src/pcapi/routes/native/v1/favorites.py
@@ -9,6 +9,7 @@ from pcapi.core.offers.models import Offer
 from pcapi.core.users.models import User
 from pcapi.models import Favorite
 from pcapi.models import Mediation
+from pcapi.models import Offerer
 from pcapi.models import Product
 from pcapi.models import Stock
 from pcapi.models import Venue
@@ -49,8 +50,22 @@ def get_favorites(user: User) -> serializers.PaginatedFavoritesResponse:
         .outerjoin(Stock.bookings)
         .filter(Favorite.userId == user.id)
         .distinct(Favorite.id)
-        .options(joinedload(Favorite.offer).load_only(Offer.name, Offer.externalTicketOfficeUrl, Offer.url, Offer.type))
-        .options(joinedload(Favorite.offer).joinedload(Offer.venue).load_only(Venue.latitude, Venue.longitude))
+        .options(
+            joinedload(Favorite.offer).load_only(
+                Offer.name, Offer.externalTicketOfficeUrl, Offer.url, Offer.type, Offer.isActive, Offer.validation
+            )
+        )
+        .options(
+            joinedload(Favorite.offer)
+            .joinedload(Offer.venue)
+            .load_only(Venue.latitude, Venue.longitude, Venue.validationToken)
+        )
+        .options(
+            joinedload(Favorite.offer)
+            .joinedload(Offer.venue)
+            .joinedload(Venue.managingOfferer)
+            .load_only(Offerer.validationToken, Offerer.isActive)
+        )
         .options(
             joinedload(Favorite.offer)
             .joinedload(Offer.mediations)

--- a/src/pcapi/routes/native/v1/serialization/favorites.py
+++ b/src/pcapi/routes/native/v1/serialization/favorites.py
@@ -48,6 +48,7 @@ class FavoriteOfferResponse(BaseModel):
     startDate: Optional[datetime] = None
     isExpired: bool = False
     expenseDomains: List[ExpenseDomain]
+    isReleased: bool
     isSoldOut: bool = False
 
     _convert_price = validator("price", pre=True, allow_reuse=True)(convert_to_cent)

--- a/tests/routes/native/v1/favorites_test.py
+++ b/tests/routes/native/v1/favorites_test.py
@@ -256,6 +256,16 @@ class Get:
                 True,
                 True,
             ]
+            assert [fav["offer"]["isReleased"] for fav in favorites] == [
+                True,
+                True,
+                True,
+                True,
+                False,
+                False,
+                True,
+                True,
+            ]
 
     class Returns401:
         def when_user_is_not_logged_in(self, app):


### PR DESCRIPTION
Flags offers that are deactivated or which venue/offerer are
deactivated or not yet validated.