### PR TITLE
(PC-8614) : native app integration of ID check feature flag

### DIFF
--- a/src/pcapi/alembic/versions/20210506_58df8264fe50_enable_native_id_check_version.py
+++ b/src/pcapi/alembic/versions/20210506_58df8264fe50_enable_native_id_check_version.py
@@ -1,0 +1,26 @@
+"""Enable native id check version
+
+Revision ID: 58df8264fe50
+Revises: c2e2425fbac6
+Create Date: 2021-05-06 15:14:21.619714
+
+"""
+from pcapi.models import feature
+
+
+# revision identifiers, used by Alembic.
+revision = "58df8264fe50"
+down_revision = "c2e2425fbac6"
+branch_labels = None
+depends_on = None
+
+
+FLAG = feature.FeatureToggle.ENABLE_NATIVE_ID_CHECK_VERSION
+
+
+def upgrade():
+    feature.add_feature_to_database(FLAG)
+
+
+def downgrade():
+    feature.remove_feature_from_database(FLAG)

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -50,6 +50,7 @@ class FeatureToggle(enum.Enum):
     ENABLE_ACTIVATION_CODES = "Permet la création de codes d'activation"
     ENABLE_PHONE_VALIDATION = "Active la validation du numéro de téléphone"
     USE_NEW_BATCH_INDEX_OFFERS_BEHAVIOUR = "Utilise une boucle dans le cron de réindexation Algolia"
+    ENABLE_NATIVE_ID_CHECK_VERSION = "Utilise la version d'ID-Check intégrée à l'application native"
 
 
 class Feature(PcObject, Model, DeactivableMixin):
@@ -67,6 +68,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.AUTO_ACTIVATE_DIGITAL_BOOKINGS,
     FeatureToggle.ENABLE_ACTIVATION_CODES,
     FeatureToggle.USE_NEW_BATCH_INDEX_OFFERS_BEHAVIOUR,
+    FeatureToggle.ENABLE_NATIVE_ID_CHECK_VERSION,
 )
 
 

--- a/src/pcapi/routes/native/v1/serialization/settings.py
+++ b/src/pcapi/routes/native/v1/serialization/settings.py
@@ -11,6 +11,7 @@ class SettingsResponse(BaseModel):
     is_recaptcha_enabled: bool
     auto_activate_digital_bookings: bool
     allow_id_check_registration: bool
+    enable_native_id_check_version: bool
 
     _convert_deposit_amount = validator("deposit_amount", pre=True, allow_reuse=True)(convert_to_cent)
 

--- a/src/pcapi/routes/native/v1/settings.py
+++ b/src/pcapi/routes/native/v1/settings.py
@@ -18,4 +18,5 @@ def get_settings() -> serializers.SettingsResponse:
         is_recaptcha_enabled=feature_queries.is_active(FeatureToggle.ENABLE_NATIVE_APP_RECAPTCHA),
         allow_id_check_registration=feature_queries.is_active(FeatureToggle.ALLOW_IDCHECK_REGISTRATION),
         auto_activate_digital_bookings=feature_queries.is_active(FeatureToggle.AUTO_ACTIVATE_DIGITAL_BOOKINGS),
+        enable_native_id_check_version=feature_queries.is_active(FeatureToggle.ENABLE_NATIVE_ID_CHECK_VERSION),
     )

--- a/tests/routes/native/v1/settings_test.py
+++ b/tests/routes/native/v1/settings_test.py
@@ -14,6 +14,7 @@ class SettingsTest:
         ALLOW_IDCHECK_REGISTRATION=True,
         ENABLE_NATIVE_APP_RECAPTCHA=True,
         AUTO_ACTIVATE_DIGITAL_BOOKINGS=False,
+        ENABLE_NATIVE_ID_CHECK_VERSION=False,
     )
     def test_get_settings_feature_combination_1(self, app):
         response = TestClient(app.test_client()).get("/native/v1/settings")
@@ -22,6 +23,7 @@ class SettingsTest:
             "allowIdCheckRegistration": True,
             "autoActivateDigitalBookings": False,
             "depositAmount": 50000,
+            "enableNativeIdCheckVersion": False,
             "isRecaptchaEnabled": True,
         }
 
@@ -30,6 +32,7 @@ class SettingsTest:
         ALLOW_IDCHECK_REGISTRATION=False,
         ENABLE_NATIVE_APP_RECAPTCHA=False,
         AUTO_ACTIVATE_DIGITAL_BOOKINGS=True,
+        ENABLE_NATIVE_ID_CHECK_VERSION=True,
     )
     def test_get_settings_feature_combination_2(self, app):
         response = TestClient(app.test_client()).get("/native/v1/settings")
@@ -38,5 +41,6 @@ class SettingsTest:
             "allowIdCheckRegistration": False,
             "autoActivateDigitalBookings": True,
             "depositAmount": 30000,
+            "enableNativeIdCheckVersion": True,
             "isRecaptchaEnabled": False,
         }


### PR DESCRIPTION
Add a feature flag to trigger the integrated version of ID Check
in the native application. Also expose the feature flag through
the settings endpoint API.