### PR TITLE
(PC-8019) : Fix Stock.dnBookedQuantity when booking is cancelled twice

### DIFF
--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -110,6 +110,15 @@ def book_offer(
 
 
 def _cancel_booking(booking: Booking, reason: BookingCancellationReasons) -> None:
+    if booking.isCancelled:
+        logger.info(
+            "Booking was already cancelled",
+            extra={
+                "booking": booking.id,
+                "reason": str(reason),
+            },
+        )
+        return
     with transaction():
         booking.isCancelled = True
         booking.cancellationReason = reason

--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -207,6 +207,20 @@ class CancelByBeneficiaryTest:
         email_data2 = mails_testing.outbox[1].sent_data
         assert email_data2["MJ-TemplateID"] == 780015  # to offerer
 
+    def test_cancel_booking_twice(self):
+        booking = factories.BookingFactory()
+        initial_quantity = booking.stock.dnBookedQuantity
+
+        api.cancel_booking_by_beneficiary(booking.user, booking)
+
+        assert booking.isCancelled
+        assert booking.stock.dnBookedQuantity == (initial_quantity - 1)
+
+        api.cancel_booking_by_beneficiary(booking.user, booking)
+
+        assert booking.isCancelled
+        assert booking.stock.dnBookedQuantity == (initial_quantity - 1)
+
     @override_features(SYNCHRONIZE_ALGOLIA=False)
     @mock.patch("pcapi.connectors.redis.add_offer_id")
     def test_do_not_sync_algolia_if_feature_is_disabled(self, mocked_add_offer_id):


### PR DESCRIPTION
Up to now, cancelling a booking twice had no side effets.
Since the addition of the `Stock.dnBookedQuantity`, cancelling
a booking twice would affect the `Stock.dnBookedQuantity`.
Let's just skip if the booking to be cancelled is already
cancelled.