### PR TITLE
(PC-8124) post Python bump cleanup

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=lxml,posix_ipc,spidev,netifaces,pydantic
+extension-pkg-whitelist=lxml,posix_ipc,spidev,netifaces,pydantic,math,binascii
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ isbnlib==3.10.3
 isort==5.6.4
 lxml==4.6.3
 mailjet-rest==1.3.3
-mypy==0.782
+mypy==0.812
 nltk==3.5
 # pandas 1.1.5 has isssues with pylint, see https://github.com/PyCQA/pylint/issues/3969
 pandas!=1.1.5

--- a/src/pcapi/admin/custom_views/allocine_pivot_view.py
+++ b/src/pcapi/admin/custom_views/allocine_pivot_view.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pcapi.admin.base_configuration import BaseAdminView
 
 
@@ -8,11 +6,11 @@ class AllocinePivotView(BaseAdminView):
     can_edit = True
     column_list = ["siret", "theaterId", "internalId"]
     column_searchable_list = ["siret", "theaterId", "internalId"]
-    column_sortable_list: List[str] = []
+    column_sortable_list: list[str] = []
     column_labels = {
         "theaterId": "Identifiant Allociné",
         "siret": "SIRET",
         "internalId": "Identifiant interne allociné",
     }
-    column_filters: List[str] = []
-    form_columns: List[str] = []
+    column_filters: list[str] = []
+    form_columns: list[str] = []

--- a/src/pcapi/admin/custom_views/criteria_view.py
+++ b/src/pcapi/admin/custom_views/criteria_view.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from wtforms.fields.core import StringField
 from wtforms.form import Form
 from wtforms.validators import DataRequired
@@ -19,7 +17,7 @@ class CriteriaView(BaseAdminView):
         endDateTime="Date de fin",
     )
     column_searchable_list = ["name", "description", "startDateTime", "endDateTime"]
-    column_filters: List[str] = []
+    column_filters: list[str] = []
     form_columns = ["description", "startDateTime", "endDateTime"]
     form_create_rules = ("name", "description", "startDateTime", "endDateTime")
 

--- a/src/pcapi/admin/custom_views/many_offers_operations_view.py
+++ b/src/pcapi/admin/custom_views/many_offers_operations_view.py
@@ -1,6 +1,4 @@
 import itertools
-from typing import Dict
-from typing import List
 
 from flask import redirect
 from flask import request
@@ -31,7 +29,7 @@ class SearchForm(SecureForm):
     )
 
 
-def _select_criteria() -> List[Criterion]:
+def _select_criteria() -> list[Criterion]:
     return Criterion.query.all()
 
 
@@ -53,8 +51,8 @@ class OfferCriteriaForm(SecureForm):
     )
 
 
-def _get_current_criteria_on_active_offers(offers: List[Offer]) -> Dict[str, Dict]:
-    current_criteria_on_offers: Dict[str, Dict] = {}
+def _get_current_criteria_on_active_offers(offers: list[Offer]) -> dict[str, dict]:
+    current_criteria_on_offers: dict[str, dict] = {}
     for offer in offers:
         if not offer.isActive:
             continue

--- a/src/pcapi/admin/custom_views/user_offerer_view.py
+++ b/src/pcapi/admin/custom_views/user_offerer_view.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pcapi.admin.base_configuration import BaseAdminView
 
 
@@ -25,7 +23,7 @@ class UserOffererView(BaseAdminView):
         "offerer.name": "Nom de la structure",
         "offerer.id": "Identifiant de la structure",
     }
-    column_sortable_list: List[str] = []
+    column_sortable_list: list[str] = []
     column_searchable_list = [
         "user.email",
         "user.firstName",

--- a/src/pcapi/algolia/infrastructure/api.py
+++ b/src/pcapi/algolia/infrastructure/api.py
@@ -1,6 +1,3 @@
-from typing import Dict
-from typing import List
-
 from algoliasearch.search_client import SearchClient
 from algoliasearch.search_index import SearchIndex
 
@@ -12,11 +9,11 @@ def init_connection() -> SearchIndex:
     return client.init_index(settings.ALGOLIA_INDEX_NAME)
 
 
-def add_objects(objects: List[Dict]) -> None:
+def add_objects(objects: list[dict]) -> None:
     init_connection().save_objects(objects)
 
 
-def delete_objects(object_ids: List[int]) -> None:
+def delete_objects(object_ids: list[int]) -> None:
     init_connection().delete_objects(object_ids)
 
 

--- a/src/pcapi/algolia/infrastructure/builder.py
+++ b/src/pcapi/algolia/infrastructure/builder.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Dict
 
 from pcapi.models import Offer
 from pcapi.utils.date import get_time_in_seconds_from_datetime
@@ -10,7 +9,7 @@ DEFAULT_LONGITUDE_FOR_NUMERIC_OFFER = 2.409289
 DEFAULT_LATITUDE_FOR_NUMERIC_OFFER = 47.158459
 
 
-def build_object(offer: Offer) -> Dict:
+def build_object(offer: Offer) -> dict:
     venue = offer.venue
     offerer = venue.managingOfferer
     humanize_offer_id = humanize(offer.id)

--- a/src/pcapi/algolia/infrastructure/worker.py
+++ b/src/pcapi/algolia/infrastructure/worker.py
@@ -1,6 +1,5 @@
 import logging
 from time import sleep
-from typing import Dict
 
 from redis import Redis
 
@@ -36,7 +35,7 @@ def process_multi_indexing(client: Redis) -> None:
             sleep(ALGOLIA_WAIT_TIME_FOR_AVAILABLE_WORKER)
 
 
-def _run_indexing(client: Redis, venue_provider: Dict) -> None:
+def _run_indexing(client: Redis, venue_provider: dict) -> None:
     venue_provider_id = venue_provider["id"]
     provider_id = venue_provider["providerId"]
     venue_id = venue_provider["venueId"]

--- a/src/pcapi/algolia/usecase/orchestrator.py
+++ b/src/pcapi/algolia/usecase/orchestrator.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 import logging
-from typing import List
 
 from algoliasearch.exceptions import AlgoliaException
 from redis import Redis
@@ -22,7 +21,7 @@ from pcapi.repository import offer_queries
 logger = logging.getLogger(__name__)
 
 
-def process_eligible_offers(client: Redis, offer_ids: List[int], from_provider_update: bool = False) -> None:
+def process_eligible_offers(client: Redis, offer_ids: list[int], from_provider_update: bool = False) -> None:
     offers_to_add = []
     offers_to_delete = []
     pipeline = client.pipeline()
@@ -58,7 +57,7 @@ def process_eligible_offers(client: Redis, offer_ids: List[int], from_provider_u
         logger.info("[ALGOLIA] no objects were added nor deleted!")
 
 
-def delete_expired_offers(client: Redis, offer_ids: List[int]) -> None:
+def delete_expired_offers(client: Redis, offer_ids: list[int]) -> None:
     offer_ids_to_delete = []
     for offer_id in offer_ids:
         offer_exists = check_offer_exists(client=client, offer_id=offer_id)
@@ -81,7 +80,7 @@ def _build_offer_details_to_be_indexed(offer: Offer) -> dict:
     return {"name": offer.name, "dates": event_dates, "prices": prices}
 
 
-def _process_adding(pipeline: Pipeline, client: Redis, offer_ids: List[int], adding_objects: List[dict]) -> None:
+def _process_adding(pipeline: Pipeline, client: Redis, offer_ids: list[int], adding_objects: list[dict]) -> None:
     try:
         add_objects(objects=adding_objects)
         logger.info("[ALGOLIA] %i objects were indexed!", len(adding_objects))
@@ -93,7 +92,7 @@ def _process_adding(pipeline: Pipeline, client: Redis, offer_ids: List[int], add
         pipeline.reset()
 
 
-def _process_deleting(client: Redis, offer_ids_to_delete: List[int]) -> None:
+def _process_deleting(client: Redis, offer_ids_to_delete: list[int]) -> None:
     try:
         delete_objects(object_ids=offer_ids_to_delete)
         delete_indexed_offers(client=client, offer_ids=offer_ids_to_delete)

--- a/src/pcapi/connectors/api_entreprises.py
+++ b/src/pcapi/connectors/api_entreprises.py
@@ -1,6 +1,3 @@
-from typing import Dict
-from typing import List
-
 from pcapi.connectors.utils.legal_category_code_to_labels import CODE_TO_CATEGORY_MAPPING
 from pcapi.core.offerers.models import Offerer
 from pcapi.utils import requests
@@ -10,7 +7,7 @@ class ApiEntrepriseException(Exception):
     pass
 
 
-def get_by_offerer(offerer: Offerer) -> Dict:
+def get_by_offerer(offerer: Offerer) -> dict:
     response = requests.get(
         f"https://entreprise.data.gouv.fr/api/sirene/v3/unites_legales/{offerer.siren}", verify=False
     )
@@ -25,14 +22,14 @@ def get_by_offerer(offerer: Offerer) -> Dict:
     return response_json
 
 
-def _extract_etablissements_communs_siren(etablissements: List[dict]) -> List[dict]:
+def _extract_etablissements_communs_siren(etablissements: list[dict]) -> list[dict]:
     etablissements_communs = [
         etablissement for etablissement in etablissements if etablissement["etablissement_siege"] == "false"
     ]
     return [etablissement["siret"] for etablissement in etablissements_communs]
 
 
-def get_offerer_legal_category(offerer: Offerer) -> Dict:
+def get_offerer_legal_category(offerer: Offerer) -> dict:
     legal_category = get_by_offerer(offerer)["unite_legale"]["categorie_juridique"]
     legal_category_label = CODE_TO_CATEGORY_MAPPING.get(int(legal_category)) if legal_category else None
 

--- a/src/pcapi/connectors/ftp_titelive.py
+++ b/src/pcapi/connectors/ftp_titelive.py
@@ -1,7 +1,6 @@
 import ftplib
 from io import BytesIO
 import logging
-from typing import List
 from typing import Pattern
 from zipfile import ZipFile
 
@@ -35,7 +34,7 @@ def get_zip_file_from_ftp(zip_file_name: str, folder_name: str) -> ZipFile:
     return ZipFile(data_file, "r")
 
 
-def get_files_to_process_from_titelive_ftp(titelive_folder_name: str, date_regexp: Pattern[str]) -> List[str]:
+def get_files_to_process_from_titelive_ftp(titelive_folder_name: str, date_regexp: Pattern[str]) -> list[str]:
     ftp_titelive = connect_to_titelive_ftp()
     files_list = ftp_titelive.nlst(titelive_folder_name)
 

--- a/src/pcapi/connectors/redis.py
+++ b/src/pcapi/connectors/redis.py
@@ -1,8 +1,6 @@
 from enum import Enum
 import json
 import logging
-from typing import Dict
-from typing import List
 
 import redis
 from redis import Redis
@@ -55,7 +53,7 @@ def _add_venue_provider(client: Redis, venue_provider) -> None:
         logger.exception("[REDIS] %s", error)
 
 
-def get_offer_ids(client: Redis) -> List[int]:
+def get_offer_ids(client: Redis) -> list[int]:
     try:
         offer_ids = client.lrange(RedisBucket.REDIS_LIST_OFFER_IDS_NAME.value, 0, settings.REDIS_OFFER_IDS_CHUNK_SIZE)
         return offer_ids
@@ -64,7 +62,7 @@ def get_offer_ids(client: Redis) -> List[int]:
         return []
 
 
-def get_venue_ids(client: Redis) -> List[int]:
+def get_venue_ids(client: Redis) -> list[int]:
     try:
         venue_ids = client.lrange(RedisBucket.REDIS_LIST_VENUE_IDS_NAME.value, 0, settings.REDIS_VENUE_IDS_CHUNK_SIZE)
         return venue_ids
@@ -73,7 +71,7 @@ def get_venue_ids(client: Redis) -> List[int]:
         return []
 
 
-def get_venue_providers(client: Redis) -> List[dict]:
+def get_venue_providers(client: Redis) -> list[dict]:
     try:
         venue_providers_as_string = client.lrange(
             RedisBucket.REDIS_LIST_VENUE_PROVIDERS_NAME.value, 0, settings.REDIS_VENUE_PROVIDERS_CHUNK_SIZE
@@ -113,7 +111,7 @@ def add_to_indexed_offers(pipeline: Pipeline, offer_id: int, offer_details: dict
         logger.exception("[REDIS] %s", error)
 
 
-def delete_indexed_offers(client: Redis, offer_ids: List[int]) -> None:
+def delete_indexed_offers(client: Redis, offer_ids: list[int]) -> None:
     try:
         client.hdel(RedisBucket.REDIS_HASHMAP_INDEXED_OFFERS_NAME.value, *offer_ids)
     except redis.exceptions.RedisError as error:
@@ -129,7 +127,7 @@ def check_offer_exists(client: Redis, offer_id: int) -> bool:
         return False
 
 
-def get_offer_details(client: Redis, offer_id: int) -> Dict:
+def get_offer_details(client: Redis, offer_id: int) -> dict:
     try:
         offer_details = client.hget(RedisBucket.REDIS_HASHMAP_INDEXED_OFFERS_NAME.value, offer_id)
 
@@ -171,14 +169,14 @@ def get_number_of_venue_providers_currently_in_sync(client: Redis) -> int:
         return 0
 
 
-def add_offer_ids_in_error(client: Redis, offer_ids: List[int]) -> None:
+def add_offer_ids_in_error(client: Redis, offer_ids: list[int]) -> None:
     try:
         client.rpush(RedisBucket.REDIS_LIST_OFFER_IDS_IN_ERROR_NAME.value, *offer_ids)
     except redis.exceptions.RedisError as error:
         logger.exception("[REDIS] %s", error)
 
 
-def get_offer_ids_in_error(client: Redis) -> List[int]:
+def get_offer_ids_in_error(client: Redis) -> list[int]:
     try:
         offer_ids = client.lrange(
             RedisBucket.REDIS_LIST_OFFER_IDS_IN_ERROR_NAME.value, 0, settings.REDIS_OFFER_IDS_CHUNK_SIZE

--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -137,7 +137,7 @@ def _cancel_booking(booking: Booking, reason: BookingCancellationReasons) -> Non
         redis.add_offer_id(client=app.redis_client, offer_id=booking.stock.offerId)
 
 
-def _cancel_bookings_from_stock(stock: Stock, reason: BookingCancellationReasons) -> typing.List[Booking]:
+def _cancel_bookings_from_stock(stock: Stock, reason: BookingCancellationReasons) -> list[Booking]:
     with transaction():
         deleted_bookings = []
         stock = offers_repository.get_and_lock_stock(stock_id=stock.id)
@@ -172,7 +172,7 @@ def cancel_booking_by_offerer(booking: Booking) -> None:
     send_cancel_booking_notification.delay([booking.id])
 
 
-def cancel_bookings_when_offerer_deletes_stock(stock: Stock) -> typing.List[Booking]:
+def cancel_bookings_when_offerer_deletes_stock(stock: Stock) -> list[Booking]:
     return _cancel_bookings_from_stock(stock, BookingCancellationReasons.OFFERER)
 
 
@@ -274,8 +274,8 @@ def compute_confirmation_date(
 
 
 def update_confirmation_dates(
-    bookings_to_update: typing.List[Booking], new_beginning_datetime: datetime.datetime
-) -> typing.List[Booking]:
+    bookings_to_update: list[Booking], new_beginning_datetime: datetime.datetime
+) -> list[Booking]:
     for booking in bookings_to_update:
         booking.confirmationDate = compute_confirmation_date(
             event_beginning=new_beginning_datetime, booking_creation_or_event_edition=datetime.datetime.utcnow()
@@ -284,7 +284,7 @@ def update_confirmation_dates(
     return bookings_to_update
 
 
-def recompute_dnBookedQuantity(stock_ids: typing.List[int]) -> None:
+def recompute_dnBookedQuantity(stock_ids: list[int]) -> None:
     query = """
       WITH bookings_per_stock AS (
         SELECT

--- a/src/pcapi/core/bookings/repository.py
+++ b/src/pcapi/core/bookings/repository.py
@@ -2,7 +2,6 @@ from datetime import date
 from datetime import datetime
 from datetime import time
 import math
-from typing import List
 
 from dateutil import tz
 from sqlalchemy import Date
@@ -81,15 +80,15 @@ def find_by_pro_user_id(user_id: int, page: int = 1, per_page_limit: int = 1000)
     )
 
 
-def find_ongoing_bookings_by_stock(stock_id: int) -> List[Booking]:
+def find_ongoing_bookings_by_stock(stock_id: int) -> list[Booking]:
     return Booking.query.filter_by(stockId=stock_id, isCancelled=False, isUsed=False).all()
 
 
-def find_not_cancelled_bookings_by_stock(stock: Stock) -> List[Booking]:
+def find_not_cancelled_bookings_by_stock(stock: Stock) -> list[Booking]:
     return Booking.query.filter_by(stockId=stock.id, isCancelled=False).all()
 
 
-def find_bookings_eligible_for_payment_for_venue(venue_id: int) -> List[Booking]:
+def find_bookings_eligible_for_payment_for_venue(venue_id: int) -> list[Booking]:
     return (
         _find_bookings_eligible_for_payment()
         .filter(Venue.id == venue_id)
@@ -104,7 +103,7 @@ def token_exists(token: str) -> bool:
     return db.session.query(Booking.query.filter_by(token=token.upper()).exists()).scalar()
 
 
-def find_not_used_and_not_cancelled() -> List[Booking]:
+def find_not_used_and_not_cancelled() -> list[Booking]:
     return Booking.query.filter(Booking.isUsed.is_(False)).filter(Booking.isCancelled.is_(False)).all()
 
 
@@ -216,7 +215,7 @@ def get_validated_bookings_quantity_for_venue(venue_id: int) -> int:
     )
 
 
-def find_offers_booked_by_beneficiaries(users: List[User]) -> List[Offer]:
+def find_offers_booked_by_beneficiaries(users: list[User]) -> list[Offer]:
     return (
         Offer.query.distinct(Offer.id)
         .join(Stock)
@@ -226,7 +225,7 @@ def find_offers_booked_by_beneficiaries(users: List[User]) -> List[Offer]:
     )
 
 
-def find_cancellable_bookings_by_beneficiaries(users: List[User]) -> List[Booking]:
+def find_cancellable_bookings_by_beneficiaries(users: list[User]) -> list[Booking]:
     return (
         Booking.query.filter(Booking.userId.in_(user.id for user in users))
         .filter(Booking.isCancelled.is_(False))
@@ -289,7 +288,7 @@ def _build_bookings_recap_query(user_id: int) -> Query:
 
 
 def _paginated_bookings_sql_entities_to_bookings_recap(
-    paginated_bookings: List[object], page: int, per_page_limit: int, total_bookings_recap: int
+    paginated_bookings: list[object], page: int, per_page_limit: int, total_bookings_recap: int
 ) -> BookingsRecapPaginated:
     return BookingsRecapPaginated(
         bookings_recap=[_serialize_booking_recap(booking) for booking in paginated_bookings],

--- a/src/pcapi/core/logging.py
+++ b/src/pcapi/core/logging.py
@@ -139,13 +139,7 @@ def install_logging():
         handler2 = logging.StreamHandler(stream=open("/proc/1/fd/1", "w"))
         handler2.setFormatter(JsonFormatter())
         handlers.append(handler2)
-    # FIXME (dbaty, 2021-03-17): `basicConfig()` accepts `force=True`
-    # as of Python 3.8. Use that instead of this `for` loop (which is
-    # what Python 3.7 does).
-    for _handler in logging.root.handlers[:]:
-        logging.root.removeHandler(_handler)
-        _handler.close()
-    logging.basicConfig(level=settings.LOG_LEVEL, handlers=handlers)
+    logging.basicConfig(level=settings.LOG_LEVEL, handlers=handlers, force=True)
 
     _internal_logger = logging.getLogger(__name__)
 

--- a/src/pcapi/core/offerers/repository.py
+++ b/src/pcapi/core/offerers/repository.py
@@ -1,11 +1,9 @@
-from typing import List
-
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.users.models import User
 from pcapi.models import UserOfferer
 
 
-def get_all_offerers_for_user(user: User, filters: dict) -> List[Offerer]:
+def get_all_offerers_for_user(user: User, filters: dict) -> list[Offerer]:
     query = Offerer.query.filter(Offerer.isActive.is_(True))
 
     if not user.isAdmin:

--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-from typing import List
 from typing import Optional
 from typing import Union
 
@@ -158,7 +157,7 @@ def update_offer(  # pylint: disable=redefined-builtin
     isActive: bool = UNCHANGED,
     isDuo: bool = UNCHANGED,
     durationMinutes: int = UNCHANGED,
-    mediaUrls: List[str] = UNCHANGED,
+    mediaUrls: list[str] = UNCHANGED,
     ageMin: int = UNCHANGED,
     ageMax: int = UNCHANGED,
     conditions: str = UNCHANGED,
@@ -317,8 +316,8 @@ def _notify_beneficiaries_upon_stock_edit(stock: Stock):
 
 
 def upsert_stocks(
-    offer_id: int, stock_data_list: List[Union[StockCreationBodyModel, StockEditionBodyModel]]
-) -> List[Stock]:
+    offer_id: int, stock_data_list: list[Union[StockCreationBodyModel, StockEditionBodyModel]]
+) -> list[Stock]:
     stocks = []
     edited_stocks = []
     edited_stocks_previous_beginnings = {}
@@ -375,7 +374,7 @@ def upsert_stocks(
     return stocks
 
 
-def _invalidate_bookings(bookings: List[Booking]) -> List[Booking]:
+def _invalidate_bookings(bookings: list[Booking]) -> list[Booking]:
     for booking in bookings:
         if booking.isUsed:
             mark_as_unused(booking)
@@ -510,7 +509,7 @@ def update_offer_and_stock_id_at_providers(venue: Venue, old_siret: str) -> None
         stock_index = stock_index + batch_size
 
 
-def get_expense_domains(offer: Offer) -> List[ExpenseDomain]:
+def get_expense_domains(offer: Offer) -> list[ExpenseDomain]:
     domains = {ExpenseDomain.ALL.value}
 
     for configuration in LIMIT_CONFIGURATIONS.values():
@@ -522,7 +521,7 @@ def get_expense_domains(offer: Offer) -> List[ExpenseDomain]:
     return list(domains)
 
 
-def add_criteria_to_offers(criteria: List[Criterion], isbn: str) -> bool:
+def add_criteria_to_offers(criteria: list[Criterion], isbn: str) -> bool:
     isbn = isbn.replace("-", "").replace(" ", "")
 
     products = Product.query.filter(Product.extraData["isbn"].astext == isbn).all()
@@ -537,7 +536,7 @@ def add_criteria_to_offers(criteria: List[Criterion], isbn: str) -> bool:
     if not offer_ids:
         return False
 
-    offer_criteria: List[OfferCriterion] = []
+    offer_criteria: list[OfferCriterion] = []
     for criterion in criteria:
         logger.info("Adding criterion %s to %d offers", criterion, len(offer_ids))
 

--- a/src/pcapi/core/offers/models.py
+++ b/src/pcapi/core/offers/models.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from datetime import timedelta
 import enum
 import logging
-from typing import List
 from typing import Optional
 
 from sqlalchemy import ARRAY
@@ -434,11 +433,11 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin, ProvidableMixin, 
         )
 
     @property
-    def activeStocks(self) -> List[Stock]:
+    def activeStocks(self) -> list[Stock]:
         return [stock for stock in self.stocks if not stock.isSoftDeleted]
 
     @property
-    def bookableStocks(self) -> List[Stock]:
+    def bookableStocks(self) -> list[Stock]:
         return [stock for stock in self.stocks if stock.isBookable]
 
     @property

--- a/src/pcapi/core/offers/repository.py
+++ b/src/pcapi/core/offers/repository.py
@@ -2,8 +2,6 @@ from datetime import datetime
 from datetime import time
 from datetime import timedelta
 import math
-from typing import Dict
-from typing import List
 from typing import Optional
 
 from sqlalchemy import and_
@@ -83,7 +81,7 @@ def get_paginated_offers_for_filters(
     )
 
 
-def get_offers_by_ids(user: User, offer_ids: List[int]) -> Query:
+def get_offers_by_ids(user: User, offer_ids: list[int]) -> Query:
     query = Offer.query
     if not user.isAdmin:
         query = query.join(Venue, Offerer, UserOfferer).filter(
@@ -173,11 +171,11 @@ def _filter_by_status(query: Query, status: str) -> Query:
     return query.filter(Offer.status == OfferStatus[status].name)
 
 
-def get_stocks_for_offers(offer_ids: List[int]) -> List[Stock]:
+def get_stocks_for_offers(offer_ids: list[int]) -> list[Stock]:
     return Stock.query.filter(Stock.offerId.in_(offer_ids)).all()
 
 
-def get_stocks_for_offer(offer_id: int) -> List[Stock]:
+def get_stocks_for_offer(offer_id: int) -> list[Stock]:
     return (
         Stock.query.options(joinedload(Stock.bookings))
         .filter(Stock.offerId == offer_id)
@@ -186,7 +184,7 @@ def get_stocks_for_offer(offer_id: int) -> List[Stock]:
     )
 
 
-def get_products_map_by_id_at_providers(id_at_providers: List[str]) -> Dict[str, Product]:
+def get_products_map_by_id_at_providers(id_at_providers: list[str]) -> dict[str, Product]:
     products = (
         Product.query.filter(Product.isGcuCompatible)
         .filter(Product.type == str(ThingType.LIVRE_EDITION))
@@ -196,7 +194,7 @@ def get_products_map_by_id_at_providers(id_at_providers: List[str]) -> Dict[str,
     return {product.idAtProviders: product for product in products}
 
 
-def get_offers_map_by_id_at_providers(id_at_providers: List[str]) -> Dict[str, int]:
+def get_offers_map_by_id_at_providers(id_at_providers: list[str]) -> dict[str, int]:
     offers_map = {}
     for offer_id, offer_id_at_providers in (
         db.session.query(Offer.id, Offer.idAtProviders).filter(Offer.idAtProviders.in_(id_at_providers)).all()
@@ -206,7 +204,7 @@ def get_offers_map_by_id_at_providers(id_at_providers: List[str]) -> Dict[str, i
     return offers_map
 
 
-def get_stocks_by_id_at_providers(id_at_providers: List[str]) -> Dict:
+def get_stocks_by_id_at_providers(id_at_providers: list[str]) -> dict:
     stocks = (
         Stock.query.filter(Stock.idAtProviders.in_(id_at_providers))
         .outerjoin(Booking, and_(Stock.id == Booking.stockId, Booking.isCancelled.is_(False)))
@@ -249,7 +247,7 @@ def get_and_lock_stock(stock_id: int) -> Stock:
     return stock
 
 
-def check_stock_consistency() -> List[int]:
+def check_stock_consistency() -> list[int]:
     return [
         item[0]
         for item in db.session.query(Stock.id)
@@ -262,7 +260,7 @@ def check_stock_consistency() -> List[int]:
     ]
 
 
-def find_tomorrow_event_stock_ids() -> List[int]:
+def find_tomorrow_event_stock_ids() -> list[int]:
     """Find stocks linked to offers that happen tomorrow (and that are not cancelled)"""
     tomorrow = datetime.now() + timedelta(days=1)
     tomorrow_min = datetime.combine(tomorrow, time.min)

--- a/src/pcapi/core/users/models.py
+++ b/src/pcapi/core/users/models.py
@@ -6,7 +6,6 @@ from datetime import time
 from decimal import Decimal
 import enum
 from hashlib import md5
-from typing import List
 from typing import Optional
 
 import bcrypt
@@ -230,7 +229,7 @@ class User(PcObject, Model, NeedsValidationMixin, VersionedMixin):
         self.clearTextPassword = newpass
         self.password = hash_password(newpass)
 
-    def get_not_cancelled_bookings(self) -> List[Booking]:
+    def get_not_cancelled_bookings(self) -> list[Booking]:
         return (
             db.session.query(Booking)
             .with_parent(self)

--- a/src/pcapi/core/users/repository.py
+++ b/src/pcapi/core/users/repository.py
@@ -1,6 +1,5 @@
 from datetime import date
 from datetime import datetime
-from typing import List
 from typing import Optional
 
 from dateutil.relativedelta import relativedelta
@@ -39,7 +38,7 @@ def get_user_with_credentials(identifier: str, password: str) -> User:
 
 
 def get_user_with_valid_token(
-    token_value: str, token_types: List[models.TokenType], delete_token: bool = False
+    token_value: str, token_types: list[models.TokenType], delete_token: bool = False
 ) -> Optional[User]:
     token = models.Token.query.filter(models.Token.value == token_value, models.Token.type.in_(token_types)).first()
     if not token:
@@ -60,7 +59,7 @@ def get_id_check_token(token_value: str) -> models.Token:
     ).first()
 
 
-def get_newly_eligible_users(since: date) -> List[User]:
+def get_newly_eligible_users(since: date) -> list[User]:
     """get users that are eligible between `since` (excluded) and now (included) and that have
     created their account before `since`"""
     today = datetime.combine(datetime.today(), datetime.min.time())
@@ -86,11 +85,11 @@ def find_favorite_for_offer_and_user(offer_id: int, user_id: int) -> Query:
     return models.Favorite.query.filter(models.Favorite.offerId == offer_id, models.Favorite.userId == user_id)
 
 
-def get_favorites_for_offers(offer_ids: List[int]) -> List[models.Favorite]:
+def get_favorites_for_offers(offer_ids: list[int]) -> list[models.Favorite]:
     return models.Favorite.query.filter(models.Favorite.offerId.in_(offer_ids)).all()
 
 
-def find_favorites_domain_by_beneficiary(beneficiary_identifier: int) -> List[FavoriteDomain]:
+def find_favorites_domain_by_beneficiary(beneficiary_identifier: int) -> list[FavoriteDomain]:
     favorite_sql_entities = (
         models.Favorite.query.filter(models.Favorite.userId == beneficiary_identifier)
         .options(joinedload(models.Favorite.offer).joinedload(Offer.venue).joinedload(Venue.managingOfferer))

--- a/src/pcapi/domain/admin_emails.py
+++ b/src/pcapi/domain/admin_emails.py
@@ -1,6 +1,3 @@
-from typing import Dict
-from typing import List
-
 from pcapi import settings
 from pcapi.core import mails
 from pcapi.core.offerers.models import Offerer
@@ -23,17 +20,17 @@ def maybe_send_offerer_validation_email(offerer: Offerer, user_offerer: UserOffe
     return mails.send(recipients=recipients, data=email)
 
 
-def send_payment_message_email(xml_attachment: str, checksum: bytes, recipients: List[str]) -> bool:
+def send_payment_message_email(xml_attachment: str, checksum: bytes, recipients: list[str]) -> bool:
     email = make_payment_message_email(xml_attachment, checksum)
     return mails.send(recipients=recipients, data=email)
 
 
-def send_payment_details_email(csv_attachment: str, recipients: List[str]) -> bool:
+def send_payment_details_email(csv_attachment: str, recipients: list[str]) -> bool:
     email = make_payment_details_email(csv_attachment)
     return mails.send(recipients=recipients, data=email)
 
 
-def send_wallet_balances_email(csv_attachment: str, recipients: List[str]) -> bool:
+def send_wallet_balances_email(csv_attachment: str, recipients: list[str]) -> bool:
     email = make_wallet_balances_email(csv_attachment)
     return mails.send(recipients=recipients, data=email)
 
@@ -41,8 +38,8 @@ def send_wallet_balances_email(csv_attachment: str, recipients: List[str]) -> bo
 def send_payments_report_emails(
     not_processable_payments_csv: str,
     error_payments_csv: str,
-    grouped_payments: Dict,
-    recipients: List[str],
+    grouped_payments: dict,
+    recipients: list[str],
 ) -> bool:
     email = make_payments_report_email(not_processable_payments_csv, error_payments_csv, grouped_payments)
     return mails.send(recipients=recipients, data=email)

--- a/src/pcapi/domain/bank_information.py
+++ b/src/pcapi/domain/bank_information.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pcapi.core.offerers.models import Offerer
 from pcapi.domain.bank_informations.bank_informations import BankInformations
 from pcapi.domain.venue.venue_with_basic_information.venue_with_basic_information import VenueWithBasicInformation
@@ -23,7 +21,7 @@ def check_venue_presence(venue: VenueWithBasicInformation):
         raise CannotRegisterBankInformation("Venue not found")
 
 
-def check_venue_queried_by_name(venues: List[VenueWithBasicInformation]):
+def check_venue_queried_by_name(venues: list[VenueWithBasicInformation]):
     if len(venues) == 0:
         raise CannotRegisterBankInformation("Venue name not found")
     if len(venues) > 1:

--- a/src/pcapi/domain/beneficiary_bookings/beneficiary_booking.py
+++ b/src/pcapi/domain/beneficiary_bookings/beneficiary_booking.py
@@ -1,6 +1,4 @@
 from datetime import datetime
-from typing import Dict
-from typing import List
 from typing import Optional
 
 import pcapi.core.bookings.api as bookings_api
@@ -38,10 +36,10 @@ class BeneficiaryBooking:
         departementCode: str,
         description: str,
         durationMinutes: int,
-        extraData: Dict,
+        extraData: dict,
         isDuo: bool,
         withdrawalDetails: Optional[str],
-        mediaUrls: List[str],
+        mediaUrls: list[str],
         isNational: bool,
         venueName: str,
         address: str,
@@ -52,7 +50,7 @@ class BeneficiaryBooking:
         price: float,
         productId: int,
         thumbCount: int,
-        active_mediations: List[ActiveMediation],
+        active_mediations: list[ActiveMediation],
     ):
         self.price = price
         self.longitude = longitude
@@ -93,7 +91,7 @@ class BeneficiaryBooking:
 
     @staticmethod
     def _compute_thumb_url(
-        active_mediations: List[ActiveMediation], product_id: int, product_thumb_count: int
+        active_mediations: list[ActiveMediation], product_id: int, product_thumb_count: int
     ) -> Optional[str]:
         if len(active_mediations) > 0:
             newest_mediation_id = sorted(active_mediations, key=lambda mediation: mediation.date_created, reverse=True)[

--- a/src/pcapi/domain/beneficiary_bookings/beneficiary_bookings_with_stocks.py
+++ b/src/pcapi/domain/beneficiary_bookings/beneficiary_bookings_with_stocks.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from pcapi.domain.beneficiary_bookings.beneficiary_booking import BeneficiaryBooking
 from pcapi.domain.beneficiary_bookings.stock import Stock
 
 
 class BeneficiaryBookingsWithStocks:
-    def __init__(self, bookings: List[BeneficiaryBooking], stocks: List[Stock]):
+    def __init__(self, bookings: list[BeneficiaryBooking], stocks: list[Stock]):
         self.bookings = bookings
         self.stocks = stocks

--- a/src/pcapi/domain/beneficiary_pre_subscription/beneficiary_pre_subscription_validator.py
+++ b/src/pcapi/domain/beneficiary_pre_subscription/beneficiary_pre_subscription_validator.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import List
 
 from pcapi.core.users.models import User
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription import BeneficiaryPreSubscription
@@ -52,7 +51,7 @@ def _is_postal_code_eligible(code: str) -> bool:
     return True
 
 
-def get_beneficiary_duplicates(first_name: str, last_name: str, date_of_birth: datetime) -> List[User]:
+def get_beneficiary_duplicates(first_name: str, last_name: str, date_of_birth: datetime) -> list[User]:
     return find_by_civility(first_name=first_name, last_name=last_name, date_of_birth=date_of_birth)
 
 

--- a/src/pcapi/domain/booking_recap/bookings_recap_paginated.py
+++ b/src/pcapi/domain/booking_recap/bookings_recap_paginated.py
@@ -1,12 +1,10 @@
-from typing import List
-
 from pcapi.domain.booking_recap.booking_recap import BookingRecap
 
 
 class BookingsRecapPaginated:
     def __init__(
         self,
-        bookings_recap: List[BookingRecap],
+        bookings_recap: list[BookingRecap],
         page: int,
         pages: int,
         total: int,

--- a/src/pcapi/domain/demarches_simplifiees.py
+++ b/src/pcapi/domain/demarches_simplifiees.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 import logging
-from typing import Dict
-from typing import List
 from typing import Optional
 from typing import Union
 
@@ -51,7 +49,7 @@ def get_all_application_ids_for_demarche_simplifiee(
     token: str,
     last_update: datetime = None,
     accepted_states: DmsApplicationStates = DmsApplicationStates,
-) -> List[int]:
+) -> list[int]:
     current_page = 1
     number_of_pages = 1
     applications = []
@@ -78,7 +76,7 @@ def get_all_application_ids_for_demarche_simplifiee(
 
 def get_closed_application_ids_for_demarche_simplifiee(
     procedure_id: str, token: str, last_update: datetime
-) -> List[int]:
+) -> list[int]:
     return get_all_application_ids_for_demarche_simplifiee(
         procedure_id, token, last_update, accepted_states=[DmsApplicationStates.closed]
     )
@@ -134,7 +132,7 @@ def _was_last_updated_after(application: dict, last_update: datetime = None) -> 
     return datetime.strptime(application["updated_at"], DATE_ISO_FORMAT) >= last_update
 
 
-def _sort_applications_by_date(applications: List) -> List:
+def _sort_applications_by_date(applications: list) -> list:
     return sorted(applications, key=lambda application: datetime.strptime(application["updated_at"], DATE_ISO_FORMAT))
 
 
@@ -155,7 +153,7 @@ def _get_status_from_demarches_simplifiees_application_state(state: str) -> Unio
     raise ValueError(f"Unexpected DMS status: '{state}'")
 
 
-def _find_value_in_fields(fields: List[Dict], value_name: str) -> dict:
+def _find_value_in_fields(fields: list[dict], value_name: str) -> dict:
     for field in fields:
         if field["type_de_champ"]["libelle"] == value_name:
             return field["value"]

--- a/src/pcapi/domain/favorite/favorite.py
+++ b/src/pcapi/domain/favorite/favorite.py
@@ -1,11 +1,9 @@
-from typing import Dict
-
 from pcapi.core.offers.models import Mediation
 from pcapi.models import Offer
 
 
 class FavoriteDomain:
-    def __init__(self, identifier: int, mediation: Mediation, offer: Offer, booking: Dict):
+    def __init__(self, identifier: int, mediation: Mediation, offer: Offer, booking: dict):
         self.identifier = identifier
         self.mediation = mediation
         self.offer = offer

--- a/src/pcapi/domain/offers.py
+++ b/src/pcapi/domain/offers.py
@@ -1,9 +1,7 @@
-from typing import List
-
 from pcapi.models import Offer
 
 
-def update_is_active_status(offers: List[Offer], status: bool) -> List[Offer]:
+def update_is_active_status(offers: list[Offer], status: bool) -> list[Offer]:
     for offer in offers:
         offer.isActive = status
 

--- a/src/pcapi/domain/password.py
+++ b/src/pcapi/domain/password.py
@@ -1,7 +1,6 @@
 import random
 import re
 import string
-from typing import Dict
 
 from pcapi.core.users.models import User
 from pcapi.core.users.models import hash_password
@@ -40,7 +39,7 @@ def check_password_validity(new_password: str, new_confirmation_password: str, o
         raise api_errors
 
 
-def validate_change_password_request(json: Dict) -> None:
+def validate_change_password_request(json: dict) -> None:
     api_errors = ApiErrors()
     if "oldPassword" not in json or not json["oldPassword"]:
         api_errors.add_error("oldPassword", "Ancien mot de passe manquant")

--- a/src/pcapi/domain/payments.py
+++ b/src/pcapi/domain/payments.py
@@ -6,10 +6,6 @@ from hashlib import sha256
 from io import BytesIO
 from io import StringIO
 import itertools
-from typing import Dict
-from typing import List
-from typing import Set
-from typing import Tuple
 import uuid
 from uuid import UUID
 
@@ -26,7 +22,7 @@ from pcapi.utils.human_ids import humanize
 
 
 class UnmatchedPayments(Exception):
-    def __init__(self, payment_ids: Set[int]):
+    def __init__(self, payment_ids: set[int]):
         super().__init__()
         self.payment_ids = payment_ids
 
@@ -148,25 +144,25 @@ def create_payment_for_booking(booking_reimbursement: BookingReimbursement) -> P
 
 
 def filter_out_already_paid_for_bookings(
-    booking_reimbursements: List[BookingReimbursement],
-) -> List[BookingReimbursement]:
+    booking_reimbursements: list[BookingReimbursement],
+) -> list[BookingReimbursement]:
     return list(filter(lambda x: not x.booking.payments, booking_reimbursements))
 
 
-def filter_out_bookings_without_cost(booking_reimbursements: List[BookingReimbursement]) -> List[BookingReimbursement]:
+def filter_out_bookings_without_cost(booking_reimbursements: list[BookingReimbursement]) -> list[BookingReimbursement]:
     return list(filter(lambda x: x.reimbursed_amount > Decimal(0), booking_reimbursements))
 
 
-def keep_only_pending_payments(payments: List[Payment]) -> List[Payment]:
+def keep_only_pending_payments(payments: list[Payment]) -> list[Payment]:
     return list(filter(lambda x: x.currentStatus.status == TransactionStatus.PENDING, payments))
 
 
-def keep_only_not_processable_payments(payments: List[Payment]) -> List[Payment]:
+def keep_only_not_processable_payments(payments: list[Payment]) -> list[Payment]:
     return list(filter(lambda x: x.currentStatus.status == TransactionStatus.NOT_PROCESSABLE, payments))
 
 
 def generate_message_file(
-    payments: List[Payment], pass_culture_iban: str, pass_culture_bic: str, message_name: str, remittance_code: str
+    payments: list[Payment], pass_culture_iban: str, pass_culture_bic: str, message_name: str, remittance_code: str
 ) -> str:
     transactions = _group_payments_into_transactions(payments)
     total_amount = sum([transaction.amount for transaction in transactions])
@@ -203,7 +199,7 @@ def generate_file_checksum(file: str):
     return sha256(encoded_file).digest()
 
 
-def create_all_payments_details(payments: List[Payment]) -> List[PaymentDetails]:
+def create_all_payments_details(payments: list[Payment]) -> list[PaymentDetails]:
     return [create_payment_details(payment) for payment in payments]
 
 
@@ -211,7 +207,7 @@ def create_payment_details(payment: Payment) -> PaymentDetails:
     return PaymentDetails(payment, payment.booking.dateUsed)
 
 
-def generate_payment_details_csv(payments_details: List[PaymentDetails]) -> str:
+def generate_payment_details_csv(payments_details: list[PaymentDetails]) -> str:
     output = StringIO()
     csv_lines = [details.as_csv_row() for details in payments_details]
     writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
@@ -220,7 +216,7 @@ def generate_payment_details_csv(payments_details: List[PaymentDetails]) -> str:
     return output.getvalue()
 
 
-def generate_wallet_balances_csv(wallet_balances: List[WalletBalance]) -> str:
+def generate_wallet_balances_csv(wallet_balances: list[WalletBalance]) -> str:
     output = StringIO()
     csv_lines = [balance.as_csv_row() for balance in wallet_balances]
     writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
@@ -235,7 +231,7 @@ def make_transaction_label(date: datetime.date) -> str:
     return "pass Culture Pro - remboursement %s quinzaine %s" % (period, month_and_year)
 
 
-def generate_payment_message(name: str, checksum: str, payments: List[Payment]) -> PaymentMessage:
+def generate_payment_message(name: str, checksum: str, payments: list[Payment]) -> PaymentMessage:
     payment_message = PaymentMessage()
     payment_message.name = name
     payment_message.checksum = checksum
@@ -243,7 +239,7 @@ def generate_payment_message(name: str, checksum: str, payments: List[Payment]) 
     return payment_message
 
 
-def group_payments_by_status(payments: List[Payment]) -> Dict:
+def group_payments_by_status(payments: list[Payment]) -> dict:
     groups = {}
     for p in payments:
         status_name = p.currentStatus.status.name
@@ -255,7 +251,7 @@ def group_payments_by_status(payments: List[Payment]) -> Dict:
     return groups
 
 
-def apply_banishment(payments: List[Payment], ids_to_ban: List[int]) -> Tuple[List[Payment], List[Payment]]:
+def apply_banishment(payments: list[Payment], ids_to_ban: list[int]) -> tuple[list[Payment], list[Payment]]:
     if not ids_to_ban:
         return [], []
 
@@ -274,7 +270,7 @@ def apply_banishment(payments: List[Payment], ids_to_ban: List[int]) -> Tuple[Li
     return banned_payments, retry_payments
 
 
-def _group_payments_into_transactions(payments: List[Payment]) -> List[Transaction]:
+def _group_payments_into_transactions(payments: list[Payment]) -> list[Transaction]:
     payments_with_iban = sorted(filter(lambda x: x.iban, payments), key=lambda x: (x.iban, x.bic))
     payments_by_iban = itertools.groupby(payments_with_iban, lambda x: (x.iban, x.bic))
 

--- a/src/pcapi/domain/pro_offerers/paginated_offerers.py
+++ b/src/pcapi/domain/pro_offerers/paginated_offerers.py
@@ -1,9 +1,7 @@
-from typing import List
-
 from pcapi.core.offerers.models import Offerer
 
 
 class PaginatedOfferers:
-    def __init__(self, offerers: List[Offerer], total: int):
+    def __init__(self, offerers: list[Offerer], total: int):
         self.offerers = offerers
         self.total = total

--- a/src/pcapi/domain/pro_offers/paginated_offers_recap.py
+++ b/src/pcapi/domain/pro_offers/paginated_offers_recap.py
@@ -1,5 +1,3 @@
-from typing import Dict
-from typing import List
 from typing import Optional
 
 from pcapi.domain.identifier.identifier import Identifier
@@ -51,7 +49,7 @@ class OfferRecap:
         venue_offerer_name: str,
         venue_public_name: str,
         venue_departement_code: Optional[str],
-        stocks: List[Dict],
+        stocks: list[dict],
         status: str,
     ):
         self.identifier = identifier
@@ -82,7 +80,7 @@ class OfferRecap:
 
 
 class PaginatedOffersRecap:
-    def __init__(self, offers_recap: List[OfferRecap], current_page: int, total_pages: int, total_offers: int):
+    def __init__(self, offers_recap: list[OfferRecap], current_page: int, total_pages: int, total_offers: int):
         self.offers = offers_recap
         self.current_page = current_page
         self.total_pages = total_pages

--- a/src/pcapi/domain/reimbursement.py
+++ b/src/pcapi/domain/reimbursement.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import List
 
 from pcapi.models import Booking
 from pcapi.models import ThingType
@@ -168,8 +167,8 @@ class BookingReimbursement:
 
 
 def find_all_booking_reimbursements(
-    bookings: List[Booking], active_rules: List[ReimbursementRules]
-) -> List[BookingReimbursement]:
+    bookings: list[Booking], active_rules: list[ReimbursementRules]
+) -> list[BookingReimbursement]:
     reimbursements = []
     cumulative_bookings_value_by_year = {}
 
@@ -192,7 +191,7 @@ def find_all_booking_reimbursements(
     return reimbursements
 
 
-def determine_elected_rule(booking: Booking, potential_rules: List[AppliedReimbursement]) -> AppliedReimbursement:
+def determine_elected_rule(booking: Booking, potential_rules: list[AppliedReimbursement]) -> AppliedReimbursement:
     if any(map(lambda r: r.rule == ReimbursementRules.BOOK_REIMBURSEMENT, potential_rules)):
         elected_rule = AppliedReimbursement(
             ReimbursementRules.BOOK_REIMBURSEMENT, ReimbursementRules.BOOK_REIMBURSEMENT.value.apply(booking)
@@ -203,8 +202,8 @@ def determine_elected_rule(booking: Booking, potential_rules: List[AppliedReimbu
 
 
 def _find_potential_rules(
-    booking: Booking, rules: List[ReimbursementRules], cumulative_bookings_value: Decimal
-) -> List:
+    booking: Booking, rules: list[ReimbursementRules], cumulative_bookings_value: Decimal
+) -> list:
     relevant_rules = []
     for rule in rules:
         if rule.value.is_active and rule.value.is_relevant(booking, cumulative_value=cumulative_bookings_value):

--- a/src/pcapi/domain/stock_provider/stock_provider_repository.py
+++ b/src/pcapi/domain/stock_provider/stock_provider_repository.py
@@ -1,7 +1,6 @@
 from abc import ABC
 from abc import abstractmethod
 import datetime
-from typing import Dict
 from typing import Iterator
 
 
@@ -9,7 +8,7 @@ class StockProviderRepository(ABC):
     @abstractmethod
     def stocks_information(
         self, siret: str, last_processed_reference: str = "", modified_since: datetime = None
-    ) -> Iterator[Dict]:
+    ) -> Iterator[dict]:
         pass
 
     @abstractmethod

--- a/src/pcapi/domain/ts_vector.py
+++ b/src/pcapi/domain/ts_vector.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from nltk.corpus import stopwords
 from sqlalchemy import Index
 from sqlalchemy import and_
@@ -58,7 +56,7 @@ def create_filter_matching_all_keywords_in_any_model(get_filter_matching_ts_quer
     return and_(*ts_filters)
 
 
-def _get_ts_queries_from_keywords_string(keywords_string) -> List[str]:
+def _get_ts_queries_from_keywords_string(keywords_string) -> list[str]:
     keywords = tokenize_for_search(keywords_string)
     keywords_without_single_letter = remove_single_letters_for_search(keywords)
 

--- a/src/pcapi/domain/types.py
+++ b/src/pcapi/domain/types.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from pcapi.models.offer_type import EventType
 from pcapi.models.offer_type import ThingType
 
 
-def get_formatted_active_product_types() -> List:
+def get_formatted_active_product_types() -> list:
     active_event_format_types = [type_obj.as_dict() for type_obj in EventType if type_obj.value["isActive"]]
     active_thing_format_types = [type_obj.as_dict() for type_obj in ThingType if type_obj.value["isActive"]]
     all_active_types = active_event_format_types + active_thing_format_types

--- a/src/pcapi/domain/user_emails.py
+++ b/src/pcapi/domain/user_emails.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from pcapi import settings
 from pcapi.core import mails
@@ -125,12 +124,12 @@ def send_attachment_validation_email_to_pro_offerer(user_offerer: UserOfferer) -
     mails.send(recipients=[user_offerer.user.email], data=data)
 
 
-def send_batch_cancellation_emails_to_users(bookings: List[Booking]) -> None:
+def send_batch_cancellation_emails_to_users(bookings: list[Booking]) -> None:
     for booking in bookings:
         send_warning_to_beneficiary_after_pro_booking_cancellation(booking)
 
 
-def send_offerer_bookings_recap_email_after_offerer_cancellation(bookings: List[Booking]) -> None:
+def send_offerer_bookings_recap_email_after_offerer_cancellation(bookings: list[Booking]) -> None:
     recipients = _build_recipients_list(bookings[0])
     data = retrieve_offerer_bookings_recap_email_data_after_offerer_cancellation(bookings)
     mails.send(recipients=recipients, data=data)
@@ -150,12 +149,12 @@ def send_booking_cancellation_emails_to_user_and_offerer(
         send_user_driven_cancellation_email_to_offerer(booking)
 
 
-def send_expired_bookings_recap_email_to_beneficiary(beneficiary: User, bookings: List[Booking]) -> None:
+def send_expired_bookings_recap_email_to_beneficiary(beneficiary: User, bookings: list[Booking]) -> None:
     data = build_expired_bookings_recap_email_data_for_beneficiary(beneficiary, bookings)
     mails.send(recipients=[beneficiary.email], data=data)
 
 
-def send_expired_bookings_recap_email_to_offerer(offerer: Offerer, bookings: List[Booking]) -> None:
+def send_expired_bookings_recap_email_to_offerer(offerer: Offerer, bookings: list[Booking]) -> None:
     recipients = _build_recipients_list(bookings[0])
     data = build_expired_bookings_recap_email_data_for_offerer(offerer, bookings)
     mails.send(recipients=recipients, data=data)
@@ -171,7 +170,7 @@ def send_admin_user_validation_email(user: User, token: Token) -> None:
     mails.send(recipients=[user.email], data=data)
 
 
-def send_soon_to_be_expired_bookings_recap_email_to_beneficiary(beneficiary: User, bookings: List[Booking]) -> None:
+def send_soon_to_be_expired_bookings_recap_email_to_beneficiary(beneficiary: User, bookings: list[Booking]) -> None:
     data = build_soon_to_be_expired_bookings_recap_email_data_for_beneficiary(beneficiary, bookings)
     mails.send(recipients=[beneficiary.email], data=data)
 
@@ -193,7 +192,7 @@ def send_accepted_as_beneficiary_email(user: User) -> bool:
     return mails.send(recipients=[user.email], data=data)
 
 
-def send_batch_stock_postponement_emails_to_users(bookings: List[Booking]) -> None:
+def send_batch_stock_postponement_emails_to_users(bookings: list[Booking]) -> None:
     for booking in bookings:
         send_booking_postponement_emails_to_users(booking)
 
@@ -229,7 +228,7 @@ def send_reset_password_link_to_admin_email(created_user: User, admin_email: Use
 
 
 def send_offer_validation_status_update_email(
-    offer: Offer, validation_status: OfferValidationStatus, recipient_email: List[str]
+    offer: Offer, validation_status: OfferValidationStatus, recipient_email: list[str]
 ) -> bool:
     if validation_status is OfferValidationStatus.APPROVED:
         offer_data = retrieve_data_for_offer_approval_email(offer)

--- a/src/pcapi/domain/venue/venue_label/venue_label_repository.py
+++ b/src/pcapi/domain/venue/venue_label/venue_label_repository.py
@@ -1,11 +1,10 @@
 from abc import ABC
 from abc import abstractmethod
-from typing import List
 
 from pcapi.domain.venue.venue_label.venue_label import VenueLabel
 
 
 class VenueLabelRepository(ABC):
     @abstractmethod
-    def get_all(self) -> List[VenueLabel]:
+    def get_all(self) -> list[VenueLabel]:
         pass

--- a/src/pcapi/domain/venue/venue_with_basic_information/venue_with_basic_information_repository.py
+++ b/src/pcapi/domain/venue/venue_with_basic_information/venue_with_basic_information_repository.py
@@ -1,6 +1,5 @@
 from abc import ABC
 from abc import abstractmethod
-from typing import List
 
 from pcapi.domain.venue.venue_with_basic_information.venue_with_basic_information import VenueWithBasicInformation
 
@@ -11,5 +10,5 @@ class VenueWithBasicInformationRepository(ABC):
         pass
 
     @abstractmethod
-    def find_by_name(self, name: str, offerer_id: int) -> List[VenueWithBasicInformation]:
+    def find_by_name(self, name: str, offerer_id: int) -> list[VenueWithBasicInformation]:
         pass

--- a/src/pcapi/domain/venue/venue_with_offerer_name/venue_with_offerer_name_repository.py
+++ b/src/pcapi/domain/venue/venue_with_offerer_name/venue_with_offerer_name_repository.py
@@ -1,6 +1,5 @@
 from abc import ABC
 from abc import abstractmethod
-from typing import List
 from typing import Optional
 
 from pcapi.domain.identifier.identifier import Identifier
@@ -17,5 +16,5 @@ class VenueWithOffererNameRepository(ABC):
         offerer_id: Optional[Identifier] = None,
         validated_offerer: Optional[bool] = None,
         validated_offerer_for_user: Optional[bool] = None,
-    ) -> List[VenueWithOffererName]:
+    ) -> list[VenueWithOffererName]:
         pass

--- a/src/pcapi/domain/venues.py
+++ b/src/pcapi/domain/venues.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from pcapi.models import Venue
 from pcapi.routes.serialization import as_dict
 
@@ -7,7 +5,7 @@ from pcapi.routes.serialization import as_dict
 VENUE_ALGOLIA_INDEXED_FIELDS = ["name", "publicName", "city"]
 
 
-def is_algolia_indexing(previous_venue: Venue, payload: Dict) -> bool:
+def is_algolia_indexing(previous_venue: Venue, payload: dict) -> bool:
     previous_venue_as_dict = as_dict(previous_venue)
     for field in VENUE_ALGOLIA_INDEXED_FIELDS:
         if field in payload.keys() and previous_venue_as_dict[field] != payload[field]:

--- a/src/pcapi/emails/beneficiary_activation.py
+++ b/src/pcapi/emails/beneficiary_activation.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Dict
 from urllib.parse import quote
 from urllib.parse import urlencode
 
@@ -10,7 +9,7 @@ from pcapi.core.bookings import conf
 from pcapi.core.users import models as users_models
 
 
-def get_activation_email_data(user: users_models.User, token: users_models.Token) -> Dict:
+def get_activation_email_data(user: users_models.User, token: users_models.Token) -> dict:
     first_name = user.firstName.capitalize()
     email = user.email
 
@@ -25,7 +24,7 @@ def get_activation_email_data(user: users_models.User, token: users_models.Token
     }
 
 
-def get_activation_email_data_for_native(user: users_models.User, token: users_models.Token) -> Dict:
+def get_activation_email_data_for_native(user: users_models.User, token: users_models.Token) -> dict:
     expiration_timestamp = int(token.expirationDate.timestamp())
     query_string = urlencode({"token": token.value, "expiration_timestamp": expiration_timestamp, "email": user.email})
     email_confirmation_link = f"{settings.NATIVE_APP_URL}/signup-confirmation?{query_string}"
@@ -44,7 +43,7 @@ def get_activation_email_data_for_native(user: users_models.User, token: users_m
     }
 
 
-def get_accepted_as_beneficiary_email_data() -> Dict:
+def get_accepted_as_beneficiary_email_data() -> dict:
     limit_configuration = conf.LIMIT_CONFIGURATIONS[conf.get_current_deposit_version()]
     deposit_amount = limit_configuration.TOTAL_CAP
     return {
@@ -56,7 +55,7 @@ def get_accepted_as_beneficiary_email_data() -> Dict:
     }
 
 
-def get_newly_eligible_user_email_data(user: users_models.User, token: users_models.Token) -> Dict:
+def get_newly_eligible_user_email_data(user: users_models.User, token: users_models.Token) -> dict:
     expiration_timestamp = int(token.expirationDate.timestamp())
     query_string = urlencode(
         {"licenceToken": token.value, "expirationTimestamp": expiration_timestamp, "email": user.email}

--- a/src/pcapi/emails/beneficiary_booking_cancellation.py
+++ b/src/pcapi/emails/beneficiary_booking_cancellation.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import Dict
 
 from pcapi.models import Booking
 from pcapi.utils.date import get_date_formatted_for_email
@@ -8,7 +7,7 @@ from pcapi.utils.date import utc_datetime_to_department_timezone
 from pcapi.utils.human_ids import humanize
 
 
-def make_beneficiary_booking_cancellation_email_data(booking: Booking) -> Dict:
+def make_beneficiary_booking_cancellation_email_data(booking: Booking) -> dict:
     stock = booking.stock
     beneficiary = booking.user
     offer = stock.offer

--- a/src/pcapi/emails/beneficiary_booking_confirmation.py
+++ b/src/pcapi/emails/beneficiary_booking_confirmation.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from pcapi.core.bookings.models import Booking
 from pcapi.models.offer_type import ProductType
 from pcapi.utils.date import get_date_formatted_for_email
@@ -8,7 +6,7 @@ from pcapi.utils.date import utc_datetime_to_department_timezone
 from pcapi.utils.human_ids import humanize
 
 
-def retrieve_data_for_beneficiary_booking_confirmation_email(booking: Booking) -> Dict:
+def retrieve_data_for_beneficiary_booking_confirmation_email(booking: Booking) -> dict:
     stock = booking.stock
     offer = stock.offer
     venue = offer.venue

--- a/src/pcapi/emails/beneficiary_expired_bookings.py
+++ b/src/pcapi/emails/beneficiary_expired_bookings.py
@@ -1,12 +1,8 @@
-import typing
-
 from pcapi.core.users.models import User
 from pcapi.models import Booking
 
 
-def build_expired_bookings_recap_email_data_for_beneficiary(
-    beneficiary: User, bookings: typing.List[Booking]
-) -> typing.Dict:
+def build_expired_bookings_recap_email_data_for_beneficiary(beneficiary: User, bookings: list[Booking]) -> dict:
     return {
         "Mj-TemplateID": 1951103,
         "Mj-TemplateLanguage": True,
@@ -17,7 +13,7 @@ def build_expired_bookings_recap_email_data_for_beneficiary(
     }
 
 
-def _extract_bookings_information_from_bookings_list(bookings: typing.List[Booking]) -> typing.List[dict]:
+def _extract_bookings_information_from_bookings_list(bookings: list[Booking]) -> list[dict]:
     bookings_info = []
     for booking in bookings:
         stock = booking.stock

--- a/src/pcapi/emails/beneficiary_offer_cancellation.py
+++ b/src/pcapi/emails/beneficiary_offer_cancellation.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from pcapi.models import Booking
 from pcapi.models import Stock
 from pcapi.utils.mailing import build_pc_pro_offer_link
@@ -8,7 +6,7 @@ from pcapi.utils.mailing import format_booking_date_for_email
 from pcapi.utils.mailing import format_booking_hours_for_email
 
 
-def retrieve_offerer_booking_recap_email_data_after_user_cancellation(booking: Booking) -> Dict:
+def retrieve_offerer_booking_recap_email_data_after_user_cancellation(booking: Booking) -> dict:
     user = booking.user
     stock = booking.stock
     bookings = list(filter(lambda ongoing_booking: not ongoing_booking.isCancelled, stock.bookings))

--- a/src/pcapi/emails/beneficiary_pre_subscription_rejected.py
+++ b/src/pcapi/emails/beneficiary_pre_subscription_rejected.py
@@ -1,14 +1,11 @@
-from typing import Dict
-
-
-def make_duplicate_beneficiary_pre_subscription_rejected_data() -> Dict:
+def make_duplicate_beneficiary_pre_subscription_rejected_data() -> dict:
     return {
         "Mj-TemplateID": 1530996,
         "Mj-TemplateLanguage": True,
     }
 
 
-def make_not_eligible_beneficiary_pre_subscription_rejected_data() -> Dict:
+def make_not_eligible_beneficiary_pre_subscription_rejected_data() -> dict:
     return {
         "Mj-TemplateID": 1619528,
         "Mj-TemplateLanguage": True,

--- a/src/pcapi/emails/beneficiary_soon_to_be_expired_bookings.py
+++ b/src/pcapi/emails/beneficiary_soon_to_be_expired_bookings.py
@@ -1,12 +1,10 @@
-import typing
-
 from pcapi.core.users.models import User
 from pcapi.models import Booking
 
 
 def build_soon_to_be_expired_bookings_recap_email_data_for_beneficiary(
-    beneficiary: User, bookings: typing.List[Booking]
-) -> typing.Dict:
+    beneficiary: User, bookings: list[Booking]
+) -> dict:
     return {
         "Mj-TemplateID": 1927224,
         "Mj-TemplateLanguage": True,
@@ -17,7 +15,7 @@ def build_soon_to_be_expired_bookings_recap_email_data_for_beneficiary(
     }
 
 
-def _extract_bookings_information_from_bookings_list(bookings: typing.List[Booking]) -> typing.List[dict]:
+def _extract_bookings_information_from_bookings_list(bookings: list[Booking]) -> list[dict]:
     bookings_info = []
     for booking in bookings:
         stock = booking.stock

--- a/src/pcapi/emails/beneficiary_warning_after_pro_booking_cancellation.py
+++ b/src/pcapi/emails/beneficiary_warning_after_pro_booking_cancellation.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import Dict
 
 from babel.dates import format_date
 
@@ -8,7 +7,7 @@ from pcapi.utils.mailing import format_booking_hours_for_email
 from pcapi.utils.mailing import get_event_datetime
 
 
-def retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation(booking: Booking) -> Dict:
+def retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation(booking: Booking) -> dict:
     stock = booking.stock
     offer = stock.offer
     event_date = ""

--- a/src/pcapi/emails/new_offer_validation.py
+++ b/src/pcapi/emails/new_offer_validation.py
@@ -1,10 +1,8 @@
-from typing import Dict
-
 from pcapi.core.offers.models import Offer
 from pcapi.utils.mailing import build_pc_pro_offer_link
 
 
-def retrieve_data_for_offer_approval_email(offer: Offer) -> Dict:
+def retrieve_data_for_offer_approval_email(offer: Offer) -> dict:
     return {
         "MJ-TemplateID": 2613721,
         "MJ-TemplateLanguage": True,

--- a/src/pcapi/emails/new_offerer_validation.py
+++ b/src/pcapi/emails/new_offerer_validation.py
@@ -1,9 +1,7 @@
-from typing import Dict
-
 from pcapi.core.offerers.models import Offerer
 
 
-def retrieve_data_for_new_offerer_validation_email(offerer: Offerer) -> Dict:
+def retrieve_data_for_new_offerer_validation_email(offerer: Offerer) -> dict:
     return {
         "MJ-TemplateID": 778723,
         "MJ-TemplateLanguage": True,

--- a/src/pcapi/emails/offerer_attachment_validation.py
+++ b/src/pcapi/emails/offerer_attachment_validation.py
@@ -1,10 +1,8 @@
-from typing import Dict
-
 from pcapi.models import UserOfferer
 from pcapi.repository.offerer_queries import find_first_by_user_offerer_id
 
 
-def retrieve_data_for_offerer_attachment_validation_email(user_offerer: UserOfferer) -> Dict:
+def retrieve_data_for_offerer_attachment_validation_email(user_offerer: UserOfferer) -> dict:
     offerer = find_first_by_user_offerer_id(user_offerer.id)
     return {
         "MJ-TemplateID": 778756,

--- a/src/pcapi/emails/offerer_booking_recap.py
+++ b/src/pcapi/emails/offerer_booking_recap.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from pcapi.core.bookings.models import Booking
 from pcapi.models.offer_type import ProductType
 from pcapi.utils.mailing import build_pc_pro_offer_link
@@ -7,7 +5,7 @@ from pcapi.utils.mailing import format_booking_date_for_email
 from pcapi.utils.mailing import format_booking_hours_for_email
 
 
-def retrieve_data_for_offerer_booking_recap_email(booking: Booking) -> Dict:
+def retrieve_data_for_offerer_booking_recap_email(booking: Booking) -> dict:
     offer = booking.stock.offer
     venue_name = offer.venue.name
     offer_name = offer.name

--- a/src/pcapi/emails/offerer_bookings_recap_after_deleting_stock.py
+++ b/src/pcapi/emails/offerer_bookings_recap_after_deleting_stock.py
@@ -1,13 +1,10 @@
-from typing import Dict
-from typing import List
-
 from pcapi.models import Booking
 from pcapi.utils.mailing import build_pc_pro_offer_link
 from pcapi.utils.mailing import format_booking_date_for_email
 from pcapi.utils.mailing import format_booking_hours_for_email
 
 
-def retrieve_offerer_bookings_recap_email_data_after_offerer_cancellation(bookings: List[Booking]) -> Dict:
+def retrieve_offerer_bookings_recap_email_data_after_offerer_cancellation(bookings: list[Booking]) -> dict:
     booking = bookings[0]
     stock = booking.stock
     offer = stock.offer
@@ -36,7 +33,7 @@ def retrieve_offerer_bookings_recap_email_data_after_offerer_cancellation(bookin
     }
 
 
-def _extract_users_information_from_bookings_list(bookings: List[Booking]) -> List[dict]:
+def _extract_users_information_from_bookings_list(bookings: list[Booking]) -> list[dict]:
     users_keys = ("firstName", "lastName", "email", "countermark")
     users_properties = [
         [booking.user.firstName, booking.user.lastName, booking.user.email, booking.token] for booking in bookings

--- a/src/pcapi/emails/offerer_expired_bookings.py
+++ b/src/pcapi/emails/offerer_expired_bookings.py
@@ -1,14 +1,10 @@
-import typing
-
 from pcapi.core.offerers.models import Offerer
 from pcapi.domain.postal_code.postal_code import PostalCode
 from pcapi.models import Booking
 from pcapi.utils.mailing import build_pc_pro_offer_link
 
 
-def build_expired_bookings_recap_email_data_for_offerer(
-    offerer: Offerer, bookings: typing.List[Booking]
-) -> typing.Dict:
+def build_expired_bookings_recap_email_data_for_offerer(offerer: Offerer, bookings: list[Booking]) -> dict:
     return {
         "Mj-TemplateID": 1952508,
         "Mj-TemplateLanguage": True,
@@ -19,7 +15,7 @@ def build_expired_bookings_recap_email_data_for_offerer(
     }
 
 
-def _extract_bookings_information_from_bookings_list(bookings: typing.List[Booking]) -> typing.List[dict]:
+def _extract_bookings_information_from_bookings_list(bookings: list[Booking]) -> list[dict]:
     bookings_info = []
     for booking in bookings:
         stock = booking.stock

--- a/src/pcapi/emails/pro_reset_password.py
+++ b/src/pcapi/emails/pro_reset_password.py
@@ -1,11 +1,9 @@
-from typing import Dict
-
 from pcapi.core.users.models import Token
 from pcapi.core.users.models import User
 from pcapi.utils.mailing import build_pc_pro_reset_password_link
 
 
-def retrieve_data_for_reset_password_pro_email(user: User, token: Token) -> Dict:
+def retrieve_data_for_reset_password_pro_email(user: User, token: Token) -> dict:
     reinit_password_url = build_pc_pro_reset_password_link(token.value)
 
     return {
@@ -15,7 +13,7 @@ def retrieve_data_for_reset_password_pro_email(user: User, token: Token) -> Dict
     }
 
 
-def retrieve_data_for_reset_password_link_to_admin_email(created_user: User, reset_password_link: str) -> Dict:
+def retrieve_data_for_reset_password_link_to_admin_email(created_user: User, reset_password_link: str) -> dict:
     return {
         "Subject": "Création d'un compte pro",
         "Html-part": (

--- a/src/pcapi/emails/user_notification_after_stock_update.py
+++ b/src/pcapi/emails/user_notification_after_stock_update.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from babel.dates import format_date
 
 from pcapi.models import Booking
@@ -7,7 +5,7 @@ from pcapi.utils.mailing import format_booking_hours_for_email
 from pcapi.utils.mailing import get_event_datetime
 
 
-def retrieve_data_to_warn_user_after_stock_update_affecting_booking(booking: Booking) -> Dict:
+def retrieve_data_to_warn_user_after_stock_update_affecting_booking(booking: Booking) -> dict:
     stock = booking.stock
     offer = stock.offer
     offer_name = offer.name

--- a/src/pcapi/emails/user_reset_password.py
+++ b/src/pcapi/emails/user_reset_password.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from urllib.parse import urlencode
 
 from pcapi import settings
@@ -6,7 +5,7 @@ from pcapi.core.users.models import Token
 from pcapi.core.users.models import User
 
 
-def retrieve_data_for_reset_password_user_email(user: User, token: Token) -> Dict:
+def retrieve_data_for_reset_password_user_email(user: User, token: Token) -> dict:
     return {
         "MJ-TemplateID": 912168,
         "MJ-TemplateLanguage": True,
@@ -14,7 +13,7 @@ def retrieve_data_for_reset_password_user_email(user: User, token: Token) -> Dic
     }
 
 
-def retrieve_data_for_reset_password_native_app_email(user: User, token: Token) -> Dict:
+def retrieve_data_for_reset_password_native_app_email(user: User, token: Token) -> dict:
     query_string = urlencode(
         {
             "token": token.value,

--- a/src/pcapi/infrastructure/repository/beneficiary_bookings/beneficiary_bookings_sql_repository.py
+++ b/src/pcapi/infrastructure/repository/beneficiary_bookings/beneficiary_bookings_sql_repository.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pcapi.core.offers.models import Mediation
 from pcapi.core.users.models import User
 from pcapi.domain.beneficiary_bookings.beneficiary_booking import BeneficiaryBooking
@@ -71,7 +69,7 @@ class BeneficiaryBookingsSQLRepository(BeneficiaryBookingsRepository):
         return BeneficiaryBookingsWithStocks(bookings=beneficiary_bookings, stocks=stocks)
 
 
-def _get_mediations_information(offers_ids: List[int]) -> List[object]:
+def _get_mediations_information(offers_ids: list[int]) -> list[object]:
     return (
         Mediation.query.join(Offer, Offer.id == Mediation.offerId)
         .filter(Mediation.offerId.in_(offers_ids))
@@ -81,7 +79,7 @@ def _get_mediations_information(offers_ids: List[int]) -> List[object]:
     )
 
 
-def _get_stocks_information(offers_ids: List[int]) -> List[object]:
+def _get_stocks_information(offers_ids: list[int]) -> list[object]:
     return (
         Stock.query.join(Offer, Offer.id == Stock.offerId)
         .filter(Stock.offerId.in_(offers_ids))
@@ -101,7 +99,7 @@ def _get_stocks_information(offers_ids: List[int]) -> List[object]:
     )
 
 
-def _get_bookings_information(beneficiary_id: int) -> List[object]:
+def _get_bookings_information(beneficiary_id: int) -> list[object]:
     offer_activation_types = ["ThingType.ACTIVATION", "EventType.ACTIVATION"]
     return (
         Booking.query.join(User, User.id == Booking.userId)

--- a/src/pcapi/infrastructure/repository/favorite/favorite_domain_converter.py
+++ b/src/pcapi/infrastructure/repository/favorite/favorite_domain_converter.py
@@ -1,10 +1,8 @@
-from typing import Dict
-
 from pcapi.domain.favorite.favorite import FavoriteDomain
 from pcapi.models import Favorite
 
 
-def to_domain(favorite_sql_entity: Favorite, booking: Dict = None) -> FavoriteDomain:
+def to_domain(favorite_sql_entity: Favorite, booking: dict = None) -> FavoriteDomain:
     return FavoriteDomain(
         identifier=favorite_sql_entity.id,
         offer=favorite_sql_entity.offer,

--- a/src/pcapi/infrastructure/repository/pro_offers/paginated_offers_recap_domain_converter.py
+++ b/src/pcapi/infrastructure/repository/pro_offers/paginated_offers_recap_domain_converter.py
@@ -1,6 +1,3 @@
-from typing import Dict
-from typing import List
-
 from pcapi.domain.identifier.identifier import Identifier
 from pcapi.domain.pro_offers.paginated_offers_recap import OfferRecap
 from pcapi.domain.pro_offers.paginated_offers_recap import PaginatedOffersRecap
@@ -8,7 +5,7 @@ from pcapi.models import Offer
 from pcapi.models import Stock
 
 
-def to_domain(offers: List[Offer], current_page: int, total_pages: int, total_offers: int) -> PaginatedOffersRecap:
+def to_domain(offers: list[Offer], current_page: int, total_pages: int, total_offers: int) -> PaginatedOffersRecap:
     offers_recap = [_offer_recap_to_domain(offer) for offer in offers]
 
     return PaginatedOffersRecap(
@@ -41,7 +38,7 @@ def _offer_recap_to_domain(offer: Offer) -> OfferRecap:
     )
 
 
-def _stock_serializer(stock: Stock) -> Dict:
+def _stock_serializer(stock: Stock) -> dict:
     return {
         "identifier": Identifier(stock.id),
         "has_booking_limit_datetime_passed": stock.hasBookingLimitDatetimePassed,

--- a/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
+++ b/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Dict
 
 from pcapi.utils import requests
 
@@ -22,7 +21,7 @@ class ProviderAPI:
 
     def stocks(
         self, siret: str, last_processed_reference: str = "", modified_since: str = "", limit: int = 1000
-    ) -> Dict:
+    ) -> dict:
         api_url = self._build_local_provider_url(siret)
         params = self._build_local_provider_params(last_processed_reference, modified_since, limit)
         headers = {}
@@ -50,7 +49,7 @@ class ProviderAPI:
         last_processed_reference: str = "",
         modified_since: str = "",
         limit: int = 1000,
-    ) -> Dict:
+    ) -> dict:
         api_responses = self.stocks(siret, last_processed_reference, modified_since, limit)
         stock_responses = api_responses.get("stocks", [])
         validated_stock_responses = []
@@ -94,7 +93,7 @@ class ProviderAPI:
     def _build_local_provider_url(self, siret: str) -> str:
         return f"{self.api_url}/{siret}"
 
-    def _build_local_provider_params(self, last_processed_isbn: str, modified_since: str, limit: int) -> Dict:
+    def _build_local_provider_params(self, last_processed_isbn: str, modified_since: str, limit: int) -> dict:
         params = {"limit": str(limit)}
 
         if last_processed_isbn:

--- a/src/pcapi/infrastructure/repository/stock_provider/stock_provider_fnac.py
+++ b/src/pcapi/infrastructure/repository/stock_provider/stock_provider_fnac.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Dict
 from typing import Iterator
 
 from pcapi import settings
@@ -17,7 +16,7 @@ class StockProviderFnacRepository(StockProviderRepository):
 
     def stocks_information(
         self, siret: str, last_processed_reference: str = "", modified_since: datetime = None
-    ) -> Iterator[Dict]:
+    ) -> Iterator[dict]:
         modified_since = datetime.strftime(modified_since, "%Y-%m-%dT%H:%M:%SZ") if modified_since else ""
         stocks = self.fnac_api.stocks(
             siret=siret, last_processed_reference=last_processed_reference, modified_since=modified_since

--- a/src/pcapi/infrastructure/repository/stock_provider/stock_provider_libraires.py
+++ b/src/pcapi/infrastructure/repository/stock_provider/stock_provider_libraires.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Dict
 from typing import Iterator
 
 from pcapi.domain.stock_provider.stock_provider_repository import StockProviderRepository
@@ -12,7 +11,7 @@ class StockProviderLibrairesRepository(StockProviderRepository):
 
     def stocks_information(
         self, siret: str, last_processed_reference: str = "", modified_since: datetime = None
-    ) -> Iterator[Dict]:
+    ) -> Iterator[dict]:
         modified_since = datetime.strftime(modified_since, "%Y-%m-%dT%H:%M:%SZ") if modified_since else ""
         stocks = self.libraires_api.stocks(
             siret=siret, last_processed_reference=last_processed_reference, modified_since=modified_since

--- a/src/pcapi/infrastructure/repository/stock_provider/stock_provider_praxiel.py
+++ b/src/pcapi/infrastructure/repository/stock_provider/stock_provider_praxiel.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Dict
 from typing import Iterator
 
 from pcapi.domain.stock_provider.stock_provider_repository import StockProviderRepository
@@ -12,7 +11,7 @@ class StockProviderPraxielRepository(StockProviderRepository):
 
     def stocks_information(
         self, siret: str, last_processed_reference: str = "", modified_since: datetime = None
-    ) -> Iterator[Dict]:
+    ) -> Iterator[dict]:
         modified_since = datetime.strftime(modified_since, "%Y-%m-%dT%H:%M:%SZ") if modified_since else ""
         stocks = self.praxiel_api.stocks(
             siret=siret, last_processed_reference=last_processed_reference, modified_since=modified_since

--- a/src/pcapi/infrastructure/repository/stock_provider/stock_provider_titelive.py
+++ b/src/pcapi/infrastructure/repository/stock_provider/stock_provider_titelive.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Dict
 from typing import Iterator
 
 from pcapi.domain.stock_provider.stock_provider_repository import StockProviderRepository
@@ -12,7 +11,7 @@ class StockProviderTiteLiveRepository(StockProviderRepository):
 
     def stocks_information(
         self, siret: str, last_processed_reference: str = "", modified_since: datetime = None
-    ) -> Iterator[Dict]:
+    ) -> Iterator[dict]:
         modified_since = datetime.strftime(modified_since, "%Y-%m-%dT%H:%M:%SZ") if modified_since else ""
         stocks = self.titelive_api.stocks(
             siret=siret, last_processed_reference=last_processed_reference, modified_since=modified_since

--- a/src/pcapi/infrastructure/repository/stock_provider/titelive_provider_api.py
+++ b/src/pcapi/infrastructure/repository/stock_provider/titelive_provider_api.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from pcapi.infrastructure.repository.stock_provider.provider_api import ProviderAPI
 
 
@@ -7,7 +5,7 @@ class TiteliveProviderAPI(ProviderAPI):
     def __init__(self, api_url: str, name: str):
         super().__init__(api_url, name)
 
-    def _build_local_provider_params(self, last_processed_isbn: str, modified_since: str, limit: int) -> Dict:
+    def _build_local_provider_params(self, last_processed_isbn: str, modified_since: str, limit: int) -> dict:
         params = {"limit": str(limit)}
 
         if last_processed_isbn:

--- a/src/pcapi/infrastructure/repository/venue/venue_label/venue_label_sql_repository.py
+++ b/src/pcapi/infrastructure/repository/venue/venue_label/venue_label_sql_repository.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pcapi.domain.venue.venue_label.venue_label import VenueLabel
 from pcapi.domain.venue.venue_label.venue_label_repository import VenueLabelRepository
 from pcapi.infrastructure.repository.venue.venue_label import venue_label_domain_converter
@@ -7,6 +5,6 @@ from pcapi.models import VenueLabelSQLEntity
 
 
 class VenueLabelSQLRepository(VenueLabelRepository):
-    def get_all(self) -> List[VenueLabel]:
+    def get_all(self) -> list[VenueLabel]:
         venue_labels_sql_entities = VenueLabelSQLEntity.query.all()
         return [venue_label_domain_converter.to_domain(venue_label) for venue_label in venue_labels_sql_entities]

--- a/src/pcapi/infrastructure/repository/venue/venue_with_basic_information/venue_with_basic_information_sql_repository.py
+++ b/src/pcapi/infrastructure/repository/venue/venue_with_basic_information/venue_with_basic_information_sql_repository.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from sqlalchemy import func
 
 from pcapi.domain.venue.venue_with_basic_information.venue_with_basic_information import VenueWithBasicInformation
@@ -17,7 +15,7 @@ class VenueWithBasicInformationSQLRepository(VenueWithBasicInformationRepository
         venue_sql_entity = Venue.query.filter_by(siret=siret).one_or_none()
         return venue_with_basic_information_domain_converter.to_domain(venue_sql_entity) if venue_sql_entity else None
 
-    def find_by_name(self, name: str, offerer_id: int) -> List[VenueWithBasicInformation]:
+    def find_by_name(self, name: str, offerer_id: int) -> list[VenueWithBasicInformation]:
         venue_sql_entities = (
             Venue.query.filter_by(managingOffererId=offerer_id)
             .filter(Venue.siret.is_(None))

--- a/src/pcapi/infrastructure/repository/venue/venue_with_offerer_name/venue_with_offerer_name_sql_repository.py
+++ b/src/pcapi/infrastructure/repository/venue/venue_with_offerer_name/venue_with_offerer_name_sql_repository.py
@@ -1,4 +1,3 @@
-from typing import List
 from typing import Optional
 
 from pcapi.core.offerers.models import Offerer
@@ -19,7 +18,7 @@ class VenueWithOffererNameSQLRepository(VenueWithOffererNameRepository):
         offerer_id: Optional[Identifier] = None,
         validated_offerer: Optional[bool] = None,
         validated_offerer_for_user: Optional[bool] = None,
-    ) -> List[VenueWithOffererName]:
+    ) -> list[VenueWithOffererName]:
         query = Venue.query.join(Offerer, Offerer.id == Venue.managingOffererId).join(
             UserOfferer, UserOfferer.offererId == Offerer.id
         )

--- a/src/pcapi/local_providers/allocine/allocine_stocks.py
+++ b/src/pcapi/local_providers/allocine/allocine_stocks.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 import re
-from typing import Dict
-from typing import List
 from typing import Optional
 from typing import Union
 
@@ -50,13 +48,13 @@ class AllocineStocks(LocalProvider):
         self.quantity = allocine_venue_provider.quantity
         self.room_internal_id = allocine_venue_provider.internalId
 
-        self.movie_information: Optional[Dict] = None
-        self.filtered_movie_showtimes: Optional[List[Dict]] = None
+        self.movie_information: Optional[dict] = None
+        self.filtered_movie_showtimes: Optional[list[dict]] = None
         self.last_product_id = None
         self.last_vf_offer_id = None
         self.last_vo_offer_id = None
 
-    def __next__(self) -> List[ProvidableInfo]:
+    def __next__(self) -> list[ProvidableInfo]:
         raw_movie_information = next(self.movies_showtimes)
         try:
             self.movie_information = retrieve_movie_information(raw_movie_information["node"]["movie"])
@@ -224,7 +222,7 @@ def get_next_offer_id_from_database():
     return db.session.execute(sequence)
 
 
-def retrieve_movie_information(raw_movie_information: Dict) -> Dict:
+def retrieve_movie_information(raw_movie_information: dict) -> dict:
     parsed_movie_information = dict()
     parsed_movie_information["id"] = raw_movie_information["id"]
     parsed_movie_information["title"] = raw_movie_information["title"]
@@ -241,7 +239,7 @@ def retrieve_movie_information(raw_movie_information: Dict) -> Dict:
     return parsed_movie_information
 
 
-def retrieve_showtime_information(showtime_information: Dict) -> Dict:
+def retrieve_showtime_information(showtime_information: dict) -> dict:
     return {
         "startsAt": parse(showtime_information["startsAt"]),
         "diffusionVersion": showtime_information["diffusionVersion"],
@@ -250,7 +248,7 @@ def retrieve_showtime_information(showtime_information: Dict) -> Dict:
     }
 
 
-def _filter_only_digital_and_non_experience_showtimes(showtimes_information: List[Dict]) -> List[Dict]:
+def _filter_only_digital_and_non_experience_showtimes(showtimes_information: list[dict]) -> list[dict]:
     return list(
         filter(
             lambda showtime: showtime["projection"][0] == DIGITAL_PROJECTION and showtime["experience"] is None,
@@ -259,7 +257,7 @@ def _filter_only_digital_and_non_experience_showtimes(showtimes_information: Lis
     )
 
 
-def _find_showtime_by_showtime_uuid(showtimes: List[Dict], showtime_uuid: str) -> Union[Dict, None]:
+def _find_showtime_by_showtime_uuid(showtimes: list[dict], showtime_uuid: str) -> Union[dict, None]:
     for showtime in showtimes:
         if _build_showtime_uuid(showtime) == showtime_uuid:
             return showtime
@@ -277,7 +275,7 @@ def _get_showtimes_uuid_by_idAtProvider(id_at_provider: str):
     return id_at_provider.split("#")[1]
 
 
-def _build_description(movie_info: Dict) -> str:
+def _build_description(movie_info: dict) -> str:
     allocine_movie_url = movie_info["backlink"]["url"].replace("\\", "")
     return f"{movie_info['synopsis']}\n{movie_info['backlink']['label']}: {allocine_movie_url}"
 
@@ -286,11 +284,11 @@ def _format_poster_url(url: str) -> str:
     return url.replace(r"\/", "/")
 
 
-def _get_operating_visa(movie_info: Dict) -> Optional[str]:
+def _get_operating_visa(movie_info: dict) -> Optional[str]:
     return movie_info["releases"][0]["data"]["visa_number"]
 
 
-def _build_stage_director_full_name(movie_info: Dict) -> str:
+def _build_stage_director_full_name(movie_info: dict) -> str:
     stage_director_first_name = movie_info["credits"]["edges"][0]["node"]["person"]["firstName"]
     stage_director_last_name = movie_info["credits"]["edges"][0]["node"]["person"]["lastName"]
     return f"{stage_director_first_name} {stage_director_last_name}"
@@ -307,11 +305,11 @@ def _parse_movie_duration(duration: str) -> Optional[int]:
     return movie_duration_hours * 60 + movie_duration_minutes
 
 
-def _has_original_version_product(movies_showtimes: List[Dict]) -> bool:
+def _has_original_version_product(movies_showtimes: list[dict]) -> bool:
     return ORIGINAL_VERSION in list(map(lambda movie: movie["diffusionVersion"], movies_showtimes))
 
 
-def _has_french_version_product(movies_showtimes: List[Dict]) -> bool:
+def _has_french_version_product(movies_showtimes: list[dict]) -> bool:
     movies = list(map(lambda movie: movie["diffusionVersion"], movies_showtimes))
     return LOCAL_VERSION in movies or DUBBED_VERSION in movies
 
@@ -320,21 +318,21 @@ def _is_original_version_offer(id_at_providers: str) -> bool:
     return id_at_providers[-3:] == f"-{ORIGINAL_VERSION_SUFFIX}"
 
 
-def _build_movie_uuid(movie_information: Dict, venue: Venue) -> str:
+def _build_movie_uuid(movie_information: dict, venue: Venue) -> str:
     return f"{movie_information['id']}%{venue.siret}"
 
 
-def _build_french_movie_uuid(movie_information: Dict, venue: Venue) -> str:
+def _build_french_movie_uuid(movie_information: dict, venue: Venue) -> str:
     return f"{_build_movie_uuid(movie_information, venue)}-{FRENCH_VERSION_SUFFIX}"
 
 
-def _build_original_movie_uuid(movie_information: Dict, venue: Venue) -> str:
+def _build_original_movie_uuid(movie_information: dict, venue: Venue) -> str:
     return f"{_build_movie_uuid(movie_information, venue)}-{ORIGINAL_VERSION_SUFFIX}"
 
 
-def _build_showtime_uuid(showtime_details: Dict) -> str:
+def _build_showtime_uuid(showtime_details: dict) -> str:
     return f"{showtime_details['diffusionVersion']}/{showtime_details['startsAt']}"
 
 
-def _build_stock_uuid(movie_information: Dict, venue: Venue, showtime_details: Dict) -> str:
+def _build_stock_uuid(movie_information: dict, venue: Venue, showtime_details: dict) -> str:
     return f"{_build_movie_uuid(movie_information, venue)}#{_build_showtime_uuid(showtime_details)}"

--- a/src/pcapi/local_providers/chunk_manager.py
+++ b/src/pcapi/local_providers/chunk_manager.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from typing import Optional
 
 from pcapi.local_providers.providable_info import ProvidableInfo
@@ -9,7 +8,7 @@ from pcapi.repository.providable_queries import update_chunk
 
 
 def get_existing_pc_obj(
-    providable_info: ProvidableInfo, chunk_to_insert: Dict, chunk_to_update: Dict
+    providable_info: ProvidableInfo, chunk_to_insert: dict, chunk_to_update: dict
 ) -> Optional[Model]:
     object_in_current_chunk = get_object_from_current_chunks(providable_info, chunk_to_insert, chunk_to_update)
     if object_in_current_chunk is None:
@@ -19,7 +18,7 @@ def get_existing_pc_obj(
 
 
 def get_object_from_current_chunks(
-    providable_info: ProvidableInfo, chunk_to_insert: Dict, chunk_to_update: Dict
+    providable_info: ProvidableInfo, chunk_to_insert: dict, chunk_to_update: dict
 ) -> Optional[Model]:
     chunk_key = f"{providable_info.id_at_providers}|{providable_info.type.__name__}"
     pc_object = chunk_to_insert.get(chunk_key)
@@ -31,7 +30,7 @@ def get_object_from_current_chunks(
     return None
 
 
-def save_chunks(chunk_to_insert: Dict[str, Model], chunk_to_update: Dict[str, Model]):
+def save_chunks(chunk_to_insert: dict[str, Model], chunk_to_update: dict[str, Model]):
     if len(chunk_to_insert) > 0:
         insert_chunk(chunk_to_insert)
 

--- a/src/pcapi/local_providers/generic_provider/generic_stocks.py
+++ b/src/pcapi/local_providers/generic_provider/generic_stocks.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import List
 
 from sqlalchemy import Sequence
 
@@ -36,7 +35,7 @@ class GenericStocks(LocalProvider):
         self.product = None
         self.offer_id = None
 
-    def __next__(self) -> List[ProvidableInfo]:
+    def __next__(self) -> list[ProvidableInfo]:
         try:
             self.provider_stocks = next(self.stock_data)
         except StopIteration:

--- a/src/pcapi/local_providers/provider_api/synchronize_provider_api.py
+++ b/src/pcapi/local_providers/provider_api/synchronize_provider_api.py
@@ -1,11 +1,7 @@
 from datetime import datetime
 import logging
 import time
-from typing import Dict
 from typing import Generator
-from typing import List
-from typing import Set
-from typing import Tuple
 from typing import Union
 
 from flask import current_app as app
@@ -125,7 +121,7 @@ def _get_stocks_by_batch(siret: str, provider_api: ProviderAPI, modified_since: 
         last_processed_provider_reference = raw_stocks[-1]["ref"]
 
 
-def _build_stock_details_from_raw_stocks(raw_stocks: List[Dict], venue_siret: str) -> List[Dict]:
+def _build_stock_details_from_raw_stocks(raw_stocks: list[dict], venue_siret: str) -> list[dict]:
     stock_details = {}
     for stock in raw_stocks:
         stock_details[stock["ref"]] = {
@@ -139,11 +135,11 @@ def _build_stock_details_from_raw_stocks(raw_stocks: List[Dict], venue_siret: st
 
 
 def _build_new_offers_from_stock_details(
-    stock_details: List,
-    existing_offers_by_provider_reference: Dict[str, int],
-    products_by_provider_reference: Dict[str, Product],
+    stock_details: list,
+    existing_offers_by_provider_reference: dict[str, int],
+    products_by_provider_reference: dict[str, Product],
     venue_provider: VenueProvider,
-) -> List[Offer]:
+) -> list[Offer]:
     new_offers = []
     for stock_detail in stock_details:
         if stock_detail["offers_provider_reference"] in existing_offers_by_provider_reference:
@@ -166,11 +162,11 @@ def _build_new_offers_from_stock_details(
 
 
 def _get_stocks_to_upsert(
-    stock_details: List[Dict],
-    stocks_by_provider_reference: Dict[str, Dict],
-    offers_by_provider_reference: Dict[str, int],
-    products_by_provider_reference: Dict[str, Product],
-) -> Tuple[List[Dict], List[Stock], Set[int]]:
+    stock_details: list[dict],
+    stocks_by_provider_reference: dict[str, dict],
+    offers_by_provider_reference: dict[str, int],
+    products_by_provider_reference: dict[str, Product],
+) -> tuple[list[dict], list[Stock], set[int]]:
     update_stock_mapping = []
     new_stocks = []
     offer_ids = set()
@@ -207,7 +203,7 @@ def _get_stocks_to_upsert(
     return update_stock_mapping, new_stocks, offer_ids
 
 
-def _build_stock_from_stock_detail(stock_detail: Dict, offers_id: int, price: float) -> Stock:
+def _build_stock_from_stock_detail(stock_detail: dict, offers_id: int, price: float) -> Stock:
     return Stock(
         quantity=stock_detail["available_quantity"],
         rawProviderQuantity=stock_detail["available_quantity"],
@@ -246,7 +242,7 @@ def _build_new_offer(venue: Venue, product: Product, id_at_providers: str, provi
     )
 
 
-def _reindex_offers(offer_ids: Set[int]) -> None:
+def _reindex_offers(offer_ids: set[int]) -> None:
     if feature_queries.is_active(FeatureToggle.SYNCHRONIZE_ALGOLIA):
         for offer_id in offer_ids:
             redis.add_offer_id(client=app.redis_client, offer_id=offer_id)

--- a/src/pcapi/local_providers/titelive_thing_descriptions/titelive_thing_descriptions.py
+++ b/src/pcapi/local_providers/titelive_thing_descriptions/titelive_thing_descriptions.py
@@ -1,6 +1,5 @@
 from pathlib import PurePath
 import re
-from typing import List
 
 from pcapi.connectors.ftp_titelive import get_files_to_process_from_titelive_ftp
 from pcapi.connectors.ftp_titelive import get_zip_file_from_ftp
@@ -32,7 +31,7 @@ class TiteLiveThingDescriptions(LocalProvider):
         self.zip_file = None
         self.date_modified = None
 
-    def __next__(self) -> List[ProvidableInfo]:
+    def __next__(self) -> list[ProvidableInfo]:
         if self.description_zip_infos is None:
             self.open_next_file()
 

--- a/src/pcapi/local_providers/titelive_thing_thumbs/titelive_thing_thumbs.py
+++ b/src/pcapi/local_providers/titelive_thing_thumbs/titelive_thing_thumbs.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from pathlib import PurePath
 import re
-from typing import List
 
 from pcapi.connectors.ftp_titelive import get_files_to_process_from_titelive_ftp
 from pcapi.connectors.ftp_titelive import get_zip_file_from_ftp
@@ -31,7 +30,7 @@ class TiteLiveThingThumbs(LocalProvider):
         self.thumb_zipinfos = None
         self.zip = None
 
-    def __next__(self) -> List[ProvidableInfo]:
+    def __next__(self) -> list[ProvidableInfo]:
         if self.thumb_zipinfos is None:
             self.open_next_file()
 

--- a/src/pcapi/local_providers/titelive_things/titelive_things.py
+++ b/src/pcapi/local_providers/titelive_things/titelive_things.py
@@ -2,8 +2,6 @@ from io import BytesIO
 from io import TextIOWrapper
 import logging
 import re
-from typing import Dict
-from typing import List
 from typing import Optional
 
 from pcapi.connectors.ftp_titelive import connect_to_titelive_ftp
@@ -95,7 +93,7 @@ class TiteLiveThings(LocalProvider):
         self.products_file = None
         self.product_extra_data = {}
 
-    def __next__(self) -> Optional[List[ProvidableInfo]]:
+    def __next__(self) -> Optional[list[ProvidableInfo]]:
         if self.data_lines is None:
             self.open_next_file()
 
@@ -250,7 +248,7 @@ def get_thing_type_and_extra_data_from_titelive_type(titelive_type):
     return None, None
 
 
-def get_infos_from_data_line(elts: []) -> Dict:
+def get_infos_from_data_line(elts: []) -> dict:
     infos = dict()
     infos["ean13"] = elts[0]
     infos["isbn"] = elts[1]
@@ -294,7 +292,7 @@ def get_infos_from_data_line(elts: []) -> Dict:
     return infos
 
 
-def get_extra_data_from_infos(infos: Dict) -> Dict:
+def get_extra_data_from_infos(infos: dict) -> dict:
     extra_data = dict()
     extra_data["author"] = infos["auteurs"]
     extra_data["isbn"] = infos["ean13"]

--- a/src/pcapi/model_creators/specific_creators.py
+++ b/src/pcapi/model_creators/specific_creators.py
@@ -3,9 +3,7 @@ from datetime import timedelta
 from decimal import Decimal
 import random
 import string
-from typing import Dict
 from typing import Iterable
-from typing import List
 from typing import Optional
 
 from pcapi.core.offerers.models import Offerer
@@ -23,7 +21,7 @@ from pcapi.models import Venue
 def create_offer_with_event_product(
     venue: Venue = None,
     booking_email: str = "booking@example.net",
-    criteria: List[Criterion] = None,
+    criteria: list[Criterion] = None,
     date_created: datetime = datetime.utcnow(),
     description: Optional[str] = None,
     duration_minutes: Optional[int] = 60,
@@ -39,7 +37,7 @@ def create_offer_with_event_product(
     last_provider: Provider = None,
     thumb_count: int = 0,
     withdrawal_details: Optional[str] = None,
-    extra_data: Optional[Dict] = None,
+    extra_data: Optional[dict] = None,
     validation: OfferValidationStatus = OfferValidationStatus.APPROVED,
 ) -> Offer:
     offer = Offer()
@@ -77,7 +75,7 @@ def create_offer_with_event_product(
 
 def create_event_occurrence(
     offer: Offer, beginning_datetime: datetime = datetime.utcnow() + timedelta(hours=2)
-) -> Dict:
+) -> dict:
     event_occurrence = {}
     event_occurrence["offer"] = offer
     event_occurrence["offerId"] = offer.id
@@ -107,7 +105,7 @@ def create_offer_with_thing_product(
     url: Optional[str] = None,
     last_provider_id: int = None,
     last_provider: Provider = None,
-    extra_data: Dict = None,
+    extra_data: dict = None,
     withdrawal_details: Optional[str] = None,
     date_modified_at_last_provider: Optional[datetime] = datetime.utcnow(),
     validation: OfferValidationStatus = OfferValidationStatus.APPROVED,
@@ -211,7 +209,7 @@ def create_product_with_thing_type(
     thumb_count: int = 1,
     url: str = None,
     owning_offerer: Offerer = None,
-    extra_data: Dict = None,
+    extra_data: dict = None,
 ) -> Product:
     product = Product()
     product.id = idx
@@ -243,7 +241,7 @@ def create_product_with_thing_type(
 
 
 def create_stock_from_event_occurrence(
-    event_occurrence: Dict,
+    event_occurrence: dict,
     price: int = 10,
     quantity: int = 10,
     soft_deleted: bool = False,

--- a/src/pcapi/models/pc_object.py
+++ b/src/pcapi/models/pc_object.py
@@ -6,7 +6,6 @@ from pprint import pprint
 import re
 from typing import Any
 from typing import Iterable
-from typing import Set
 import uuid
 
 from sqlalchemy import BigInteger
@@ -168,7 +167,7 @@ class PcObject:
         return PcObject.restize_global_error(value_error)
 
     @staticmethod
-    def _get_keys_to_populate(columns: Iterable[str], data: dict, skipped_keys: Iterable[str]) -> Set[str]:
+    def _get_keys_to_populate(columns: Iterable[str], data: dict, skipped_keys: Iterable[str]) -> set[str]:
         requested_columns_to_update = set(data.keys())
         forbidden_columns = {"id", "deleted"} | set(skipped_keys)
         allowed_columns_to_update = requested_columns_to_update - forbidden_columns

--- a/src/pcapi/notifications/push/transactional_notifications.py
+++ b/src/pcapi/notifications/push/transactional_notifications.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import List
 from typing import Optional
 
 from pcapi.core.bookings.models import Booking
@@ -21,11 +20,11 @@ class TransactionalNotificationMessage:
 @dataclass
 class TransactionalNotificationData:
     group_id: str  # Name of the campaign, useful for analytics purpose
-    user_ids: List[int]
+    user_ids: list[int]
     message: TransactionalNotificationMessage
 
 
-def get_bookings_cancellation_notification_data(booking_ids: List[int]) -> Optional[TransactionalNotificationData]:
+def get_bookings_cancellation_notification_data(booking_ids: list[int]) -> Optional[TransactionalNotificationData]:
     bookings = Booking.query.filter(Booking.id.in_(booking_ids))
 
     if not bookings:

--- a/src/pcapi/repository/beneficiary_import_queries.py
+++ b/src/pcapi/repository/beneficiary_import_queries.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from sqlalchemy import asc
 
 from pcapi.core.users.models import User
@@ -41,7 +39,7 @@ def save_beneficiary_import_with_status(
     repository.save(beneficiary_import)
 
 
-def find_applications_ids_to_retry() -> List[int]:
+def find_applications_ids_to_retry() -> list[int]:
     ids = (
         db.session.query(BeneficiaryImport.applicationId)
         .filter(BeneficiaryImport.currentStatus == ImportStatus.RETRY)

--- a/src/pcapi/repository/iris_venues_queries.py
+++ b/src/pcapi/repository/iris_venues_queries.py
@@ -1,12 +1,9 @@
-from typing import Dict
-from typing import List
-
 from pcapi.models import IrisVenues
 from pcapi.models.db import db
 from pcapi.repository import repository
 
 
-def find_ids_of_irises_located_near_venue(venue_id: int, search_radius: int) -> List[int]:
+def find_ids_of_irises_located_near_venue(venue_id: int, search_radius: int) -> list[int]:
     query = """
     WITH venue_coordinates AS (SELECT longitude, latitude from venue WHERE id = :venue_id)
     SELECT id FROM iris_france, venue_coordinates
@@ -19,7 +16,7 @@ def find_ids_of_irises_located_near_venue(venue_id: int, search_radius: int) -> 
     return [iris.id for iris in iris]
 
 
-def insert_venue_in_iris_venue(venue_id: int, iris_ids_near_venue: List[int]) -> None:
+def insert_venue_in_iris_venue(venue_id: int, iris_ids_near_venue: list[int]) -> None:
     irises_venues = [{"venueId": venue_id, "irisId": iris_id} for iris_id in iris_ids_near_venue]
     _bulk_insert_iris_venues(irises_venues)
 
@@ -29,6 +26,6 @@ def delete_venue_from_iris_venues(venue_id: int) -> None:
     repository.delete(*iris_venues_to_delete)
 
 
-def _bulk_insert_iris_venues(iris_venue_information: List[Dict]) -> None:
+def _bulk_insert_iris_venues(iris_venue_information: list[dict]) -> None:
     db.session.bulk_insert_mappings(IrisVenues, iris_venue_information)
     db.session.commit()

--- a/src/pcapi/repository/mediation_queries.py
+++ b/src/pcapi/repository/mediation_queries.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pcapi.core.offers.models import Mediation
 
 
@@ -7,5 +5,5 @@ def find_by_id(mediation_id: str) -> Mediation:
     return Mediation.query.filter_by(id=mediation_id).first()
 
 
-def get_mediations_for_offers(offer_ids: List[int]) -> List[Mediation]:
+def get_mediations_for_offers(offer_ids: list[int]) -> list[Mediation]:
     return Mediation.query.filter(Mediation.offerId.in_(offer_ids)).all()

--- a/src/pcapi/repository/offer_queries.py
+++ b/src/pcapi/repository/offer_queries.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import List
 
 from sqlalchemy import func
 from sqlalchemy.orm import aliased
@@ -45,19 +44,19 @@ def get_offer_by_id(offer_id: int):
     return Offer.query.get(offer_id)
 
 
-def get_offers_by_venue_id(venue_id: int) -> List[Offer]:
+def get_offers_by_venue_id(venue_id: int) -> list[Offer]:
     return Offer.query.filter_by(venueId=venue_id).all()
 
 
-def get_offers_by_product_id(product_id: int) -> List[Offer]:
+def get_offers_by_product_id(product_id: int) -> list[Offer]:
     return Offer.query.filter_by(productId=product_id).all()
 
 
-def get_offers_by_ids(offer_ids: List[int]) -> List[Offer]:
+def get_offers_by_ids(offer_ids: list[int]) -> list[Offer]:
     return Offer.query.filter(Offer.id.in_(offer_ids)).options(joinedload("stocks")).all()
 
 
-def get_paginated_active_offer_ids(limit: int, page: int) -> List[tuple]:
+def get_paginated_active_offer_ids(limit: int, page: int) -> list[tuple]:
     return (
         Offer.query.with_entities(Offer.id)
         .filter(Offer.isActive == True)
@@ -68,7 +67,7 @@ def get_paginated_active_offer_ids(limit: int, page: int) -> List[tuple]:
     )
 
 
-def get_paginated_offer_ids_by_venue_id(venue_id: int, limit: int, page: int) -> List[tuple]:
+def get_paginated_offer_ids_by_venue_id(venue_id: int, limit: int, page: int) -> list[tuple]:
     return (
         Offer.query.with_entities(Offer.id)
         .filter(Offer.venueId == venue_id)
@@ -81,7 +80,7 @@ def get_paginated_offer_ids_by_venue_id(venue_id: int, limit: int, page: int) ->
 
 def get_paginated_offer_ids_by_venue_id_and_last_provider_id(
     last_provider_id: str, limit: int, page: int, venue_id: int
-) -> List[tuple]:
+) -> list[tuple]:
     return (
         Offer.query.with_entities(Offer.id)
         .filter(Offer.lastProviderId == last_provider_id)  # pylint: disable=comparison-with-callable
@@ -95,7 +94,7 @@ def get_paginated_offer_ids_by_venue_id_and_last_provider_id(
 
 def get_paginated_offer_ids_given_booking_limit_datetime_interval(
     limit: int, page: int, from_date: datetime, to_date: datetime
-) -> List[tuple]:
+) -> list[tuple]:
     start_limit = from_date <= func.max(Stock.bookingLimitDatetime)
     end_limit = func.max(Stock.bookingLimitDatetime) <= to_date
 

--- a/src/pcapi/repository/payment_queries.py
+++ b/src/pcapi/repository/payment_queries.py
@@ -1,4 +1,3 @@
-from typing import List
 from typing import Optional
 
 from flask import render_template
@@ -19,23 +18,23 @@ from pcapi.models.db import db
 from pcapi.models.payment_status import TransactionStatus
 
 
-def find_error_payments() -> List[Payment]:
+def find_error_payments() -> list[Payment]:
     query = render_template("sql/find_payment_ids_with_last_status.sql", status="ERROR")
     error_payment_ids = db.session.query(PaymentStatus.paymentId).from_statement(text(query)).all()
     return Payment.query.filter(Payment.id.in_(error_payment_ids)).all()
 
 
-def find_retry_payments() -> List[Payment]:
+def find_retry_payments() -> list[Payment]:
     query = render_template("sql/find_payment_ids_with_last_status.sql", status="RETRY")
     retry_payment_ids = db.session.query(PaymentStatus.paymentId).from_statement(text(query)).all()
     return Payment.query.filter(Payment.id.in_(retry_payment_ids)).all()
 
 
-def find_payments_by_message(message_name: str) -> List[Payment]:
+def find_payments_by_message(message_name: str) -> list[Payment]:
     return Payment.query.join(PaymentMessage).filter(PaymentMessage.name == message_name).all()
 
 
-def get_payments_by_message_id(payment_message_id: str) -> List[Payment]:
+def get_payments_by_message_id(payment_message_id: str) -> list[Payment]:
     return Payment.query.join(PaymentMessage).filter(PaymentMessage.name == payment_message_id).all()
 
 
@@ -43,7 +42,7 @@ def has_payment(booking: Booking) -> Optional[Payment]:
     return db.session.query(Payment.query.filter_by(bookingId=booking.id).exists()).scalar()
 
 
-def find_not_processable_with_bank_information() -> List[Payment]:
+def find_not_processable_with_bank_information() -> list[Payment]:
     most_recent_payment_status = (
         PaymentStatus.query.with_entities(PaymentStatus.id)
         .distinct(PaymentStatus.paymentId)

--- a/src/pcapi/repository/providable_queries.py
+++ b/src/pcapi/repository/providable_queries.py
@@ -1,6 +1,4 @@
 import datetime
-from typing import Dict
-from typing import List
 from typing import Optional
 
 from pcapi import models
@@ -8,12 +6,12 @@ from pcapi.models.db import Model
 from pcapi.models.db import db
 
 
-def insert_chunk(chunk_to_insert: Dict):
+def insert_chunk(chunk_to_insert: dict):
     db.session.bulk_save_objects(chunk_to_insert.values(), return_defaults=False)
     db.session.commit()
 
 
-def update_chunk(chunk_to_update: Dict):
+def update_chunk(chunk_to_update: dict):
     models_in_chunk = set(_extract_model_name_from_chunk_key(key) for key in chunk_to_update.keys())
 
     for model_in_chunk in models_in_chunk:
@@ -25,17 +23,17 @@ def update_chunk(chunk_to_update: Dict):
     db.session.commit()
 
 
-def _filter_matching_pc_object_in_chunk(model_in_chunk: Model, chunk_to_update: Dict) -> List[Model]:
+def _filter_matching_pc_object_in_chunk(model_in_chunk: Model, chunk_to_update: dict) -> list[Model]:
     return list(
         filter(lambda item: _extract_model_name_from_chunk_key(item[0]) == model_in_chunk, chunk_to_update.items())
     )
 
 
-def _extract_dict_values_from_chunk(matching_tuples_in_chunk: List[Model]) -> List[Dict]:
+def _extract_dict_values_from_chunk(matching_tuples_in_chunk: list[Model]) -> list[dict]:
     return list(dictify_pc_object(pc_object_item) for pc_object_key, pc_object_item in matching_tuples_in_chunk)
 
 
-def get_existing_object(model_type: Model, id_at_providers: str) -> Optional[Dict]:
+def get_existing_object(model_type: Model, id_at_providers: str) -> Optional[dict]:
     return model_type.query.filter_by(idAtProviders=id_at_providers).first()
 
 
@@ -45,7 +43,7 @@ def get_last_update_for_provider(provider_id: int, pc_obj: Model) -> datetime:
     return None
 
 
-def dictify_pc_object(object_to_update: Model) -> Dict:
+def dictify_pc_object(object_to_update: Model) -> dict:
     dict_to_update = object_to_update.__dict__.copy()
     if "_sa_instance_state" in dict_to_update:
         del dict_to_update["_sa_instance_state"]

--- a/src/pcapi/repository/provider_queries.py
+++ b/src/pcapi/repository/provider_queries.py
@@ -1,5 +1,4 @@
 from operator import or_
-from typing import List
 from typing import Optional
 
 from pcapi.models.provider import Provider
@@ -13,11 +12,11 @@ def get_provider_by_local_class(local_class: str) -> Provider:
     return Provider.query.filter_by(localClass=local_class).first()
 
 
-def get_enabled_providers_for_pro() -> List[Provider]:
+def get_enabled_providers_for_pro() -> list[Provider]:
     return Provider.query.filter_by(isActive=True).filter_by(enabledForPro=True).order_by(Provider.name).all()
 
 
-def get_providers_enabled_for_pro_excluding_specific_provider(allocine_local_class: str) -> List[Provider]:
+def get_providers_enabled_for_pro_excluding_specific_provider(allocine_local_class: str) -> list[Provider]:
     return (
         Provider.query.filter_by(isActive=True)
         .filter_by(enabledForPro=True)

--- a/src/pcapi/repository/reimbursement_queries.py
+++ b/src/pcapi/repository/reimbursement_queries.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from typing import List
 
 from sqlalchemy import subquery
 from sqlalchemy.orm import aliased
@@ -14,7 +13,7 @@ from pcapi.models import Venue
 from pcapi.models.payment import Payment
 
 
-def find_all_offerer_payments(offerer_id: int) -> List[namedtuple]:
+def find_all_offerer_payments(offerer_id: int) -> list[namedtuple]:
     payment_status_query = _build_payment_status_subquery()
 
     return (

--- a/src/pcapi/repository/repository.py
+++ b/src/pcapi/repository/repository.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from sqlalchemy.exc import DataError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.exc import InternalError
@@ -11,7 +9,7 @@ from pcapi.models.db import db
 from pcapi.validation.models import entity_validator
 
 
-def delete(*models: List[Model]) -> None:
+def delete(*models: list[Model]) -> None:
     for model in models:
         db.session.delete(model)
     db.session.commit()

--- a/src/pcapi/repository/user_queries.py
+++ b/src/pcapi/repository/user_queries.py
@@ -1,6 +1,5 @@
 from datetime import MINYEAR
 from datetime import datetime
-from typing import List
 
 from sqlalchemy import Column
 from sqlalchemy import func
@@ -29,7 +28,7 @@ def find_user_by_email(email: str) -> User:
     return User.query.filter(func.lower(User.email) == format_email(email)).first()
 
 
-def find_beneficiary_users_by_email_provider(email_provider: str) -> List[User]:
+def find_beneficiary_users_by_email_provider(email_provider: str) -> list[User]:
     formatted_email_provider = f"%@%{email_provider}"
     return (
         User.query.filter_by(isBeneficiary=True, isActive=True)
@@ -38,7 +37,7 @@ def find_beneficiary_users_by_email_provider(email_provider: str) -> List[User]:
     )
 
 
-def find_by_civility(first_name: str, last_name: str, date_of_birth: datetime) -> List[User]:
+def find_by_civility(first_name: str, last_name: str, date_of_birth: datetime) -> list[User]:
     civility_predicate = (
         (_matching(User.firstName, first_name))
         & (_matching(User.lastName, last_name))
@@ -56,7 +55,7 @@ def find_user_by_reset_password_token(token: str) -> User:
     return User.query.filter_by(resetPasswordToken=token).first()
 
 
-def get_all_users_wallet_balances() -> List[WalletBalance]:
+def get_all_users_wallet_balances() -> list[WalletBalance]:
     """Return wallet balances.
 
     WARNING: it ignores the expiration date of the deposits.

--- a/src/pcapi/repository/venue_provider_queries.py
+++ b/src/pcapi/repository/venue_provider_queries.py
@@ -1,17 +1,15 @@
-from typing import List
-
 from sqlalchemy import not_
 
 from pcapi.models import VenueProvider
 
 
-def get_active_venue_providers_for_specific_provider(provider_id: int) -> List[VenueProvider]:
+def get_active_venue_providers_for_specific_provider(provider_id: int) -> list[VenueProvider]:
     return (
         VenueProvider.query.filter(VenueProvider.providerId == provider_id).filter(VenueProvider.isActive == True).all()
     )
 
 
-def get_venue_providers_to_sync(provider_id: int) -> List[VenueProvider]:
+def get_venue_providers_to_sync(provider_id: int) -> list[VenueProvider]:
     return (
         VenueProvider.query.filter(VenueProvider.isActive == True)
         .filter(VenueProvider.providerId == provider_id)

--- a/src/pcapi/repository/venue_types_queries.py
+++ b/src/pcapi/repository/venue_types_queries.py
@@ -1,7 +1,5 @@
-from typing import List
-
 from pcapi.models import VenueType
 
 
-def get_all_venue_types() -> List[VenueType]:
+def get_all_venue_types() -> list[VenueType]:
     return VenueType.query.all()

--- a/src/pcapi/routes/error_handlers/generic_error_handlers.py
+++ b/src/pcapi/routes/error_handlers/generic_error_handlers.py
@@ -1,6 +1,4 @@
 import logging
-from typing import Dict
-from typing import Tuple
 from typing import Union
 
 from flask import current_app as app
@@ -24,22 +22,22 @@ logger = logging.getLogger(__name__)
 
 
 @app.errorhandler(NotFound)
-def restize_not_found_route_errors(error: NotFound) -> Tuple[Dict, int]:
+def restize_not_found_route_errors(error: NotFound) -> tuple[dict, int]:
     return {}, 404
 
 
 @app.errorhandler(ApiErrors)
-def restize_api_errors(error: ApiErrors) -> Tuple[Dict, int]:
+def restize_api_errors(error: ApiErrors) -> tuple[dict, int]:
     return jsonify(error.errors), error.status_code or 400
 
 
 @app.errorhandler(offers_exceptions.TooLateToDeleteStock)
-def restize_too_late_to_delete_stock(error: offers_exceptions.TooLateToDeleteStock) -> Tuple[Dict, int]:
+def restize_too_late_to_delete_stock(error: offers_exceptions.TooLateToDeleteStock) -> tuple[dict, int]:
     return jsonify(error.errors), 400
 
 
 @app.errorhandler(Exception)
-def internal_error(error: Exception) -> Union[Tuple[Dict, int], HTTPException]:
+def internal_error(error: Exception) -> Union[tuple[dict, int], HTTPException]:
     # pass through HTTP errors
     if isinstance(error, HTTPException):
         return error
@@ -50,7 +48,7 @@ def internal_error(error: Exception) -> Union[Tuple[Dict, int], HTTPException]:
 
 
 @app.errorhandler(MethodNotAllowed)
-def method_not_allowed(error: MethodNotAllowed) -> Tuple[Dict, int]:
+def method_not_allowed(error: MethodNotAllowed) -> tuple[dict, int]:
     api_errors = ApiErrors()
     api_errors.add_error("global", "La méthode que vous utilisez n'existe pas sur notre serveur")
     logger.error("405 %s", error)
@@ -59,7 +57,7 @@ def method_not_allowed(error: MethodNotAllowed) -> Tuple[Dict, int]:
 
 @app.errorhandler(NonProperlyFormattedScrambledId)
 @app.errorhandler(NonDehumanizableId)
-def invalid_id_for_dehumanize_error(error: NonDehumanizableId) -> Tuple[Dict, int]:
+def invalid_id_for_dehumanize_error(error: NonDehumanizableId) -> tuple[dict, int]:
     api_errors = ApiErrors()
     api_errors.add_error("global", "La page que vous recherchez n'existe pas")
     logger.error("404 %s", error)
@@ -67,7 +65,7 @@ def invalid_id_for_dehumanize_error(error: NonDehumanizableId) -> Tuple[Dict, in
 
 
 @app.errorhandler(DecimalCastError)
-def decimal_cast_error(error: DecimalCastError) -> Tuple[Dict, int]:
+def decimal_cast_error(error: DecimalCastError) -> tuple[dict, int]:
     api_errors = ApiErrors()
     logger.warning(json.dumps(error.errors))
     for field in error.errors.keys():
@@ -76,7 +74,7 @@ def decimal_cast_error(error: DecimalCastError) -> Tuple[Dict, int]:
 
 
 @app.errorhandler(DateTimeCastError)
-def date_time_cast_error(error: DateTimeCastError) -> Tuple[Dict, int]:
+def date_time_cast_error(error: DateTimeCastError) -> tuple[dict, int]:
     api_errors = ApiErrors()
     logger.warning(json.dumps(error.errors))
     for field in error.errors.keys():
@@ -85,7 +83,7 @@ def date_time_cast_error(error: DateTimeCastError) -> Tuple[Dict, int]:
 
 
 @app.errorhandler(AlreadyActivatedException)
-def already_activated_exception(error: AlreadyActivatedException) -> Tuple[Dict, int]:
+def already_activated_exception(error: AlreadyActivatedException) -> tuple[dict, int]:
     logger.error(json.dumps(error.errors))
     return jsonify(error.errors), 405
 

--- a/src/pcapi/routes/native/v1/serialization/account.py
+++ b/src/pcapi/routes/native/v1/serialization/account.py
@@ -1,6 +1,5 @@
 import datetime
 from datetime import date
-from typing import Dict
 from typing import Optional
 from uuid import UUID
 
@@ -89,7 +88,7 @@ class DomainsCredit(BaseModel):
 
 class UserProfileResponse(BaseModel):
     id: int
-    booked_offers: Dict[str, int]
+    booked_offers: dict[str, int]
     domains_credit: Optional[DomainsCredit]
     dateOfBirth: Optional[datetime.date]
     deposit_expiration_date: Optional[datetime.datetime]

--- a/src/pcapi/routes/native/v1/serialization/bookings.py
+++ b/src/pcapi/routes/native/v1/serialization/bookings.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from typing import Any
-from typing import List
 from typing import Optional
 
 from pydantic.class_validators import validator
@@ -103,8 +102,8 @@ class BookingReponse(BaseModel):
 
 
 class BookingsResponse(BaseModel):
-    ended_bookings: List[BookingReponse]
-    ongoing_bookings: List[BookingReponse]
+    ended_bookings: list[BookingReponse]
+    ongoing_bookings: list[BookingReponse]
 
     class Config:
         json_encoders = {datetime: format_into_utc_date}

--- a/src/pcapi/routes/native/v1/serialization/favorites.py
+++ b/src/pcapi/routes/native/v1/serialization/favorites.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from decimal import Decimal
-from typing import List
 from typing import Optional
 
 from pydantic.class_validators import validator
@@ -47,7 +46,7 @@ class FavoriteOfferResponse(BaseModel):
     date: Optional[datetime] = None
     startDate: Optional[datetime] = None
     isExpired: bool = False
-    expenseDomains: List[ExpenseDomain]
+    expenseDomains: list[ExpenseDomain]
     isReleased: bool
     isSoldOut: bool = False
 
@@ -80,7 +79,7 @@ class FavoriteResponse(BaseModel):
 class PaginatedFavoritesResponse(BaseModel):
     page: int
     nbFavorites: int
-    favorites: List[FavoriteResponse]
+    favorites: list[FavoriteResponse]
 
     class Config:
         json_encoders = {datetime: format_into_utc_date}

--- a/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/src/pcapi/routes/native/v1/serialization/offers.py
@@ -2,8 +2,6 @@ from datetime import datetime
 import logging
 from typing import Any
 from typing import Callable
-from typing import Dict
-from typing import List
 from typing import Optional
 
 from pydantic.class_validators import validator
@@ -95,7 +93,7 @@ class OfferVenueResponse(BaseModel):
 LABELS_BY_DICT_MAPPING = {"musicSubType": ""}
 
 
-def get_id_converter(labels_by_id: Dict, field_name: str) -> Callable[[Optional[str]], Optional[str]]:
+def get_id_converter(labels_by_id: dict, field_name: str) -> Callable[[Optional[str]], Optional[str]]:
     def convert_id_into_label(value_id: Optional[str]) -> Optional[str]:
         try:
             return labels_by_id[int(value_id)] if value_id else None
@@ -181,7 +179,7 @@ class OfferResponse(BaseModel):
     id: int
     accessibility: OfferAccessibilityResponse
     description: Optional[str]
-    expense_domains: List[ExpenseDomain]
+    expense_domains: list[ExpenseDomain]
     externalTicketOfficeUrl: Optional[str]
     extraData: Optional[OfferExtraData]
     isActive: bool  # TODO (viconnex): remove field when frontend uses isReleased
@@ -192,7 +190,7 @@ class OfferResponse(BaseModel):
     isDuo: bool
     name: str
     category: OfferCategoryResponse
-    stocks: List[OfferStockResponse]
+    stocks: list[OfferStockResponse]
     image: Optional[OfferImageResponse]
     venue: OfferVenueResponse
     withdrawalDetails: Optional[str]

--- a/src/pcapi/routes/pro/bookings.py
+++ b/src/pcapi/routes/pro/bookings.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from flask import jsonify
 from flask import request
 from flask_login import current_user
@@ -168,7 +166,7 @@ def patch_booking_keep_by_token(token: str):
     return "", 204
 
 
-def _get_api_key_from_header(received_request: Dict) -> ApiKey:
+def _get_api_key_from_header(received_request: dict) -> ApiKey:
     authorization_header = received_request.headers.get("Authorization", None)
     headers_contains_api_key_authorization = authorization_header and "Bearer" in authorization_header
 
@@ -180,7 +178,7 @@ def _get_api_key_from_header(received_request: Dict) -> ApiKey:
     return find_api_key_by_value(app_authorization_api_key)
 
 
-def _create_response_to_get_booking_by_token(booking: Booking) -> Dict:
+def _create_response_to_get_booking_by_token(booking: Booking) -> dict:
     offer_name = booking.stock.offer.product.name
     date = None
     offer = booking.stock.offer

--- a/src/pcapi/routes/pro/offerers.py
+++ b/src/pcapi/routes/pro/offerers.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from flask import jsonify
 from flask import request
@@ -41,7 +40,7 @@ def get_dict_offerer(offerer: Offerer) -> dict:
     return as_dict(offerer, includes=OFFERER_INCLUDES)
 
 
-def get_dict_offerers(offerers: List[Offerer]) -> list:
+def get_dict_offerers(offerers: list[Offerer]) -> list:
     return [as_dict(offerer, includes=OFFERER_INCLUDES) for offerer in offerers]
 
 

--- a/src/pcapi/routes/serialization/beneficiary_bookings_serialize.py
+++ b/src/pcapi/routes/serialization/beneficiary_bookings_serialize.py
@@ -1,6 +1,3 @@
-from typing import Dict
-from typing import List
-
 from pcapi.domain.beneficiary_bookings.beneficiary_booking import BeneficiaryBooking
 from pcapi.domain.beneficiary_bookings.beneficiary_bookings_with_stocks import BeneficiaryBookingsWithStocks
 from pcapi.domain.beneficiary_bookings.stock import Stock
@@ -10,7 +7,7 @@ from pcapi.utils.human_ids import humanize
 
 def serialize_beneficiary_bookings(
     beneficiary_bookings: BeneficiaryBookingsWithStocks, with_qr_code: bool = False
-) -> List:
+) -> list:
     results = []
     for beneficiary_booking in beneficiary_bookings.bookings:
         serialized_stocks = _serialize_stocks_for_beneficiary_bookings(
@@ -23,7 +20,7 @@ def serialize_beneficiary_bookings(
     return results
 
 
-def _serialize_stock_for_beneficiary_booking(stock: Stock) -> Dict:
+def _serialize_stock_for_beneficiary_booking(stock: Stock) -> dict:
     return {
         "dateCreated": serialize(stock.date_created),
         "beginningDatetime": serialize(stock.beginning_datetime),
@@ -38,18 +35,18 @@ def _serialize_stock_for_beneficiary_booking(stock: Stock) -> Dict:
     }
 
 
-def _serialize_stocks_for_beneficiary_bookings(matched_offer_id: int, stocks: List[Stock]) -> List[Dict]:
+def _serialize_stocks_for_beneficiary_bookings(matched_offer_id: int, stocks: list[Stock]) -> list[dict]:
     return [_serialize_stock_for_beneficiary_booking(stock) for stock in stocks if stock.offer_id == matched_offer_id]
 
 
-def _serialize_offer_is_bookable(serialized_stocks: List[Dict]) -> bool:
+def _serialize_offer_is_bookable(serialized_stocks: list[dict]) -> bool:
     are_stocks_bookable = [stock["isBookable"] for stock in serialized_stocks]
     return True in are_stocks_bookable
 
 
 def _serialize_beneficiary_booking(
-    beneficiary_booking: BeneficiaryBooking, serialized_stocks: List[Dict], with_qr_code: bool = False
-) -> Dict:
+    beneficiary_booking: BeneficiaryBooking, serialized_stocks: list[dict], with_qr_code: bool = False
+) -> dict:
     dictified_booking = {
         "completedUrl": beneficiary_booking.booking_access_url,
         "isEventExpired": beneficiary_booking.is_event_expired,

--- a/src/pcapi/routes/serialization/bookings_recap_serialize.py
+++ b/src/pcapi/routes/serialization/bookings_recap_serialize.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 from typing import Any
-from typing import Dict
-from typing import List
 
 from pcapi.domain.booking_recap.booking_recap import BookBookingRecap
 from pcapi.domain.booking_recap.booking_recap import BookingRecap
@@ -17,7 +15,7 @@ from pcapi.utils.date import format_into_timezoned_date
 from pcapi.utils.human_ids import humanize
 
 
-def serialize_bookings_recap_paginated(bookings_recap_paginated: BookingsRecapPaginated) -> Dict[str, Any]:
+def serialize_bookings_recap_paginated(bookings_recap_paginated: BookingsRecapPaginated) -> dict[str, Any]:
     return {
         "bookings_recap": [
             _serialize_booking_recap(booking_recap) for booking_recap in bookings_recap_paginated.bookings_recap
@@ -28,7 +26,7 @@ def serialize_bookings_recap_paginated(bookings_recap_paginated: BookingsRecapPa
     }
 
 
-def _serialize_booking_status_info(booking_status: BookingRecapStatus, booking_status_date: datetime) -> Dict[str, str]:
+def _serialize_booking_status_info(booking_status: BookingRecapStatus, booking_status_date: datetime) -> dict[str, str]:
 
     serialized_booking_status_date = format_into_timezoned_date(booking_status_date) if booking_status_date else None
 
@@ -38,7 +36,7 @@ def _serialize_booking_status_info(booking_status: BookingRecapStatus, booking_s
     }
 
 
-def _serialize_booking_status_history(booking_status_history: BookingRecapHistory) -> List[Dict[str, str]]:
+def _serialize_booking_status_history(booking_status_history: BookingRecapHistory) -> list[dict[str, str]]:
     serialized_booking_status_history = [
         _serialize_booking_status_info(BookingRecapStatus.booked, booking_status_history.booking_date)
     ]
@@ -65,7 +63,7 @@ def _serialize_booking_status_history(booking_status_history: BookingRecapHistor
     return serialized_booking_status_history
 
 
-def _serialize_booking_recap(booking_recap: BookingRecap) -> Dict[str, Any]:
+def _serialize_booking_recap(booking_recap: BookingRecap) -> dict[str, Any]:
     serialized_booking_recap = {
         "stock": {
             "type": "thing",

--- a/src/pcapi/routes/serialization/bookings_serialize.py
+++ b/src/pcapi/routes/serialization/bookings_serialize.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from typing import Optional
 
 from pydantic import BaseModel
@@ -11,7 +10,7 @@ from pcapi.serialization.utils import to_camel
 from pcapi.utils.human_ids import humanize
 
 
-def serialize_booking(booking: Booking) -> Dict:
+def serialize_booking(booking: Booking) -> dict:
     booking_id = humanize(booking.id)
     user_email = booking.user.email
     is_used = booking.isUsed
@@ -68,7 +67,7 @@ def serialize_booking(booking: Booking) -> Dict:
     }
 
 
-def serialize_booking_minimal(booking: Booking) -> Dict:
+def serialize_booking_minimal(booking: Booking) -> dict:
     return {
         "amount": float(booking.amount),
         "completedUrl": booking.completedUrl,

--- a/src/pcapi/routes/serialization/dictifier.py
+++ b/src/pcapi/routes/serialization/dictifier.py
@@ -1,8 +1,6 @@
 from collections import OrderedDict
 from functools import singledispatch
 from typing import Iterable
-from typing import List
-from typing import Set
 
 from sqlalchemy.orm.collections import InstrumentedList
 
@@ -74,17 +72,17 @@ def _(model, column=None, includes: Iterable = ()):
     return result
 
 
-def _joins_to_serialize(includes: Iterable) -> List[dict]:
+def _joins_to_serialize(includes: Iterable) -> list[dict]:
     dict_joins = filter(lambda a: isinstance(a, dict), includes)
     return list(dict_joins)
 
 
-def _keys_to_serialize(model, includes: Iterable) -> Set[str]:
+def _keys_to_serialize(model, includes: Iterable) -> set[str]:
     model_attributes = model.__mapper__.c.keys()
     return set(model_attributes).union(_included_properties(includes)) - _excluded_keys(includes)
 
 
-def _included_properties(includes: Iterable) -> Set[str]:
+def _included_properties(includes: Iterable) -> set[str]:
     string_keys = filter(lambda a: isinstance(a, str), includes)
     included_keys = filter(lambda a: not a.startswith("-"), string_keys)
     return set(included_keys)

--- a/src/pcapi/routes/serialization/favorites_serialize.py
+++ b/src/pcapi/routes/serialization/favorites_serialize.py
@@ -1,16 +1,13 @@
-from typing import Dict
-from typing import List
-
 from pcapi.domain.favorite.favorite import FavoriteDomain
 from pcapi.routes.serialization.serializer import serialize
 from pcapi.utils.human_ids import humanize
 
 
-def serialize_favorites(favorites: List[FavoriteDomain]) -> List:
+def serialize_favorites(favorites: list[FavoriteDomain]) -> list:
     return [serialize_favorite(favorite) for favorite in favorites]
 
 
-def serialize_favorite(favorite: FavoriteDomain) -> Dict:
+def serialize_favorite(favorite: FavoriteDomain) -> dict:
     offer = favorite.offer
     venue = offer.venue
     humanized_offer_id = humanize(offer.id)

--- a/src/pcapi/routes/serialization/mediations_serialize.py
+++ b/src/pcapi/routes/serialization/mediations_serialize.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 import logging
 from pathlib import Path
-from typing import List
 from typing import Optional
 
 from pydantic import BaseModel
@@ -107,7 +106,7 @@ class UpdateMediationResponseModel(BaseModel):
     credit: Optional[str]
     dateCreated: Optional[datetime]
     dateModifiedAtLastProvider: Optional[datetime]
-    fieldsUpdated: Optional[List[str]]
+    fieldsUpdated: Optional[list[str]]
     id: str
     idAtProviders: Optional[str]
     isActive: bool

--- a/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/src/pcapi/routes/serialization/offerers_serialize.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import List
 from typing import Optional
 
 from pydantic import BaseModel
@@ -52,13 +51,13 @@ class GetOffererResponseModel(BaseModel):
     dateCreated: datetime
     dateModifiedAtLastProvider: Optional[datetime]
     demarchesSimplifieesApplicationId: Optional[str]
-    fieldsUpdated: List[str]
+    fieldsUpdated: list[str]
     iban: Optional[str]
     id: str
     idAtProviders: Optional[str]
     isValidated: bool
     lastProviderId: Optional[str]
-    managedVenues: List[GetOffererVenueResponseModel]
+    managedVenues: list[GetOffererVenueResponseModel]
     name: str
     nOffers: int
     postalCode: str
@@ -83,7 +82,7 @@ class GetOffererNameResponseModel(BaseModel):
 
 
 class GetOfferersNamesResponseModel(BaseModel):
-    offerersNames: List[GetOffererNameResponseModel]
+    offerersNames: list[GetOffererNameResponseModel]
 
     class Config:
         orm_mode = True

--- a/src/pcapi/routes/serialization/offers_recap_serialize.py
+++ b/src/pcapi/routes/serialization/offers_recap_serialize.py
@@ -1,5 +1,4 @@
 from typing import Any
-from typing import Dict
 
 from pcapi.domain.identifier.identifier import Identifier
 from pcapi.domain.pro_offers.paginated_offers_recap import OfferRecap
@@ -8,7 +7,7 @@ from pcapi.domain.pro_offers.paginated_offers_recap import OfferRecapVenue
 from pcapi.domain.pro_offers.paginated_offers_recap import PaginatedOffersRecap
 
 
-def serialize_offers_recap_paginated(paginated_offers: PaginatedOffersRecap) -> Dict[str, Any]:
+def serialize_offers_recap_paginated(paginated_offers: PaginatedOffersRecap) -> dict[str, Any]:
     return {
         "offers": [_serialize_offer_paginated(offer) for offer in paginated_offers.offers],
         "page": paginated_offers.current_page,
@@ -17,7 +16,7 @@ def serialize_offers_recap_paginated(paginated_offers: PaginatedOffersRecap) -> 
     }
 
 
-def _serialize_offer_paginated(offer: OfferRecap) -> Dict:
+def _serialize_offer_paginated(offer: OfferRecap) -> dict:
     serialized_stocks = [_serialize_stock(offer.identifier, stock) for stock in offer.stocks]
 
     return {
@@ -37,7 +36,7 @@ def _serialize_offer_paginated(offer: OfferRecap) -> Dict:
     }
 
 
-def _serialize_stock(offer_identifier: Identifier, stock: OfferRecapStock) -> Dict:
+def _serialize_stock(offer_identifier: Identifier, stock: OfferRecapStock) -> dict:
     return {
         "id": stock.identifier.scrambled,
         "offerId": offer_identifier.scrambled,
@@ -46,7 +45,7 @@ def _serialize_stock(offer_identifier: Identifier, stock: OfferRecapStock) -> Di
     }
 
 
-def _serialize_venue(venue: OfferRecapVenue) -> Dict:
+def _serialize_venue(venue: OfferRecapVenue) -> dict:
     return {
         "id": venue.identifier.scrambled,
         "isVirtual": venue.is_virtual,

--- a/src/pcapi/routes/serialization/offers_serialize.py
+++ b/src/pcapi/routes/serialization/offers_serialize.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from typing import Any
-from typing import List
 from typing import Optional
 from typing import Union
 
@@ -30,7 +29,7 @@ class PostOfferBodyModel(BaseModel):
     booking_email: Optional[str]
     external_ticket_office_url: Optional[HttpUrl]
     url: Optional[HttpUrl]
-    media_urls: Optional[List[str]]
+    media_urls: Optional[list[str]]
     description: Optional[str]
     withdrawal_details: Optional[str]
     conditions: Optional[str]
@@ -81,7 +80,7 @@ class PatchOfferBodyModel(BaseModel):
     isActive: Optional[bool]
     isDuo: Optional[bool]
     durationMinutes: Optional[int]
-    mediaUrls: Optional[List[str]]
+    mediaUrls: Optional[list[str]]
     ageMin: Optional[int]
     ageMax: Optional[int]
     conditions: Optional[str]
@@ -116,7 +115,7 @@ class OfferResponseIdModel(BaseModel):
 
 class PatchOfferActiveStatusBodyModel(BaseModel):
     is_active: bool
-    ids: List[int]
+    ids: list[int]
 
     _dehumanize_ids = dehumanize_list_field("ids")
 
@@ -173,7 +172,7 @@ class ListOffersOfferResponseModel(BaseModel):
     isEvent: bool
     isThing: bool
     name: str
-    stocks: List[ListOffersStockResponseModel]
+    stocks: list[ListOffersStockResponseModel]
     thumbUrl: Optional[str]
     type: str
     venue: ListOffersVenueResponseModel
@@ -182,7 +181,7 @@ class ListOffersOfferResponseModel(BaseModel):
 
 
 class ListOffersResponseModel(BaseModel):
-    offers: List[ListOffersOfferResponseModel]
+    offers: list[ListOffersOfferResponseModel]
     page: int
     page_count: int
     total_count: int
@@ -214,7 +213,7 @@ class ListOffersQueryModel(BaseModel):
 class GetOfferOfferTypeResponseModel(BaseModel):
     appLabel: str
     canExpire: Optional[bool]
-    conditionalFields: List[Optional[str]]
+    conditionalFields: list[Optional[str]]
     description: str
     isActive: bool
     offlineOnly: bool
@@ -236,13 +235,13 @@ class GetOfferProductResponseModel(BaseModel):
     description: Optional[str]
     durationMinutes: Optional[int]
     extraData: Any
-    fieldsUpdated: List[str]
+    fieldsUpdated: list[str]
     id: str
     idAtProviders: Optional[str]
     isGcuCompatible: bool
     isNational: bool
     lastProviderId: Optional[str]
-    mediaUrls: List[str]
+    mediaUrls: list[str]
     name: str
     owningOffererId: Optional[str]
     thumbCount: int
@@ -265,7 +264,7 @@ class GetOfferStockResponseModel(BaseModel):
     dateCreated: datetime
     dateModified: datetime
     dateModifiedAtLastProvider: Optional[datetime]
-    fieldsUpdated: List[str]
+    fieldsUpdated: list[str]
     id: str
     idAtProviders: Optional[str]
     isBookable: bool
@@ -297,7 +296,7 @@ class GetOfferManagingOffererResponseModel(BaseModel):
     city: str
     dateCreated: datetime
     dateModifiedAtLastProvider: Optional[datetime]
-    fieldsUpdated: List[str]
+    fieldsUpdated: list[str]
     id: str
     idAtProviders: Optional[str]
     isActive: bool
@@ -323,7 +322,7 @@ class GetOfferVenueResponseModel(BaseModel):
     dateCreated: Optional[datetime]
     dateModifiedAtLastProvider: Optional[datetime]
     departementCode: Optional[str]
-    fieldsUpdated: List[str]
+    fieldsUpdated: list[str]
     id: str
     idAtProviders: Optional[str]
     isValidated: bool
@@ -374,7 +373,7 @@ class GetOfferMediationResponseModel(BaseModel):
     credit: Optional[str]
     dateCreated: datetime
     dateModifiedAtLastProvider: Optional[datetime]
-    fieldsUpdated: List[str]
+    fieldsUpdated: list[str]
     id: str
     idAtProviders: Optional[str]
     isActive: bool
@@ -400,11 +399,11 @@ class GetOfferResponseModel(BaseModel):
     conditions: Optional[str]
     dateCreated: datetime
     dateModifiedAtLastProvider: Optional[datetime]
-    dateRange: List[datetime]
+    dateRange: list[datetime]
     description: Optional[str]
     durationMinutes: Optional[int]
     extraData: Any
-    fieldsUpdated: List[str]
+    fieldsUpdated: list[str]
     hasBookingLimitDatetimesPassed: bool
     id: str
     idAtProviders: Optional[str]
@@ -422,13 +421,13 @@ class GetOfferResponseModel(BaseModel):
     visualDisabilityCompliant: Optional[bool]
     lastProvider: Optional[GetOfferLastProviderResponseModel]
     lastProviderId: Optional[str]
-    mediaUrls: List[str]
-    mediations: List[GetOfferMediationResponseModel]
+    mediaUrls: list[str]
+    mediations: list[GetOfferMediationResponseModel]
     name: str
     offerType: GetOfferOfferTypeResponseModel
     product: GetOfferProductResponseModel
     productId: str
-    stocks: List[GetOfferStockResponseModel]
+    stocks: list[GetOfferStockResponseModel]
     thumbUrl: Optional[str]
     type: str
     externalTicketOfficeUrl: Optional[str]
@@ -462,5 +461,5 @@ class ImageBodyModel(BaseModel):
 
 
 class ImageResponseModel(BaseModel):
-    errors: Optional[List[str]]
+    errors: Optional[list[str]]
     image: Optional[str]

--- a/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
+++ b/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 import csv
 from io import StringIO
-from typing import List
 
 from pcapi.models.payment_status import TransactionStatus
 from pcapi.repository.reimbursement_queries import find_all_offerer_payments
@@ -86,7 +85,7 @@ class ReimbursementDetails:
         ]
 
 
-def generate_reimbursement_details_csv(reimbursement_details: List[ReimbursementDetails]):
+def generate_reimbursement_details_csv(reimbursement_details: list[ReimbursementDetails]):
     output = StringIO()
     csv_lines = [reimbursement_detail.as_csv_row() for reimbursement_detail in reimbursement_details]
     writer = csv.writer(output, dialect=csv.excel, delimiter=";", quoting=csv.QUOTE_NONNUMERIC)
@@ -95,7 +94,7 @@ def generate_reimbursement_details_csv(reimbursement_details: List[Reimbursement
     return output.getvalue()
 
 
-def find_all_offerer_reimbursement_details(offerer_id: int) -> List[ReimbursementDetails]:
+def find_all_offerer_reimbursement_details(offerer_id: int) -> list[ReimbursementDetails]:
     offerer_payments = find_all_offerer_payments(offerer_id)
     reimbursement_details = [ReimbursementDetails(offerer_payment) for offerer_payment in offerer_payments]
 

--- a/src/pcapi/routes/serialization/stock_serialize.py
+++ b/src/pcapi/routes/serialization/stock_serialize.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import List
 from typing import Optional
 from typing import Union
 
@@ -35,7 +34,7 @@ class StockResponseModel(BaseModel):
 
 
 class StocksResponseModel(BaseModel):
-    stocks: List[StockResponseModel]
+    stocks: list[StockResponseModel]
 
     class Config:
         json_encoders = {datetime: format_into_utc_date}
@@ -79,7 +78,7 @@ class StockIdResponseModel(BaseModel):
 
 class StocksUpsertBodyModel(BaseModel):
     offer_id: int
-    stocks: List[Union[StockCreationBodyModel, StockEditionBodyModel]]
+    stocks: list[Union[StockCreationBodyModel, StockEditionBodyModel]]
 
     _dehumanize_offer_id = dehumanize_field("offer_id")
 
@@ -88,4 +87,4 @@ class StocksUpsertBodyModel(BaseModel):
 
 
 class StockIdsResponseModel(BaseModel):
-    stockIds: List[StockIdResponseModel]
+    stockIds: list[StockIdResponseModel]

--- a/src/pcapi/routes/serialization/venue_labels_serialize.py
+++ b/src/pcapi/routes/serialization/venue_labels_serialize.py
@@ -1,10 +1,8 @@
-from typing import Dict
-
 from pcapi.domain.venue.venue_label.venue_label import VenueLabel
 from pcapi.utils.human_ids import humanize
 
 
-def serialize_venue_label(venue_label: VenueLabel) -> Dict:
+def serialize_venue_label(venue_label: VenueLabel) -> dict:
     return {
         "id": humanize(venue_label.identifier),
         "label": venue_label.label,

--- a/src/pcapi/routes/serialization/venues_serialize.py
+++ b/src/pcapi/routes/serialization/venues_serialize.py
@@ -1,6 +1,4 @@
 from datetime import datetime
-from typing import Dict
-from typing import List
 from typing import Optional
 
 from pydantic import BaseModel
@@ -11,11 +9,11 @@ from pcapi.utils.date import format_into_utc_date
 from pcapi.utils.human_ids import humanize
 
 
-def serialize_venues_with_offerer_name(venues: List[VenueWithOffererName]) -> List[Dict]:
+def serialize_venues_with_offerer_name(venues: list[VenueWithOffererName]) -> list[dict]:
     return [serialize_venue_with_offerer_name(venue) for venue in venues]
 
 
-def serialize_venue_with_offerer_name(venue: VenueWithOffererName) -> Dict:
+def serialize_venue_with_offerer_name(venue: VenueWithOffererName) -> dict:
     return {
         "id": humanize(venue.identifier),
         "managingOffererId": humanize(venue.managing_offerer_identifier),
@@ -41,7 +39,7 @@ class GetVenueManagingOffererResponseModel(BaseModel):
     dateCreated: datetime
     dateModifiedAtLastProvider: Optional[datetime]
     demarchesSimplifieesApplicationId: Optional[str]
-    fieldsUpdated: List[str]
+    fieldsUpdated: list[str]
     iban: Optional[str]
     id: str
     idAtProviders: Optional[str]
@@ -69,7 +67,7 @@ class GetVenueResponseModel(BaseModel):
     dateModifiedAtLastProvider: Optional[datetime]
     demarchesSimplifieesApplicationId: Optional[str]
     departementCode: Optional[str]
-    fieldsUpdated: List[str]
+    fieldsUpdated: list[str]
     iban: Optional[str]
     id: str
     idAtProviders: Optional[str]

--- a/src/pcapi/routes/webapp/beneficiaries.py
+++ b/src/pcapi/routes/webapp/beneficiaries.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Tuple
 
 from flask import abort
 from flask import jsonify
@@ -97,7 +96,7 @@ def change_beneficiary_email(body: ChangeBeneficiaryEmailBody) -> None:
 @private_api.route("/beneficiaries/signin", methods=["POST"])
 @email_rate_limiter
 @ip_rate_limiter
-def signin_beneficiary() -> Tuple[str, int]:
+def signin_beneficiary() -> tuple[str, int]:
     json = request.get_json()
     identifier = json.get("identifier")
     password = json.get("password")

--- a/src/pcapi/sandboxes/scripts/creators/beneficiary_import/beneficiary_import.py
+++ b/src/pcapi/sandboxes/scripts/creators/beneficiary_import/beneficiary_import.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from pcapi.core.users.models import User
 from pcapi.model_creators.generic_creators import create_beneficiary_import
@@ -28,7 +27,7 @@ def create_admin_user():
     logger.info("created 1 admin user")
 
 
-def create_beneficiary_imports(beneficiary_user: User) -> List[BeneficiaryImport]:
+def create_beneficiary_imports(beneficiary_user: User) -> list[BeneficiaryImport]:
     beneficiary_imports = []
     index_of_beneficiary_imports = 1
     for status in ImportStatus:

--- a/src/pcapi/sandboxes/scripts/creators/helpers/sql_creators.py
+++ b/src/pcapi/sandboxes/scripts/creators/helpers/sql_creators.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from hashlib import sha256
 import random
 import string
-from typing import Dict
 from typing import Iterable
 from typing import Optional
 
@@ -290,7 +289,7 @@ def create_product_with_thing_type(
     thumb_count: int = 1,
     url: str = None,
     owning_offerer: Offerer = None,
-    extra_data: Dict = None,
+    extra_data: dict = None,
 ) -> Product:
     product = Product()
     product.type = str(thing_type)
@@ -340,7 +339,7 @@ def create_offer_with_thing_product(
     url: Optional[str] = None,
     last_provider_id: int = None,
     last_provider: Provider = None,
-    extra_data: Dict = None,
+    extra_data: dict = None,
     withdrawal_details: Optional[str] = None,
 ) -> Offer:
     offer = Offer()

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_pro_users.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_pro_users.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
 import logging
-from typing import Dict
 
 from pcapi.core.offers.factories import UserOffererFactory
 from pcapi.model_creators.generic_creators import create_user
@@ -15,7 +14,7 @@ PROS_COUNT = 1
 departement_codes = ["93", "97"]
 
 
-def create_industrial_pro_users(offerers_by_name: Dict) -> Dict:
+def create_industrial_pro_users(offerers_by_name: dict) -> dict:
     logger.info("create_industrial_pro_users")
 
     users_by_name = {}

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venue_types.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venue_types.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from pcapi.model_creators.generic_creators import create_venue_type
 from pcapi.models.venue_type import VenueType
@@ -9,7 +8,7 @@ from pcapi.repository import repository
 logger = logging.getLogger(__name__)
 
 
-def create_industrial_venue_types() -> List[VenueType]:
+def create_industrial_venue_types() -> list[VenueType]:
     logger.info("create_industrial_venue_types")
 
     labels = [

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues.py
@@ -1,8 +1,6 @@
 import logging
 import random
 import re
-from typing import Dict
-from typing import List
 
 from pcapi.model_creators.generic_creators import create_bank_information
 from pcapi.model_creators.generic_creators import create_venue
@@ -18,7 +16,7 @@ OFFERERS_WITH_PHYSICAL_VENUE_REMOVE_MODULO = 3
 OFFERERS_WITH_PHYSICAL_VENUE_WITH_SIRET_REMOVE_MODULO = OFFERERS_WITH_PHYSICAL_VENUE_REMOVE_MODULO * 2
 
 
-def create_industrial_venues(offerers_by_name: Dict, venue_types: List[VenueType]) -> Dict:
+def create_industrial_venues(offerers_by_name: dict, venue_types: list[VenueType]) -> dict:
     logger.info("create_industrial_venues")
 
     venue_by_name = {}

--- a/src/pcapi/scripts/add_allocine_internal_ids.py
+++ b/src/pcapi/scripts/add_allocine_internal_ids.py
@@ -1,7 +1,5 @@
 import base64
 import logging
-from typing import List
-from typing import Tuple
 
 from sqlalchemy.orm.util import aliased
 
@@ -18,7 +16,7 @@ def add_allocine_internal_ids() -> None:
     logger.info("Starting to update allocine pivots internal id")
 
     # Approx 900 rows so no performance issue to select all
-    allocine_pivots: List[AllocinePivot] = AllocinePivot.query.all()
+    allocine_pivots: list[AllocinePivot] = AllocinePivot.query.all()
     logger.info("%d allocine pivots found", len(allocine_pivots))
 
     for allocine_pivot in allocine_pivots:
@@ -35,7 +33,7 @@ def add_allocine_internal_ids() -> None:
 
     # Approx 48 rows so no performance issue to select all
     venue_alias = aliased(Venue)
-    allocine_venue_providers_with_pivot: List[Tuple[AllocineVenueProvider, AllocinePivot]] = (
+    allocine_venue_providers_with_pivot: list[tuple[AllocineVenueProvider, AllocinePivot]] = (
         AllocineVenueProvider.query.join(venue_alias, venue_alias.id == AllocineVenueProvider.venueId)
         .join(AllocinePivot, AllocinePivot.siret == venue_alias.siret)
         .with_entities(AllocineVenueProvider, AllocinePivot)

--- a/src/pcapi/scripts/beneficiary/import_users.py
+++ b/src/pcapi/scripts/beneficiary/import_users.py
@@ -3,7 +3,7 @@ import csv
 from datetime import datetime
 import sys
 from typing import Iterable
-from typing import List
+
 
 import pcapi.models  # pylint: disable=unused-import
 from pcapi import settings
@@ -17,7 +17,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def create_or_update_users(rows: Iterable[dict]) -> List[User]:
+def create_or_update_users(rows: Iterable[dict]) -> list[User]:
     # The purpose of this function is to recreate test users on
     # staging after the staging database is reset. It's not meant to
     # be used anywhere else, and certainly not on production.

--- a/src/pcapi/scripts/beneficiary/remote_import.py
+++ b/src/pcapi/scripts/beneficiary/remote_import.py
@@ -2,8 +2,6 @@ from datetime import datetime
 import logging
 import re
 from typing import Callable
-from typing import Dict
-from typing import List
 from typing import Optional
 
 from pcapi import settings
@@ -33,9 +31,9 @@ from pcapi.utils.mailing import MailServiceException
 
 def run(
     process_applications_updated_after: datetime,
-    get_all_applications_ids: Callable[..., List[int]] = get_closed_application_ids_for_demarche_simplifiee,
-    get_applications_ids_to_retry: Callable[..., List[int]] = find_applications_ids_to_retry,
-    get_details: Callable[..., Dict] = get_application_details,
+    get_all_applications_ids: Callable[..., list[int]] = get_closed_application_ids_for_demarche_simplifiee,
+    get_applications_ids_to_retry: Callable[..., list[int]] = find_applications_ids_to_retry,
+    get_details: Callable[..., dict] = get_application_details,
     already_imported: Callable[..., bool] = is_already_imported,
     already_existing_user: Callable[..., User] = find_user_by_email,
 ) -> None:
@@ -46,8 +44,8 @@ def run(
         procedure_id,
         procedure_id,
     )
-    error_messages: List[str] = []
-    new_beneficiaries: List[User] = []
+    error_messages: list[str] = []
+    new_beneficiaries: list[User] = []
     applications_ids = get_all_applications_ids(procedure_id, settings.DMS_TOKEN, process_applications_updated_after)
     retry_ids = get_applications_ids_to_retry()
 
@@ -106,10 +104,10 @@ def run(
 
 
 def process_beneficiary_application(
-    information: Dict,
-    error_messages: List[str],
-    new_beneficiaries: List[User],
-    retry_ids: List[int],
+    information: dict,
+    error_messages: list[str],
+    new_beneficiaries: list[User],
+    retry_ids: list[int],
     procedure_id: int,
     user: Optional[User] = None,
 ) -> None:
@@ -125,7 +123,7 @@ def process_beneficiary_application(
         _process_duplication(duplicate_users, error_messages, information, procedure_id)
 
 
-def parse_beneficiary_information(application_detail: Dict) -> Dict:
+def parse_beneficiary_information(application_detail: dict) -> dict:
     dossier = application_detail["dossier"]
 
     information = {
@@ -156,9 +154,9 @@ def parse_beneficiary_information(application_detail: Dict) -> Dict:
 
 
 def _process_creation(
-    error_messages: List[str],
-    information: Dict,
-    new_beneficiaries: List[User],
+    error_messages: list[str],
+    information: dict,
+    new_beneficiaries: list[User],
     procedure_id: int,
     user: Optional[User] = None,
 ) -> None:
@@ -206,7 +204,7 @@ def _process_creation(
 
 
 def _process_duplication(
-    duplicate_users: List[User], error_messages: List[str], information: Dict, procedure_id: int
+    duplicate_users: list[User], error_messages: list[str], information: dict, procedure_id: int
 ) -> None:
     number_of_beneficiaries = len(duplicate_users)
     duplicate_ids = ", ".join([str(u.id) for u in duplicate_users])
@@ -222,7 +220,7 @@ def _process_duplication(
     )
 
 
-def _process_rejection(information: Dict, procedure_id: int) -> None:
+def _process_rejection(information: dict, procedure_id: int) -> None:
     save_beneficiary_import_with_status(
         ImportStatus.REJECTED,
         information["application_id"],

--- a/src/pcapi/scripts/booking/cancel_bookings_of_events_from_file.py
+++ b/src/pcapi/scripts/booking/cancel_bookings_of_events_from_file.py
@@ -1,7 +1,6 @@
 import csv
 import logging
 from typing import Iterable
-from typing import List
 
 from pcapi.models import ApiErrors
 from pcapi.models import Booking
@@ -78,15 +77,15 @@ def _cancel_bookings_of_offers_from_rows(csv_rows: Iterable) -> None:
         logger.error(offers_in_error)
 
 
-def _is_header_or_blank_row(row: List[str]) -> bool:
+def _is_header_or_blank_row(row: list[str]) -> bool:
     return not row or not row[0] or row[0] == FIRST_TITLE
 
 
-def _is_not_flagged_for_cancellation(row: List[str]) -> bool:
+def _is_not_flagged_for_cancellation(row: list[str]) -> bool:
     return row[CANCELATION_FLAG_COLUMN_INDEX] == NO_FLAG
 
 
-def _get_bookings_from_offer(offer_id: int) -> List[Booking]:
+def _get_bookings_from_offer(offer_id: int) -> list[Booking]:
     return (
         Booking.query.filter(Booking.token.notin_(BOOKINGS_TOKEN_NOT_TO_UPDATE))
         .join(Stock, Stock.id == Booking.stockId)

--- a/src/pcapi/scripts/booking/cancel_old_unused_bookings_for_venue.py
+++ b/src/pcapi/scripts/booking/cancel_old_unused_bookings_for_venue.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
 import logging
-from typing import List
 
 from sqlalchemy.sql.sqltypes import DateTime
 
@@ -38,7 +37,7 @@ def cancel_old_unused_bookings_for_venue(humanized_venue_id: str) -> None:
         logger.info("'%i' bookings cancelled for venue '%s'", len(old_unused_bookings), venue.name)
 
 
-def _get_old_unused_bookings_from_venue_id(venue_id: int, limit_date: DateTime) -> List[Booking]:
+def _get_old_unused_bookings_from_venue_id(venue_id: int, limit_date: DateTime) -> list[Booking]:
     return (
         Booking.query.join(Stock, Stock.id == Booking.stockId)
         .join(Offer, Offer.id == Stock.offerId)

--- a/src/pcapi/scripts/cancel_bookings_during_quarantine.py
+++ b/src/pcapi/scripts/cancel_bookings_during_quarantine.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import List
 
 from sqlalchemy import and_
 
@@ -14,7 +13,7 @@ def cancel_booking_status_for_events_happening_during_quarantine():
     cancel_bookings(bookings)
 
 
-def find_bookings_to_cancel() -> List[Booking]:
+def find_bookings_to_cancel() -> list[Booking]:
     minimal_date = datetime(2020, 3, 14, 0, 0, 0)
     return (
         Booking.query.join(Stock)
@@ -27,7 +26,7 @@ def find_bookings_to_cancel() -> List[Booking]:
     )
 
 
-def cancel_bookings(bookings: List[Booking]):
+def cancel_bookings(bookings: list[Booking]):
     for booking in bookings:
         booking.isUsed = False
         booking.dateUsed = None

--- a/src/pcapi/scripts/change_some_pro_users_to_beneficiary.py
+++ b/src/pcapi/scripts/change_some_pro_users_to_beneficiary.py
@@ -1,12 +1,10 @@
-from typing import List
-
 import pcapi.core.payments.api as payments_api
 from pcapi.core.users.models import User
 from pcapi.models import UserOfferer
 from pcapi.repository import repository
 
 
-def change_pro_users_to_beneficiary(pro_users_ids: List[int]) -> None:
+def change_pro_users_to_beneficiary(pro_users_ids: list[int]) -> None:
     users = User.query.filter(User.id.in_(pro_users_ids)).all()
     for user in users:
         user.isBeneficiary = True

--- a/src/pcapi/scripts/deactivate_offers_during_quarantine/deactivate_offers.py
+++ b/src/pcapi/scripts/deactivate_offers_during_quarantine/deactivate_offers.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from typing import Callable
-from typing import List
 
 from sqlalchemy import func
 
@@ -14,7 +13,7 @@ from pcapi.repository import repository
 
 def get_offers_with_max_stock_date_between_today_and_end_of_quarantine(
     first_day_after_quarantine: datetime, today: datetime
-) -> List[Offer]:
+) -> list[Offer]:
     quarantine_offers_query = build_query_offers_with_max_stock_date_between_today_and_end_of_quarantine(
         first_day_after_quarantine, today
     )
@@ -35,7 +34,7 @@ def build_query_offers_with_max_stock_date_between_today_and_end_of_quarantine(f
     return quarantine_offers_query
 
 
-def deactivate_offers(offers: List[Offer]):
+def deactivate_offers(offers: list[Offer]):
     for offer in offers:
         offer.isActive = False
     repository.save(*offers)

--- a/src/pcapi/scripts/grant_wallet_to_existing_users.py
+++ b/src/pcapi/scripts/grant_wallet_to_existing_users.py
@@ -1,12 +1,10 @@
-from typing import List
-
 from pcapi import settings
 import pcapi.core.payments.api as payments_api
 from pcapi.core.users.models import User
 from pcapi.repository import repository
 
 
-def grant_wallet_to_existing_users(user_ids: List[int]):
+def grant_wallet_to_existing_users(user_ids: list[int]):
     if settings.IS_PROD:
         raise ValueError("This action is not available on production")
     users = User.query.filter(User.id.in_(user_ids)).all()

--- a/src/pcapi/scripts/iris/link_iris_to_venues.py
+++ b/src/pcapi/scripts/iris/link_iris_to_venues.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pcapi.core.offerers.models import Offerer
 from pcapi.models import Venue
 from pcapi.repository.iris_venues_queries import find_ids_of_irises_located_near_venue
@@ -13,7 +11,7 @@ def link_irises_to_existing_physical_venues(search_radius: int):
         insert_venue_in_iris_venue(venue_id, iris_ids)
 
 
-def _find_all_venue_ids_to_link() -> List[int]:
+def _find_all_venue_ids_to_link() -> list[int]:
     venues = (
         Venue.query.join(Offerer)
         .filter(Venue.isVirtual.is_(False))

--- a/src/pcapi/scripts/offerer/file_import.py
+++ b/src/pcapi/scripts/offerer/file_import.py
@@ -2,7 +2,6 @@ import csv
 from datetime import datetime
 import logging
 from typing import Callable
-from typing import List
 
 from pcapi.core.offerers.api import create_digital_venue
 from pcapi.core.offerers.models import Offerer
@@ -37,7 +36,7 @@ class OffererNotCreatedException(Exception):
     pass
 
 
-def iterate_rows_for_user_offerers(csv_rows: List[List[str]]) -> List:
+def iterate_rows_for_user_offerers(csv_rows: list[list[str]]) -> list:
     user_offerers = []
     for row in csv_rows:
         if _is_header_or_blank_line(row):
@@ -51,7 +50,7 @@ def iterate_rows_for_user_offerers(csv_rows: List[List[str]]) -> List:
 
 
 def create_activated_user_offerer(
-    csv_row: List[str],
+    csv_row: list[str],
     find_user: Callable = find_user_by_email,
     find_offerer: Callable = find_by_siren,
     find_user_offerer: Callable = find_one_or_none_by_user_id_and_offerer_id,
@@ -93,7 +92,7 @@ def fill_user_offerer_from(user_offerer: UserOfferer, created_user: User, create
     return user_offerer
 
 
-def fill_user_from(csv_row: List[str], user: User) -> User:
+def fill_user_from(csv_row: list[str], user: User) -> User:
     user.lastName = csv_row[USER_LAST_NAME_COLUMN_INDEX]
     user.firstName = csv_row[USER_FIRST_NAME_COLUMN_INDEX].split(" ")[0]
     user.publicName = "%s %s" % (user.firstName, user.lastName)
@@ -105,7 +104,7 @@ def fill_user_from(csv_row: List[str], user: User) -> User:
     return user
 
 
-def fill_offerer_from(csv_row: List[str], offerer: Offerer) -> Offerer:
+def fill_offerer_from(csv_row: list[str], offerer: Offerer) -> Offerer:
     offerer.siren = csv_row[OFFERER_SIREN_COLUMN_INDEX]
     offerer.name = csv_row[OFFERER_NAME_COLUMN_INDEX]
     offerer.thumbCount = 0

--- a/src/pcapi/scripts/offerer/import_offerer_from_csv.py
+++ b/src/pcapi/scripts/offerer/import_offerer_from_csv.py
@@ -2,7 +2,6 @@ import csv
 import json
 from json import JSONDecodeError
 import logging
-from typing import Dict
 
 from pcapi.core.offerers.api import create_digital_venue
 from pcapi.core.offerers.models import Offerer
@@ -20,7 +19,7 @@ from pcapi.routes.serialization.users import ProUserCreationBodyModel
 logger = logging.getLogger(__name__)
 
 
-def create_offerer_from_csv(row: Dict) -> Offerer:
+def create_offerer_from_csv(row: dict) -> Offerer:
     offerer = Offerer()
     offerer.name = row["nom_structure"] if row["nom_structure"] else row["Name"]
     offerer.siren = row["SIREN"]
@@ -31,7 +30,7 @@ def create_offerer_from_csv(row: Dict) -> Offerer:
     return offerer
 
 
-def create_venue_from_csv(row: Dict, offerer: Offerer) -> Venue:
+def create_venue_from_csv(row: dict, offerer: Offerer) -> Venue:
     venue = Venue(
         address=_get_address_from_row(row),
         postalCode=_get_postal_code(row),
@@ -62,15 +61,15 @@ def create_venue_from_csv(row: Dict, offerer: Offerer) -> Venue:
     return venue
 
 
-def _get_address_from_row(row: Dict) -> str:
+def _get_address_from_row(row: dict) -> str:
     return row["adresse"].split(",")[0]
 
 
-def _get_postal_code(row: Dict) -> str:
+def _get_postal_code(row: dict) -> str:
     return row["code_postal"] if row["code_postal"] else row["Postal Code"]
 
 
-def create_user_model_from_csv(row: Dict) -> ProUserCreationBodyModel:
+def create_user_model_from_csv(row: dict) -> ProUserCreationBodyModel:
     pro_user_creation_model = ProUserCreationBodyModel(
         email=row["Email"],
         password=random_password(),
@@ -85,7 +84,7 @@ def create_user_model_from_csv(row: Dict) -> ProUserCreationBodyModel:
     return pro_user_creation_model
 
 
-def import_new_offerer_from_csv(row: Dict) -> None:
+def import_new_offerer_from_csv(row: dict) -> None:
     # We can't process a row without a postal code
     if not row["Postal Code"] and not row["code_postal"]:
         logger.warning("Unable to import this line %s - %s", row[""], row["Company ID"])
@@ -122,7 +121,7 @@ def import_new_offerer_from_csv(row: Dict) -> None:
 
 def import_from_csv_file(csv_file_path: str) -> None:
     csv_file = open(csv_file_path)
-    csv_reader = csv.DictReader(csv_file)
+    csv_reader = csv.dictReader(csv_file)
 
     for row in csv_reader:
         import_new_offerer_from_csv(row)

--- a/src/pcapi/scripts/payment/banishment.py
+++ b/src/pcapi/scripts/payment/banishment.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from pcapi.domain.payments import UnmatchedPayments
 from pcapi.domain.payments import apply_banishment
@@ -10,11 +9,11 @@ from pcapi.repository.payment_queries import find_payments_by_message
 logger = logging.getLogger(__name__)
 
 
-def parse_raw_payments_ids(raw_ids: str) -> List[int]:
+def parse_raw_payments_ids(raw_ids: str) -> list[int]:
     return [int(id_) for id_ in raw_ids.split(",")]
 
 
-def do_ban_payments(message_id: str, payment_ids_to_ban: List[int]):
+def do_ban_payments(message_id: str, payment_ids_to_ban: list[int]):
     matching_payments = find_payments_by_message(message_id)
 
     try:

--- a/src/pcapi/scripts/payment/batch.py
+++ b/src/pcapi/scripts/payment/batch.py
@@ -1,6 +1,4 @@
 import logging
-from typing import List
-from typing import Tuple
 
 from pcapi import settings
 from pcapi.models.feature import FeatureToggle
@@ -60,7 +58,7 @@ def generate_and_send_payments(payment_message_id: str = None):
     logger.info("[BATCH][PAYMENTS] generate_and_send_payments is done")
 
 
-def generate_or_collect_payments(payment_message_id: str = None) -> Tuple[List[Payment], List[Payment]]:
+def generate_or_collect_payments(payment_message_id: str = None) -> tuple[list[Payment], list[Payment]]:
     if payment_message_id is None:
         logger.info("[BATCH][PAYMENTS] STEP 1 : generate payments")
         pending_payments, not_processable_payments = generate_new_payments()

--- a/src/pcapi/scripts/payment/batch_steps.py
+++ b/src/pcapi/scripts/payment/batch_steps.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 import logging
-from typing import List
 from typing import Optional
-from typing import Tuple
 
 from lxml.etree import DocumentInvalid
 
@@ -39,7 +37,7 @@ logger = logging.getLogger(__name__)
 from pcapi.utils.mailing import MailServiceException
 
 
-def concatenate_payments_with_errors_and_retries(payments: List[Payment]) -> List[Payment]:
+def concatenate_payments_with_errors_and_retries(payments: list[Payment]) -> list[Payment]:
     error_payments = payment_queries.find_error_payments()
     retry_payments = payment_queries.find_retry_payments()
     payments = payments + error_payments + retry_payments
@@ -51,7 +49,7 @@ def concatenate_payments_with_errors_and_retries(payments: List[Payment]) -> Lis
     return payments
 
 
-def generate_new_payments() -> Tuple[List[Payment], List[Payment]]:
+def generate_new_payments() -> tuple[list[Payment], list[Payment]]:
     offerers = Offerer.query.all()
     all_payments = []
 
@@ -82,11 +80,11 @@ def generate_new_payments() -> Tuple[List[Payment], List[Payment]]:
 
 
 def send_transactions(
-    payments: List[Payment],
+    payments: list[Payment],
     pass_culture_iban: Optional[str],
     pass_culture_bic: Optional[str],
     pass_culture_remittance_code: Optional[str],
-    recipients: List[str],
+    recipients: list[str],
 ) -> None:
     if not pass_culture_iban or not pass_culture_bic or not pass_culture_remittance_code:
         raise Exception(
@@ -129,7 +127,7 @@ def send_transactions(
     repository.save(message, *payments)
 
 
-def send_payments_details(payments: List[Payment], recipients: List[str]) -> None:
+def send_payments_details(payments: list[Payment], recipients: list[str]) -> None:
     if not recipients:
         raise Exception("[BATCH][PAYMENTS] Missing PASS_CULTURE_PAYMENTS_DETAILS_RECIPIENTS in environment variables")
 
@@ -146,7 +144,7 @@ def send_payments_details(payments: List[Payment], recipients: List[str]) -> Non
             logger.exception("[BATCH][PAYMENTS] Error while sending payment details email to MailJet: %s", exception)
 
 
-def send_wallet_balances(recipients: List[str]) -> None:
+def send_wallet_balances(recipients: list[str]) -> None:
     if not recipients:
         raise Exception("[BATCH][PAYMENTS] Missing PASS_CULTURE_WALLET_BALANCES_RECIPIENTS in environment variables")
 
@@ -160,7 +158,7 @@ def send_wallet_balances(recipients: List[str]) -> None:
         logger.exception("[BATCH][PAYMENTS] Error while sending users wallet balances email to MailJet: %s", exception)
 
 
-def send_payments_report(payments: List[Payment], recipients: List[str]) -> None:
+def send_payments_report(payments: list[Payment], recipients: list[str]) -> None:
     if not payments:
         logger.info("[BATCH][PAYMENTS] No payments to report to the pass Culture team")
         return

--- a/src/pcapi/scripts/payment/mark_payments_as_sent.py
+++ b/src/pcapi/scripts/payment/mark_payments_as_sent.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from sqlalchemy.sql.functions import func
 
@@ -12,7 +11,7 @@ from pcapi.models.payment_status import TransactionStatus
 logger = logging.getLogger(__name__)
 
 
-def get_payments_ids_under_review(min_id: int, batch_size: int, transaction_label: str) -> List[int]:
+def get_payments_ids_under_review(min_id: int, batch_size: int, transaction_label: str) -> list[int]:
     payments_ids_query = (
         Payment.query.filter(Payment.transactionLabel == transaction_label)
         .filter(Payment.id.between(min_id, min_id + batch_size - 1))
@@ -41,7 +40,7 @@ def mark_payments_as_sent(transaction_label: str, batch_size: int = 1000) -> Non
         if len(payments_ids) == 0:
             continue
 
-        payment_statuses_to_add: List[PaymentStatus] = []
+        payment_statuses_to_add: list[PaymentStatus] = []
         for payment_id in payments_ids:
             payment_statuses_to_add.append(PaymentStatus(paymentId=payment_id, status=TransactionStatus.SENT))
 

--- a/src/pcapi/scripts/suspend_fraudulent_beneficiary_users.py
+++ b/src/pcapi/scripts/suspend_fraudulent_beneficiary_users.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from pcapi.core.bookings.api import cancel_booking_for_fraud
 from pcapi.core.bookings.repository import find_cancellable_bookings_by_beneficiaries
@@ -14,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def suspend_fraudulent_beneficiary_users_by_email_providers(
-    fraudulent_email_providers: List[str], admin_user: User, dry_run: bool = True
+    fraudulent_email_providers: list[str], admin_user: User, dry_run: bool = True
 ) -> None:
     fraudulent_users = []
 
@@ -31,12 +30,12 @@ def suspend_fraudulent_beneficiary_users_by_email_providers(
         print(f"Suspended users booked following distinct offers {[offer.id for offer in offers]}")
 
 
-def suspend_fraudulent_beneficiary_users(fraudulent_users: List[User], admin_user: User) -> None:
+def suspend_fraudulent_beneficiary_users(fraudulent_users: list[User], admin_user: User) -> None:
     for fraudulent_user in fraudulent_users:
         suspend_account(fraudulent_user, SuspensionReason.FRAUD, admin_user)
 
 
-def cancel_bookings_by_fraudulent_beneficiary_users(fraudulent_users: List[User]) -> None:
+def cancel_bookings_by_fraudulent_beneficiary_users(fraudulent_users: list[User]) -> None:
     bookings_to_cancel = find_cancellable_bookings_by_beneficiaries(fraudulent_users)
     for booking in bookings_to_cancel:
         cancel_booking_for_fraud(booking)

--- a/src/pcapi/scripts/update_venue_type.py
+++ b/src/pcapi/scripts/update_venue_type.py
@@ -1,5 +1,4 @@
 import csv
-from typing import List
 
 from pcapi.models import ApiErrors
 from pcapi.models import Venue
@@ -34,7 +33,7 @@ def update_venue_type(file_path: str):
     print(f"{updated_venue_count} venues have been updated")
 
 
-def _read_venue_type_from_file(file_path: str) -> List[tuple]:
+def _read_venue_type_from_file(file_path: str) -> list[tuple]:
     with open(file_path, mode="r", newline="\n") as file:
         data = [tuple(line) for line in csv.reader(file, delimiter=";")]
         return data

--- a/src/pcapi/scripts/user_offerer/delete_user_offerer_from_csv.py
+++ b/src/pcapi/scripts/user_offerer/delete_user_offerer_from_csv.py
@@ -1,7 +1,6 @@
 import csv
 import logging
 from typing import Iterable
-from typing import List
 
 from pcapi.models import ApiErrors
 from pcapi.repository import repository
@@ -80,5 +79,5 @@ def _delete_user_offerers_from_rows(csv_rows: Iterable) -> None:
         logger.error(user_offerers_in_error)
 
 
-def _is_blank_row(row: List[str]) -> bool:
+def _is_blank_row(row: list[str]) -> bool:
     return not row or not row[0] or row[0] == FIRST_TITLE

--- a/src/pcapi/scripts/venue/venue_label/create_venue_labels.py
+++ b/src/pcapi/scripts/venue/venue_label/create_venue_labels.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pcapi.models import VenueLabelSQLEntity
 from pcapi.repository import repository
 
@@ -39,7 +37,7 @@ def create_venue_labels():
     save_new_venue_labels(venue_labels)
 
 
-def save_new_venue_labels(venue_labels: List[str]):
+def save_new_venue_labels(venue_labels: list[str]):
     venue_label_sql_entities = []
     for venue_label in venue_labels:
         venue_label_sql_entity = VenueLabelSQLEntity()

--- a/src/pcapi/serialization/decorator.py
+++ b/src/pcapi/serialization/decorator.py
@@ -1,7 +1,6 @@
 from functools import wraps
 from typing import Any
 from typing import Callable
-from typing import List
 from typing import Optional
 from typing import Type
 
@@ -46,7 +45,7 @@ def spectree_serialize(  # pylint: disable=dangerous-default-value
     response_by_alias: bool = True,
     exclude_none: bool = False,
     on_success_status: int = 200,
-    on_error_statuses: List[int] = [],
+    on_error_statuses: list[int] = [],
     api: SpecTree = default_api,
 ) -> Callable[[Any], Any]:
     """A decorator that serialize/deserialize and validate input/output
@@ -60,7 +59,7 @@ def spectree_serialize(  # pylint: disable=dangerous-default-value
         response_by_alias (bool, optional): whether or not the alias generator will be used. Defaults to True.
         exclude_none (bool, optional): whether or not to remove the none values. Defaults to False.
         on_success_status (int, optional): status returned when the validation is a success. Defaults to 200.
-        on_error_statuses (List[int], optional): list of possible error statuses. Defaults to [].
+        on_error_statuses (list[int], optional): list of possible error statuses. Defaults to [].
         api (SpecTree, optional): [description]. Defaults to default_api.
 
     Returns:

--- a/src/pcapi/use_cases/connect_venue_to_allocine.py
+++ b/src/pcapi/use_cases/connect_venue_to_allocine.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from typing import Dict
 
 from pcapi.domain.price_rule import PriceRule
 from pcapi.models import AllocineVenueProvider
@@ -16,7 +15,7 @@ ERROR_CODE_PROVIDER_NOT_SUPPORTED = 400
 ERROR_CODE_SIRET_NOT_SUPPORTED = 422
 
 
-def connect_venue_to_allocine(venue: Venue, venue_provider_payload: Dict) -> AllocineVenueProvider:
+def connect_venue_to_allocine(venue: Venue, venue_provider_payload: dict) -> AllocineVenueProvider:
     allocine_pivot = get_allocine_pivot_for_venue(venue)
     venue_provider = _create_allocine_venue_provider(allocine_pivot, venue_provider_payload, venue)
     venue_provider_price_rule = _create_allocine_venue_provider_price_rule(
@@ -40,7 +39,7 @@ def _create_allocine_venue_provider_price_rule(
 
 
 def _create_allocine_venue_provider(
-    allocine_pivot: AllocinePivot, venue_provider_payload: Dict, venue: Venue
+    allocine_pivot: AllocinePivot, venue_provider_payload: dict, venue: Venue
 ) -> AllocineVenueProvider:
     allocine_venue_provider = AllocineVenueProvider()
     allocine_venue_provider.venue = venue

--- a/src/pcapi/use_cases/create_venue.py
+++ b/src/pcapi/use_cases/create_venue.py
@@ -1,11 +1,10 @@
 from typing import Callable
-from typing import Dict
 
 from pcapi.domain.iris import link_valid_venue_to_irises
 from pcapi.models import Venue
 
 
-def create_venue(venue_properties: Dict, save: Callable) -> Venue:
+def create_venue(venue_properties: dict, save: Callable) -> Venue:
     venue = Venue(from_dict=venue_properties)
 
     save(venue)

--- a/src/pcapi/use_cases/get_types_of_venues.py
+++ b/src/pcapi/use_cases/get_types_of_venues.py
@@ -1,8 +1,7 @@
 from typing import Callable
-from typing import List
 
 from pcapi.models import VenueType
 
 
-def get_types_of_venues(get_all_venue_types: Callable) -> List[VenueType]:
+def get_types_of_venues(get_all_venue_types: Callable) -> list[VenueType]:
     return get_all_venue_types()

--- a/src/pcapi/use_cases/get_venue_labels.py
+++ b/src/pcapi/use_cases/get_venue_labels.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pcapi.domain.venue.venue_label.venue_label import VenueLabel
 from pcapi.domain.venue.venue_label.venue_label_repository import VenueLabelRepository
 
@@ -8,5 +6,5 @@ class GetVenueLabels:
     def __init__(self, venue_label_repository: VenueLabelRepository):
         self.venue_label_repository = venue_label_repository
 
-    def execute(self) -> List[VenueLabel]:
+    def execute(self) -> list[VenueLabel]:
         return self.venue_label_repository.get_all()

--- a/src/pcapi/use_cases/get_venues_by_pro_user.py
+++ b/src/pcapi/use_cases/get_venues_by_pro_user.py
@@ -1,4 +1,3 @@
-from typing import List
 from typing import Optional
 
 from pcapi.domain.identifier.identifier import Identifier
@@ -18,7 +17,7 @@ class GetVenuesByProUser:
         offerer_id: Optional[Identifier] = None,
         validated_offerer: Optional[bool] = None,
         validated_offerer_for_user: Optional[bool] = None,
-    ) -> List[VenueWithOffererName]:
+    ) -> list[VenueWithOffererName]:
         return self.venue_repository.get_by_pro_identifier(
             pro_identifier,
             user_is_admin,

--- a/src/pcapi/utils/converter.py
+++ b/src/pcapi/utils/converter.py
@@ -1,5 +1,2 @@
-from typing import List
-
-
-def from_tuple_to_int(offer_ids: List[tuple]) -> List[int]:
+def from_tuple_to_int(offer_ids: list[tuple]) -> list[int]:
     return [offer[0] for offer in offer_ids]

--- a/src/pcapi/utils/human_ids.py
+++ b/src/pcapi/utils/human_ids.py
@@ -2,14 +2,14 @@
 from base64 import b32decode
 from base64 import b32encode
 import binascii
+from typing import Optional
+
 
 # This library creates IDs for use in our URLs,
 # trying to achieve a balance between having a short
 # length and being usable by humans
 # We use base32, but replace O and I, which can be mistaken for 0 and 1
 # by 8 and 9
-from typing import List
-from typing import Optional
 
 
 class NonDehumanizableId(Exception):
@@ -37,7 +37,7 @@ def humanize(integer):
     return b32.decode("ascii").replace("O", "8").replace("I", "9").rstrip("=")
 
 
-def dehumanize_ids_list(humanized_list: List):
+def dehumanize_ids_list(humanized_list: list):
     return list(map(dehumanize, humanized_list)) if humanized_list else []
 
 

--- a/src/pcapi/utils/mailing.py
+++ b/src/pcapi/utils/mailing.py
@@ -2,8 +2,6 @@ import base64
 from datetime import datetime
 import io
 from pprint import pformat
-from typing import Dict
-from typing import List
 import zipfile
 
 from flask import render_template
@@ -47,7 +45,7 @@ def build_pc_webapp_reset_password_link(token_value: str) -> str:
     return f"{settings.WEBAPP_URL}/mot-de-passe-perdu?token={token_value}"
 
 
-def extract_users_information_from_bookings(bookings: List[Booking]) -> List[dict]:
+def extract_users_information_from_bookings(bookings: list[Booking]) -> list[dict]:
     users_keys = ("firstName", "lastName", "email", "contremarque")
     users_properties = [
         [booking.user.firstName, booking.user.lastName, booking.user.email, booking.token] for booking in bookings
@@ -75,7 +73,7 @@ def format_booking_hours_for_email(booking: Booking) -> str:
 
 def make_validation_email_object(
     offerer: Offerer, user_offerer: UserOfferer, get_by_siren=api_entreprises.get_by_offerer
-) -> Dict:
+) -> dict:
     vars_obj_user = vars(user_offerer.user)
     vars_obj_user.pop("clearTextPassword", None)
     api_entreprise = get_by_siren(offerer)
@@ -103,7 +101,7 @@ def make_validation_email_object(
     }
 
 
-def make_offerer_driven_cancellation_email_for_offerer(booking: Booking) -> Dict:
+def make_offerer_driven_cancellation_email_for_offerer(booking: Booking) -> dict:
     stock_name = booking.stock.offer.name
     venue = booking.stock.offer.venue
     user_name = booking.user.publicName
@@ -135,7 +133,7 @@ def make_offerer_driven_cancellation_email_for_offerer(booking: Booking) -> Dict
     }
 
 
-def make_payment_message_email(xml: str, checksum: bytes) -> Dict:
+def make_payment_message_email(xml: str, checksum: bytes) -> dict:
     now = datetime.utcnow()
     xml_b64encode = base64.b64encode(xml.encode("utf-8")).decode()
     file_name = "message_banque_de_france_{}.xml".format(datetime.strftime(now, "%Y%m%d"))
@@ -160,7 +158,7 @@ def _get_zipfile_content(content: str, filename: str):
     return stream.read()
 
 
-def make_payment_details_email(csv: str) -> Dict:
+def make_payment_details_email(csv: str) -> dict:
     now = datetime.utcnow()
     csv_filename = f"details_des_paiements_{datetime.strftime(now, '%Y%m%d')}.csv"
     zipfile_content = _get_zipfile_content(csv, csv_filename)
@@ -178,7 +176,7 @@ def make_payment_details_email(csv: str) -> Dict:
     }
 
 
-def make_payments_report_email(not_processable_csv: str, error_csv: str, grouped_payments: Dict) -> Dict:
+def make_payments_report_email(not_processable_csv: str, error_csv: str, grouped_payments: dict) -> dict:
     now = datetime.utcnow()
     not_processable_csv_b64encode = base64.b64encode(not_processable_csv.encode("utf-8")).decode()
     error_csv_b64encode = base64.b64encode(error_csv.encode("utf-8")).decode()
@@ -213,7 +211,7 @@ def make_payments_report_email(not_processable_csv: str, error_csv: str, grouped
     }
 
 
-def make_wallet_balances_email(csv: str) -> Dict:
+def make_wallet_balances_email(csv: str) -> dict:
     now = datetime.utcnow()
     csv_b64encode = base64.b64encode(csv.encode("utf-8")).decode()
     return {
@@ -230,7 +228,7 @@ def make_wallet_balances_email(csv: str) -> Dict:
     }
 
 
-def make_offer_creation_notification_email(offer: Offer, author: User) -> Dict:
+def make_offer_creation_notification_email(offer: Offer, author: User) -> dict:
     pro_link_to_offer = f"{settings.PRO_URL}/offres/{humanize(offer.id)}/edition"
     webapp_link_to_offer = f"{settings.WEBAPP_URL}/offre/details/{humanize(offer.id)}"
     venue = offer.venue
@@ -262,7 +260,7 @@ def get_event_datetime(stock: Stock) -> datetime:
     return date_in_tz
 
 
-def make_pro_user_validation_email(user: User) -> Dict:
+def make_pro_user_validation_email(user: User) -> dict:
     return {
         "FromName": "pass Culture pro",
         "Subject": "[pass Culture pro] Validation de votre adresse email pour le pass Culture",
@@ -275,7 +273,7 @@ def make_pro_user_validation_email(user: User) -> Dict:
     }
 
 
-def make_admin_user_validation_email(user: User, token: str) -> Dict:
+def make_admin_user_validation_email(user: User, token: str) -> dict:
     return {
         "FromName": "pass Culture admin",
         "Subject": "[pass Culture admin] Validation de votre adresse email pour le pass Culture",
@@ -287,14 +285,14 @@ def make_admin_user_validation_email(user: User, token: str) -> Dict:
     }
 
 
-def _add_template_debugging(message_data: Dict) -> None:
+def _add_template_debugging(message_data: dict) -> None:
     message_data["TemplateErrorReporting"] = {
         "Email": settings.DEV_EMAIL_ADDRESS,
         "Name": "Mailjet Template Errors",
     }
 
 
-def _summarize_offerer_vars(offerer: Offerer, api_entreprise: Dict) -> Dict:
+def _summarize_offerer_vars(offerer: Offerer, api_entreprise: dict) -> dict:
     return {
         "name": offerer.name,
         "siren": offerer.siren,
@@ -306,7 +304,7 @@ def _summarize_offerer_vars(offerer: Offerer, api_entreprise: Dict) -> Dict:
     }
 
 
-def _summarize_user_vars(user_offerer: UserOfferer) -> Dict:
+def _summarize_user_vars(user_offerer: UserOfferer) -> dict:
     return {
         "firstName": user_offerer.user.firstName,
         "lastName": user_offerer.user.lastName,

--- a/src/pcapi/utils/settings.py
+++ b/src/pcapi/utils/settings.py
@@ -1,11 +1,11 @@
 # This file is intended to be helpers for the pcapi.settings
 # Please do not import other pcapi modules as it may lead to
 # circular imports resulting in environ variables not be loaded.
-from typing import List
+
 from typing import Optional
 
 
-def parse_email_addresses(addresses: Optional[str]) -> List[str]:
+def parse_email_addresses(addresses: Optional[str]) -> list[str]:
     if not addresses:
         return []
     if "," in addresses:

--- a/src/pcapi/validation/routes/bank_informations.py
+++ b/src/pcapi/validation/routes/bank_informations.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from flask import request
 
 from pcapi import settings
@@ -7,7 +5,7 @@ from pcapi.models.api_errors import ApiErrors
 from pcapi.models.api_errors import ForbiddenError
 
 
-def check_demarches_simplifiees_webhook_payload(payload: Dict):
+def check_demarches_simplifiees_webhook_payload(payload: dict):
     try:
         request.form["dossier_id"]
     except:

--- a/src/pcapi/validation/routes/mailing_contacts.py
+++ b/src/pcapi/validation/routes/mailing_contacts.py
@@ -1,9 +1,7 @@
-from typing import Dict
-
 from pcapi.models import ApiErrors
 
 
-def validate_save_mailing_contact_request(json: Dict):
+def validate_save_mailing_contact_request(json: dict):
     if "email" not in json or not json["email"]:
         errors = ApiErrors()
         errors.add_error("email", "L'email est manquant")

--- a/src/pcapi/workers/push_notification_job.py
+++ b/src/pcapi/workers/push_notification_job.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from rq.decorators import job
 
@@ -32,7 +31,7 @@ def update_user_attributes_job(user_id: int) -> None:
 @job(worker.default_queue, connection=worker.conn)
 @job_context
 @log_job
-def send_cancel_booking_notification(bookings_ids: List[int]) -> None:
+def send_cancel_booking_notification(bookings_ids: list[int]) -> None:
     notification_data = get_bookings_cancellation_notification_data(bookings_ids)
     if notification_data:
         send_transactional_notification(notification_data)

--- a/tests/connector_creators/demarches_simplifiees_creators.py
+++ b/tests/connector_creators/demarches_simplifiees_creators.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from typing import Optional
 
 
@@ -9,7 +8,7 @@ def offerer_demarche_simplifiee_application_detail_response(
     idx: int = 1,
     updated_at: str = "2020-01-21T18:55:03.387Z",
     state: str = "closed",
-) -> Dict:
+) -> dict:
     return {
         "dossier": {
             "id": idx,
@@ -52,7 +51,7 @@ def venue_demarche_simplifiee_application_detail_response_with_siret(
     updated_at: str = "2020-01-21T18:55:03.387Z",
     siren: Optional[str] = None,
     state: str = "closed",
-) -> Dict:
+) -> dict:
     return {
         "dossier": {
             "id": idx,
@@ -111,7 +110,7 @@ def venue_demarche_simplifiee_application_detail_response_without_siret(
     idx: int = 1,
     updated_at: str = "2020-01-21T18:55:03.387Z",
     state: str = "closed",
-) -> Dict:
+) -> dict:
     return {
         "dossier": {
             "id": idx,

--- a/tests/connectors/beneficiaries/beneficiary_jouve_repository_test.py
+++ b/tests/connectors/beneficiaries/beneficiary_jouve_repository_test.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Dict
 from unittest.mock import MagicMock
 from unittest.mock import call
 from unittest.mock import patch
@@ -15,7 +14,7 @@ from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription impo
 def get_application_by_detail_response(
     application_id: int = 2,
     birth_date: str = "09/08/1995",
-) -> Dict:
+) -> dict:
     return {
         "id": application_id,
         "birthDate": birth_date,
@@ -32,7 +31,7 @@ def get_application_by_detail_response(
     }
 
 
-def get_token_detail_response(token: str) -> Dict:
+def get_token_detail_response(token: str) -> dict:
     return {"Value": token}
 
 

--- a/tests/infrastructure/repository/venue/venue_label/venue_labels_queries_test.py
+++ b/tests/infrastructure/repository/venue/venue_label/venue_labels_queries_test.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 from pcapi.domain.venue.venue_label.venue_label import VenueLabel
@@ -29,7 +27,7 @@ class VenueLabelSQLRepositoryTest:
         assert self._are_venue_label_present(expected_house_label, venue_labels)
         assert self._are_venue_label_present(expected_monuments_label, venue_labels)
 
-    def _are_venue_label_present(self, expected_venue_label: VenueLabel, venue_labels: List[VenueLabel]) -> bool:
+    def _are_venue_label_present(self, expected_venue_label: VenueLabel, venue_labels: list[VenueLabel]) -> bool:
         for venue_label in venue_labels:
             if (
                 expected_venue_label.identifier == venue_label.identifier

--- a/tests/sandboxes/scripts/bookings_recap/bookings_recap_test.py
+++ b/tests/sandboxes/scripts/bookings_recap/bookings_recap_test.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 from pytest import fixture
 
@@ -28,5 +26,5 @@ class BookingsRecapTest:
         assert self._find_bookings_by_user_firstname("Fifi") == 4
         assert self._find_bookings_by_user_firstname("Loulou") == 6
 
-    def _find_bookings_by_user_firstname(self, name: str) -> List[Booking]:
+    def _find_bookings_by_user_firstname(self, name: str) -> list[Booking]:
         return Booking.query.join(User).filter(User.firstName == name).count()

--- a/tests/scripts/beneficiary/fixture.py
+++ b/tests/scripts/beneficiary/fixture.py
@@ -1,5 +1,4 @@
 import copy
-from typing import Dict
 
 
 APPLICATION_DETAIL_STANDARD_RESPONSE = {
@@ -225,7 +224,7 @@ def make_new_beneficiary_application_details(
     department_code: str = "67 - Bas-Rhin",
     civility: str = "Mme",
     activity: str = "Étudiant",
-) -> Dict:
+) -> dict:
     application = copy.deepcopy(APPLICATION_DETAIL_STANDARD_RESPONSE)
     application["dossier"]["id"] = application_id
     application["dossier"]["state"] = state

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-from typing import List
 from unittest.mock import Mock
 
 from shapely.geometry import Polygon
@@ -6,7 +5,7 @@ from shapely.geometry import Polygon
 from pcapi.models import Booking
 
 
-def create_mocked_bookings(num_bookings: int, venue_email: str, name: str = "Offer name") -> List[Booking]:
+def create_mocked_bookings(num_bookings: int, venue_email: str, name: str = "Offer name") -> list[Booking]:
     bookings = []
 
     for counter in range(num_bookings):


### PR DESCRIPTION
##  Objectif

Suite aux montées de version de Python de 3.7 à 3.9, cette PR propose de :
- Traiter les dépréciations (silencieuses) de _type hints_ génériques basés sur le module typing (cf https://www.python.org/dev/peps/pep-0585/#implementation)
- Traiter des avertissements Pylint [I1101](http://pylint.pycqa.org/en/latest/technical_reference/c_extensions.html)
- Traiter un _FIXME_ de `pcapi.core.logging`


##  Implémentation

- bump de la version mypy
- remplacement des appels à 
  - `typing.List` par `list`,
  -  `typing.Dict` par `dict`,
  -  `typing.Tuple` par `tuple`,
  -  `typing.Set` par `set`.
- ajout des modules `math` et `binascii` à la directive `extension-pkg-whitelist` du fichier de configuration _pylint_
- Utiliser le _kwarg_ `force=True` de `logging.basicConfig()`

