### PR TITLE
(PC-6879) Corrections : contenu notification + set compr au lieu de list compr

### DIFF
--- a/src/pcapi/core/offers/repository.py
+++ b/src/pcapi/core/offers/repository.py
@@ -260,7 +260,7 @@ def check_stock_consistency() -> list[int]:
     ]
 
 
-def find_tomorrow_event_stock_ids() -> list[int]:
+def find_tomorrow_event_stock_ids() -> set[int]:
     """Find stocks linked to offers that happen tomorrow (and that are not cancelled)"""
     tomorrow = datetime.now() + timedelta(days=1)
     tomorrow_min = datetime.combine(tomorrow, time.min)
@@ -273,4 +273,4 @@ def find_tomorrow_event_stock_ids() -> list[int]:
         .options(load_only(Stock.id))
     )
 
-    return [stock.id for stock in stocks]
+    return {stock.id for stock in stocks}

--- a/src/pcapi/notifications/push/transactional_notifications.py
+++ b/src/pcapi/notifications/push/transactional_notifications.py
@@ -55,6 +55,6 @@ def get_tomorrow_stock_notification_data(stock_id: int) -> Optional[Transactiona
         user_ids=[booking.userId for booking in bookings],
         message=TransactionalNotificationMessage(
             title=f"{stock.offer.name}, c'est demain !",
-            body="Retrouve les détails de la réservation sur l’appli Pass Culture",
+            body="Retrouve les détails de la réservation sur l’application pass Culture",
         ),
     )


### PR DESCRIPTION
Apparemment l'ORM se charge d'éviter les doublons (avec la jointure sur Booking on pourrait avoir des Stock apparaître plusieurs fois). Dans le doute, on préfère retourner un set d'id plutôt qu'une liste.