### PR TITLE
(PC-8360) : native API returns 403 when client needs to upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,7 @@ qrcode==6.1
 requests_mock==1.8.0
 rq==1.5.2
 schwifty==2020.9.0
+semver==2.13.0
 sentry-sdk==0.18.0
 simplejson==3.17.2
 spectree==0.3.15

--- a/src/pcapi/routes/native/utils.py
+++ b/src/pcapi/routes/native/utils.py
@@ -1,8 +1,27 @@
 from decimal import Decimal
 from typing import Optional
 
+import flask
+import semver
+
+from pcapi import settings
+from pcapi.models.api_errors import ForbiddenError
+
 
 def convert_to_cent(amount: Optional[Decimal]) -> Optional[int]:
     if amount is None:
         return None
     return int(amount * 100)
+
+
+def check_client_version() -> None:
+    client_version_header = flask.request.headers.get("app-version", None)
+    if not client_version_header:
+        return
+    try:
+        client_version = semver.VersionInfo.parse(client_version_header)
+    except ValueError:
+        raise ForbiddenError(errors={"ERROR": "UPGRADE_REQUIRED"})
+
+    if client_version < settings.NATIVE_APP_MINIMAL_CLIENT_VERSION:
+        raise ForbiddenError(errors={"ERROR": "UPGRADE_REQUIRED"})

--- a/src/pcapi/routes/native/v1/blueprint.py
+++ b/src/pcapi/routes/native/v1/blueprint.py
@@ -2,10 +2,12 @@ from flask import Blueprint
 from spectree import SpecTree
 
 from pcapi.routes.native import security
+from pcapi.routes.native import utils
 from pcapi.serialization.utils import before_handler
 
 
 native_v1 = Blueprint("native_v1", __name__)
+native_v1.before_request(utils.check_client_version)
 
 
 class NativeSpecTree(SpecTree):

--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 from dotenv import load_dotenv
+import semver
 
 from .utils import settings as utils
 
@@ -55,6 +56,12 @@ PROFILE_REQUESTS_LINES_LIMIT = int(os.environ.get("PROFILE_REQUESTS_LINES_LIMIT"
 FLASK_PORT = int(os.environ.get("PORT", 5000))
 FLASK_SECRET = os.environ.get("FLASK_SECRET", "+%+3Q23!zbc+!Dd@")
 CORS_ALLOWED_ORIGIN = os.environ.get("CORS_ALLOWED_ORIGIN")
+
+
+# NATIVE APP SPECIFIC SETTINGS
+NATIVE_APP_MINIMAL_CLIENT_VERSION = semver.VersionInfo.parse(
+    os.environ.get("NATIVE_APP_MINIMAL_CLIENT_VERSION", "1.132.1")
+)
 
 
 # REDIS

--- a/tests/routes/native/v1/utils_test.py
+++ b/tests/routes/native/v1/utils_test.py
@@ -1,0 +1,45 @@
+import pytest
+import semver
+
+from pcapi.core.testing import override_settings
+
+from tests.conftest import TestClient
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class CheckClientVersionTest:
+    def test_with_invalid_version(self, app):
+        test_client = TestClient(app.test_client())
+        response = test_client.post("/native/v1/signin", json={}, headers={"app-version": "caramba"})
+        assert response.status_code == 403
+        assert response.content_type == "application/json"
+        assert response.json == {"ERROR": "UPGRADE_REQUIRED"}
+
+    @override_settings(NATIVE_APP_MINIMAL_CLIENT_VERSION=semver.VersionInfo.parse("1.0.1"))
+    def test_with_exact_version(self, app):
+        test_client = TestClient(app.test_client())
+        response = test_client.post("/native/v1/signin", json={}, headers={"app-version": "1.0.1"})
+        assert response.status_code == 400
+        assert response.json == {
+            "identifier": ["Ce champ est obligatoire"],
+            "password": ["Ce champ est obligatoire"],
+        }
+
+    @override_settings(NATIVE_APP_MINIMAL_CLIENT_VERSION=semver.VersionInfo.parse("1.0.1"))
+    def test_with_newer_version(self, app):
+        test_client = TestClient(app.test_client())
+        response = test_client.post("/native/v1/signin", json={}, headers={"app-version": "1.0.2"})
+        assert response.status_code == 400
+        assert response.json == {
+            "identifier": ["Ce champ est obligatoire"],
+            "password": ["Ce champ est obligatoire"],
+        }
+
+    @override_settings(NATIVE_APP_MINIMAL_CLIENT_VERSION=semver.VersionInfo.parse("1.0.1"))
+    def test_with_older_version(self, app):
+        test_client = TestClient(app.test_client())
+        response = test_client.post("/native/v1/signin", json={}, headers={"app-version": "1.0.0"})
+        assert response.status_code == 403
+        assert response.json == {"ERROR": "UPGRADE_REQUIRED"}


### PR DESCRIPTION
Any request on the native API will now be scanned for the
`app-version` header - if present - and will be checked against
`NATIVE_APP_MINIMAL_CLIENT_VERSION` settings.
If the version is lower - according to semver - or the client's
version is not parsable then a 403 will be returned with the
`{"ERROR": "UPGRADE_REQUIRED"}` body.
Otherwise, the request will be processed as usual.