### PR TITLE
(PC-8458) circleci: stop run-tests job when step fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,6 @@ jobs:
           steps:
             - run:
                 name: Running tests
-                when: always
                 command: |
                   RUN_ENV=tests venv/bin/pytest tests --cov --cov-report html --junitxml=test-results/junit.xml
                   venv/bin/coveralls
@@ -237,7 +236,6 @@ jobs:
           condition: << parameters.is_nightly_build >>
           steps:
             - run:
-                when: always
                 name: Running tests
                 command: |
                   RUN_ENV=tests venv/bin/pytest tests --junitxml=test-results/junit.xml


### PR DESCRIPTION
In particular, this prevents unit tests to run when alembic migrations
are incorrect.
The directive `when: always` is no longer needed, because the quality
checks are now in a separate job.