### PR TITLE
(FIX) fix flacky test by adding order

### DIFF
--- a/tests/routes/native/v1/offers_test.py
+++ b/tests/routes/native/v1/offers_test.py
@@ -64,6 +64,8 @@ class OffersTest:
             response = TestClient(app.test_client()).get(f"/native/v1/offer/{offer_id}")
 
         assert response.status_code == 200
+        response_content = response.json
+        response_content["stocks"].sort(key=lambda stock: stock["id"])
         assert response.json == {
             "id": offer.id,
             "accessibility": {


### PR DESCRIPTION
Most of the time, the order would be good but since it is not
enforced it may fail. Ensure we get reliable results by ordering
the results.