### PR TITLE
(PC-7882) Add depositAmount variable to user eligible for credit confirmation email

### DIFF
--- a/src/pcapi/emails/beneficiary_activation.py
+++ b/src/pcapi/emails/beneficiary_activation.py
@@ -46,10 +46,14 @@ def get_activation_email_data_for_native(user: users_models.User, token: users_m
 
 
 def get_accepted_as_beneficiary_email_data() -> Dict:
+    limit_configuration = conf.LIMIT_CONFIGURATIONS[conf.get_current_deposit_version()]
+    deposit_amount = limit_configuration.TOTAL_CAP
     return {
         "Mj-TemplateID": 2016025,
         "Mj-TemplateLanguage": True,
-        "Vars": {},
+        "Vars": {
+            "depositAmount": int(deposit_amount),
+        },
     }
 
 

--- a/tests/emails/beneficiary_activation_test.py
+++ b/tests/emails/beneficiary_activation_test.py
@@ -81,3 +81,35 @@ class GetActivationEmailTest:
         assert not activation_email_data["Vars"]["isEligible"]
         assert activation_email_data["Vars"]["isMinor"]
         assert activation_email_data["Vars"]["depositAmount"] == 300
+
+
+@freeze_time("2011-05-15 09:00:00")
+class GetAcceptedAsBeneficiaryEmailTest:
+    def test_return_correct_email_metadata(self):
+        # When
+        email_data = beneficiary_activation.get_accepted_as_beneficiary_email_data()
+
+        # Then
+        assert email_data == {
+            "Mj-TemplateID": 2016025,
+            "Mj-TemplateLanguage": True,
+            "Vars": {
+                "depositAmount": 500,
+            },
+        }
+
+    @override_features(APPLY_BOOKING_LIMITS_V2=False)
+    def test_return_deposit_amount_500_for_eligible_user_v1(self):
+        # When
+        email_data = beneficiary_activation.get_accepted_as_beneficiary_email_data()
+
+        # Then
+        assert email_data["Vars"]["depositAmount"] == 500
+
+    @override_features(APPLY_BOOKING_LIMITS_V2=True)
+    def test_return_deposit_amount_300_for_eligible_user_v2(self):
+        # When
+        email_data = beneficiary_activation.get_accepted_as_beneficiary_email_data()
+
+        # Then
+        assert email_data["Vars"]["depositAmount"] == 300


### PR DESCRIPTION
Ticket Jira : https://passculture.atlassian.net/browse/PC-7882

Test unitaires ajoutés ? ✅ 

Est-ce que le code a été fait avec classe et élégance ? ✅ 

Template Mailjet associé à la PR : https://app.mailjet.com/template/2016025/build ==> Ajouter `{{var:depositAmount:"300"}}` dans le template pour utiliser la nouvelle variable `depositAmount`.