### PR TITLE
(PC-7963) : Add postalCode to the native app account creation

### DIFF
--- a/src/pcapi/routes/native/v1/serialization/account.py
+++ b/src/pcapi/routes/native/v1/serialization/account.py
@@ -32,6 +32,7 @@ class AccountRequest(BaseModel):
     birthdate: date
     marketing_email_subscription: Optional[bool] = False
     token: str
+    postal_code: Optional[str] = None
 
     class Config:
         alias_generator = to_camel


### PR DESCRIPTION
`postalCode` will be required for native app account creation
as long as the product is restricted to some area.
Also note that it is currently flagged as optional - for now -
to avoid breaking account creation. Mandatory flag will be
added in a second step depending on the value of the
`WHOLE_FRANCE_OPENING` flag.