### PR TITLE
(PC-7247) modify offer and stocks creation

### DIFF
--- a/src/pcapi/alembic/versions/20210413_719b8b8e632f_add_draft_to_validation_status_enum.py
+++ b/src/pcapi/alembic/versions/20210413_719b8b8e632f_add_draft_to_validation_status_enum.py
@@ -1,0 +1,26 @@
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "719b8b8e632f"
+down_revision = "ccf69bc028ef"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TYPE validation_status ADD VALUE 'DRAFT'")
+
+
+def downgrade():
+    op.execute("ALTER TYPE validation_status RENAME TO validation_status_to_drop")
+    op.execute("CREATE TYPE validation_status AS ENUM ('APPROVED', 'AWAITING', 'REJECTED')")
+    op.alter_column("offer", "validation", server_default=None)
+    op.execute(
+        (
+            'ALTER TABLE offer ALTER COLUMN "validation" TYPE validation_status USING '
+            '"validation"::text::validation_status'
+        )
+    )
+    op.alter_column("offer", "validation", server_default="APPROVED")
+    op.execute("DROP TYPE validation_status_to_drop")

--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -135,10 +135,7 @@ def create_offer(offer_data: PostOfferBodyModel, user: User) -> Offer:
     offer.mentalDisabilityCompliant = offer_data.mental_disability_compliant
     offer.motorDisabilityCompliant = offer_data.motor_disability_compliant
     offer.visualDisabilityCompliant = offer_data.visual_disability_compliant
-    # TODO(fseguin): remove after the real implementation is added
-    offer.validation = compute_offer_validation_from_name(offer)
-    if offer.validation == OfferValidationStatus.REJECTED:
-        offer.isActive = False
+    offer.validation = OfferValidationStatus.DRAFT
 
     repository.save(offer)
     logger.info("Offer has been created", extra={"offer": offer.id, "venue": venue.id, "product": offer.productId})
@@ -360,6 +357,13 @@ def upsert_stocks(
 
     repository.save(*stocks)
     logger.info("Stock has been created or updated", extra={"offer": offer_id})
+
+    if offer.validation == OfferValidationStatus.DRAFT:
+        # TODO(fseguin): remove after the real implementation is added
+        offer.validation = compute_offer_validation_from_name(offer)
+        if offer.validation == OfferValidationStatus.REJECTED:
+            offer.isActive = False
+        repository.save(offer)
 
     for stock in edited_stocks:
         previous_beginning = edited_stocks_previous_beginnings[stock.id]

--- a/src/pcapi/core/offers/models.py
+++ b/src/pcapi/core/offers/models.py
@@ -263,6 +263,7 @@ class OfferStatus(enum.Enum):
 class OfferValidationStatus(enum.Enum):
     APPROVED = "APPROVED"
     AWAITING = "AWAITING"
+    DRAFT = "DRAFT"
     REJECTED = "REJECTED"
 
 

--- a/src/pcapi/core/offers/models.py
+++ b/src/pcapi/core/offers/models.py
@@ -258,6 +258,7 @@ class OfferStatus(enum.Enum):
     REJECTED = "REJECTED"
     SOLD_OUT = "SOLD_OUT"
     INACTIVE = "INACTIVE"
+    DRAFT = "DRAFT"
 
 
 class OfferValidationStatus(enum.Enum):
@@ -511,11 +512,15 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin, ProvidableMixin, 
 
     @hybrid_property
     def status(self) -> OfferStatus:
+        # pylint: disable=too-many-return-statements
         if self.validation == OfferValidationStatus.REJECTED:
             return OfferStatus.REJECTED
 
         if self.validation == OfferValidationStatus.AWAITING:
             return OfferStatus.AWAITING
+
+        if self.validation == OfferValidationStatus.DRAFT:
+            return OfferStatus.DRAFT
 
         if not self.isActive:
             return OfferStatus.INACTIVE
@@ -535,6 +540,7 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin, ProvidableMixin, 
             [
                 (cls.validation == OfferValidationStatus.REJECTED.name, OfferStatus.REJECTED.name),
                 (cls.validation == OfferValidationStatus.AWAITING.name, OfferStatus.AWAITING.name),
+                (cls.validation == OfferValidationStatus.DRAFT.name, OfferStatus.DRAFT.name),
                 (cls.isActive.is_(False), OfferStatus.INACTIVE.name),
                 (cls.hasBookingLimitDatetimesPassed.is_(True), OfferStatus.EXPIRED.name),
                 (cls.isSoldOut.is_(True), OfferStatus.SOLD_OUT.name),

--- a/src/pcapi/core/offers/repository.py
+++ b/src/pcapi/core/offers/repository.py
@@ -15,6 +15,7 @@ from pcapi.core.bookings.models import Booking
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offers.exceptions import StockDoesNotExist
 from pcapi.core.offers.models import OfferStatus
+from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.core.users.models import User
 from pcapi.domain.pro_offers.paginated_offers_recap import PaginatedOffersRecap
 from pcapi.infrastructure.repository.pro_offers.paginated_offers_recap_domain_converter import to_domain
@@ -101,7 +102,7 @@ def get_offers_by_filters(
     period_beginning_date: Optional[datetime] = None,
     period_ending_date: Optional[datetime] = None,
 ) -> Query:
-    query = Offer.query
+    query = Offer.query.filter(Offer.validation != OfferValidationStatus.DRAFT)
 
     if not user_is_admin:
         query = (

--- a/src/pcapi/core/offers/validation.py
+++ b/src/pcapi/core/offers/validation.py
@@ -200,7 +200,7 @@ def check_image(
 
 
 def check_validation_status(offer: Offer) -> None:
-    if offer.validation != OfferValidationStatus.APPROVED:
+    if offer.validation in (OfferValidationStatus.REJECTED, OfferValidationStatus.AWAITING):
         error = ApiErrors()
         error.add_error("global", "Les offres refusées ou en attente de validation ne sont pas modifiables")
         raise error

--- a/src/pcapi/model_creators/specific_creators.py
+++ b/src/pcapi/model_creators/specific_creators.py
@@ -40,6 +40,7 @@ def create_offer_with_event_product(
     thumb_count: int = 0,
     withdrawal_details: Optional[str] = None,
     extra_data: Optional[Dict] = None,
+    validation: OfferValidationStatus = OfferValidationStatus.APPROVED,
 ) -> Offer:
     offer = Offer()
     if product is None:
@@ -67,7 +68,7 @@ def create_offer_with_event_product(
     offer.lastProvider = last_provider
     offer.idAtProviders = id_at_providers
     offer.isDuo = is_duo
-    offer.validation = OfferValidationStatus.APPROVED
+    offer.validation = validation
     offer.withdrawalDetails = withdrawal_details
     offer.extraData = extra_data
 
@@ -109,6 +110,7 @@ def create_offer_with_thing_product(
     extra_data: Dict = None,
     withdrawal_details: Optional[str] = None,
     date_modified_at_last_provider: Optional[datetime] = datetime.utcnow(),
+    validation: OfferValidationStatus = OfferValidationStatus.APPROVED,
 ) -> Offer:
     offer = Offer()
     if product:
@@ -155,7 +157,7 @@ def create_offer_with_thing_product(
     offer.id = idx
     offer.withdrawalDetails = withdrawal_details
     offer.isDuo = False
-    offer.validation = OfferValidationStatus.APPROVED
+    offer.validation = validation
 
     if extra_data:
         offer.extraData = extra_data

--- a/tests/core/offers/test_repository.py
+++ b/tests/core/offers/test_repository.py
@@ -6,6 +6,7 @@ import pytest
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import OfferStatus
+from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.core.offers.repository import check_stock_consistency
 from pcapi.core.offers.repository import get_active_offers_count_for_venue
 from pcapi.core.offers.repository import get_offers_by_ids
@@ -953,7 +954,7 @@ class PaginatedOfferForFiltersTest:
             unexpired_booking_limit_date = datetime.utcnow() + timedelta(days=3)
 
             awaiting_offer = offers_factories.ThingOfferFactory(
-                validation=OfferStatus.AWAITING.name, name="Offre en attente"
+                validation=OfferValidationStatus.AWAITING, name="Offre en attente"
             )
             offers_factories.StockFactory(bookingLimitDatetime=unexpired_booking_limit_date, offer=awaiting_offer)
 
@@ -978,7 +979,7 @@ class PaginatedOfferForFiltersTest:
             unexpired_booking_limit_date = datetime.utcnow() + timedelta(days=3)
 
             rejected_offer = offers_factories.ThingOfferFactory(
-                validation=OfferStatus.REJECTED.name, name="Offre rejetée", isActive=False
+                validation=OfferValidationStatus.REJECTED, name="Offre rejetée", isActive=False
             )
             offers_factories.StockFactory(bookingLimitDatetime=unexpired_booking_limit_date, offer=rejected_offer)
 

--- a/tests/core/offers/test_validation.py
+++ b/tests/core/offers/test_validation.py
@@ -408,6 +408,11 @@ class CheckValidationStatus:
 
         validation.check_validation_status(approved_offer)
 
+    def test_draft_offer(self):
+        draft_offer = factories.OfferFactory(validation=OfferValidationStatus.DRAFT)
+
+        validation.check_validation_status(draft_offer)
+
     def test_awaiting_offer(self):
         awaiting_validation_offer = factories.OfferFactory(validation=OfferValidationStatus.AWAITING)
 


### PR DESCRIPTION
##  Objectif

Modifier le workflow de création d'offre et d'ajout de stocks


##  Implémentation

- ajout de la valeur `DRAFT` à l'enum `OfferValidationStatus`
- ajout de la migration modifiant le type SQL enum (en ajoutant une valeur) de la colonne `validation` de la table `offer`
- affectation du statut de validation DRAFT à l'offre dans la fonction `create_offer()`
- déplacement du calcul de statut d'offre, de `create_offer()` à `upsert_stocks()`
- ajout de la valeur `DRAFT` à l'enum `OfferStatus`
- exclusion des offres au statut `DRAFT` dans la liste des offres renvoyée par la route `list_offers()`

