### PR TITLE
(PC-8209) Send user's offers' categories to Batch

### DIFF
--- a/src/pcapi/core/users/repository.py
+++ b/src/pcapi/core/users/repository.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from dateutil.relativedelta import relativedelta
 from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import load_only
 from sqlalchemy.orm.query import Query
 
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_validator import _is_postal_code_eligible
@@ -128,3 +129,9 @@ def find_favorites_domain_by_beneficiary(beneficiary_identifier: int) -> list[Fa
         )
         for favorite_sql_entity in favorite_sql_entities
     ]
+
+
+def get_booking_categories(user: User) -> list[str]:
+    """Get a list of a user's (unique) categories"""
+    offers = Offer.query.join(Stock).join(Booking).filter(Booking.userId == user.id).options(load_only(Offer.type))
+    return list(set(offer.type for offer in offers))

--- a/src/pcapi/notifications/push/user_attributes_updates.py
+++ b/src/pcapi/notifications/push/user_attributes_updates.py
@@ -32,11 +32,19 @@ def get_user_attributes(user: User) -> dict:
 def get_user_booking_attributes(user: User) -> dict:
     from pcapi.core.users.api import get_domains_credit
     from pcapi.core.users.api import get_last_booking_date
+    from pcapi.core.users.repository import get_booking_categories
 
     credit = get_domains_credit(user)
     last_booking_date = get_last_booking_date(user)
+    booking_categories = get_booking_categories(user)
 
-    return {
-        "date(u.lastBookingDate)": last_booking_date.strftime(BATCH_DATETIME_FORMAT) if last_booking_date else None,
+    attributes = {
+        "date(u.last_booking_date)": last_booking_date.strftime(BATCH_DATETIME_FORMAT) if last_booking_date else None,
         "u.credit": int(credit.all.remaining * 100) if credit else 0,
     }
+
+    # A Batch tag can't be an empty list, otherwise the API returns an error
+    if booking_categories:
+        attributes["ut.booking_categories"] = booking_categories
+
+    return attributes


### PR DESCRIPTION
Ajout d'une information à Batch : la liste des catégories des réservations d'un utilisateur. Cette liste doit contenir des éléments uniques.