### PR TITLE
(PC-8522) fully_sync_venue: Do not reset Stock.quantity on manually added offers

### DIFF
--- a/src/pcapi/scripts/stock/fully_sync_venue.py
+++ b/src/pcapi/scripts/stock/fully_sync_venue.py
@@ -16,7 +16,10 @@ def _reset_stock_quantity(venue: Venue) -> None:
       UPDATE stock
       SET quantity = "dnBookedQuantity"
       FROM offer
-      WHERE offer.id = stock."offerId" and offer."venueId" = :venue_id
+      WHERE
+          offer."idAtProviders" IS NOT NULL
+          AND offer.id = stock."offerId"
+          AND offer."venueId" = :venue_id
     """
     db.session.execute(query, {"venue_id": venue.id})
     db.session.commit()


### PR DESCRIPTION
Only synchronized offers are handled by `fully_sync_venue()`: when
resetting stocks beforehand, offers that have been manually added
should be ignored.