### PR TITLE
(PC-8124) bump Python version to 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
         default: false
     working_directory: ~/pass-culture-api-ci
     docker:
-      - image: circleci/python:3.8.8
+      - image: circleci/python:3.9.4
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD
@@ -249,7 +249,7 @@ jobs:
   quality:
     working_directory: ~/pass-culture-api-ci
     docker:
-      - image: circleci/python:3.8.8
+      - image: circleci/python:3.9.4
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.8-slim
+FROM python:3.9.4-slim
 
 ENV PYTHONUNBUFFERED 1
 WORKDIR /usr/local/bin

--- a/Dockerfile.gcp
+++ b/Dockerfile.gcp
@@ -1,6 +1,6 @@
 ##################### Local environment layer #####################
 
-FROM python:3.8.8-slim AS api-flask
+FROM python:3.9.4-slim AS api-flask
 
 ENV PYTHONUNBUFFERED 1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ pydantic[email]==1.7.3
 PyJWT==1.7.1
 pylint
 pylint-strict-informational
-PyMemoize==1.0.3
 pytest-cov==2.10.1
 pytest-flask==1.0.0
 pytest-flask-sqlalchemy==1.0.2

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.8
+python-3.9.4

--- a/src/pcapi/core/object_storage/backends/local.py
+++ b/src/pcapi/core/object_storage/backends/local.py
@@ -28,15 +28,15 @@ class LocalBackend(BaseBackend):
         try:
             os.makedirs(self.local_dir(bucket, object_id), exist_ok=True)
             file_local_path = self.local_path(bucket, object_id)
-            new_type_file = open(str(file_local_path) + ".type", "w")
-            new_type_file.write(content_type)
+            with open(str(file_local_path) + ".type", "w") as new_type_file:
+                new_type_file.write(content_type)
 
             if symlink_path and not os.path.isfile(file_local_path) and not os.path.islink(file_local_path):
                 os.symlink(symlink_path, file_local_path)
                 return
 
-            new_file = open(file_local_path, "wb")
-            new_file.write(blob)
+            with open(file_local_path, "wb") as new_file:
+                new_file.write(blob)
 
         except Exception as exc:
             logger.exception("An error has occured while trying to upload file on local file storage: %s", exc)

--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 install_logging()
 
 if settings.IS_DEV is False:
+    # pylint: disable=abstract-class-instantiated
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
         integrations=[FlaskIntegration(), RedisIntegration(), RqIntegration(), SqlalchemyIntegration()],

--- a/src/pcapi/routes/webapp/signup.py
+++ b/src/pcapi/routes/webapp/signup.py
@@ -6,6 +6,7 @@ from flask import request
 
 from pcapi import settings
 from pcapi.connectors.google_spreadsheet import get_authorized_emails_and_dept_codes
+from pcapi.connectors.google_spreadsheet import get_ttl_hash
 from pcapi.core.payments import api as payments_api
 from pcapi.core.users.models import NotificationSubscriptions
 from pcapi.core.users.models import User
@@ -39,7 +40,7 @@ def signup_webapp():
         new_user.departementCode = "00"
         objects_to_save.append(payments_api.create_deposit(new_user, "test"))
     else:
-        authorized_emails, departement_codes = get_authorized_emails_and_dept_codes()
+        authorized_emails, departement_codes = get_authorized_emails_and_dept_codes(ttl_hash=get_ttl_hash())
         departement_code = _get_departement_code_when_authorized_or_error(authorized_emails, departement_codes)
         new_user.departementCode = departement_code
 

--- a/src/pcapi/workers/worker.py
+++ b/src/pcapi/workers/worker.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
     log_database_connection_status()
 
     if settings.IS_DEV is False:
+        # pylint: disable=abstract-class-instantiated
         sentry_sdk.init(
             dsn=settings.SENTRY_DSN,
             integrations=[RedisIntegration(), RqIntegration(), SqlalchemyIntegration()],

--- a/tests/local_providers/allocine_stocks_test.py
+++ b/tests/local_providers/allocine_stocks_test.py
@@ -923,7 +923,8 @@ class UpdateObjectsTest:
             ]
         )
         file_path = Path(pcapi.sandboxes.__path__[0]) / "providers" / "titelive_mocks" / "provider_thumb.jpeg"
-        mock_get_object_thumb.return_value = open(file_path, "rb").read()
+        with open(file_path, "rb") as thumb_file:
+            mock_get_object_thumb.return_value = thumb_file.read()
 
         product = create_product_with_event_type(
             event_name="Test event",
@@ -1024,7 +1025,8 @@ class UpdateObjectsTest:
             ]
         )
         file_path = Path(pcapi.sandboxes.__path__[0]) / "providers" / "titelive_mocks" / "provider_thumb.jpeg"
-        mock_get_object_thumb.return_value = open(file_path, "rb").read()
+        with open(file_path, "rb") as thumb_file:
+            mock_get_object_thumb.return_value = thumb_file.read()
 
         product = create_product_with_event_type(
             event_name="Test event",

--- a/tests/local_providers/provider_test_utils.py
+++ b/tests/local_providers/provider_test_utils.py
@@ -66,7 +66,8 @@ class TestLocalProviderWithThumb(LocalProvider):
 
     def get_object_thumb(self) -> bytes:
         file_path = Path(pcapi.sandboxes.__path__[0]) / "providers" / "titelive_mocks" / "provider_thumb.jpeg"
-        return open(file_path, "rb").read()
+        with open(file_path, "rb") as f:
+            return f.read()
 
     def get_object_thumb_index(self) -> int:
         return 1
@@ -89,7 +90,8 @@ class TestLocalProviderWithThumbIndexAt4(LocalProvider):
 
     def get_object_thumb(self) -> bytes:
         file_path = Path(pcapi.sandboxes.__path__[0]) / "providers" / "titelive_mocks" / "provider_thumb.jpeg"
-        return open(file_path, "rb").read()
+        with open(file_path, "rb") as f:
+            return f.read()
 
     def get_object_thumb_index(self) -> int:
         return 4


### PR DESCRIPTION
##  Objectif

Mettre à jour la version de Python d'api vers Python 3.9


##  Implémentation

- supprimer une dépendance obsolète
- éditer les fichiers de configuration adéquats (CircleCI, Dockerfiles, runtime.txt)
- ignorer un faux positif pylint

##  Informations supplémentaires

En bonus, correction de warnings à l'exécution de l'api