### PR TITLE
(PC-7891): LCF add save and go to the next offer in offer validation page FlaskAdmin

### DIFF
--- a/src/pcapi/admin/custom_views/offer_view.py
+++ b/src/pcapi/admin/custom_views/offer_view.py
@@ -1,5 +1,6 @@
 from flask import abort
 from flask import flash
+from flask import redirect
 from flask import request
 from flask import url_for
 from flask_admin.base import expose
@@ -174,6 +175,16 @@ class ValidationView(BaseAdminView):
                 )
                 if is_offer_updated:
                     flash("Le statut de l'offre a bien été modifié", "success")
+                    if request.form["action"] == "save-and-go-next":
+                        next_offer_query = (
+                            Offer.query.filter(Offer.validation == OfferValidationStatus.AWAITING)
+                            .filter(Offer.id != offer_id)
+                            .limit(1)
+                        )
+                        if next_offer_query.count() > 0:
+                            next_offer = next_offer_query.one()
+                            return redirect(url_for(".edit", id=next_offer.id))
+                        return redirect(url_for("/validation.index_view"))
                 else:
                     flash("Une erreur s'est produite lors de la mise à jour du statut de validation", "error")
 

--- a/src/pcapi/templates/admin/edit_offer_validation.html
+++ b/src/pcapi/templates/admin/edit_offer_validation.html
@@ -13,7 +13,7 @@
         <div>Code de catégorie juridique : <strong>{{ legal_category_code }}</strong></div>
         <div>Libellé de catégorie juridique : <strong>{{ legal_category_label }}</strong></div>
     </p>
-    <form action="{{ action }}" method="POST">
+    <form method="POST">
         {% for field in form %}
             {% if field.name == "csrf_token" %}
                 {{ field }}
@@ -29,12 +29,13 @@
             {% endif %}
         {% endfor %}
         <div class="row">
-            <div class="col-md-5"></div>
-            <div class="col-md-2">
+            <div class="col-md-4"></div>
+            <div class="col-md-4">
                 <a class="btn btn-default" href="{{ cancel_link_url }}" role="button">Annuler</a>
-                <input class="btn btn-success" type="submit" value="Enregistrer">
+                <button class="btn btn-success" name="action" type="submit" value="save">Enregistrer</button>
+                <button class="btn btn-success" name="action" type="submit" value="save-and-go-next">Enregistrer et passer à l'offre suivante</button>
             </div>
-            <div class="col-md-5"></div>
+            <div class="col-md-4"></div>
         </div>
     </form>
 {% endblock %}


### PR DESCRIPTION
Ajout d'un bouton 'Enregistrer et passer à l'offre suivante' sur la page de validation d'une offre en attente de validation.
 