### PR TITLE
PC 8116 Disable automatic beneficiary activation

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -496,6 +496,10 @@ def change_user_phone_number(user: User, phone_number: str):
     repository.save(user)
 
 
+def needs_to_validate_phone(user: User) -> bool:
+    return not user.isBeneficiary and not user.is_phone_validated and user.is_eligible
+
+
 def send_phone_validation_code(user: User) -> None:
     _check_phone_number_validation_is_authorized(user)
 

--- a/src/pcapi/domain/user_activation.py
+++ b/src/pcapi/domain/user_activation.py
@@ -33,12 +33,13 @@ def create_beneficiary_from_application(application_detail: dict, user: Optional
     beneficiary.isAdmin = False
     beneficiary.hasSeenTutorials = False
 
-    beneficiary.isBeneficiary = True
-    application_id = application_detail["application_id"]
-    deposit = payments_api.create_deposit(beneficiary, f"démarches simplifiées dossier [{application_id}]")
-    beneficiary.deposits = [deposit]
-
     return beneficiary
+
+
+def setup_beneficiary(beneficiary: User, application_id: str, deposit_source: str):
+    beneficiary.isBeneficiary = True
+    deposit = payments_api.create_deposit(beneficiary, deposit_source)
+    beneficiary.deposits.append(deposit)
 
 
 def is_import_status_change_allowed(current_status: ImportStatus, new_status: ImportStatus) -> bool:

--- a/src/pcapi/infrastructure/repository/beneficiary/beneficiary_pre_subscription_sql_converter.py
+++ b/src/pcapi/infrastructure/repository/beneficiary/beneficiary_pre_subscription_sql_converter.py
@@ -31,18 +31,24 @@ def to_model(beneficiary_pre_subscription: BeneficiaryPreSubscription, user: Opt
     beneficiary.postalCode = beneficiary_pre_subscription.postal_code
     beneficiary.publicName = beneficiary_pre_subscription.public_name
 
-    beneficiary = users_api.activate_beneficiary(beneficiary, beneficiary_pre_subscription.deposit_source)
     users_api.attach_beneficiary_import_details(beneficiary, beneficiary_pre_subscription)
+    if not users_api.steps_to_become_beneficiary(beneficiary):
+        beneficiary = users_api.activate_beneficiary(beneficiary, beneficiary_pre_subscription.deposit_source)
 
     return beneficiary
 
 
-def to_rejected_model(beneficiary_pre_subscription: BeneficiaryPreSubscription, detail: str) -> BeneficiaryImport:
+def to_rejected_model(
+    beneficiary_pre_subscription: BeneficiaryPreSubscription, detail: str, user: Optional[User]
+) -> BeneficiaryImport:
     beneficiary_import = BeneficiaryImport()
 
     beneficiary_import.applicationId = beneficiary_pre_subscription.application_id
     beneficiary_import.sourceId = beneficiary_pre_subscription.source_id
     beneficiary_import.source = beneficiary_pre_subscription.source
     beneficiary_import.setStatus(status=ImportStatus.REJECTED, detail=detail)
+
+    if user:
+        user.beneficiaryImports.append(beneficiary_import)
 
     return beneficiary_import

--- a/src/pcapi/infrastructure/repository/beneficiary/beneficiary_sql_repository.py
+++ b/src/pcapi/infrastructure/repository/beneficiary/beneficiary_sql_repository.py
@@ -14,8 +14,10 @@ class BeneficiarySQLRepository:
         return user_sql_entity
 
     @classmethod
-    def reject(cls, beneficiary_pre_subscription: BeneficiaryPreSubscription, detail: str) -> None:
+    def reject(
+        cls, beneficiary_pre_subscription: BeneficiaryPreSubscription, detail: str, user: Optional[User]
+    ) -> None:
         beneficiary_import = beneficiary_pre_subscription_sql_converter.to_rejected_model(
-            beneficiary_pre_subscription, detail=detail
+            beneficiary_pre_subscription, detail=detail, user=user
         )
         repository.save(beneficiary_import)

--- a/src/pcapi/repository/beneficiary_import_queries.py
+++ b/src/pcapi/repository/beneficiary_import_queries.py
@@ -27,7 +27,7 @@ def save_beneficiary_import_with_status(
     source: BeneficiaryImportSources,
     detail: str = None,
     user: User = None,
-) -> None:
+) -> BeneficiaryImport:
     # FIXME (dbaty, 2021-04-22): see comment above about the non-uniqueness of application_id
     existing_beneficiary_import = BeneficiaryImport.query.filter_by(applicationId=application_id).first()
 
@@ -41,6 +41,8 @@ def save_beneficiary_import_with_status(
     beneficiary_import.setStatus(status=status, detail=detail, author=None)
 
     repository.save(beneficiary_import)
+
+    return beneficiary_import
 
 
 def find_applications_ids_to_retry() -> list[int]:

--- a/src/pcapi/routes/native/v1/authentication.py
+++ b/src/pcapi/routes/native/v1/authentication.py
@@ -7,6 +7,7 @@ from pcapi.connectors import api_recaptcha
 from pcapi.core.users import api as users_api
 from pcapi.core.users import exceptions as users_exceptions
 from pcapi.core.users import repository as users_repo
+from pcapi.core.users.api import needs_to_validate_phone
 from pcapi.core.users.models import TokenType
 from pcapi.core.users.models import User
 from pcapi.domain.password import check_password_strength
@@ -139,6 +140,7 @@ def validate_email(body: ValidateEmailRequest) -> ValidateEmailResponse:
         access_token=create_user_access_token(user),
         refresh_token=create_refresh_token(identity=user.email),
         id_check_token=id_check_token.value if id_check_token else None,
+        needsToValidatePhone=needs_to_validate_phone(user),
     )
 
     return response

--- a/src/pcapi/scripts/beneficiary/remote_import.py
+++ b/src/pcapi/scripts/beneficiary/remote_import.py
@@ -7,11 +7,13 @@ from typing import Optional
 from pcapi import settings
 from pcapi.connectors.api_demarches_simplifiees import get_application_details
 from pcapi.core.users.api import create_reset_password_token
+from pcapi.core.users.api import steps_to_become_beneficiary
 from pcapi.core.users.constants import RESET_PASSWORD_TOKEN_LIFE_TIME_EXTENDED
 from pcapi.core.users.models import User
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_validator import get_beneficiary_duplicates
 from pcapi.domain.demarches_simplifiees import get_closed_application_ids_for_demarche_simplifiee
 from pcapi.domain.user_activation import create_beneficiary_from_application
+from pcapi.domain.user_activation import setup_beneficiary
 from pcapi.domain.user_emails import send_accepted_as_beneficiary_email
 from pcapi.domain.user_emails import send_activation_email
 from pcapi.models import ApiErrors
@@ -95,7 +97,7 @@ def run(
                 new_beneficiaries=new_beneficiaries,
                 retry_ids=retry_ids,
                 procedure_id=procedure_id,
-                user=user,
+                preexisting_account=user,
             )
 
     logger.info(
@@ -109,7 +111,7 @@ def process_beneficiary_application(
     new_beneficiaries: list[User],
     retry_ids: list[int],
     procedure_id: int,
-    user: Optional[User] = None,
+    preexisting_account: Optional[User] = None,
 ) -> None:
     duplicate_users = get_beneficiary_duplicates(
         first_name=information["first_name"],
@@ -118,7 +120,9 @@ def process_beneficiary_application(
     )
 
     if not duplicate_users or information["application_id"] in retry_ids:
-        _process_creation(error_messages, information, new_beneficiaries, procedure_id, user=user)
+        _process_creation(
+            error_messages, information, new_beneficiaries, procedure_id, preexisting_account=preexisting_account
+        )
     else:
         _process_duplication(duplicate_users, error_messages, information, procedure_id)
 
@@ -160,11 +164,15 @@ def _process_creation(
     information: dict,
     new_beneficiaries: list[User],
     procedure_id: int,
-    user: Optional[User] = None,
+    preexisting_account: Optional[User] = None,
 ) -> None:
-    new_beneficiary = create_beneficiary_from_application(information, user=user)
+    """
+    Create/update a user account and complete the import process.
+    Note that a 'user' is not always a beneficiary.
+    """
+    user = create_beneficiary_from_application(information, user=preexisting_account)
     try:
-        repository.save(new_beneficiary)
+        repository.save(user)
     except ApiErrors as api_errors:
         logger.warning(
             "[BATCH][REMOTE IMPORT BENEFICIARIES] Could not save application %s, because of error: %s - Procedure %s",
@@ -173,36 +181,41 @@ def _process_creation(
             procedure_id,
         )
         error_messages.append(str(api_errors))
-    else:
-        logger.info(
-            "[BATCH][REMOTE IMPORT BENEFICIARIES] Successfully created user for application %s - Procedure %s",
+        return
+
+    logger.info(
+        "[BATCH][REMOTE IMPORT BENEFICIARIES] Successfully created user for application %s - Procedure %s",
+        information["application_id"],
+        procedure_id,
+    )
+
+    beneficiary_import = save_beneficiary_import_with_status(
+        ImportStatus.CREATED,
+        information["application_id"],
+        source=BeneficiaryImportSources.demarches_simplifiees,
+        source_id=procedure_id,
+        user=user,
+    )
+
+    if not steps_to_become_beneficiary(user):
+        deposit_source = beneficiary_import.get_detailed_source()
+        setup_beneficiary(user, information["application_id"], deposit_source)
+
+    new_beneficiaries.append(user)
+    update_user_attributes_job.delay(user.id)
+    try:
+        if preexisting_account is None:
+            token = create_reset_password_token(user, token_life_time=RESET_PASSWORD_TOKEN_LIFE_TIME_EXTENDED)
+            send_activation_email(user, token=token)
+        else:
+            send_accepted_as_beneficiary_email(user)
+    except MailServiceException as mail_service_exception:
+        logger.exception(
+            "Email send_activation_email failure for application %s - Procedure %s : %s",
             information["application_id"],
             procedure_id,
+            mail_service_exception,
         )
-        save_beneficiary_import_with_status(
-            ImportStatus.CREATED,
-            information["application_id"],
-            source=BeneficiaryImportSources.demarches_simplifiees,
-            source_id=procedure_id,
-            user=new_beneficiary,
-        )
-        new_beneficiaries.append(new_beneficiary)
-        update_user_attributes_job.delay(new_beneficiary.id)
-        try:
-            if user is None:
-                token = create_reset_password_token(
-                    new_beneficiary, token_life_time=RESET_PASSWORD_TOKEN_LIFE_TIME_EXTENDED
-                )
-                send_activation_email(new_beneficiary, token=token)
-            else:
-                send_accepted_as_beneficiary_email(new_beneficiary)
-        except MailServiceException as mail_service_exception:
-            logger.exception(
-                "Email send_activation_email failure for application %s - Procedure %s : %s",
-                information["application_id"],
-                procedure_id,
-                mail_service_exception,
-            )
 
 
 def _process_duplication(

--- a/tests/core/users/test_api.py
+++ b/tests/core/users/test_api.py
@@ -16,7 +16,6 @@ from pcapi.core.users import constants as users_constants
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users.api import BeneficiaryValidationStep
 from pcapi.core.users.api import _set_offerer_departement_code
-from pcapi.core.users.api import check_and_activate_beneficiary
 from pcapi.core.users.api import create_id_check_token
 from pcapi.core.users.api import delete_expired_tokens
 from pcapi.core.users.api import fulfill_account_password
@@ -24,6 +23,7 @@ from pcapi.core.users.api import fulfill_beneficiary_data
 from pcapi.core.users.api import generate_and_save_token
 from pcapi.core.users.api import get_domains_credit
 from pcapi.core.users.api import set_pro_tuto_as_seen
+from pcapi.core.users.api import steps_to_become_beneficiary
 from pcapi.core.users.factories import BeneficiaryImportFactory
 from pcapi.core.users.models import Credit
 from pcapi.core.users.models import DomainsCredit
@@ -369,7 +369,7 @@ class CreateBeneficiaryTest:
         assert len(user.deposits) == 1
 
 
-class CheckAndActivateUserTest:
+class StepsToBecomeBeneficiaryTest:
     def eligible_user(self, validate_phone: bool):
         eligible_date = date.today() - relativedelta(years=18, days=30)
         phone_validation_status = PhoneValidationStatusType.VALIDATED if validate_phone else None
@@ -384,7 +384,7 @@ class CheckAndActivateUserTest:
 
         return beneficiary_import
 
-    def test_all_valid(self):
+    def test_no_missing_step(self):
         user = self.eligible_user(validate_phone=True)
 
         beneficiary_import = BeneficiaryImportFactory(
@@ -392,12 +392,7 @@ class CheckAndActivateUserTest:
         )
         beneficiary_import.setStatus(ImportStatus.CREATED, author=user)
 
-        assert check_and_activate_beneficiary(user) == []
-        assert user.isBeneficiary
-        assert len(user.deposits) == 1
-
-        deposit = user.deposits[0]
-        assert deposit.source == "dossier jouve [0]"
+        assert steps_to_become_beneficiary(user) == []
 
     def test_missing_step(self):
         user = self.eligible_user(validate_phone=False)
@@ -405,7 +400,7 @@ class CheckAndActivateUserTest:
         beneficiary_import = BeneficiaryImportFactory(beneficiary=user)
         beneficiary_import.setStatus(ImportStatus.CREATED, author=user)
 
-        assert check_and_activate_beneficiary(user) == [BeneficiaryValidationStep.PHONE_VALIDATION]
+        assert steps_to_become_beneficiary(user) == [BeneficiaryValidationStep.PHONE_VALIDATION]
         assert not user.isBeneficiary
 
     def test_rejected_import(self):
@@ -418,7 +413,7 @@ class CheckAndActivateUserTest:
             BeneficiaryValidationStep.PHONE_VALIDATION,
             BeneficiaryValidationStep.ID_CHECK,
         ]
-        assert check_and_activate_beneficiary(user) == expected
+        assert steps_to_become_beneficiary(user) == expected
         assert not user.isBeneficiary
 
     def test_missing_all(self):
@@ -428,7 +423,7 @@ class CheckAndActivateUserTest:
             BeneficiaryValidationStep.PHONE_VALIDATION,
             BeneficiaryValidationStep.ID_CHECK,
         ]
-        assert check_and_activate_beneficiary(user) == expected
+        assert steps_to_become_beneficiary(user) == expected
         assert not user.isBeneficiary
 
 

--- a/tests/domain/user_activation_test.py
+++ b/tests/domain/user_activation_test.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from decimal import Decimal
 
 import pytest
 
@@ -80,12 +79,13 @@ class CreateBeneficiaryFromApplicationTest:
         assert beneficiary.postalCode == "67200"
         assert beneficiary.address == "11 Rue du Test"
         assert beneficiary.dateOfBirth == datetime(2000, 5, 1)
-        assert beneficiary.isBeneficiary == True
-        assert beneficiary.isAdmin == False
+        assert not beneficiary.isBeneficiary
+        assert not beneficiary.isAdmin
         assert beneficiary.password is not None
         assert beneficiary.activity == "Lycéen"
         assert beneficiary.civility == "Mme"
         assert beneficiary.hasSeenTutorials == False
+        assert not beneficiary.deposits
 
     def test_updates_existing_user(self):
         # given
@@ -128,32 +128,10 @@ class CreateBeneficiaryFromApplicationTest:
         assert beneficiary.postalCode == "67200"
         assert beneficiary.address == "11 Rue du Test"
         assert beneficiary.dateOfBirth == datetime(2000, 5, 1)
-        assert beneficiary.isBeneficiary == True
-        assert beneficiary.isAdmin == False
+        assert not beneficiary.isBeneficiary
+        assert not beneficiary.isAdmin
         assert beneficiary.password is not None
         assert beneficiary.activity == "Lycéen"
         assert beneficiary.civility == "Mme"
-        assert beneficiary.hasSeenTutorials == False
-
-    def test_a_deposit_is_made_for_the_new_beneficiary(self):
-        # given
-        beneficiary_information = {
-            "department": "67",
-            "last_name": "Doe",
-            "first_name": "Jane",
-            "activity": "Lycéen",
-            "civility": "Mme",
-            "birth_date": datetime(2000, 5, 1),
-            "email": "jane.doe@test.com",
-            "phone": "0612345678",
-            "postal_code": "67200",
-            "address": "11 Rue du Test",
-            "application_id": 123,
-        }
-        # when
-        beneficiary = create_beneficiary_from_application(beneficiary_information, user=None)
-
-        # then
-        assert len(beneficiary.deposits) == 1
-        assert beneficiary.deposit.amount == Decimal(500)
-        assert beneficiary.deposit.source == "démarches simplifiées dossier [123]"
+        assert not beneficiary.hasSeenTutorials
+        assert not beneficiary.deposits

--- a/tests/routes/webapp/post_id_check_application_update_test.py
+++ b/tests/routes/webapp/post_id_check_application_update_test.py
@@ -17,6 +17,166 @@ class Post:
             assert response.status_code == 200
             mocked_beneficiary_job.assert_called_once_with(5)
 
+        @patch("pcapi.use_cases.create_beneficiary_from_application.send_accepted_as_beneficiary_email")
+        @patch("pcapi.use_cases.create_beneficiary_from_application.send_activation_email")
+        @patch("pcapi.domain.password.random_token")
+        @patch(
+            "pcapi.settings.JOUVE_APPLICATION_BACKEND",
+            "tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
+        )
+        @freeze_time("2013-05-15 09:00:00")
+        @pytest.mark.usefixtures("db_session")
+        def test_user_becomes_beneficiary(
+            self, stubed_random_token, mocked_send_activation_email, mocked_send_accepted_as_beneficiary_email, app
+        ):
+            """
+            Test that a user which has validated its email and phone number, becomes a
+            beneficiary. And that this user's information is updated with the
+            application's.
+            """
+            # Given
+            application_id = 35
+            stubed_random_token.return_value = "token"
+
+            # Create a user that has validated its email and phone number, meaning it
+            # should become beneficiary.
+            user = create_user(idx=4, email="rennes@example.org", is_beneficiary=False, is_email_validated=True)
+
+            user.phoneValidationStatus = PhoneValidationStatusType.VALIDATED
+            repository.save(user)
+
+            # When
+            data = {"id": "35"}
+            response = TestClient(app.test_client()).post("/beneficiaries/application_update", json=data)
+
+            # Then
+            assert response.status_code == 200
+
+            beneficiary = User.query.one()
+            assert beneficiary.activity == "Apprenti"
+            assert beneficiary.address == "3 rue de Valois"
+            assert beneficiary.isBeneficiary is True
+            assert beneficiary.city == "Paris"
+            assert beneficiary.civility == "Mme"
+            assert beneficiary.dateOfBirth == datetime(1995, 2, 5)
+            assert beneficiary.departementCode == "35"
+            assert beneficiary.email == "rennes@example.org"
+            assert beneficiary.firstName == "Thomas"
+            assert beneficiary.hasSeenTutorials is False
+            assert beneficiary.isAdmin is False
+            assert beneficiary.lastName == "DURAND"
+            assert beneficiary.password is not None
+            assert beneficiary.phoneNumber == "0123456789"
+            assert beneficiary.postalCode == "35123"
+            assert beneficiary.publicName == "Thomas DURAND"
+            assert beneficiary.notificationSubscriptions == {"marketing_push": True, "marketing_email": True}
+            assert not users_api.needs_to_validate_phone(user)
+
+            deposit = Deposit.query.one()
+            assert deposit.amount == 500
+            assert deposit.source == "dossier jouve [35]"
+            assert deposit.userId == beneficiary.id
+
+            beneficiary_import = BeneficiaryImport.query.one()
+            assert beneficiary_import.currentStatus == ImportStatus.CREATED
+            assert beneficiary_import.applicationId == application_id
+            assert beneficiary_import.beneficiary == beneficiary
+
+            # New beneficiary already received the account activation email with
+            # the reset password token
+            assert not beneficiary.tokens
+            mocked_send_activation_email.assert_not_called()
+            mocked_send_accepted_as_beneficiary_email.assert_called_once()
+
+            assert push_testing.requests == [
+                {
+                    "user_id": beneficiary.id,
+                    "attribute_values": {
+                        "u.credit": 50000,
+                        "date(u.date_of_birth)": "1995-02-05T00:00:00",
+                        "u.postal_code": "35123",
+                        "date(u.date_created)": beneficiary.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
+                        "u.marketing_push_subscription": True,
+                        "u.is_beneficiary": True,
+                        "date(u.deposit_expiration_date)": "2015-05-15T09:00:00",
+                    },
+                }
+            ]
+
+        @patch("pcapi.use_cases.create_beneficiary_from_application.send_accepted_as_beneficiary_email")
+        @patch("pcapi.use_cases.create_beneficiary_from_application.send_activation_email")
+        @patch("pcapi.domain.password.random_token")
+        @patch(
+            "pcapi.settings.JOUVE_APPLICATION_BACKEND",
+            "tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
+        )
+        @freeze_time("2013-05-15 09:00:00")
+        @pytest.mark.usefixtures("db_session")
+        def test_user_does_not_become_beneficiary(
+            self, stubed_random_token, mocked_send_activation_email, mocked_send_accepted_as_beneficiary_email, app
+        ):
+            """
+            Test that an application is correctly processed and that a non-beneficiary
+            user is created. It cannot become a beneficiary since validation steps are
+            missing.
+            """
+            # Given
+            application_id = 35
+            stubed_random_token.return_value = "token"
+
+            # When
+            data = {"id": "35"}
+            response = TestClient(app.test_client()).post("/beneficiaries/application_update", json=data)
+
+            # Then
+            assert response.status_code == 200
+
+            user = User.query.one()
+            assert user.activity == "Apprenti"
+            assert user.address == "3 rue de Valois"
+            assert not user.isBeneficiary
+            assert user.city == "Paris"
+            assert user.civility == "Mme"
+            assert user.dateOfBirth == datetime(1995, 2, 5)
+            assert user.departementCode == "35"
+            assert user.email == "rennes@example.org"
+            assert user.firstName == "Thomas"
+            assert not user.hasSeenTutorials
+            assert not user.isAdmin
+            assert user.lastName == "DURAND"
+            assert user.password is not None
+            assert user.phoneNumber == "0123456789"
+            assert user.postalCode == "35123"
+            assert user.publicName == "Thomas DURAND"
+            assert user.notificationSubscriptions == {"marketing_push": True, "marketing_email": True}
+            assert users_api.needs_to_validate_phone(user)
+
+            assert not Deposit.query.one_or_none()
+
+            beneficiary_import = BeneficiaryImport.query.one()
+            assert beneficiary_import.currentStatus == ImportStatus.CREATED
+            assert beneficiary_import.applicationId == application_id
+            assert beneficiary_import.beneficiary == user
+
+            assert len(user.tokens) == 1
+            mocked_send_activation_email.assert_called_once()
+            mocked_send_accepted_as_beneficiary_email.assert_not_called()
+
+            assert push_testing.requests == [
+                {
+                    "user_id": user.id,
+                    "attribute_values": {
+                        "u.credit": 0,
+                        "date(u.date_of_birth)": "1995-02-05T00:00:00",
+                        "u.postal_code": "35123",
+                        "date(u.date_created)": user.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
+                        "u.marketing_push_subscription": True,
+                        "u.is_beneficiary": False,
+                        "date(u.deposit_expiration_date)": None,
+                    },
+                }
+            ]
+
     class Returns400:
         @patch("pcapi.routes.webapp.beneficiaries.beneficiary_job.delay")
         def when_no_payload(self, mocked_beneficiary_job, app):

--- a/tests/use_cases/create_beneficiary_from_application_test.py
+++ b/tests/use_cases/create_beneficiary_from_application_test.py
@@ -44,6 +44,7 @@ class FakeBeneficiaryJouveBackend:
         )
 
 
+@override_features(ENABLE_PHONE_VALIDATION=False)
 @patch("pcapi.use_cases.create_beneficiary_from_application.send_activation_email")
 @patch("pcapi.domain.password.random_token")
 @patch(
@@ -111,6 +112,7 @@ def test_saved_a_beneficiary_from_application(stubed_random_token, mocked_send_a
     ]
 
 
+@override_features(ENABLE_PHONE_VALIDATION=False)
 @patch("pcapi.use_cases.create_beneficiary_from_application.send_accepted_as_beneficiary_email")
 @patch(
     "pcapi.settings.JOUVE_APPLICATION_BACKEND",
@@ -165,6 +167,7 @@ def test_application_for_native_app_user(mocked_send_accepted_as_beneficiary_ema
     ]
 
 
+@override_features(ENABLE_PHONE_VALIDATION=False)
 @patch(
     "pcapi.settings.JOUVE_APPLICATION_BACKEND",
     "tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
@@ -187,7 +190,7 @@ def test_cannot_save_beneficiary_if_email_is_already_taken(app):
     beneficiary_import = BeneficiaryImport.query.one()
     assert beneficiary_import.currentStatus == ImportStatus.REJECTED
     assert beneficiary_import.applicationId == application_id
-    assert beneficiary_import.beneficiary is None
+    assert beneficiary_import.beneficiary == user
     assert beneficiary_import.detail == f"Email {email} is already taken."
 
     assert push_testing.requests == []


### PR DESCRIPTION
* un utilisateur dont l'import (id-check) est validé ne devient plus bénéficiaire automatiquement : on vérifie qu'il a passé toutes les autres étapes nécessaires avant (aujourd'hui cela signifie avoir validé son numéro de téléphone).
* désactiver le champ `id_check_token` dans la réponse à `/validate_email` puisque une nouvelle étape a été ajoutée entre la validation d'email et id-check : la validation du numéro de téléphone. On ajoute donc un nouveau champ : `needsToValidatePhone` afin d'indiquer au front la prochaine étape (validation du numéro de téléphone ou id-check).