### PR TITLE
(PC-8242) send offer link notification

### DIFF
--- a/src/pcapi/core/offers/utils.py
+++ b/src/pcapi/core/offers/utils.py
@@ -1,0 +1,7 @@
+from pcapi import settings
+from pcapi.core.offers.models import Offer
+from pcapi.utils.human_ids import humanize
+
+
+def offer_webapp_link(offer: Offer) -> str:
+    return f"{settings.WEBAPP_URL}/offre/details/{humanize(offer.id)}"

--- a/src/pcapi/emails/offer_webapp_link.py
+++ b/src/pcapi/emails/offer_webapp_link.py
@@ -1,7 +1,6 @@
-from pcapi import settings
 from pcapi.core.offers.models import Offer
+from pcapi.core.offers.utils import offer_webapp_link
 from pcapi.core.users.models import User
-from pcapi.utils.human_ids import humanize
 
 
 def build_data_for_offer_webapp_link(user: User, offer: Offer) -> dict:
@@ -9,7 +8,7 @@ def build_data_for_offer_webapp_link(user: User, offer: Offer) -> dict:
         "MJ-TemplateID": 2826195,
         "MJ-TemplateLanguage": True,
         "Vars": {
-            "offer_webapp_link": f"{settings.WEBAPP_URL}/offre/details/{humanize(offer.id)}",
+            "offer_webapp_link": offer_webapp_link(offer),
             "user_first_name": user.firstName,
             "offer_name": offer.name,
             "venue_name": offer.venue.name,

--- a/src/pcapi/notifications/push/backends/batch.py
+++ b/src/pcapi/notifications/push/backends/batch.py
@@ -83,6 +83,7 @@ class BatchBackend:
                             "title": notification_data.message.title,
                             "body": notification_data.message.body,
                         },
+                        **notification_data.extra,
                     },
                 )
             except Exception as exc:  # pylint: disable=broad-except

--- a/src/pcapi/notifications/push/backends/testing.py
+++ b/src/pcapi/notifications/push/backends/testing.py
@@ -20,5 +20,6 @@ class TestingBackend(LoggerBackend):
                 "group_id": notification_data.group_id,
                 "user_ids": notification_data.user_ids,
                 "message": {"title": notification_data.message.title, "body": notification_data.message.body},
+                **notification_data.extra,
             }
         )

--- a/src/pcapi/notifications/push/transactional_notifications.py
+++ b/src/pcapi/notifications/push/transactional_notifications.py
@@ -1,14 +1,18 @@
 from dataclasses import dataclass
+from dataclasses import field
 from enum import Enum
 from typing import Optional
 
 from pcapi.core.bookings.models import Booking
+from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
+from pcapi.core.offers.utils import offer_webapp_link
 
 
 class GroupId(Enum):
     CANCEL_BOOKING = "Cancel_booking"
     TOMORROW_STOCK = "Tomorrow_stock"
+    OFFER_LINK = "Offer_link"
 
 
 @dataclass
@@ -22,6 +26,7 @@ class TransactionalNotificationData:
     group_id: str  # Name of the campaign, useful for analytics purpose
     user_ids: list[int]
     message: TransactionalNotificationMessage
+    extra: dict = field(default_factory=dict)
 
 
 def get_bookings_cancellation_notification_data(booking_ids: list[int]) -> Optional[TransactionalNotificationData]:
@@ -57,4 +62,16 @@ def get_tomorrow_stock_notification_data(stock_id: int) -> Optional[Transactiona
             title=f"{stock.offer.name}, c'est demain !",
             body="Retrouve les détails de la réservation sur l’application pass Culture",
         ),
+    )
+
+
+def get_offer_notification_data(user_id: int, offer: Offer) -> TransactionalNotificationData:
+    return TransactionalNotificationData(
+        group_id=GroupId.OFFER_LINK.value,
+        user_ids=[user_id],
+        message=TransactionalNotificationMessage(
+            title=f"{offer.name}",
+            body="Pour réserver, c'est par ici !",
+        ),
+        extra={"deeplink": offer_webapp_link(offer)},
     )

--- a/src/pcapi/workers/push_notification_job.py
+++ b/src/pcapi/workers/push_notification_job.py
@@ -3,10 +3,12 @@ from typing import Callable
 
 from rq.decorators import job
 
+from pcapi.core.offers.models import Offer
 from pcapi.core.users.models import User
 from pcapi.notifications.push import send_transactional_notification
 from pcapi.notifications.push import update_user_attributes
 from pcapi.notifications.push.transactional_notifications import get_bookings_cancellation_notification_data
+from pcapi.notifications.push.transactional_notifications import get_offer_notification_data
 from pcapi.notifications.push.transactional_notifications import get_tomorrow_stock_notification_data
 from pcapi.notifications.push.user_attributes_updates import get_user_attributes
 from pcapi.notifications.push.user_attributes_updates import get_user_booking_attributes
@@ -58,3 +60,12 @@ def send_tomorrow_stock_notification(stock_id: int) -> None:
     notification_data = get_tomorrow_stock_notification_data(stock_id)
     if notification_data:
         send_transactional_notification(notification_data)
+
+
+@job(worker.default_queue, connection=worker.conn)
+@job_context
+@log_job
+def send_offer_link_by_push_job(user_id: int, offer_id: int) -> None:
+    offer = Offer.query.get(offer_id)
+    notification_data = get_offer_notification_data(user_id, offer)
+    send_transactional_notification(notification_data)


### PR DESCRIPTION
Ajout d'une route permettant l'envoi d'une notification contenant un lien vers une offre.
Cette nouvelle route sera utilisée iOS uniquement afin de contourner certaines limites de l'os mobile.

+ ajout d'un champ `extra` à `TransactionalNotificationData` afin de passer d'autres informations : ici, on a besoin d'ajouter un champ `deeplink` au JSON envoyé à Batch
+ nouvelle fonction `offer_webapp_link` qui sert à construire le lien webapp d'une offre -> utilisé par les notifications push et email.