### PR TITLE
(PC-8169) : extend birthday email to users registered the day before

### DIFF
--- a/src/pcapi/core/users/repository.py
+++ b/src/pcapi/core/users/repository.py
@@ -74,7 +74,7 @@ def get_newly_eligible_users(since: date) -> List[User]:
             User.dateOfBirth > today - relativedelta(years=(constants.ELIGIBILITY_AGE + 1)),  # less than 19yo
             User.dateOfBirth <= today - relativedelta(years=constants.ELIGIBILITY_AGE),  # more than or 18yo
             User.dateOfBirth > since - relativedelta(years=constants.ELIGIBILITY_AGE),  # less than 18yo at since
-            User.dateCreated < since,
+            User.dateCreated < today,
         )
         .all()
     )

--- a/tests/core/users/test_repository.py
+++ b/tests/core/users/test_repository.py
@@ -72,7 +72,7 @@ class GetNewlyEligibleUsersTest:
         user_just_18_in_eligible_area = factories.UserFactory(
             isBeneficiary=False,
             dateOfBirth=datetime(2000, 1, 1),
-            dateCreated=datetime(2017, 12, 1),
+            dateCreated=datetime(2017, 12, 31),
             departementCode="93",
         )
         # Same as above in a non eligible area
@@ -128,7 +128,7 @@ class GetNewlyEligibleUsersTest:
         user_just_18_in_eligible_area = factories.UserFactory(
             isBeneficiary=False,
             dateOfBirth=datetime(2000, 1, 1),
-            dateCreated=datetime(2017, 12, 1),
+            dateCreated=datetime(2017, 12, 31),
             departementCode="93",
         )
         user_just_18_in_ineligible_area = factories.UserFactory(


### PR DESCRIPTION
Extends the birthday email to users that registered the day right
before their birthday.