### PR TITLE
offers: Log ISBN in `deactivate_inappropriate_products()`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,13 @@ python-dotenv==0.14.0
 python-json-logger==0.1.11
 python-swiftclient==3.10.1
 qrcode==6.1
-requests_mock
+# FIXME (dbaty, 2021-04-28): as of version 1.9 [1], requests_mock
+# quotes URLs passed to Mocker. If we send a request on a URL that is
+# not quoted, requests_mock does not find a match anymore and the test
+# fails. This is the case on a few tests of the Mailjet client, which
+# does not quote URLs in its `build_url()` function.
+# [1] https://github.com/jamielennox/requests-mock/commit/f072845c0cb13c6c0fb18824160639a8bb3c7fe8
+requests_mock==1.8.0
 rq==1.5.2
 schwifty==2020.9.0
 sentry-sdk==0.18.0

--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -576,10 +576,13 @@ def deactivate_inappropriate_products(isbn: str) -> bool:
     except Exception as exception:  # pylint: disable=broad-except
         logger.exception(
             "Could not mark product and offers as inappropriate: %s",
-            extra={"products": [p.id for p in products], "exc": str(exception)},
+            extra={"isbn": isbn, "products": [p.id for p in products], "exc": str(exception)},
         )
         return False
-    logger.info("Deactivated inappropriate products", extra={"products": [p.id for p in products], "offers": offer_ids})
+    logger.info(
+        "Deactivated inappropriate products",
+        extra={"isbn": isbn, "products": [p.id for p in products], "offers": offer_ids},
+    )
 
     if feature_queries.is_active(FeatureToggle.SYNCHRONIZE_ALGOLIA):
         for offer_id in offer_ids:


### PR DESCRIPTION
When searching the logs, it's sometimes easier to look for the ISBN
instead of the product ids.