### PR TITLE
Pc 8159 update credit on booking update

### DIFF
--- a/tests/routes/pro/delete_stock_test.py
+++ b/tests/routes/pro/delete_stock_test.py
@@ -28,16 +28,14 @@ class Returns200:
         assert response.status_code == 200
         assert response.json == {"id": humanize(stock.id)}
         assert stock.isSoftDeleted
-        assert push_testing.requests == [
-            {
-                "group_id": "Cancel_booking",
-                "message": {
-                    "body": f"""Ta commande "{offer.name}" a été annulée par l'offreur.""",
-                    "title": "Commande annulée",
-                },
-                "user_ids": [booking.userId],
-            }
-        ]
+        assert push_testing.requests[-1] == {
+            "group_id": "Cancel_booking",
+            "message": {
+                "body": f"""Ta commande "{offer.name}" a été annulée par l'offreur.""",
+                "title": "Commande annulée",
+            },
+            "user_ids": [booking.userId],
+        }
 
 
 class Returns400:


### PR DESCRIPTION
**Besoin**

Mettre à jour les informations de l'utilisateur lors de la création ou de l'annulation d'une réservation.

**Implémentation**

Le code pour l'envoi de la requête et le calcul du montant du crédit existe déjà.

**Discussion**

Les nouveaux décorateurs pour les tests (module `utils.py`) permettent de limiter l répétition mais on perd peut-être un peu en lisibilité ? 