### PR TITLE
(PC-8007) : Add `externalTicketOfficeUrl` to native bookings

### DIFF
--- a/src/pcapi/routes/native/v1/bookings.py
+++ b/src/pcapi/routes/native/v1/bookings.py
@@ -71,7 +71,14 @@ def get_bookings(user: User) -> BookingsResponse:
         .options(
             joinedload(Booking.stock)
             .joinedload(Stock.offer)
-            .load_only(Offer.name, Offer.url, Offer.type, Offer.withdrawalDetails, Offer.extraData)
+            .load_only(
+                Offer.name,
+                Offer.url,
+                Offer.type,
+                Offer.withdrawalDetails,
+                Offer.extraData,
+                Offer.externalTicketOfficeUrl,
+            )
         )
         .options(joinedload(Booking.stock).joinedload(Stock.offer).joinedload(Offer.mediations))
         .options(

--- a/src/pcapi/routes/native/v1/serialization/bookings.py
+++ b/src/pcapi/routes/native/v1/serialization/bookings.py
@@ -56,6 +56,7 @@ class BookingOfferResponse(BaseModel):
     name: str
     category: OfferCategoryResponse
     extraData: Optional[BookingOfferExtraData]
+    externalTicketOfficeUrl: Optional[str]
     image: Optional[OfferImageResponse]
     isDigital: bool
     isPermanent: bool

--- a/tests/routes/native/v1/bookings_test.py
+++ b/tests/routes/native/v1/bookings_test.py
@@ -83,6 +83,7 @@ class GetBookingsTest:
 
     @freeze_time("2021-03-12")
     def test_get_bookings(self, app):
+        EXTERNAL_TICKET_OFFICE_URL = "https://demo.pass/some/path"
         user = users_factories.UserFactory(email=self.identifier)
 
         permanent_booking = BookingFactory(
@@ -99,7 +100,12 @@ class GetBookingsTest:
 
         cancelled = BookingFactory(user=user, isCancelled=True)
         used1 = BookingFactory(user=user, isUsed=True, dateUsed=datetime(2021, 3, 1))
-        used2 = BookingFactory(user=user, isUsed=True, dateUsed=datetime(2021, 3, 2))
+        used2 = BookingFactory(
+            user=user,
+            isUsed=True,
+            dateUsed=datetime(2021, 3, 2),
+            stock__offer__externalTicketOfficeUrl=EXTERNAL_TICKET_OFFICE_URL,
+        )
 
         mediation = MediationFactory(id=111, offer=used2.stock.offer, thumbCount=1, credit="street credit")
 
@@ -137,6 +143,7 @@ class GetBookingsTest:
                 "id": used2.stock.id,
                 "offer": {
                     "category": {"categoryType": "Thing", "label": "Film", "name": "FILM"},
+                    "externalTicketOfficeUrl": EXTERNAL_TICKET_OFFICE_URL,
                     "extraData": None,
                     "id": used2.stock.offer.id,
                     "image": {"credit": "street credit", "url": mediation.thumbUrl},


### PR DESCRIPTION
The native app bookings front expects the `externalTicketOfficeUrl`
field to be part of the response.