### PR TITLE
(PC-8039) : don't set eligibility date in non eligible area

### DIFF
--- a/src/pcapi/core/users/models.py
+++ b/src/pcapi/core/users/models.py
@@ -319,17 +319,27 @@ class User(PcObject, Model, NeedsValidationMixin, VersionedMixin):
 
     @property
     def eligibility_start_datetime(self) -> Optional[datetime]:
+        # To avoid import loops
+        from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_validator import (
+            _is_postal_code_eligible,
+        )
+
         return (
             datetime.combine(self.dateOfBirth, time(0, 0)) + relativedelta(years=constants.ELIGIBILITY_AGE)
-            if self.dateOfBirth
+            if self.dateOfBirth and _is_postal_code_eligible(self.departementCode)
             else None
         )
 
     @property
     def eligibility_end_datetime(self) -> Optional[datetime]:
+        # To avoid import loops
+        from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_validator import (
+            _is_postal_code_eligible,
+        )
+
         return (
             datetime.combine(self.dateOfBirth, time(0, 0)) + relativedelta(years=constants.ELIGIBILITY_AGE + 1)
-            if self.dateOfBirth
+            if self.dateOfBirth and _is_postal_code_eligible(self.departementCode)
             else None
         )
 


### PR DESCRIPTION
Since the grand opening is postponed after the official native
application release the `eligibility_start_datetime` and
`eligibility_end_datetime` are subject to the location.