### PR TITLE
PC 6879 Send notification to user for offer that occur tomorrow 

### DIFF
--- a/src/pcapi/notifications/push/transactional_notifications.py
+++ b/src/pcapi/notifications/push/transactional_notifications.py
@@ -4,10 +4,12 @@ from typing import List
 from typing import Optional
 
 from pcapi.core.bookings.models import Booking
+from pcapi.core.offers.models import Stock
 
 
 class GroupId(Enum):
     CANCEL_BOOKING = "Cancel_booking"
+    TOMORROW_STOCK = "Tomorrow_stock"
 
 
 @dataclass
@@ -38,5 +40,22 @@ def get_bookings_cancellation_notification_data(booking_ids: List[int]) -> Optio
         message=TransactionalNotificationMessage(
             title=f"{cancelled_object.capitalize()} annulée",
             body=f"""Ta {cancelled_object} "{bookings[0].stock.offer.name}" a été annulée par l'offreur.""",
+        ),
+    )
+
+
+def get_tomorrow_stock_notification_data(stock_id: int) -> Optional[TransactionalNotificationData]:
+    stock = Stock.query.filter_by(id=stock_id).join(Booking).join(Stock.offer).one()
+    bookings = [booking for booking in stock.bookings if not booking.isCancelled]
+
+    if not bookings:
+        return None
+
+    return TransactionalNotificationData(
+        group_id=GroupId.TOMORROW_STOCK.value,
+        user_ids=[booking.userId for booking in bookings],
+        message=TransactionalNotificationMessage(
+            title=f"{stock.offer.name}, c'est demain !",
+            body="Retrouve les détails de la réservation sur l’appli Pass Culture",
         ),
     )

--- a/src/pcapi/workers/push_notification_job.py
+++ b/src/pcapi/workers/push_notification_job.py
@@ -7,6 +7,7 @@ from pcapi.core.users.models import User
 from pcapi.notifications.push import send_transactional_notification
 from pcapi.notifications.push import update_user_attributes
 from pcapi.notifications.push.transactional_notifications import get_bookings_cancellation_notification_data
+from pcapi.notifications.push.transactional_notifications import get_tomorrow_stock_notification_data
 from pcapi.notifications.push.user_attributes_updates import get_user_attributes
 from pcapi.workers import worker
 from pcapi.workers.decorators import job_context
@@ -33,5 +34,14 @@ def update_user_attributes_job(user_id: int) -> None:
 @log_job
 def send_cancel_booking_notification(bookings_ids: List[int]) -> None:
     notification_data = get_bookings_cancellation_notification_data(bookings_ids)
+    if notification_data:
+        send_transactional_notification(notification_data)
+
+
+@job(worker.default_queue, connection=worker.conn)
+@job_context
+@log_job
+def send_tomorrow_stock_notification(stock_id: int) -> None:
+    notification_data = get_tomorrow_stock_notification_data(stock_id)
     if notification_data:
         send_transactional_notification(notification_data)

--- a/tests/scheduled_tasks/clock_test.py
+++ b/tests/scheduled_tasks/clock_test.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from datetime import timedelta
+
+import pytest
+
+from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.offers.factories import EventStockFactory
+from pcapi.notifications.push import testing
+from pcapi.scheduled_tasks.clock import pc_send_tomorrow_events_notifications
+
+
+@pytest.mark.usefixtures("db_session")
+def test_pc_send_tomorrow_events_notifications(app, clear_push_notification_requests):
+    """
+    Test that each stock that is linked to an offer that occurs tomorrow and
+    creates a job that will send a notification to all of the stock's users
+    with a valid (not cancelled) booking.
+    """
+    tomorrow = datetime.now() + timedelta(days=1)
+    stock_tomorrow = EventStockFactory(beginningDatetime=tomorrow, offer__name="my_offer")
+
+    begin = datetime.now() + timedelta(days=7)
+    stock_next_week = EventStockFactory(beginningDatetime=begin)
+
+    bookings_tomorrow = BookingFactory.create_batch(2, stock=stock_tomorrow, isCancelled=False)
+    BookingFactory.create_batch(2, stock=stock_next_week, isCancelled=False)
+
+    pc_send_tomorrow_events_notifications(app)
+
+    assert len(testing.requests) == 1
+    assert all(data["message"]["title"] == "my_offer, c'est demain !" for data in testing.requests)
+
+    user_ids = set()
+    for data in testing.requests:
+        for user_id in data["user_ids"]:
+            user_ids.add(user_id)
+
+    expected_user_ids = {booking.userId for booking in bookings_tomorrow}
+    assert user_ids == expected_user_ids


### PR DESCRIPTION
https://passculture.atlassian.net/secure/RapidBoard.jspa?rapidView=34&projectKey=PC&modal=detail&selectedIssue=PC-6879

**Besoins**

Envoyer des notifications aux utilisateurs qui ont une réservation pour une offre qui a lieu le lendemain.

**Implémentation**

1. tâche cron lancée chaque nuit (1AM) qui va récupérer la liste des identifiants des `Booking` concernés, et pour chacun créer une tâche asynchrone.
2. chaque tâche s'occupe d'un `Booking` : récupérer les informations liées (utilisateur et offre - via stock), formater les données et envoyer la notification.

**Discussion**

Une tâche asynchrone par Booking -> beaucoup de tâche, mais ça ne devrait pas être un soucis. L'avantage de cette approche est la simplicité. On pourrait chercher à grouper par offre et faire des tirs groupés si c'est un problème.

:warning: Nouvelles dépendance :warning: 

Ajout de `fakeredis` : nécessaire pour les tests -> permet de passer une fausse connexion au worker et tester la tâche cron. En testing, la `Queue` est asynchrone mais s'attend à avoir une connexion à Redis, avec fakeredis, on a toutes les pièces pour tester des fonctions qui lancent des tâches.

EDIT : option retenue -> ne pas ajouter fakeredis et partir du principe d'un redis tourne lorsqu'on lance les test.
