### PR TITLE
(FIX) : lower memory usage for check_stock_consistence

### DIFF
--- a/src/pcapi/core/offers/repository.py
+++ b/src/pcapi/core/offers/repository.py
@@ -245,12 +245,14 @@ def get_and_lock_stock(stock_id: int) -> Stock:
     return stock
 
 
-def check_stock_consistence() -> List[Stock]:
-    return (
-        Stock.query.outerjoin(Stock.bookings)
+def check_stock_consistency() -> List[int]:
+    return [
+        item[0]
+        for item in db.session.query(Stock.id)
+        .outerjoin(Stock.bookings)
         .group_by(Stock.id)
         .having(
             Stock.dnBookedQuantity != func.coalesce(func.sum(Booking.quantity).filter(Booking.isCancelled == False), 0)
         )
         .all()
-    )
+    ]

--- a/src/pcapi/scheduled_tasks/clock.py
+++ b/src/pcapi/scheduled_tasks/clock.py
@@ -9,7 +9,7 @@ from flask import Flask
 from pcapi import models  # pylint: disable=unused-import
 from pcapi import settings
 from pcapi.core.logging import install_logging
-from pcapi.core.offers.repository import check_stock_consistence
+from pcapi.core.offers.repository import check_stock_consistency
 from pcapi.core.users import api as users_api
 from pcapi.core.users.repository import get_newly_eligible_users
 from pcapi.domain.user_emails import send_newly_eligible_user_email
@@ -115,8 +115,9 @@ def pc_clean_expired_tokens(app: Flask) -> None:
 @log_cron
 @cron_context
 def pc_check_stock_quantity_consistency(app: Flask) -> None:
-    inconsistent_stocks = check_stock_consistence()
-    logger.error("Found inconsistent stocks: %s", ", ".join([str(stock.id) for stock in inconsistent_stocks]))
+    inconsistent_stocks = check_stock_consistency()
+    if inconsistent_stocks:
+        logger.error("Found inconsistent stocks: %s", ", ".join([str(stock_id) for stock_id in inconsistent_stocks]))
 
 
 def main() -> None:

--- a/tests/core/offers/test_repository.py
+++ b/tests/core/offers/test_repository.py
@@ -6,7 +6,7 @@ import pytest
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import OfferStatus
-from pcapi.core.offers.repository import check_stock_consistence
+from pcapi.core.offers.repository import check_stock_consistency
 from pcapi.core.offers.repository import get_active_offers_count_for_venue
 from pcapi.core.offers.repository import get_offers_by_ids
 from pcapi.core.offers.repository import get_paginated_offers_for_filters
@@ -1200,6 +1200,5 @@ class CheckStockConsistenceTest:
         stock6 = offers_factories.StockFactory(dnBookedQuantity=2)
         bookings_factories.BookingFactory(stock=stock6, quantity=2, isCancelled=True)
 
-        stocks = check_stock_consistence()
-        stock_ids = {stock.id for stock in stocks}
+        stock_ids = set(check_stock_consistency())
         assert stock_ids == {stock2.id, stock4.id, stock6.id}


### PR DESCRIPTION
check_stock_consistence was initially meant to return stock objects
to perfom operations on it. Since the design around it changed, we
can lower the memory usage by only fetching the id.