### PR TITLE
(PC-8360) : consistent message when native client needs to upgrade

### DIFF
--- a/src/pcapi/routes/native/utils.py
+++ b/src/pcapi/routes/native/utils.py
@@ -21,7 +21,7 @@ def check_client_version() -> None:
     try:
         client_version = semver.VersionInfo.parse(client_version_header)
     except ValueError:
-        raise ForbiddenError(errors={"ERROR": "UPGRADE_REQUIRED"})
+        raise ForbiddenError(errors={"code": "UPGRADE_REQUIRED"})
 
     if client_version < settings.NATIVE_APP_MINIMAL_CLIENT_VERSION:
-        raise ForbiddenError(errors={"ERROR": "UPGRADE_REQUIRED"})
+        raise ForbiddenError(errors={"code": "UPGRADE_REQUIRED"})

--- a/tests/routes/native/v1/utils_test.py
+++ b/tests/routes/native/v1/utils_test.py
@@ -15,7 +15,7 @@ class CheckClientVersionTest:
         response = test_client.post("/native/v1/signin", json={}, headers={"app-version": "caramba"})
         assert response.status_code == 403
         assert response.content_type == "application/json"
-        assert response.json == {"ERROR": "UPGRADE_REQUIRED"}
+        assert response.json == {"code": "UPGRADE_REQUIRED"}
 
     @override_settings(NATIVE_APP_MINIMAL_CLIENT_VERSION=semver.VersionInfo.parse("1.0.1"))
     def test_with_exact_version(self, app):
@@ -42,4 +42,4 @@ class CheckClientVersionTest:
         test_client = TestClient(app.test_client())
         response = test_client.post("/native/v1/signin", json={}, headers={"app-version": "1.0.0"})
         assert response.status_code == 403
-        assert response.json == {"ERROR": "UPGRADE_REQUIRED"}
+        assert response.json == {"code": "UPGRADE_REQUIRED"}


### PR DESCRIPTION
Obvioussly I went too fast in commit 1bac52b47547e0493f0cf868293d626188cf5385
and error message is not aligned with the other part of the native
API which usually returns {"code": "XXXX"}