### PR TITLE
(PC-8290) algolia: Make offer reindexation cron job the queue consume the full queue

### DIFF
--- a/src/pcapi/alembic/versions/20210428_9cff93fc69f2_feature_new_batch_index_offers.py
+++ b/src/pcapi/alembic/versions/20210428_9cff93fc69f2_feature_new_batch_index_offers.py
@@ -1,0 +1,26 @@
+"""Add new feature flag: USE_NEW_BATCH_INDEX_OFFERS_BEHAVIOUR
+
+Revision ID: 9cff93fc69f2
+Revises: ff04dc8fe18e
+Create Date: 2021-04-28 17:44:43.120881
+"""
+
+from pcapi.models import feature
+
+
+# revision identifiers, used by Alembic.
+revision = "9cff93fc69f2"
+down_revision = "ff04dc8fe18e"
+branch_labels = None
+depends_on = None
+
+
+FLAG = feature.FeatureToggle.USE_NEW_BATCH_INDEX_OFFERS_BEHAVIOUR
+
+
+def upgrade():
+    feature.add_feature_to_database(FLAG)
+
+
+def downgrade():
+    feature.remove_feature_from_database(FLAG)

--- a/src/pcapi/connectors/redis.py
+++ b/src/pcapi/connectors/redis.py
@@ -62,6 +62,20 @@ def get_offer_ids(client: Redis) -> list[int]:
         return []
 
 
+def pop_offer_ids(client: Redis) -> list[int]:
+    try:
+        # FIXME (dbaty, 2021-04-28): `lpop()` does not yet allow to
+        # specify the number of arguments to pop. See
+        # https://github.com/andymccurdy/redis-py/pull/1467/files
+        # Until it is implemented upstream, manually send the command.
+        return client.execute_command(
+            "LPOP", RedisBucket.REDIS_LIST_OFFER_IDS_NAME.value, settings.REDIS_OFFER_IDS_CHUNK_SIZE
+        )
+    except redis.exceptions.RedisError as error:
+        logger.exception("[REDIS] %s", error)
+        return []
+
+
 def get_venue_ids(client: Redis) -> list[int]:
     try:
         venue_ids = client.lrange(RedisBucket.REDIS_LIST_VENUE_IDS_NAME.value, 0, settings.REDIS_VENUE_IDS_CHUNK_SIZE)

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -49,6 +49,7 @@ class FeatureToggle(enum.Enum):
     )
     ENABLE_ACTIVATION_CODES = "Permet la création de codes d'activation"
     ENABLE_PHONE_VALIDATION = "Active la validation du numéro de téléphone"
+    USE_NEW_BATCH_INDEX_OFFERS_BEHAVIOUR = "Utilise une boucle dans le cron de réindexation Algolia"
 
 
 class Feature(PcObject, Model, DeactivableMixin):
@@ -65,6 +66,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.WHOLE_FRANCE_OPENING,
     FeatureToggle.AUTO_ACTIVATE_DIGITAL_BOOKINGS,
     FeatureToggle.ENABLE_ACTIVATION_CODES,
+    FeatureToggle.USE_NEW_BATCH_INDEX_OFFERS_BEHAVIOUR,
 )
 
 

--- a/src/pcapi/scheduled_tasks/algolia_clock.py
+++ b/src/pcapi/scheduled_tasks/algolia_clock.py
@@ -4,6 +4,7 @@ from pcapi import settings
 from pcapi.algolia.infrastructure.worker import process_multi_indexing
 from pcapi.core.logging import install_logging
 from pcapi.models.feature import FeatureToggle
+from pcapi.repository import feature_queries
 from pcapi.scheduled_tasks import utils
 from pcapi.scheduled_tasks.decorators import cron_context
 from pcapi.scheduled_tasks.decorators import cron_require_feature
@@ -12,6 +13,7 @@ from pcapi.scripts.algolia_indexing.indexing import batch_deleting_expired_offer
 from pcapi.scripts.algolia_indexing.indexing import batch_indexing_offers_in_algolia_by_offer
 from pcapi.scripts.algolia_indexing.indexing import batch_indexing_offers_in_algolia_by_venue
 from pcapi.scripts.algolia_indexing.indexing import batch_processing_offer_ids_in_error
+from pcapi.scripts.algolia_indexing.indexing import legacy_batch_indexing_offers_in_algolia_by_offer
 
 
 install_logging()
@@ -21,7 +23,10 @@ install_logging()
 @cron_context
 @cron_require_feature(FeatureToggle.SYNCHRONIZE_ALGOLIA)
 def index_offers_in_algolia_by_offer(app):
-    batch_indexing_offers_in_algolia_by_offer(client=app.redis_client)
+    if feature_queries.is_active(FeatureToggle.USE_NEW_BATCH_INDEX_OFFERS_BEHAVIOUR):
+        batch_indexing_offers_in_algolia_by_offer(client=app.redis_client)
+    else:
+        legacy_batch_indexing_offers_in_algolia_by_offer(client=app.redis_client)
 
 
 @log_cron

--- a/src/pcapi/scripts/algolia_indexing/commands.py
+++ b/src/pcapi/scripts/algolia_indexing/commands.py
@@ -5,12 +5,15 @@ from flask import current_app as app
 
 from pcapi.algolia.infrastructure.api import clear_index
 from pcapi.connectors.redis import delete_all_indexed_offers
+from pcapi.models.feature import FeatureToggle
+from pcapi.repository import feature_queries
 from pcapi.scripts.algolia_indexing.indexing import _process_venue_provider
 from pcapi.scripts.algolia_indexing.indexing import batch_deleting_expired_offers_in_algolia
 from pcapi.scripts.algolia_indexing.indexing import batch_indexing_offers_in_algolia_by_offer
 from pcapi.scripts.algolia_indexing.indexing import batch_indexing_offers_in_algolia_by_venue
 from pcapi.scripts.algolia_indexing.indexing import batch_indexing_offers_in_algolia_by_venue_provider
 from pcapi.scripts.algolia_indexing.indexing import batch_indexing_offers_in_algolia_from_database
+from pcapi.scripts.algolia_indexing.indexing import legacy_batch_indexing_offers_in_algolia_by_offer
 
 
 logger = logging.getLogger(__name__)
@@ -19,7 +22,10 @@ logger = logging.getLogger(__name__)
 @app.manager.command
 def process_offers():
     with app.app_context():
-        batch_indexing_offers_in_algolia_by_offer(client=app.redis_client)
+        if feature_queries.is_active(FeatureToggle.USE_NEW_BATCH_INDEX_OFFERS_BEHAVIOUR):
+            batch_indexing_offers_in_algolia_by_offer(client=app.redis_client, stop_only_when_empty=True)
+        else:
+            legacy_batch_indexing_offers_in_algolia_by_offer(client=app.redis_client)
 
 
 @app.manager.command


### PR DESCRIPTION
Until now, `index_offers_in_algolia_by_offer` popped a limited amount
of offers from the queue (currently: 1.000) and stopped. The process
took a few seconds, and the cron job would only be run every minute.

During the night, we synchronize offers from various providers, which
requires to index/reindex a lot of offers. The queue gets quite big
and the cron job processes only 1.000 items every minute. The queue
hence takes a lot of time to be fully processed.

With the new behaviour, the cron job pops at least once a batch of
1.000 items and continues to do so until the queue is exhausted (or
until the queue has less than 1.000 items, so that we don't have a
cron job that never stops because something keeps on filling the
queue).

This new behaviour is behind a feature flag which is disabled by
default. Because I'm a coward.