### PR TITLE
circleci: switch nightly test pro to sandbox testcafe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -501,7 +501,7 @@ jobs:
             cd pass-culture-main
             dockerize -wait http://localhost/health/api -timeout 5m -wait-retry-interval 5s
             dockerize -wait http://localhost/health/database -timeout 5m -wait-retry-interval 5s
-            ./pc sandbox --name=industrial
+            ./pc sandbox --name=testcafe
       - run:
           name: Running end2end tests PRO
           command: |


### PR DESCRIPTION
un dernière ligne à changer dans le build circleci pour passer nightly en vert. 