### PR TITLE
(PC-8100): API Stock

### DIFF
--- a/src/pcapi/app.py
+++ b/src/pcapi/app.py
@@ -11,6 +11,7 @@ from pcapi.local_providers.install import install_local_providers
 from pcapi.models.install import install_activity
 from pcapi.routes import install_routes
 from pcapi.routes.native.v1.blueprint import native_v1
+from pcapi.routes.pro.blueprints import pro_api_v1
 
 
 if settings.PROFILE_REQUESTS:
@@ -35,6 +36,7 @@ with app.app_context():
     install_routes(app)
 
     app.register_blueprint(native_v1, url_prefix="/native/v1")
+    app.register_blueprint(pro_api_v1, url_prefix="/pro/v1")
 
 if __name__ == "__main__":
     port = settings.FLASK_PORT

--- a/src/pcapi/core/providers/api.py
+++ b/src/pcapi/core/providers/api.py
@@ -143,7 +143,7 @@ def _get_synchronization_error_message(provider_name: str, siret: Optional[str])
     return f"L’importation d’offres avec {provider_name} n’est pas disponible sans SIRET associé au lieu. Ajoutez un SIRET pour pouvoir importer les offres."
 
 
-def synchronize_stocks(stock_details, venue, provider_id):
+def synchronize_stocks(stock_details, venue: Venue, provider_id: Optional[int] = None):
     products_provider_references = [stock_detail["products_provider_reference"] for stock_detail in stock_details]
     products_by_provider_reference = get_products_map_by_id_at_providers(products_provider_references)
 
@@ -188,7 +188,7 @@ def _build_new_offers_from_stock_details(
     existing_offers_by_provider_reference: Dict[str, int],
     products_by_provider_reference: Dict[str, Product],
     venue: Venue,
-    provider_id=None,
+    provider_id: Optional[int],
 ) -> List[Offer]:
     new_offers = []
     for stock_detail in stock_details:

--- a/src/pcapi/core/providers/api.py
+++ b/src/pcapi/core/providers/api.py
@@ -1,7 +1,22 @@
+from datetime import datetime
+import logging
 import subprocess
+from typing import Dict
+from typing import List
 from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import Union
 
+from flask import current_app as app
+
+from pcapi.connectors import redis
 from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.models import Offer
+from pcapi.core.offers.models import Stock
+from pcapi.core.offers.repository import get_offers_map_by_id_at_providers
+from pcapi.core.offers.repository import get_products_map_by_id_at_providers
+from pcapi.core.offers.repository import get_stocks_by_id_at_providers
 from pcapi.core.providers.models import Provider
 from pcapi.core.providers.models import VenueProvider
 from pcapi.core.providers.repository import get_provider_enabled_for_pro_by_id
@@ -11,6 +26,9 @@ from pcapi.infrastructure.container import api_praxiel_stocks
 from pcapi.infrastructure.container import api_titelive_stocks
 from pcapi.local_providers.provider_api import synchronize_provider_api
 from pcapi.models import ApiErrors
+from pcapi.models import Product
+from pcapi.models import Venue
+from pcapi.models.db import db
 from pcapi.models.feature import FeatureToggle
 from pcapi.repository import feature_queries
 from pcapi.repository import repository
@@ -18,9 +36,13 @@ from pcapi.repository.venue_queries import find_by_id
 from pcapi.routes.serialization.venue_provider_serialize import PostVenueProviderBody
 from pcapi.use_cases.connect_venue_to_allocine import connect_venue_to_allocine
 from pcapi.utils.human_ids import dehumanize
+from pcapi.validation.models.entity_validator import validate
 from pcapi.validation.routes.venue_providers import check_existing_provider
 from pcapi.validation.routes.venues import check_existing_venue
 from pcapi.workers.venue_provider_job import venue_provider_job
+
+
+logger = logging.getLogger(__name__)
 
 
 def create_venue_provider(venue_provider: PostVenueProviderBody) -> VenueProvider:
@@ -119,3 +141,158 @@ def _get_synchronization_error_message(provider_name: str, siret: Optional[str])
     if siret:
         return f"L’importation d’offres avec {provider_name} n’est pas disponible pour le SIRET {siret}"
     return f"L’importation d’offres avec {provider_name} n’est pas disponible sans SIRET associé au lieu. Ajoutez un SIRET pour pouvoir importer les offres."
+
+
+def synchronize_stocks(stock_details, venue, provider_id):
+    products_provider_references = [stock_detail["products_provider_reference"] for stock_detail in stock_details]
+    products_by_provider_reference = get_products_map_by_id_at_providers(products_provider_references)
+
+    stock_details = [
+        stock for stock in stock_details if stock["products_provider_reference"] in products_by_provider_reference
+    ]
+
+    offers_provider_references = [stock_detail["offers_provider_reference"] for stock_detail in stock_details]
+    offers_by_provider_reference = get_offers_map_by_id_at_providers(offers_provider_references)
+
+    new_offers = _build_new_offers_from_stock_details(
+        stock_details, offers_by_provider_reference, products_by_provider_reference, venue, provider_id
+    )
+    new_offers_references = [new_offer.idAtProviders for new_offer in new_offers]
+
+    db.session.bulk_save_objects(new_offers)
+
+    new_offers_by_provider_reference = get_offers_map_by_id_at_providers(new_offers_references)
+    offers_by_provider_reference = {**offers_by_provider_reference, **new_offers_by_provider_reference}
+
+    stocks_provider_references = [stock["stocks_provider_reference"] for stock in stock_details]
+    stocks_by_provider_reference = get_stocks_by_id_at_providers(stocks_provider_references)
+    update_stock_mapping, new_stocks, offer_ids = _get_stocks_to_upsert(
+        stock_details,
+        stocks_by_provider_reference,
+        offers_by_provider_reference,
+        products_by_provider_reference,
+    )
+
+    db.session.bulk_save_objects(new_stocks)
+    db.session.bulk_update_mappings(Stock, update_stock_mapping)
+
+    db.session.commit()
+
+    _reindex_offers(offer_ids)
+
+    return {"new_offers": len(new_offers), "new_stocks": len(new_stocks), "updated_stocks": len(update_stock_mapping)}
+
+
+def _build_new_offers_from_stock_details(
+    stock_details: List,
+    existing_offers_by_provider_reference: Dict[str, int],
+    products_by_provider_reference: Dict[str, Product],
+    venue: Venue,
+    provider_id=None,
+) -> List[Offer]:
+    new_offers = []
+    for stock_detail in stock_details:
+        if stock_detail["offers_provider_reference"] in existing_offers_by_provider_reference:
+            continue
+
+        product = products_by_provider_reference[stock_detail["products_provider_reference"]]
+        offer = _build_new_offer(
+            venue,
+            product,
+            id_at_providers=stock_detail["offers_provider_reference"],
+            provider_id=provider_id,
+        )
+
+        if not _validate_stock_or_offer(offer):
+            continue
+
+        new_offers.append(offer)
+
+    return new_offers
+
+
+def _get_stocks_to_upsert(
+    stock_details: List[Dict],
+    stocks_by_provider_reference: Dict[str, Dict],
+    offers_by_provider_reference: Dict[str, int],
+    products_by_provider_reference: Dict[str, Product],
+) -> Tuple[List[Dict], List[Stock], Set[int]]:
+    update_stock_mapping = []
+    new_stocks = []
+    offer_ids = set()
+
+    for stock_detail in stock_details:
+        stock_provider_reference = stock_detail["stocks_provider_reference"]
+        product = products_by_provider_reference[stock_detail["products_provider_reference"]]
+        book_price = float(product.extraData["prix_livre"])
+        if stock_provider_reference in stocks_by_provider_reference:
+            stock = stocks_by_provider_reference[stock_provider_reference]
+
+            update_stock_mapping.append(
+                {
+                    "id": stock["id"],
+                    "quantity": stock_detail["available_quantity"] + stock["booking_quantity"],
+                    "rawProviderQuantity": stock_detail["available_quantity"],
+                    "price": book_price,
+                }
+            )
+            offer_ids.add(offers_by_provider_reference[stock_detail["offers_provider_reference"]])
+
+        else:
+            stock = _build_stock_from_stock_detail(
+                stock_detail,
+                offers_by_provider_reference[stock_detail["offers_provider_reference"]],
+                book_price,
+            )
+            if not _validate_stock_or_offer(stock):
+                continue
+
+            new_stocks.append(stock)
+            offer_ids.add(stock.offerId)
+
+    return update_stock_mapping, new_stocks, offer_ids
+
+
+def _build_stock_from_stock_detail(stock_detail: Dict, offers_id: int, price: float) -> Stock:
+    return Stock(
+        quantity=stock_detail["available_quantity"],
+        rawProviderQuantity=stock_detail["available_quantity"],
+        bookingLimitDatetime=None,
+        offerId=offers_id,
+        price=price,
+        dateModified=datetime.now(),
+        idAtProviders=stock_detail["stocks_provider_reference"],
+    )
+
+
+def _validate_stock_or_offer(model: Union[Offer, Stock]) -> bool:
+    model_api_errors = validate(model)
+    if model_api_errors.errors.keys():
+        logger.exception(
+            "[SYNC] errors while trying to add stock or offer with ref %s: %s",
+            model.idAtProviders,
+            model_api_errors.errors,
+        )
+        return False
+
+    return True
+
+
+def _build_new_offer(venue: Venue, product: Product, id_at_providers: str, provider_id: str) -> Offer:
+    return Offer(
+        bookingEmail=venue.bookingEmail,
+        description=product.description,
+        extraData=product.extraData,
+        idAtProviders=id_at_providers,
+        lastProviderId=provider_id,
+        name=product.name,
+        productId=product.id,
+        venueId=venue.id,
+        type=product.type,
+    )
+
+
+def _reindex_offers(offer_ids: Set[int]) -> None:
+    if feature_queries.is_active(FeatureToggle.SYNCHRONIZE_ALGOLIA):
+        for offer_id in offer_ids:
+            redis.add_offer_id(client=app.redis_client, offer_id=offer_id)

--- a/src/pcapi/local_providers/provider_api/synchronize_provider_api.py
+++ b/src/pcapi/local_providers/provider_api/synchronize_provider_api.py
@@ -2,25 +2,17 @@ from datetime import datetime
 import logging
 import time
 from typing import Counter
-from typing import Dict
 from typing import Generator
-from typing import List
 
 from sqlalchemy.sql.sqltypes import DateTime
 
 from pcapi.core.providers.api import synchronize_stocks
-from pcapi.core.providers.models import Provider
 from pcapi.core.providers.models import VenueProvider
 from pcapi.infrastructure.repository.stock_provider.provider_api import ProviderAPI
 from pcapi.repository import repository
 
 
 logger = logging.getLogger(__name__)
-
-
-def check_siret_can_be_synchronized(siret: str, provider: Provider) -> bool:
-    provider_api = provider.getProviderAPI()
-    return provider_api.is_siret_registered(siret)
 
 
 def synchronize_venue_provider(venue_provider: VenueProvider) -> None:

--- a/src/pcapi/routes/CONTRIBUTING.md
+++ b/src/pcapi/routes/CONTRIBUTING.md
@@ -1,12 +1,15 @@
 # Package `routes`
+
 Les modules de ce package contiennent des fonctions python de type _controller_ ainsi que le _binding_ de ces fonctions
 avec les routes d'API grâce au _framework Flask_.
 
 ## Do
+
 Ces fonctions doivent contenir : des appels à des fontions de `domain`, `connectors` ou `repository` ainsi que
 les différents _HTTP status codes_ que l'ont souhaite retourner.
 
 Par exemple :
+
 ```python
 @private_api.route("/users/current", methods=["GET"])
 @login_required
@@ -17,13 +20,15 @@ def get_profile():
 ```
 
 ## Don't
+
 Ces fonctions ne doivent pas contenir : des règles de gestion, des _queries_ vers la base de données ou des appels à des
 web services.
 
 Par exemple :
+
 ```python
 @private_api.route('/eventOccurrences', methods=['POST'])
-@login_or_api_key_required
+@login_required
 @expect_json_data
 def create_event_occurrence():
     product = Product.query \
@@ -37,20 +42,24 @@ def create_event_occurrence():
 ```
 
 ## Testing
+
 Ces fonctions sont testées au travers des routes, avec des tests fonctionnels. Ces tests utilisent des appels HTTP et
 se positionnent donc "du point de vue du client".
 
 Ils ont pour objectif de :
-* documenter les différents status codes qui existent pour chaque route
-* documenter le JSON attendu en entrée pour chaque route
-* documenter le JSON attendu en sortie pour chaque route
-* détecter les régressions sur les routes d'API
+
+- documenter les différents status codes qui existent pour chaque route
+- documenter le JSON attendu en entrée pour chaque route
+- documenter le JSON attendu en sortie pour chaque route
+- détecter les régressions sur les routes d'API
 
 Ils n'ont pas pour objectifs de :
-* tester l'intégralité des cas passants ou non-passants possibles. Ces cas là seront testés plus près du code, dans des
-modules de `domain` ou de `repository` par exemple.
+
+- tester l'intégralité des cas passants ou non-passants possibles. Ces cas là seront testés plus près du code, dans des
+  modules de `domain` ou de `repository` par exemple.
 
 Par exemple :
+
 ```python
 class Get:
     class Returns200:
@@ -71,4 +80,5 @@ class Get:
 ```
 
 ## Pour en savoir plus
-* http://flask.pocoo.org/docs/1.0/quickstart/#routing
+
+- http://flask.pocoo.org/docs/1.0/quickstart/#routing

--- a/src/pcapi/routes/pro/blueprints.py
+++ b/src/pcapi/routes/pro/blueprints.py
@@ -1,0 +1,44 @@
+from flask import Blueprint
+from spectree import SpecTree
+
+from pcapi.serialization.utils import before_handler
+from pcapi.validation.routes import users_authentifications
+
+
+pro_api_v1 = Blueprint("pro_api_v1", __name__)
+
+
+API_KEY_AUTH = "ApiKeyAuth"
+
+
+class ProApiV1BluePrints(SpecTree):
+    def _generate_spec(self) -> dict:
+        schema = super()._generate_spec()
+        schema["components"]["securitySchemes"] = {
+            API_KEY_AUTH: {
+                "type": "http",
+                "scheme": "bearer",
+            }
+        }
+
+        # Find routes that are protected by authentication
+        # We may drop this whenever Spectree supports authentication
+        for route in self.backend.find_routes():
+            path, _parameters = self.backend.parse_path(route)
+            if path not in schema["paths"]:
+                continue
+            for method, func in self.backend.parse_func(route):
+                if method.lower() not in schema["paths"][path]:
+                    continue
+                if self.backend.bypass(func, method) or self.bypass(func):
+                    continue
+
+                if getattr(func, "requires_authentication", None):
+                    if users_authentifications.API_KEY in func.requires_authentication:
+                        schema["paths"][path][method.lower()]["security"] = [{API_KEY_AUTH: []}]
+
+        return schema
+
+
+api = ProApiV1BluePrints("flask", MODE="strict", before=before_handler, PATH="/")
+api.register(pro_api_v1)

--- a/src/pcapi/routes/pro/bookings.py
+++ b/src/pcapi/routes/pro/bookings.py
@@ -23,7 +23,7 @@ from pcapi.utils.rest import check_user_has_access_to_offerer
 from pcapi.validation.routes.bookings import check_email_and_offer_id_for_anonymous_user
 from pcapi.validation.routes.bookings import check_page_format_is_number
 from pcapi.validation.routes.users_authentifications import check_user_is_logged_in_or_email_is_provided
-from pcapi.validation.routes.users_authentifications import login_or_api_key_required_v2
+from pcapi.validation.routes.users_authentifications import login_or_api_key_required
 from pcapi.validation.routes.users_authorizations import check_api_key_allows_to_cancel_booking
 from pcapi.validation.routes.users_authorizations import check_api_key_allows_to_validate_booking
 from pcapi.validation.routes.users_authorizations import check_user_can_validate_bookings
@@ -85,7 +85,7 @@ def get_all_bookings():
 
 # @debt api-migration
 @public_api.route("/v2/bookings/token/<token>", methods=["GET"])
-@login_or_api_key_required_v2
+@login_or_api_key_required
 def get_booking_by_token_v2(token: str):
     valid_api_key = _get_api_key_from_header(request)
     booking = booking_repository.find_by(token=token)
@@ -107,7 +107,7 @@ def get_booking_by_token_v2(token: str):
 
 # @debt api-migration
 @public_api.route("/v2/bookings/use/token/<token>", methods=["PATCH"])
-@login_or_api_key_required_v2
+@login_or_api_key_required
 def patch_booking_use_by_token(token: str):
     """Let a pro user mark a booking as used."""
     booking = booking_repository.find_by(token=token)
@@ -127,7 +127,7 @@ def patch_booking_use_by_token(token: str):
 
 # @debt api-migration
 @private_api.route("/v2/bookings/cancel/token/<token>", methods=["PATCH"])
-@login_or_api_key_required_v2
+@login_or_api_key_required
 def patch_cancel_booking_by_token(token: str):
     """Let a pro user cancel a booking."""
     valid_api_key = _get_api_key_from_header(request)
@@ -148,7 +148,7 @@ def patch_cancel_booking_by_token(token: str):
 
 # @debt api-migration
 @public_api.route("/v2/bookings/keep/token/<token>", methods=["PATCH"])
-@login_or_api_key_required_v2
+@login_or_api_key_required
 def patch_booking_keep_by_token(token: str):
     """Let a pro user mark a booking as _not_ used."""
     booking = booking_repository.find_by(token=token)

--- a/src/pcapi/routes/pro/offerers.py
+++ b/src/pcapi/routes/pro/offerers.py
@@ -28,7 +28,6 @@ from pcapi.utils.mailing import MailServiceException
 from pcapi.utils.rest import check_user_has_access_to_offerer
 from pcapi.utils.rest import expect_json_data
 from pcapi.utils.rest import load_or_404
-from pcapi.utils.rest import login_or_api_key_required
 
 
 logger = logging.getLogger(__name__)
@@ -109,7 +108,7 @@ def get_offerer(offerer_id: str) -> GetOffererResponseModel:
 
 # @debt api-migration
 @private_api.route("/offerers", methods=["POST"])
-@login_or_api_key_required
+@login_required
 @expect_json_data
 def create_offerer():
     siren = request.json["siren"]

--- a/src/pcapi/routes/pro/offers.py
+++ b/src/pcapi/routes/pro/offers.py
@@ -32,7 +32,6 @@ from pcapi.serialization.decorator import spectree_serialize
 logger = logging.getLogger(__name__)
 from pcapi.utils.rest import check_user_has_access_to_offerer
 from pcapi.utils.rest import load_or_404
-from pcapi.utils.rest import login_or_api_key_required
 
 
 @private_api.route("/offers", methods=["GET"])
@@ -66,7 +65,7 @@ def get_offer(offer_id: str) -> GetOfferResponseModel:
 
 
 @private_api.route("/offers", methods=["POST"])
-@login_or_api_key_required
+@login_required
 @spectree_serialize(response_model=OfferResponseIdModel, on_success_status=201)  # type: ignore
 def post_offer(body: PostOfferBodyModel) -> OfferResponseIdModel:
     offer = offers_api.create_offer(offer_data=body, user=current_user)
@@ -74,7 +73,7 @@ def post_offer(body: PostOfferBodyModel) -> OfferResponseIdModel:
 
 
 @private_api.route("/offers/active-status", methods=["PATCH"])
-@login_or_api_key_required
+@login_required
 @spectree_serialize(response_model=None, on_success_status=204)  # type: ignore
 def patch_offers_active_status(body: PatchOfferActiveStatusBodyModel) -> None:
     query = offers_repository.get_offers_by_ids(current_user, body.ids)
@@ -82,7 +81,7 @@ def patch_offers_active_status(body: PatchOfferActiveStatusBodyModel) -> None:
 
 
 @private_api.route("/offers/all-active-status", methods=["PATCH"])
-@login_or_api_key_required
+@login_required
 @spectree_serialize(response_model=None, on_success_status=204)
 def patch_all_offers_active_status(body: PatchAllOffersActiveStatusBodyModel) -> None:
     query = offers_repository.get_offers_by_filters(
@@ -101,7 +100,7 @@ def patch_all_offers_active_status(body: PatchAllOffersActiveStatusBodyModel) ->
 
 
 @private_api.route("/offers/<offer_id>", methods=["PATCH"])
-@login_or_api_key_required
+@login_required
 @spectree_serialize(response_model=OfferResponseIdModel)  # type: ignore
 def patch_offer(offer_id: str, body: PatchOfferBodyModel) -> OfferResponseIdModel:
     offer = load_or_404(Offer, human_id=offer_id)
@@ -113,7 +112,7 @@ def patch_offer(offer_id: str, body: PatchOfferBodyModel) -> OfferResponseIdMode
 
 
 @private_api.route("/offers/thumbnail-url-validation", methods=["POST"])
-@login_or_api_key_required
+@login_required
 @spectree_serialize(response_model=ImageResponseModel)
 def validate_distant_image(body: ImageBodyModel) -> ImageResponseModel:
     errors = []

--- a/src/pcapi/routes/pro/stocks.py
+++ b/src/pcapi/routes/pro/stocks.py
@@ -1,6 +1,9 @@
+from typing import List
+
 from flask_login import current_user
 from flask_login import login_required
 
+from pcapi.core.offerers.models import Offerer
 import pcapi.core.offers.api as offers_api
 from pcapi.core.offers.repository import get_stocks_for_offer
 from pcapi.flask_app import private_api
@@ -13,9 +16,14 @@ from pcapi.routes.serialization.stock_serialize import StockIdsResponseModel
 from pcapi.routes.serialization.stock_serialize import StockResponseModel
 from pcapi.routes.serialization.stock_serialize import StocksResponseModel
 from pcapi.routes.serialization.stock_serialize import StocksUpsertBodyModel
+from pcapi.routes.serialization.stock_serialize import UpdateVenueStockBodyModel
+from pcapi.routes.serialization.stock_serialize import UpdateVenueStocksBodyModel
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.utils.human_ids import dehumanize
 from pcapi.utils.rest import check_user_has_access_to_offerer
+from pcapi.validation.routes.users_authentifications import api_key_required
+from pcapi.validation.routes.users_authentifications import current_api_key
+from pcapi.workers.synchronize_stocks_job import synchronize_stocks_job
 
 
 @private_api.route("/offers/<offer_id>/stocks", methods=["GET"])
@@ -63,3 +71,26 @@ def delete_stock(stock_id: str) -> StockIdResponseModel:
     offers_api.delete_stock(stock)
 
     return StockIdResponseModel.from_orm(stock)
+
+
+@private_api.route("/venue/<int:venue_id>/stocks", methods=["POST"])
+@api_key_required
+@spectree_serialize(on_success_status=204)
+def update_stocks(venue_id: int, body: UpdateVenueStocksBodyModel) -> None:
+    offerer_id = current_api_key.offererId
+    venue = Venue.query.join(Offerer).filter(Venue.id == venue_id, Offerer.id == offerer_id).first_or_404()
+
+    stock_details = _build_stock_details_from_body(body.stocks, venue.id)
+    synchronize_stocks_job.delay(stock_details, venue.id)
+
+
+def _build_stock_details_from_body(raw_stocks: List[UpdateVenueStockBodyModel], venue_id: int):
+    stock_details = {}
+    for stock in raw_stocks:
+        stock_details[stock.ref] = {
+            "products_provider_reference": stock.ref,
+            "offers_provider_reference": f"{stock.ref}@{str(venue_id)}",
+            "stocks_provider_reference": f"{stock.ref}@{str(venue_id)}",
+            "available_quantity": stock.available,
+        }
+    return list(stock_details.values())

--- a/src/pcapi/routes/pro/stocks.py
+++ b/src/pcapi/routes/pro/stocks.py
@@ -1,4 +1,5 @@
 from flask_login import current_user
+from flask_login import login_required
 
 import pcapi.core.offers.api as offers_api
 from pcapi.core.offers.repository import get_stocks_for_offer
@@ -15,11 +16,10 @@ from pcapi.routes.serialization.stock_serialize import StocksUpsertBodyModel
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.utils.human_ids import dehumanize
 from pcapi.utils.rest import check_user_has_access_to_offerer
-from pcapi.utils.rest import login_or_api_key_required
 
 
 @private_api.route("/offers/<offer_id>/stocks", methods=["GET"])
-@login_or_api_key_required
+@login_required
 @spectree_serialize(response_model=StocksResponseModel)
 def get_stocks(offer_id: str) -> StocksResponseModel:
     offerer = offerer_queries.get_by_offer_id(dehumanize(offer_id))
@@ -32,7 +32,7 @@ def get_stocks(offer_id: str) -> StocksResponseModel:
 
 
 @private_api.route("/stocks/bulk", methods=["POST"])
-@login_or_api_key_required
+@login_required
 @spectree_serialize(on_success_status=201, response_model=StockIdsResponseModel)
 def upsert_stocks(body: StocksUpsertBodyModel) -> StockIdsResponseModel:
     offerer = offerer_queries.get_by_offer_id(body.offer_id)
@@ -45,7 +45,7 @@ def upsert_stocks(body: StocksUpsertBodyModel) -> StockIdsResponseModel:
 
 
 @private_api.route("/stocks/<stock_id>", methods=["DELETE"])
-@login_or_api_key_required
+@login_required
 @spectree_serialize(response_model=StockIdResponseModel)
 def delete_stock(stock_id: str) -> StockIdResponseModel:
     # fmt: off

--- a/src/pcapi/routes/pro/stocks.py
+++ b/src/pcapi/routes/pro/stocks.py
@@ -25,6 +25,9 @@ from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
 from pcapi.workers.synchronize_stocks_job import synchronize_stocks_job
 
+from .blueprints import api
+from .blueprints import pro_api_v1
+
 
 @private_api.route("/offers/<offer_id>/stocks", methods=["GET"])
 @login_required
@@ -73,9 +76,9 @@ def delete_stock(stock_id: str) -> StockIdResponseModel:
     return StockIdResponseModel.from_orm(stock)
 
 
-@private_api.route("/venue/<int:venue_id>/stocks", methods=["POST"])
+@pro_api_v1.route("/venue/<int:venue_id>/stocks", methods=["POST"])
 @api_key_required
-@spectree_serialize(on_success_status=204)
+@spectree_serialize(on_success_status=204, on_error_statuses=[401, 404], api=api)
 def update_stocks(venue_id: int, body: UpdateVenueStocksBodyModel) -> None:
     offerer_id = current_api_key.offererId
     venue = Venue.query.join(Offerer).filter(Venue.id == venue_id, Offerer.id == offerer_id).first_or_404()

--- a/src/pcapi/routes/pro/users.py
+++ b/src/pcapi/routes/pro/users.py
@@ -1,5 +1,6 @@
 from flask import abort
 from flask_login import current_user
+from flask_login import login_required
 
 from pcapi.core.users import api as users_api
 from pcapi.core.users.models import User
@@ -10,11 +11,10 @@ from pcapi.routes.serialization.users import PatchProUserResponseModel
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.utils.human_ids import dehumanize
 from pcapi.utils.rest import load_or_404
-from pcapi.utils.rest import login_or_api_key_required
 
 
 @private_api.route("/users/<user_id>/tuto-seen", methods=["PATCH"])
-@login_or_api_key_required
+@login_required
 @spectree_serialize(response_model=None, on_success_status=204)
 def patch_user_tuto_seen(user_id: str) -> None:
     user = load_or_404(User, user_id)
@@ -23,7 +23,7 @@ def patch_user_tuto_seen(user_id: str) -> None:
 
 
 @private_api.route("/users/current", methods=["PATCH"])
-@login_or_api_key_required
+@login_required
 @spectree_serialize(response_model=PatchProUserResponseModel)  # type: ignore
 def patch_profile(body: PatchProUserBodyModel) -> PatchProUserResponseModel:
     user = current_user._get_current_object()  # get underlying User object from proxy

--- a/src/pcapi/routes/serialization/stock_serialize.py
+++ b/src/pcapi/routes/serialization/stock_serialize.py
@@ -88,3 +88,12 @@ class StocksUpsertBodyModel(BaseModel):
 
 class StockIdsResponseModel(BaseModel):
     stockIds: list[StockIdResponseModel]
+
+
+class UpdateVenueStockBodyModel(BaseModel):
+    ref: str
+    available: int
+
+
+class UpdateVenueStocksBodyModel(BaseModel):
+    stocks: list[UpdateVenueStockBodyModel]

--- a/src/pcapi/routes/webapp/beneficiaries.py
+++ b/src/pcapi/routes/webapp/beneficiaries.py
@@ -26,7 +26,6 @@ from pcapi.utils.login_manager import stamp_session
 from pcapi.utils.mailing import MailServiceException
 from pcapi.utils.rate_limiting import email_rate_limiter
 from pcapi.utils.rate_limiting import ip_rate_limiter
-from pcapi.utils.rest import login_or_api_key_required
 from pcapi.validation.routes.users import check_valid_signin
 from pcapi.workers.beneficiary_job import beneficiary_job
 
@@ -45,7 +44,7 @@ def get_beneficiary_profile() -> BeneficiaryAccountResponse:
 
 
 @private_api.route("/beneficiaries/current", methods=["PATCH"])
-@login_or_api_key_required
+@login_required
 @spectree_serialize(response_model=BeneficiaryAccountResponse)
 def patch_beneficiary(body: PatchBeneficiaryBodyModel) -> BeneficiaryAccountResponse:
     user = current_user._get_current_object()
@@ -58,7 +57,7 @@ def patch_beneficiary(body: PatchBeneficiaryBodyModel) -> BeneficiaryAccountResp
 
 
 @private_api.route("/beneficiaries/change_email_request", methods=["PUT"])
-@login_or_api_key_required
+@login_required
 @spectree_serialize(on_success_status=204, on_error_statuses=[401, 503])
 def change_beneficiary_email_request(body: ChangeBeneficiaryEmailRequestBody) -> None:
     errors = ApiErrors()

--- a/src/pcapi/utils/rest.py
+++ b/src/pcapi/utils/rest.py
@@ -3,7 +3,6 @@ from functools import wraps
 import re
 
 from flask import request
-from flask_login import current_user
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.sql.elements import UnaryExpression
 from sqlalchemy.sql.functions import random
@@ -11,17 +10,6 @@ from sqlalchemy.sql.functions import random
 from pcapi.core.users.models import User
 from pcapi.models.api_errors import ApiErrors
 from pcapi.utils.human_ids import dehumanize
-
-
-def login_or_api_key_required(f):
-    @wraps(f)
-    def wrapper(*args, **kwds):
-        if not current_user.is_authenticated:
-            return "API key or login required", 403
-
-        return f(*args, **kwds)
-
-    return wrapper
 
 
 def expect_json_data(f):

--- a/src/pcapi/validation/routes/users_authentifications.py
+++ b/src/pcapi/validation/routes/users_authentifications.py
@@ -15,7 +15,7 @@ def check_user_is_logged_in_or_email_is_provided(user: User, email: str):
         raise api_errors
 
 
-def login_or_api_key_required_v2(function):
+def login_or_api_key_required(function):
     @wraps(function)
     def wrapper(*args, **kwds):
         mandatory_authorization_type = "Bearer "

--- a/src/pcapi/validation/routes/users_authorizations.py
+++ b/src/pcapi/validation/routes/users_authorizations.py
@@ -1,5 +1,4 @@
 from pcapi.models import ApiErrors
-from pcapi.models import ApiKey
 from pcapi.models.api_errors import ForbiddenError
 
 
@@ -22,14 +21,14 @@ def check_user_can_validate_bookings_v2(user, offerer_id: int):
         raise api_errors
 
 
-def check_api_key_allows_to_validate_booking(valid_api_key: ApiKey, offerer_id: int):
+def check_api_key_allows_to_validate_booking(valid_api_key, offerer_id: int):
     if not valid_api_key.offererId == offerer_id:
         api_errors = ForbiddenError()
         api_errors.add_error("user", "Vous n'avez pas les droits suffisants pour valider cette contremarque.")
         raise api_errors
 
 
-def check_api_key_allows_to_cancel_booking(valid_api_key: ApiKey, offerer_id: int):
+def check_api_key_allows_to_cancel_booking(valid_api_key, offerer_id: int):
     if not valid_api_key.offererId == offerer_id:
         api_errors = ForbiddenError()
         api_errors.add_error("user", "Vous n'avez pas les droits suffisants pour annuler cette réservation.")

--- a/src/pcapi/workers/synchronize_stocks_job.py
+++ b/src/pcapi/workers/synchronize_stocks_job.py
@@ -1,0 +1,15 @@
+from rq.decorators import job
+
+from pcapi.core.providers import api
+from pcapi.repository import venue_queries
+from pcapi.workers import worker
+from pcapi.workers.decorators import job_context
+from pcapi.workers.decorators import log_job
+
+
+@job(worker.low_queue, connection=worker.conn)
+@job_context
+@log_job
+def synchronize_stocks_job(stock_details, venue_id: str) -> None:
+    venue = venue_queries.find_by_id(venue_id)
+    api.synchronize_stocks(stock_details, venue)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ from pcapi.notifications.push import testing as push_notifications_testing
 from pcapi.repository.clean_database import clean_all_database
 from pcapi.routes import install_routes
 from pcapi.routes.native.v1.blueprint import native_v1
+from pcapi.routes.pro.blueprints import pro_api_v1
 from pcapi.utils.json_encoder import EnumJSONEncoder
 
 
@@ -76,6 +77,7 @@ def app():
 
     app.redis_client = Mock()
     app.register_blueprint(native_v1, url_prefix="/native/v1")
+    app.register_blueprint(pro_api_v1, url_prefix="/pro/v1")
 
     JWTManager(app)
 

--- a/tests/core/providers/connect_provider_to_venue_test.py
+++ b/tests/core/providers/connect_provider_to_venue_test.py
@@ -212,7 +212,7 @@ class WhenProviderImplementsProviderAPI:
 
     @pytest.mark.usefixtures("db_session")
     @patch(
-        "pcapi.core.providers.api.synchronize_provider_api.check_siret_can_be_synchronized",
+        "pcapi.core.providers.api._siret_can_be_synchronized",
         return_value=True,
     )
     def should_connect_venue_when_synchronization_is_allowed(self, app):
@@ -237,7 +237,7 @@ class WhenProviderImplementsProviderAPI:
 
     @pytest.mark.usefixtures("db_session")
     @patch(
-        "pcapi.core.providers.api.synchronize_provider_api.check_siret_can_be_synchronized",
+        "pcapi.core.providers.api._siret_can_be_synchronized",
         return_value=False,
     )
     def should_not_connect_venue_when_synchronization_is_not_allowed(self, app):

--- a/tests/core/providers/test_api.py
+++ b/tests/core/providers/test_api.py
@@ -1,7 +1,21 @@
+from decimal import Decimal
+from unittest import mock
+
+from flask import current_app as app
+from freezegun.api import freeze_time
 import pytest
 
+from pcapi.core.bookings.factories import BookingFactory
+import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.offers import factories
+from pcapi.core.offers.factories import VenueFactory
+from pcapi.core.offers.models import Offer
 from pcapi.core.providers import api
+from pcapi.core.testing import override_features
+from pcapi.local_providers.provider_api import synchronize_provider_api
 from pcapi.models import ApiErrors
+from pcapi.models import ThingType
+from pcapi.models.product import Product
 from pcapi.routes.serialization.venue_provider_serialize import PostVenueProviderBody
 
 
@@ -19,3 +33,213 @@ class CreateVenueProviderTest:
 
         # Then
         assert error.value.errors["provider"] == ["Cette source n'est pas disponible"]
+
+
+def create_product(isbn, **kwargs):
+    return factories.ProductFactory(
+        idAtProviders=isbn,
+        type=str(ThingType.LIVRE_EDITION),
+        extraData={"prix_livre": 12},
+        **kwargs,
+    )
+
+
+def create_offer(isbn, siret):
+    return factories.OfferFactory(product=create_product(isbn), idAtProviders=f"{isbn}@{siret}")
+
+
+def create_stock(isbn, siret, **kwargs):
+    return factories.StockFactory(offer=create_offer(isbn, siret), idAtProviders=f"{isbn}@{siret}", **kwargs)
+
+
+class SynchronizeStocksTest:
+    @pytest.mark.usefixtures("db_session")
+    @freeze_time("2020-10-15 09:00:00")
+    @override_features(SYNCHRONIZE_ALGOLIA=True)
+    @mock.patch("pcapi.connectors.redis.add_offer_id")
+    def test_execution(self, mocked_add_offer_id):
+        # Given
+        spec = [
+            {"ref": "3010000101789", "available": 6},
+            {"ref": "3010000101797", "available": 4},
+            {"ref": "3010000103769", "available": 18},
+            {"ref": "3010000107163", "available": 12},
+            {"ref": "3010000108123", "available": 17},
+            {"ref": "3010000108124", "available": 17},
+            {"ref": "3010000108125", "available": 17},
+        ]
+        provider = offerers_factories.APIProviderFactory(apiUrl="https://provider_url", authToken="fake_token")
+        venue = VenueFactory()
+        siret = venue.siret
+        stock_details = synchronize_provider_api._build_stock_details_from_raw_stocks(spec, siret)
+
+        stock = create_stock(
+            spec[0]["ref"],
+            siret,
+            quantity=20,
+        )
+        offer = create_offer(spec[1]["ref"], siret)
+        product = create_product(spec[2]["ref"])
+        create_product(spec[4]["ref"])
+        create_product(spec[6]["ref"], isGcuCompatible=False)
+
+        stock_with_booking = create_stock(spec[5]["ref"], siret, quantity=20)
+        BookingFactory(stock=stock_with_booking)
+        BookingFactory(stock=stock_with_booking, quantity=2)
+
+        # When
+        api.synchronize_stocks(stock_details, venue, provider_id=provider.id)
+
+        # Then
+        # Test updates stock if already exists
+        assert stock.quantity == 6
+        assert stock.rawProviderQuantity == 6
+
+        # Test creates stock if does not exist
+        assert len(offer.stocks) == 1
+        created_stock = offer.stocks[0]
+        assert created_stock.quantity == 4
+        assert created_stock.rawProviderQuantity == 4
+
+        # Test creates offer if does not exist
+        created_offer = Offer.query.filter_by(idAtProviders=f"{spec[2]['ref']}@{siret}").one()
+        assert created_offer.stocks[0].quantity == 18
+
+        # Test doesn't create offer if product does not exist or not gcu compatible
+        assert Offer.query.filter_by(idAtProviders=f"{spec[3]['ref']}@{siret}").count() == 0
+        assert Offer.query.filter_by(idAtProviders=f"{spec[6]['ref']}@{siret}").count() == 0
+
+        # Test second page is actually processed
+        second_created_offer = Offer.query.filter_by(idAtProviders=f"{spec[4]['ref']}@{siret}").one()
+        assert second_created_offer.stocks[0].quantity == 17
+
+        # Test existing bookings are added to quantity
+        assert stock_with_booking.quantity == 17 + 1 + 2
+        assert stock_with_booking.rawProviderQuantity == 17
+
+        # Test fill stock attributes
+        assert created_stock.price == Decimal("12.00")
+        assert created_stock.idAtProviders == f"{spec[1]['ref']}@{siret}"
+
+        # Test fill offers attributes
+        assert created_offer.bookingEmail == venue.bookingEmail
+        assert created_offer.description == product.description
+        assert created_offer.extraData == product.extraData
+        assert created_offer.name == product.name
+        assert created_offer.productId == product.id
+        assert created_offer.venueId == venue.id
+        assert created_offer.type == product.type
+        assert created_offer.idAtProviders == f"{spec[2]['ref']}@{siret}"
+        assert created_offer.lastProviderId == provider.id
+
+        # Test it adds offer in redis
+        assert mocked_add_offer_id.call_count == 5
+        mocked_add_offer_id.assert_has_calls(
+            [
+                mock.call(client=app.redis_client, offer_id=offer.id),
+                mock.call(client=app.redis_client, offer_id=stock_with_booking.offer.id),
+                mock.call(client=app.redis_client, offer_id=created_offer.id),
+                mock.call(client=app.redis_client, offer_id=second_created_offer.id),
+                mock.call(client=app.redis_client, offer_id=stock.offer.id),
+            ],
+            any_order=True,
+        )
+
+    def test_build_new_offers_from_stock_details(self, db_session):
+        # Given
+        spec = [
+            {
+                "offers_provider_reference": "offer_ref1",
+            },
+            {
+                "available_quantity": 17,
+                "offers_provider_reference": "offer_ref_2",
+                "price": 28.989,
+                "products_provider_reference": "product_ref",
+                "stocks_provider_reference": "stock_ref",
+            },
+        ]
+
+        existing_offers_by_provider_reference = {"offer_ref1"}
+        provider = offerers_factories.APIProviderFactory(apiUrl="https://provider_url", authToken="fake_token")
+        venue = VenueFactory(bookingEmail="booking_email")
+        product = Product(
+            id=456, name="product_name", description="product_desc", extraData="extra", type="product_type"
+        )
+        products_by_provider_reference = {"product_ref": product}
+
+        # When
+        new_offers = api._build_new_offers_from_stock_details(
+            spec,
+            existing_offers_by_provider_reference,
+            products_by_provider_reference,
+            venue,
+            provider_id=provider.id,
+        )
+
+        # Then
+        assert new_offers == [
+            Offer(
+                bookingEmail="booking_email",
+                description="product_desc",
+                extraData="extra",
+                idAtProviders="offer_ref_2",
+                lastProviderId=provider.id,
+                name="product_name",
+                productId=456,
+                venueId=venue.id,
+                type="product_type",
+            )
+        ]
+
+    def test_get_stocks_to_upsert(self):
+        # Given
+        spec = [
+            {
+                "offers_provider_reference": "offer_ref1",
+                "available_quantity": 15,
+                "price": 15.78,
+                "products_provider_reference": "product_ref1",
+                "stocks_provider_reference": "stock_ref1",
+            },
+            {
+                "available_quantity": 17,
+                "offers_provider_reference": "offer_ref2",
+                "price": 28.989,
+                "products_provider_reference": "product_ref2",
+                "stocks_provider_reference": "stock_ref2",
+            },
+        ]
+
+        stocks_by_provider_reference = {"stock_ref1": {"id": 1, "booking_quantity": 3}}
+        offers_by_provider_reference = {"offer_ref1": 123, "offer_ref2": 134}
+        products_by_provider_reference = {
+            "product_ref1": Product(extraData={"prix_livre": 7.01}),
+            "product_ref2": Product(extraData={"prix_livre": 9.02}),
+        }
+
+        # When
+        update_stock_mapping, new_stocks, offer_ids = api._get_stocks_to_upsert(
+            spec,
+            stocks_by_provider_reference,
+            offers_by_provider_reference,
+            products_by_provider_reference,
+        )
+
+        assert update_stock_mapping == [
+            {
+                "id": 1,
+                "quantity": 15 + 3,
+                "price": 7.01,
+                "rawProviderQuantity": 15,
+            }
+        ]
+
+        new_stock = new_stocks[0]
+        assert new_stock.quantity == 17
+        assert new_stock.bookingLimitDatetime is None
+        assert new_stock.offerId == 134
+        assert new_stock.price == 9.02
+        assert new_stock.idAtProviders == "stock_ref2"
+
+        assert offer_ids == set([123, 134])

--- a/tests/routes/pro/patch_user_has_seen_tuto_test.py
+++ b/tests/routes/pro/patch_user_has_seen_tuto_test.py
@@ -48,7 +48,7 @@ class Returns403:
 
         # then
         updated_user = User.query.one()
-        assert response.status_code == 403
+        assert response.status_code == 401
         assert updated_user.hasSeenProTutorials == False
 
     def when_user_has_no_rights(self, app):

--- a/tests/routes/pro/post_venue_stocks_test.py
+++ b/tests/routes/pro/post_venue_stocks_test.py
@@ -1,0 +1,71 @@
+from unittest.mock import patch
+
+import pcapi.core.offers.factories as offers_factories
+
+from tests.conftest import TestClient
+from tests.conftest import clean_database
+
+
+class Post:
+    @clean_database
+    @patch("pcapi.core.providers.api.synchronize_stocks")
+    def test_accepts_request(self, mock_synchronize_stocks, app):
+        offerer = offers_factories.OffererFactory(siren=123456789)
+        venue = offers_factories.VenueFactory(managingOfferer=offerer, id=3)
+        api_key = offers_factories.ApiKeyFactory(offerer=offerer)
+
+        mock_synchronize_stocks.return_value = {}
+
+        test_client = TestClient(app.test_client())
+        test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
+
+        response = test_client.post("/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
+
+        assert response.status_code == 204
+        mock_synchronize_stocks.assert_called_once_with(
+            [
+                {
+                    "products_provider_reference": "123456789",
+                    "offers_provider_reference": "123456789@3",
+                    "stocks_provider_reference": "123456789@3",
+                    "available_quantity": 4,
+                }
+            ],
+            venue,
+        )
+
+    @clean_database
+    @patch("pcapi.core.providers.api.synchronize_stocks")
+    def test_requires_an_api_key(self, mock_synchronize_stocks, app):
+        offerer = offers_factories.OffererFactory(siren=123456789)
+        offers_factories.VenueFactory(managingOfferer=offerer, id=3)
+
+        mock_synchronize_stocks.return_value = {}
+
+        test_client = TestClient(app.test_client())
+
+        response = test_client.post("/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
+
+        assert response.status_code == 401
+        mock_synchronize_stocks.assert_not_called()
+
+    @clean_database
+    @patch("pcapi.core.providers.api.synchronize_stocks")
+    def test_returns_404_if_api_key_cant_access_venue(self, mock_synchronize_stocks, app):
+        offerer = offers_factories.OffererFactory(siren=123456789)
+        offers_factories.VenueFactory(managingOfferer=offerer, id=3)
+
+        offerer2 = offers_factories.OffererFactory(siren=123456780)
+        api_key = offers_factories.ApiKeyFactory(offerer=offerer2)
+
+        mock_synchronize_stocks.return_value = {}
+
+        test_client = TestClient(app.test_client())
+        test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
+
+        response1 = test_client.post("/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
+        response2 = test_client.post("/venue/123/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
+
+        assert response1.status_code == 404
+        assert response2.status_code == 404
+        mock_synchronize_stocks.assert_not_called()

--- a/tests/routes/pro/post_venue_stocks_test.py
+++ b/tests/routes/pro/post_venue_stocks_test.py
@@ -19,7 +19,7 @@ class Post:
         test_client = TestClient(app.test_client())
         test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
 
-        response = test_client.post("/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
+        response = test_client.post("/pro/v1/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
 
         assert response.status_code == 204
         mock_synchronize_stocks.assert_called_once_with(
@@ -44,7 +44,7 @@ class Post:
 
         test_client = TestClient(app.test_client())
 
-        response = test_client.post("/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
+        response = test_client.post("/pro/v1/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
 
         assert response.status_code == 401
         mock_synchronize_stocks.assert_not_called()
@@ -63,8 +63,10 @@ class Post:
         test_client = TestClient(app.test_client())
         test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
 
-        response1 = test_client.post("/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
-        response2 = test_client.post("/venue/123/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
+        response1 = test_client.post("/pro/v1/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
+        response2 = test_client.post(
+            "/pro/v1/venue/123/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]}
+        )
 
         assert response1.status_code == 404
         assert response2.status_code == 404


### PR DESCRIPTION
Ouverture d'un endpoint pour les synchronisations plus spécifiques, notamment les petits acteurs culturels qui souhaitent s'intégrer eux mêmes sans que le pass valide, créé et gère une synchronisation complète avec eux

Point d'attention / parti pris : 
- fonctionnement calque sur l'api fournisseur pour uniformiser documentation et code
- sauf pour l'utilisation de venue_id au lieu du siret : les premiers partinaires sont ok. Doit-on prévoir un moyen de gérer le siret aussi ?
- utilisation du worker en cas de forte demande, doit-on prendre d'autres précautions ? Comme du rate limit
- y a t-il des erreurs qui peuvent survenir dans le worker et qui ne sont donc pas remontées en direct au fournisseur ?
- utilisation des champs idAtProviders ?
	- ceux-ci duppliquent de l'info déjà présente et compliquent le code
	- mais ils fonctionnent déjà pour les providers et cette même fonctionnalité est utile pour la synchro
	- à remettre en cause en même temps que ça sera revu pour les providers ?
	- utilisation du venue_id plutôt que le siret avec "id:" pour bien séparer
	- pas de remplissage de providerId : l'unique effet de ce champ est de bloquer l'édition des offres sur pro

A vérifier
- [x] l'endoint en mode REST /venue/venue_id/stocks ?
- [x] ou mettre la fonction "synchronize_stocks" => dans le fichier offers/api.py mais elle est très grosse et il est déjà bien rempli
- [x] meilleur nom à trouver, pleins de fonctions s'appellent synchronize_stocks