### PR TITLE
(PC): Python shell graphic bugs on long expressions

### DIFF
--- a/src/pcapi/scripts/interact.py
+++ b/src/pcapi/scripts/interact.py
@@ -50,8 +50,16 @@ def set_python_prompt():
         color = "\x1b[1;49;36m"  # cyan
     else:
         color = None
+
     if color:
-        sys.ps1 = f"{color}{env} >>>\x1b[0m "
+        color = _non_printable(color)
+        reset = _non_printable("\x1b[0m")
+
+        sys.ps1 = f"{color}{env} >>> {reset}"
+
+
+def _non_printable(seq):
+    return f"\001{seq}\002"
 
 
 set_python_prompt()


### PR DESCRIPTION
Pour certains expressions un bug graphique apparaissait en console python, en particulier pour des expressions plus longue que la taille du shell, ou multiline, et en remontant l'historique

Par exemple : 

![image](https://user-images.githubusercontent.com/10156873/116041060-0e825280-a66d-11eb-9f41-05219cde9095.png)
