### PR TITLE
(PC-8329) : push native app users to the request context

### DIFF
--- a/src/pcapi/routes/native/security.py
+++ b/src/pcapi/routes/native/security.py
@@ -1,6 +1,7 @@
 from functools import wraps
 import logging
 
+from flask import _request_ctx_stack
 from flask_jwt_extended.utils import get_jwt_identity
 from flask_jwt_extended.view_decorators import jwt_required
 
@@ -27,6 +28,10 @@ def authenticated_user_required(route_function):  # type: ignore
         if user is None or not user.isActive:
             logger.error("Authenticated user with email %s not found or inactive", email)
             raise ForbiddenError({"email": ["Utilisateur introuvable"]})
+
+        # push the user to the current context - similar to flask-login
+        ctx = _request_ctx_stack.top
+        ctx.user = user
 
         return route_function(user, *args, **kwargs)
 


### PR DESCRIPTION
Since the native app does not use flask-login the current user
is not pushed to the request context and therefore it does not
appear in the logs.
By pushing it to the context just like flask-login does the user
will be available in the logs created by the native application
API.