### PR TITLE
(PC-7710) Suspend fraudulent pro user

### DIFF
--- a/src/pcapi/core/bookings/exceptions.py
+++ b/src/pcapi/core/bookings/exceptions.py
@@ -56,3 +56,11 @@ class CannotCancelConfirmedBooking(ClientError):
 class BookingDoesntExist(ClientError):
     def __init__(self):
         super().__init__("bookingId", "bookingId ne correspond à aucune réservation")
+
+
+class CannotDeleteOffererWithBookingsException(ClientError):
+    def __init__(self):
+        super().__init__(
+            "cannotDeleteOffererWithBookingsException",
+            "Structure juridique non supprimable car elle contient des réservations",
+        )

--- a/src/pcapi/core/bookings/repository.py
+++ b/src/pcapi/core/bookings/repository.py
@@ -234,6 +234,18 @@ def find_cancellable_bookings_by_beneficiaries(users: list[User]) -> list[Bookin
     )
 
 
+def find_cancellable_bookings_by_offerer(offerer_id: int) -> list[Booking]:
+    return (
+        Booking.query.join(Stock)
+        .join(Offer)
+        .join(Venue)
+        .filter(Venue.managingOffererId == offerer_id)
+        .filter(Booking.isCancelled.is_(False))
+        .filter(Booking.isUsed.is_(False))
+        .all()
+    )
+
+
 def _query_keep_on_non_activation_offers() -> Query:
     offer_types = ["ThingType.ACTIVATION", "EventType.ACTIVATION"]
 

--- a/src/pcapi/repository/user_queries.py
+++ b/src/pcapi/repository/user_queries.py
@@ -37,6 +37,15 @@ def find_beneficiary_users_by_email_provider(email_provider: str) -> list[User]:
     )
 
 
+def find_pro_users_by_email_provider(email_provider: str) -> list[User]:
+    formatted_email_provider = f"%@%{email_provider}"
+    return (
+        User.query.filter_by(isBeneficiary=False, isActive=True)
+        .filter(func.lower(User.email).like(func.lower(formatted_email_provider)))
+        .all()
+    )
+
+
 def find_by_civility(first_name: str, last_name: str, date_of_birth: datetime) -> list[User]:
     civility_predicate = (
         (_matching(User.firstName, first_name))

--- a/src/pcapi/scripts/offerer/delete_cascade_offerer_by_id.py
+++ b/src/pcapi/scripts/offerer/delete_cascade_offerer_by_id.py
@@ -1,5 +1,6 @@
 import logging
 
+from pcapi.core.bookings.exceptions import CannotDeleteOffererWithBookingsException
 from pcapi.core.bookings.models import Booking
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import Venue
@@ -28,7 +29,7 @@ def delete_cascade_offerer_by_id(offerer_id: int) -> None:
     ).scalar()
 
     if offerer_has_bookings:
-        raise AttributeError("Structure juridique non supprimable car elle contient des réservations")
+        raise CannotDeleteOffererWithBookingsException()
 
     deleted_stocks_count = Stock.query.filter(
         Stock.offerId == Offer.id, Offer.venueId == Venue.id, Venue.managingOffererId == offerer_id

--- a/src/pcapi/scripts/suspend_fraudulent_pro_users.py
+++ b/src/pcapi/scripts/suspend_fraudulent_pro_users.py
@@ -1,0 +1,45 @@
+from pcapi.core.bookings.api import cancel_booking_for_fraud
+from pcapi.core.bookings.exceptions import CannotDeleteOffererWithBookingsException
+from pcapi.core.bookings.repository import find_cancellable_bookings_by_offerer
+from pcapi.core.users.api import suspend_account
+from pcapi.core.users.constants import SuspensionReason
+from pcapi.core.users.models import User
+from pcapi.repository.user_offerer_queries import find_one_or_none_by_user_id
+from pcapi.repository.user_queries import find_pro_users_by_email_provider
+from pcapi.scripts.offerer.delete_cascade_offerer_by_id import delete_cascade_offerer_by_id
+
+
+def suspend_fraudulent_pro_by_email_providers(
+    fraudulent_email_providers: list[str], admin_user: User, dry_run: bool = True
+) -> None:
+    fraudulent_pros = []
+
+    for email_provider in fraudulent_email_providers:
+        fraudulent_pros.extend(find_pro_users_by_email_provider(email_provider=email_provider))
+
+    if not dry_run:
+        for fraudulent_pro in fraudulent_pros:
+            user_offerrer = find_one_or_none_by_user_id(user_id=fraudulent_pro.id)
+            try:
+                delete_cascade_offerer_by_id(offerer_id=user_offerrer.offererId)
+            except CannotDeleteOffererWithBookingsException:
+                _cancel_bookings_by_fraudulent_pro(offerer_id=user_offerrer.offererId)
+
+        _suspend_fraudulent_pro_users(users=fraudulent_pros, admin_user=admin_user)
+    else:
+        print(f"dry run: would suspend {len(fraudulent_pros)} fraudulent pro user")
+        print("dry run: all emails of fraudulent pro user:")
+        for _, pros in enumerate(fraudulent_pros):
+            print(f"{pros.publicName}: {pros.email}")
+
+
+def _suspend_fraudulent_pro_users(users: list[User], admin_user: User) -> None:
+    for fraudulent_user in users:
+        suspend_account(fraudulent_user, SuspensionReason.FRAUD, admin_user)
+
+
+def _cancel_bookings_by_fraudulent_pro(offerer_id: int) -> None:
+    bookings_to_cancel = find_cancellable_bookings_by_offerer(offerer_id=offerer_id)
+
+    for booking in bookings_to_cancel:
+        cancel_booking_for_fraud(booking=booking)

--- a/tests/scripts/suspend_suspected_fraudulent_pro_users_test.py
+++ b/tests/scripts/suspend_suspected_fraudulent_pro_users_test.py
@@ -1,0 +1,127 @@
+import pytest
+
+from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.models import Booking
+from pcapi.core.bookings.models import BookingCancellationReasons
+from pcapi.core.offerers.models import Offerer
+from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.factories import OfferFactory
+from pcapi.core.offers.factories import OffererFactory
+from pcapi.core.offers.factories import StockFactory
+from pcapi.core.offers.factories import UserOffererFactory
+from pcapi.core.offers.factories import VenueFactory
+from pcapi.core.offers.models import Offer
+from pcapi.core.offers.models import Stock
+from pcapi.core.users.factories import UserFactory
+from pcapi.scripts.suspend_fraudulent_pro_users import suspend_fraudulent_pro_by_email_providers
+
+
+@pytest.mark.usefixtures("db_session")
+def test_suspend_pros_in_given_emails_providers_list():
+    # Given
+    fraudulent_emails_providers = ["example.com"]
+    admin_user = UserFactory(isBeneficiary=False, isAdmin=True, email="admin@example.net")
+    fraudulent_user = UserFactory(
+        isBeneficiary=False,
+        email="jesuisunefraude@example.com",
+    )
+    offerer = OffererFactory()
+    UserOffererFactory(user=fraudulent_user, offerer=offerer)
+
+    # When
+    suspend_fraudulent_pro_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
+
+    # Then
+    assert not fraudulent_user.isActive
+
+
+@pytest.mark.usefixtures("db_session")
+def test_only_suspend_pro_users_in_given_emails_providers_list():
+    # Given
+    fraudulent_emails_providers = ["example.com"]
+    admin_user = UserFactory(isBeneficiary=False, isAdmin=True, email="admin@example.net")
+    pro_fraudulent_user_with_uppercase_domain = UserFactory(isBeneficiary=False, email="jesuisunefraude@EXAmple.com")
+    pro_fraudulent_user_with_subdomain = UserFactory(isBeneficiary=False, email="jesuisunefraude@sub.example.com")
+    beneficiary_fraudulent_user = UserFactory(isBeneficiary=True, email="jesuisuneautrefraude@example.com")
+    offerer1 = OffererFactory()
+    UserOffererFactory(user=pro_fraudulent_user_with_uppercase_domain, offerer=offerer1)
+    offerer2 = OffererFactory()
+    UserOffererFactory(user=pro_fraudulent_user_with_subdomain, offerer=offerer2)
+
+    # When
+    suspend_fraudulent_pro_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
+
+    # Then
+    assert not pro_fraudulent_user_with_uppercase_domain.isActive
+    assert not pro_fraudulent_user_with_subdomain.isActive
+    assert beneficiary_fraudulent_user.isActive
+
+
+@pytest.mark.usefixtures("db_session")
+def test_dont_suspend_users_not_in_given_emails_providers_list():
+    # Given
+    fraudulent_emails_providers = ["example.com"]
+    admin_user = UserFactory(isBeneficiary=False, isAdmin=True, email="admin@example.net")
+    non_fraudulent_pro = UserFactory(isBeneficiary=False, email="jenesuispasunefraude@gmoil.com")
+
+    # When
+    suspend_fraudulent_pro_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
+
+    # Then
+    assert non_fraudulent_pro.isActive
+
+
+@pytest.mark.usefixtures("db_session")
+def test_delete_offerer_and_venue():
+    # Given
+    fraudulent_emails_providers = ["example.com"]
+    admin_user = UserFactory(isBeneficiary=False, isAdmin=True, email="admin@example.net")
+    fraudulent_user = UserFactory(
+        isBeneficiary=False,
+        email="jesuisunefraude@example.com",
+    )
+    offerer = OffererFactory()
+    UserOffererFactory(user=fraudulent_user, offerer=offerer)
+    VenueFactory(managingOfferer=offerer)
+
+    # When
+    suspend_fraudulent_pro_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
+
+    # Then
+    assert Offerer.query.count() == 0
+    assert Venue.query.count() == 0
+
+
+@pytest.mark.usefixtures("db_session")
+def test_cancel_bookings_when_offerer_has_one_or_more():
+    # Given
+    fraudulent_emails_providers = ["example.com"]
+    admin_user = UserFactory(isBeneficiary=False, isAdmin=True, email="admin@example.net")
+    beneficiary1 = UserFactory(email="beneficiary1@example.net")
+    beneficiary2 = UserFactory(email="beneficiary2@example.net")
+    fraudulent_user = UserFactory(
+        isBeneficiary=False,
+        email="jesuisunefraude@example.com",
+    )
+    offerer_with_bookings = OffererFactory()
+    UserOffererFactory(user=fraudulent_user, offerer=offerer_with_bookings)
+    offer1 = OfferFactory(venue__managingOfferer=offerer_with_bookings)
+    offer2 = OfferFactory(venue__managingOfferer=offerer_with_bookings)
+    stock1 = StockFactory(offer=offer1)
+    stock2 = StockFactory(offer=offer2)
+    booking1 = BookingFactory(user=beneficiary1, stock=stock1)
+    booking2 = BookingFactory(user=beneficiary2, stock=stock2)
+
+    # When
+    suspend_fraudulent_pro_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
+
+    # Then
+    assert Offerer.query.count() == 1
+    assert Venue.query.count() == 2
+    assert Offer.query.count() == 2
+    assert Stock.query.count() == 2
+    assert Booking.query.count() == 2
+    assert booking1.isCancelled
+    assert booking1.cancellationReason == BookingCancellationReasons.FRAUD
+    assert booking2.isCancelled
+    assert booking2.cancellationReason == BookingCancellationReasons.FRAUD


### PR DESCRIPTION
Script qui :
- Suspend le compte d'une liste d'acteurs frauduleux (basé sur #2159) ;
- Supprime ses structures/lieux si pas de réservations (basé sur #2274);
- Annule les réservations associées si existantes (basé sur #2174).