### PR TITLE
(PC-7779) Ajout d'un feature flag ENABLE_ACTIVATION_CODES et d'un utilitaire pour simplifier les migrations de feature flags

### DIFF
--- a/src/pcapi/alembic/versions/20210408_84cab0060952_feature_enable_activation_codes.py
+++ b/src/pcapi/alembic/versions/20210408_84cab0060952_feature_enable_activation_codes.py
@@ -1,0 +1,27 @@
+"""Add ENABLE_ACTIVATION_CODES feature flag
+
+Revision ID: 84cab0060952
+Revises: 5e52ca521f36
+Create Date: 2021-04-08 09:12:50.617498
+
+"""
+
+from pcapi.models import feature
+
+
+# revision identifiers, used by Alembic.
+revision = "84cab0060952"
+down_revision = "5e52ca521f36"
+branch_labels = None
+depends_on = None
+
+
+FLAG = feature.FeatureToggle.ENABLE_ACTIVATION_CODES
+
+
+def upgrade():
+    feature.add_feature_to_database(FLAG)
+
+
+def downgrade():
+    feature.remove_feature_from_database(FLAG)

--- a/src/pcapi/app.py
+++ b/src/pcapi/app.py
@@ -9,7 +9,6 @@ from pcapi.flask_app import app
 from pcapi.flask_app import db
 from pcapi.local_providers.install import install_local_providers
 from pcapi.models.install import install_activity
-from pcapi.models.install import install_features
 from pcapi.routes import install_routes
 from pcapi.routes.native.v1.blueprint import native_v1
 
@@ -29,7 +28,6 @@ with app.app_context():
     if settings.IS_DEV:
         install_activity()
         install_local_providers()
-        install_features()
 
     install_login_manager()
     install_documentation()

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -48,6 +48,7 @@ class FeatureToggle(enum.Enum):
     AUTO_ACTIVATE_DIGITAL_BOOKINGS = (
         "Activer (marquer comme utilisée) les réservations dès leur création pour les offres digitales"
     )
+    ENABLE_ACTIVATION_CODES = "Permet la création de codes d'activation"
 
 
 class Feature(PcObject, Model, DeactivableMixin):
@@ -64,6 +65,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.WHOLE_FRANCE_OPENING,
     FeatureToggle.PRO_HOMEPAGE,
     FeatureToggle.AUTO_ACTIVATE_DIGITAL_BOOKINGS,
+    FeatureToggle.ENABLE_ACTIVATION_CODES,
 )
 
 


### PR DESCRIPTION
Commits à relire séparément.