### PR TITLE
Set default logger in dev mode

### DIFF
--- a/src/pcapi/core/logging.py
+++ b/src/pcapi/core/logging.py
@@ -116,6 +116,13 @@ class JsonFormatter(logging.Formatter):
 
 
 def install_logging():
+    if settings.IS_DEV and not settings.IS_RUNNING_TESTS:
+        # JSON is hard to read, keep the default plain text logger.
+        logging.basicConfig(level=settings.LOG_LEVEL)
+        _silence_noisy_loggers()
+
+        return
+
     global _internal_logger  # pylint: disable=global-statement
 
     # Avoid side effects of calling this function more than once.

--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -50,8 +50,9 @@ if settings.IS_DEV is False:
 
 app = Flask(__name__, static_url_path="/static")
 
-# Remove default logger/handler, since we use our own (see pcapi.core.logging)
-app.logger.removeHandler(default_handler)
+if not settings.IS_DEV or settings.IS_RUNNING_TESTS:
+    # Remove default logger/handler, since we use our own (see pcapi.core.logging)
+    app.logger.removeHandler(default_handler)
 
 api = SpecTree("flask", MODE="strict", before=before_handler)
 api.register(app)


### PR DESCRIPTION
En dev, il y a 2 problèmes avec notre logger custom :

1. Les logs au format json sont difficiles à lire
2. La config `app.config["SQLALCHEMY_ECHO"] = True` ne fonctionne pas (boucle infinie)

Avant :
![image](https://user-images.githubusercontent.com/22373097/115013279-1c87e480-9eb1-11eb-9d94-841662df587f.png)

Après:
![image](https://user-images.githubusercontent.com/22373097/115013322-2a3d6a00-9eb1-11eb-9064-9d0472a9a953.png)
