### PR TITLE
(PC-7143): Offer validation edit page flask admin

### DIFF
--- a/src/pcapi/templates/admin/edit_offer_validation.html
+++ b/src/pcapi/templates/admin/edit_offer_validation.html
@@ -1,0 +1,40 @@
+{% extends 'admin/master.html' %}
+
+{% block body %}
+    <h3>Validation de l'offre :</h3>
+    <p>
+        <div>Titre de l'offre : <strong>{{ offer_name }}</strong></div>
+        <div>Liens : <a href="{{ pc_offer_url }}" target="_blank" rel="noopener noreferrer"><strong>PRO</strong></a>
+            {% if metabase_offer_url %}
+                | <a href="{{ metabase_offer_url }}" target="_blank" rel="noopener noreferrer"><strong>Metabase</strong></a>
+            {% endif %}
+        </div>
+        <div>Score : </div>
+        <div>Code de catégorie juridique : <strong>{{ legal_category_code }}</strong></div>
+        <div>Libellé de catégorie juridique : <strong>{{ legal_category_label }}</strong></div>
+    </p>
+    <form action="{{ action }}" method="POST">
+        {% for field in form %}
+            {% if field.name == "csrf_token" %}
+                {{ field }}
+            {% else %}
+                <div class="row form-group">
+                <div class="col-md-3"></div>
+                <div class="col-md-6">
+                    <label>{{ field.label }} {% if field.flags.required %}*{% endif %}</label>
+                    {{ field(class_="form-control") }}
+                </div>
+                <div class="col-md-3"></div>
+                </div>
+            {% endif %}
+        {% endfor %}
+        <div class="row">
+            <div class="col-md-5"></div>
+            <div class="col-md-2">
+                <a class="btn btn-default" href="{{ cancel_link_url }}" role="button">Annuler</a>
+                <input class="btn btn-success" type="submit" value="Enregistrer">
+            </div>
+            <div class="col-md-5"></div>
+        </div>
+    </form>
+{% endblock %}

--- a/tests/admin/custom_views/offer_view_test.py
+++ b/tests/admin/custom_views/offer_view_test.py
@@ -1,5 +1,14 @@
+from unittest.mock import patch
+
+import pytest
+
 from pcapi.admin.custom_views.offer_view import OfferView
+import pcapi.core.offers.factories as offers_factories
+from pcapi.core.offers.models import OfferValidationStatus
+import pcapi.core.users.factories as users_factories
 from pcapi.models import Offer
+
+from tests.conftest import TestClient
 
 
 class BeneficiaryUserViewTest:
@@ -9,3 +18,39 @@ class BeneficiaryUserViewTest:
 
         # Then
         assert offer_view.column_searchable_list is None or len(offer_view.column_searchable_list) == 0
+
+
+@pytest.mark.usefixtures("db_session")
+class OfferValidationViewTest:
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("pcapi.admin.custom_views.offer_view.get_offerer_legal_category")
+    def test_approve_offer(self, mocked_get_offerer_legal_category, mocked_validate_csrf_token, app):
+        users_factories.UserFactory(email="admin@example.com", isAdmin=True)
+        offer = offers_factories.OfferFactory(validation=OfferValidationStatus.AWAITING)
+        mocked_get_offerer_legal_category.return_value = {
+            "legal_category_code": 5202,
+            "legal_category_label": "Société en nom collectif",
+        }
+        data = dict(validation=OfferValidationStatus.APPROVED.value)
+        client = TestClient(app.test_client()).with_auth("admin@example.com")
+        response = client.post(f"/pc/back-office/validation/edit?id={offer.id}", form=data)
+
+        assert response.status_code == 200
+        assert offer.validation == OfferValidationStatus.APPROVED
+
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("pcapi.admin.custom_views.offer_view.get_offerer_legal_category")
+    def test_reject_offer(self, mocked_get_offerer_legal_category, mocked_validate_csrf_token, app):
+        users_factories.UserFactory(email="admin@example.com", isAdmin=True)
+        offer = offers_factories.OfferFactory(validation=OfferValidationStatus.AWAITING, isActive=True)
+        mocked_get_offerer_legal_category.return_value = {
+            "legal_category_code": 5202,
+            "legal_category_label": "Société en nom collectif",
+        }
+        data = dict(validation=OfferValidationStatus.REJECTED.value)
+        client = TestClient(app.test_client()).with_auth("admin@example.com")
+        response = client.post(f"/pc/back-office/validation/edit?id={offer.id}", form=data)
+
+        assert response.status_code == 200
+        assert offer.validation == OfferValidationStatus.REJECTED
+        assert offer.isActive is False


### PR DESCRIPTION
Création d'une page Flask Admin qui permet au validateur des offres du pôle fraude d'approuver ou refuser une offre qui est en attente de validation.
La page permet d'affiche les informations nécessaires qui permettent d'analyser les offres avant d'approuver ou refuser. 