### PR TITLE
(PC-7710): update find pro users by email provider to get only pro users

### DIFF
--- a/src/pcapi/repository/user_queries.py
+++ b/src/pcapi/repository/user_queries.py
@@ -40,6 +40,8 @@ def find_pro_users_by_email_provider(email_provider: str) -> list[User]:
     formatted_email_provider = f"%@%{email_provider}"
     return (
         User.query.filter_by(isBeneficiary=False, isActive=True)
+        .join(UserOfferer)
+        .filter(User.offerers.any())
         .filter(func.lower(User.email).like(func.lower(formatted_email_provider)))
         .all()
     )

--- a/tests/scripts/suspend_suspected_fraudulent_pro_users_test.py
+++ b/tests/scripts/suspend_suspected_fraudulent_pro_users_test.py
@@ -36,6 +36,17 @@ def test_suspend_pros_in_given_emails_providers_list():
 
 
 @pytest.mark.usefixtures("db_session")
+def test_not_suspend_none_beneficiary_and_none_pro_in_given_email_providers_list():
+    fraudulent_emails_providers = ["example.com"]
+    admin_user = UserFactory(isBeneficiary=False, isAdmin=True, email="admin@example.net")
+    fraudulent_user = UserFactory(isBeneficiary=False, email="jenesuispasbenificiairenipro@example.com")
+
+    suspend_fraudulent_pro_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
+
+    assert fraudulent_user.isActive
+
+
+@pytest.mark.usefixtures("db_session")
 def test_only_suspend_pro_users_in_given_emails_providers_list():
     # Given
     fraudulent_emails_providers = ["example.com"]

--- a/tests/scripts/suspend_suspected_fraudulent_pro_users_test.py
+++ b/tests/scripts/suspend_suspected_fraudulent_pro_users_test.py
@@ -36,17 +36,6 @@ def test_suspend_pros_in_given_emails_providers_list():
 
 
 @pytest.mark.usefixtures("db_session")
-def test_not_suspend_none_beneficiary_and_none_pro_in_given_email_providers_list():
-    fraudulent_emails_providers = ["example.com"]
-    admin_user = UserFactory(isBeneficiary=False, isAdmin=True, email="admin@example.net")
-    fraudulent_user = UserFactory(isBeneficiary=False, email="jenesuispasbenificiairenipro@example.com")
-
-    suspend_fraudulent_pro_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
-
-    assert fraudulent_user.isActive
-
-
-@pytest.mark.usefixtures("db_session")
 def test_only_suspend_pro_users_in_given_emails_providers_list():
     # Given
     fraudulent_emails_providers = ["example.com"]
@@ -80,6 +69,25 @@ def test_dont_suspend_users_not_in_given_emails_providers_list():
 
     # Then
     assert non_fraudulent_pro.isActive
+
+
+@pytest.mark.usefixtures("db_session")
+def test_suspend_pro_user_with_many_offerers_and_delete_all_offerers():
+    fraudulent_emails_providers = ["example.com"]
+    admin_user = UserFactory(isBeneficiary=False, isAdmin=True, email="admin@example.net")
+    fraudulent_user = UserFactory(
+        isBeneficiary=False,
+        email="jesuisunefraude@example.com",
+    )
+    first_offerer = OffererFactory()
+    UserOffererFactory(user=fraudulent_user, offerer=first_offerer)
+    second_offerer = OffererFactory()
+    UserOffererFactory(user=fraudulent_user, offerer=second_offerer)
+
+    suspend_fraudulent_pro_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
+
+    assert not fraudulent_user.isActive
+    assert Offerer.query.count() == 0
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Après un premier lancement sur prod du script (#2312 ) de suspension d'acteurs pros ayant des adresses mail avec des noms de domaine spécifiques, Le script plante. Certains utilisateurs ne sont ni bénéficiaires ni acteurs pro (Pas de `Offerer`) ont été récupéré par ce script, Une tentative de suppression d'Offerer a planté le script. 
Dans cette PR une jointure avec `UserOfferer` avec un filtre `User.offerers.any()` ont été ajouté à la requête pour récupérer que les acteurs pro 

Sur le script précédent seulement la suspension d'acteurs avec un seul `Offerer` était possible. La possibilité de suspendre des acteurs avec plusieurs `Offerer` est ajoutée dans cette PR.