### PR TITLE
(PC-8222) : null prices for stock upset uses the offer's price

### DIFF
--- a/src/pcapi/core/providers/api.py
+++ b/src/pcapi/core/providers/api.py
@@ -228,7 +228,7 @@ def _get_stocks_to_upsert(
     for stock_detail in stock_details:
         stock_provider_reference = stock_detail["stocks_provider_reference"]
         product = products_by_provider_reference[stock_detail["products_provider_reference"]]
-        book_price = stock_detail.get("price", float(product.extraData["prix_livre"]))
+        book_price = stock_detail.get("price") or float(product.extraData["prix_livre"])
         if stock_provider_reference in stocks_by_provider_reference:
             stock = stocks_by_provider_reference[stock_provider_reference]
 

--- a/src/pcapi/routes/serialization/stock_serialize.py
+++ b/src/pcapi/routes/serialization/stock_serialize.py
@@ -99,7 +99,9 @@ class UpdateVenueStockBodyModel(BaseModel):
 
     ref: str = Field(title="ISBN", description="Format: EAN13")
     available: int
-    price: condecimal(decimal_places=2) = Field(None, description="prix en Euros avec 2 décimales possibles")
+    price: condecimal(decimal_places=2) = Field(
+        None, description="(Optionnel) Prix en Euros avec 2 décimales possibles"
+    )
 
     @validator("price", pre=True)
     def empty_string_price_casted_to_none(cls, v):  # pylint: disable=no-self-argument

--- a/tests/core/providers/test_api.py
+++ b/tests/core/providers/test_api.py
@@ -223,14 +223,25 @@ class SynchronizeStocksTest:
                 "products_provider_reference": "product_ref3",
                 "stocks_provider_reference": "stock_ref3",
             },
+            {  # existing, will update but set product's price
+                "offers_provider_reference": "offer_ref4",
+                "available_quantity": 15,
+                "price": None,
+                "products_provider_reference": "product_ref4",
+                "stocks_provider_reference": "stock_ref4",
+            },
         ]
 
-        stocks_by_provider_reference = {"stock_ref1": {"id": 1, "booking_quantity": 3}}
-        offers_by_provider_reference = {"offer_ref1": 123, "offer_ref2": 134}
+        stocks_by_provider_reference = {
+            "stock_ref1": {"id": 1, "booking_quantity": 3},
+            "stock_ref4": {"id": 2, "booking_quantity": 3},
+        }
+        offers_by_provider_reference = {"offer_ref1": 123, "offer_ref2": 134, "offer_ref4": 123}
         products_by_provider_reference = {
             "product_ref1": Product(extraData={"prix_livre": 7.01}),
             "product_ref2": Product(extraData={"prix_livre": 9.02}),
             "product_ref3": Product(extraData={"prix_livre": 11.03}),
+            "product_ref4": Product(extraData={"prix_livre": 7.01}),
         }
 
         # When
@@ -247,7 +258,13 @@ class SynchronizeStocksTest:
                 "quantity": 15 + 3,
                 "price": 15.78,
                 "rawProviderQuantity": 15,
-            }
+            },
+            {
+                "id": 2,
+                "quantity": 15 + 3,
+                "price": 7.01,
+                "rawProviderQuantity": 15,
+            },
         ]
 
         new_stock = new_stocks[0]


### PR DESCRIPTION
Null stock prices convey the idea that they were not set by
the provider and therefore the stock price should be set to
the product's price.