### PR TITLE
(PC-8591) : add favorites/count to the native API

### DIFF
--- a/src/pcapi/routes/native/v1/favorites.py
+++ b/src/pcapi/routes/native/v1/favorites.py
@@ -23,6 +23,13 @@ from . import blueprint
 from .serialization import favorites as serializers
 
 
+@blueprint.native_v1.route("/me/favorites/count", methods=["GET"])
+@spectree_serialize(response_model=serializers.FavoritesCountResponse, api=blueprint.api)  # type: ignore
+@authenticated_user_required
+def get_favorites_count(user: User) -> serializers.FavoritesCountResponse:
+    return serializers.FavoritesCountResponse(count=Favorite.query.filter_by(user=user).count())
+
+
 @blueprint.native_v1.route("/me/favorites", methods=["GET"])
 @spectree_serialize(response_model=serializers.PaginatedFavoritesResponse, api=blueprint.api)  # type: ignore
 @authenticated_user_required

--- a/src/pcapi/routes/native/v1/serialization/favorites.py
+++ b/src/pcapi/routes/native/v1/serialization/favorites.py
@@ -87,3 +87,7 @@ class PaginatedFavoritesResponse(BaseModel):
 
 class FavoriteRequest(BaseModel):
     offerId: int
+
+
+class FavoritesCountResponse(BaseModel):
+    count: int


### PR DESCRIPTION
Since the native application displays a badge with the number of
favorites for a user, it should not need to fetch the full favorites
data since they are costly to compute.
Instead of loading the entire favorites data, we add an endpoint
to return the number of favorites which is fast and simple to get.