### PR TITLE
(PC-3455) pro: Do not automatically validate offerer and user offerer on integration environment

### DIFF
--- a/src/pcapi/routes/pro/validate.py
+++ b/src/pcapi/routes/pro/validate.py
@@ -2,7 +2,6 @@ import logging
 
 from flask import current_app as app
 
-from pcapi import settings
 from pcapi.connectors import redis
 from pcapi.core.offerers.models import Offerer
 from pcapi.domain.admin_emails import maybe_send_offerer_validation_email
@@ -88,11 +87,7 @@ def validate_user(token):
 
     if user_offerer:
         offerer = user_offerer.offerer
-
-        if settings.IS_INTEGRATION:
-            _validate_offerer(offerer, user_offerer)
-        else:
-            _ask_for_validation(offerer, user_offerer)
+        _ask_for_validation(offerer, user_offerer)
 
     return "", 204
 

--- a/tests/routes/pro/validate_user_test.py
+++ b/tests/routes/pro/validate_user_test.py
@@ -2,69 +2,30 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.core.users.models import User
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_user
-from pcapi.model_creators.generic_creators import create_user_offerer
-from pcapi.repository import repository
+import pcapi.core.offers.factories as offers_factories
 
 from tests.conftest import TestClient
 
 
-class Patch:
-    class Returns204:
-        @pytest.mark.usefixtures("db_session")
-        def expect_validation_token_to_be_set_to_none_and_email_validated(self, app):
-            # Given
-            user = create_user()
-            user.generate_validation_token()
-            repository.save(user)
-            user_id = user.id
+@pytest.mark.usefixtures("db_session")
+@patch("pcapi.routes.pro.validate.maybe_send_offerer_validation_email")
+def test_validate_user_token(mocked_maybe_send_offerer_validation_email, app):
+    user_offerer = offers_factories.UserOffererFactory(user__validationToken="token")
 
-            # When
-            response = TestClient(app.test_client()).patch(
-                f"/validate/user/{user.validationToken}", headers={"origin": "http://localhost:3000"}
-            )
+    client = TestClient(app.test_client())
+    response = client.patch("/validate/user/token")
 
-            # Then
-            validated_user = User.query.get(user_id)
-            assert response.status_code == 204
-            assert validated_user.isValidated
-            assert validated_user.isEmailValidated
+    assert response.status_code == 204
+    assert user_offerer.user.isValidated
+    assert user_offerer.user.isEmailValidated
 
-        @pytest.mark.usefixtures("db_session")
-        @patch("pcapi.routes.pro.validate.maybe_send_offerer_validation_email", return_value=True)
-        def test_maybe_send_offerer_validation_email(self, mock_maybe_send_offerer_validation_email, app):
-            # Given
-            pro = create_user()
-            offerer = create_offerer(siren="775671464")
-            user_offerer = create_user_offerer(pro, offerer)
-
-            pro.generate_validation_token()
-
-            repository.save(user_offerer)
-
-            # When
-            response = TestClient(app.test_client()).patch(
-                f"/validate/user/{pro.validationToken}", headers={"origin": "http://localhost:3000"}
-            )
-
-            # Then
-            assert response.status_code == 204
-            mock_maybe_send_offerer_validation_email.assert_called_once_with(offerer, user_offerer)
+    mocked_maybe_send_offerer_validation_email.assert_called_once_with(user_offerer.offerer, user_offerer)
 
 
-class Returns404:
-    @pytest.mark.usefixtures("db_session")
-    def when_validation_token_is_not_found(self, app):
-        # Given
-        random_token = "0987TYGHHJMJ"
+@pytest.mark.usefixtures("db_session")
+def test_fail_if_unknown_token(app):
+    client = TestClient(app.test_client())
+    response = client.patch("/validate/user/unknown-token")
 
-        # When
-        response = TestClient(app.test_client()).patch(
-            f"/validate/user/{random_token}", headers={"origin": "http://localhost:3000"}
-        )
-
-        # Then
-        assert response.status_code == 404
-        assert response.json["global"] == ["Ce lien est invalide"]
+    assert response.status_code == 404
+    assert response.json["global"] == ["Ce lien est invalide"]


### PR DESCRIPTION
Otherwise pro user nevers receive an e-mail that says that their
offerer has been created and validated.