### PR TITLE
(PC-8222) : add price to the update_stocks entry point

### DIFF
--- a/src/pcapi/core/providers/api.py
+++ b/src/pcapi/core/providers/api.py
@@ -228,7 +228,7 @@ def _get_stocks_to_upsert(
     for stock_detail in stock_details:
         stock_provider_reference = stock_detail["stocks_provider_reference"]
         product = products_by_provider_reference[stock_detail["products_provider_reference"]]
-        book_price = float(product.extraData["prix_livre"])
+        book_price = stock_detail.get("price", float(product.extraData["prix_livre"]))
         if stock_provider_reference in stocks_by_provider_reference:
             stock = stocks_by_provider_reference[stock_provider_reference]
 

--- a/src/pcapi/routes/pro/stocks.py
+++ b/src/pcapi/routes/pro/stocks.py
@@ -84,7 +84,7 @@ def update_stocks(venue_id: int, body: UpdateVenueStocksBodyModel) -> None:
 
     This endpoint can only works for venues attached to the same account the api key was issued for.
     Only books, pre existing on the pass Culture database and whitelisted by pass Culture's cgu will be taken, all other stocks are filtered.
-    Stocks are references by their isbn format EAN13.
+    Stocks are referenced by their isbn format EAN13.
     The 'available' quantity is the number of items that could be bought at the library.
     """
     offerer_id = current_api_key.offererId
@@ -102,5 +102,6 @@ def _build_stock_details_from_body(raw_stocks: List[UpdateVenueStockBodyModel], 
             "offers_provider_reference": f"{stock.ref}@{str(venue_id)}",
             "stocks_provider_reference": f"{stock.ref}@{str(venue_id)}",
             "available_quantity": stock.available,
+            "price": stock.price,
         }
     return list(stock_details.values())

--- a/src/pcapi/routes/serialization/stock_serialize.py
+++ b/src/pcapi/routes/serialization/stock_serialize.py
@@ -4,6 +4,8 @@ from typing import Union
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import condecimal
+from pydantic import validator
 
 from pcapi.serialization.utils import dehumanize_field
 from pcapi.serialization.utils import humanize_field
@@ -95,6 +97,21 @@ class UpdateVenueStockBodyModel(BaseModel):
 
     ref: str = Field(title="ISBN", description="Format: EAN13")
     available: int
+    price: condecimal(decimal_places=2) = Field(None, description="prix en Euros avec 2 décimales possibles")
+
+    @validator("price", pre=True)
+    def empty_string_price_casted_to_none(cls, v):  # pylint: disable=no-self-argument
+        # Performed before Pydantic validators to catch empty strings but will not get "0"
+        if not v:
+            return None
+        return v
+
+    @validator("price")
+    def zero_price_casted_to_none(cls, v):  # pylint: disable=no-self-argument
+        # Performed before Pydantic validators to catch empty strings but will not get "0"
+        if not v:
+            return None
+        return v
 
     class Config:
         title = "Stock"

--- a/tests/core/providers/test_api.py
+++ b/tests/core/providers/test_api.py
@@ -245,7 +245,7 @@ class SynchronizeStocksTest:
             {
                 "id": 1,
                 "quantity": 15 + 3,
-                "price": 7.01,
+                "price": 15.78,
                 "rawProviderQuantity": 15,
             }
         ]
@@ -254,7 +254,7 @@ class SynchronizeStocksTest:
         assert new_stock.quantity == 17
         assert new_stock.bookingLimitDatetime is None
         assert new_stock.offerId == 134
-        assert new_stock.price == 9.02
+        assert new_stock.price == 28.989
         assert new_stock.idAtProviders == "stock_ref2"
 
         assert offer_ids == set([123, 134])

--- a/tests/routes/pro/post_venue_stocks_test.py
+++ b/tests/routes/pro/post_venue_stocks_test.py
@@ -1,13 +1,17 @@
+from decimal import Decimal
 from unittest.mock import patch
+
+import pytest
 
 import pcapi.core.offers.factories as offers_factories
 
 from tests.conftest import TestClient
-from tests.conftest import clean_database
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
 
 
 class Post:
-    @clean_database
     @patch("pcapi.core.providers.api.synchronize_stocks")
     def test_accepts_request(self, mock_synchronize_stocks, app):
         offerer = offers_factories.OffererFactory(siren=123456789)
@@ -29,12 +33,45 @@ class Post:
                     "offers_provider_reference": "123456789@3",
                     "stocks_provider_reference": "123456789@3",
                     "available_quantity": 4,
+                    "price": None,
                 }
             ],
             venue,
         )
 
-    @clean_database
+    @pytest.mark.parametrize(
+        "price,expected_price",
+        [(None, None), ("", None), ("0", None), (0, None), (1.23, Decimal("1.23")), ("1.23", Decimal("1.23"))],
+    )
+    @patch("pcapi.core.providers.api.synchronize_stocks")
+    def test_accepts_request_with_price(self, mock_synchronize_stocks, price, expected_price, app):
+        offerer = offers_factories.OffererFactory(siren=123456789)
+        venue = offers_factories.VenueFactory(managingOfferer=offerer, id=3)
+        api_key = offers_factories.ApiKeyFactory(offerer=offerer)
+
+        mock_synchronize_stocks.return_value = {}
+
+        test_client = TestClient(app.test_client())
+        test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
+
+        response = test_client.post(
+            "/v2/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4, "price": price}]}
+        )
+
+        assert response.status_code == 204
+        mock_synchronize_stocks.assert_called_once_with(
+            [
+                {
+                    "products_provider_reference": "123456789",
+                    "offers_provider_reference": "123456789@3",
+                    "stocks_provider_reference": "123456789@3",
+                    "available_quantity": 4,
+                    "price": expected_price,
+                }
+            ],
+            venue,
+        )
+
     @patch("pcapi.core.providers.api.synchronize_stocks")
     def test_requires_an_api_key(self, mock_synchronize_stocks, app):
         offerer = offers_factories.OffererFactory(siren=123456789)
@@ -49,7 +86,6 @@ class Post:
         assert response.status_code == 401
         mock_synchronize_stocks.assert_not_called()
 
-    @clean_database
     @patch("pcapi.core.providers.api.synchronize_stocks")
     def test_returns_404_if_api_key_cant_access_venue(self, mock_synchronize_stocks, app):
         offerer = offers_factories.OffererFactory(siren=123456789)
@@ -70,7 +106,6 @@ class Post:
         assert response2.status_code == 404
         mock_synchronize_stocks.assert_not_called()
 
-    @clean_database
     @patch("pcapi.core.providers.api.synchronize_stocks")
     def test_returns_comprehensive_errors(self, mock_synchronize_stocks, app):
         api_key = offers_factories.ApiKeyFactory()


### PR DESCRIPTION
The pro public API now allows the pro users to also set the price
when they create or update books stock.
The price is an optional parameter and will override the default
product's price.