### PR TITLE
(PC-6885) Update u.lastBookingDate field on Batch on Booking creation

### DIFF
--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -28,6 +28,7 @@ from pcapi.repository import transaction
 from pcapi.utils.mailing import MailServiceException
 from pcapi.workers.push_notification_job import send_cancel_booking_notification
 from pcapi.workers.push_notification_job import update_user_attributes_job
+from pcapi.workers.push_notification_job import update_user_bookings_attributes_job
 
 from . import validation
 from .exceptions import NoActivationCodeAvailable
@@ -128,7 +129,7 @@ def book_offer(
     if feature_queries.is_active(FeatureToggle.SYNCHRONIZE_ALGOLIA):
         redis.add_offer_id(client=app.redis_client, offer_id=stock.offerId)
 
-    update_user_attributes_job.delay(beneficiary.id)
+    update_user_bookings_attributes_job.delay(beneficiary.id)
 
     return booking
 

--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -35,6 +35,7 @@ from pcapi.domain.postal_code.postal_code import PostalCode
 from pcapi.emails.beneficiary_email_change import build_beneficiary_confirmation_email_change_data
 from pcapi.emails.beneficiary_email_change import build_beneficiary_information_email_change_data
 from pcapi.models import BeneficiaryImport
+from pcapi.models import Booking
 from pcapi.models import ImportStatus
 from pcapi.models.db import db
 from pcapi.models.user_offerer import UserOfferer
@@ -321,6 +322,11 @@ def _build_link_for_email_change(current_email: str, new_email: str) -> str:
     return (
         f"{settings.WEBAPP_URL}/changement-email?token={token}&expiration_timestamp={int(expiration_date.timestamp())}"
     )
+
+
+def get_last_booking_date(user: User) -> Optional[datetime]:
+    booking = Booking.query.filter(Booking.userId == user.id).order_by(db.desc(Booking.dateCreated)).first()
+    return booking.dateCreated if booking else None
 
 
 def get_domains_credit(user: User) -> Optional[DomainsCredit]:

--- a/src/pcapi/notifications/push/user_attributes_updates.py
+++ b/src/pcapi/notifications/push/user_attributes_updates.py
@@ -27,3 +27,16 @@ def get_user_attributes(user: User) -> dict:
         if user.deposit_expiration_date
         else None,
     }
+
+
+def get_user_booking_attributes(user: User) -> dict:
+    from pcapi.core.users.api import get_domains_credit
+    from pcapi.core.users.api import get_last_booking_date
+
+    credit = get_domains_credit(user)
+    last_booking_date = get_last_booking_date(user)
+
+    return {
+        "date(u.lastBookingDate)": last_booking_date.strftime(BATCH_DATETIME_FORMAT) if last_booking_date else None,
+        "u.credit": int(credit.all.remaining * 100) if credit else 0,
+    }

--- a/src/pcapi/workers/push_notification_job.py
+++ b/src/pcapi/workers/push_notification_job.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Callable
 
 from rq.decorators import job
 
@@ -8,6 +9,7 @@ from pcapi.notifications.push import update_user_attributes
 from pcapi.notifications.push.transactional_notifications import get_bookings_cancellation_notification_data
 from pcapi.notifications.push.transactional_notifications import get_tomorrow_stock_notification_data
 from pcapi.notifications.push.user_attributes_updates import get_user_attributes
+from pcapi.notifications.push.user_attributes_updates import get_user_booking_attributes
 from pcapi.workers import worker
 from pcapi.workers.decorators import job_context
 from pcapi.workers.decorators import log_job
@@ -19,13 +21,25 @@ logger = logging.getLogger(__name__)
 @job(worker.default_queue, connection=worker.conn)
 @job_context
 @log_job
-def update_user_attributes_job(user_id: int) -> None:
+def update_user_attributes_job(user_id: int, *extra_providers: Callable[[User], dict]) -> None:
     user = User.query.get(user_id)
     if not user:
         logger.error("No user with id=%s found to send push attributes updates requests", user_id)
         return
 
     update_user_attributes(user.id, get_user_attributes(user))
+
+
+@job(worker.default_queue, connection=worker.conn)
+@job_context
+@log_job
+def update_user_bookings_attributes_job(user_id: int) -> None:
+    user = User.query.get(user_id)
+    if not user:
+        logger.error("No user with id=%s found to send push attributes updates requests", user_id)
+        return
+
+    update_user_attributes(user.id, get_user_booking_attributes(user))
 
 
 @job(worker.default_queue, connection=worker.conn)

--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -22,6 +22,7 @@ from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
 from pcapi.models import api_errors
 import pcapi.notifications.push.testing as push_testing
+from pcapi.notifications.push.user_attributes_updates import BATCH_DATETIME_FORMAT
 from pcapi.utils.token import random_token
 
 from tests.conftest import clean_database
@@ -98,6 +99,9 @@ class BookOfferTest:
         data = push_testing.requests[0]
         assert data["attribute_values"]["u.credit"] == 49_000  # values in cents
 
+        expected_date = booking.dateCreated.strftime(BATCH_DATETIME_FORMAT)
+        assert data["attribute_values"]["date(u.lastBookingDate)"] == expected_date
+
         assert booking.quantity == 1
         assert booking.amount == 10
         assert booking.stock == stock
@@ -115,6 +119,23 @@ class BookOfferTest:
         email_data2 = mails_testing.outbox[1].sent_data
         assert email_data2["MJ-TemplateID"] == 1163067  # to beneficiary
 
+    def test_last_booking_date_update(self, app):
+        user = users_factories.UserFactory()
+        stock = offers_factories.StockFactory(price=10, dnBookedQuantity=5)
+
+        date_created = datetime.now() - timedelta(days=5)
+        factories.BookingFactory.create_batch(3, user=user, dateCreated=date_created)
+
+        booking = api.book_offer(beneficiary=user, stock_id=stock.id, quantity=1)
+
+        # One request should have been sent to Batch with the user's
+        # updated attributes
+        assert len(push_testing.requests) == 1
+
+        data = push_testing.requests[0]
+        expected_date = booking.dateCreated.strftime(BATCH_DATETIME_FORMAT)
+        assert data["attribute_values"]["date(u.lastBookingDate)"] == expected_date
+
     @override_features(AUTO_ACTIVATE_DIGITAL_BOOKINGS=True)
     def test_create_booking_on_digital_offer(self):
         offer = offers_factories.OfferFactory(product=offers_factories.DigitalProductFactory())
@@ -129,6 +150,9 @@ class BookOfferTest:
 
         data = push_testing.requests[0]
         assert data["attribute_values"]["u.credit"] == 49_000  # values in cents
+
+        expected_date = booking.dateCreated.strftime(BATCH_DATETIME_FORMAT)
+        assert data["attribute_values"]["date(u.lastBookingDate)"] == expected_date
 
         assert booking.isUsed
 
@@ -145,6 +169,9 @@ class BookOfferTest:
 
         data = push_testing.requests[0]
         assert data["attribute_values"]["u.credit"] == 49_000  # values in cents
+
+        expected_date = booking.dateCreated.strftime(BATCH_DATETIME_FORMAT)
+        assert data["attribute_values"]["date(u.lastBookingDate)"] == expected_date
 
         two_days_after_booking = booking.dateCreated + timedelta(days=2)
         assert booking.quantity == 1


### PR DESCRIPTION
**Besoin**

Mettre à jour/créer le champ `lastBookingDate` d'un utilisateur sur Batch. Peu importe le statut de la réservation : même une réservation annulée doit être utilisée.

**Autres**

La fonction `get_last_booking_date` part du principe qu'il y a au moins un `Booking` existant : dans le cas contraire :arrow_right: erreur.

Si elle est appelée alors que l'utilisateur n'a aucune réservation, il vaut peut-être mieux avoir une erreur rapidement plutôt que de gérer des `None` pas très explicites, voire de laisser passer un `None` jusqu'à Batch et faire une mise à jour inattendue.