### PR TITLE
(PC-8709) : Rollback offer change on native bookings list API

### DIFF
--- a/src/pcapi/routes/native/v1/bookings.py
+++ b/src/pcapi/routes/native/v1/bookings.py
@@ -12,6 +12,7 @@ from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
 from pcapi.core.users.models import User
 from pcapi.models.api_errors import ApiErrors
+from pcapi.models.db import db
 from pcapi.models.feature import FeatureToggle
 from pcapi.models.product import Product
 from pcapi.repository import feature_queries
@@ -108,7 +109,7 @@ def get_bookings(user: User) -> BookingsResponse:
             ongoing_bookings.append(booking)
             booking.qrCodeData = bookings_api.get_qr_code_data(booking.token)
 
-    return BookingsResponse(
+    result = BookingsResponse(
         ended_bookings=[
             BookingReponse.from_orm(booking)
             for booking in sorted(
@@ -125,6 +126,9 @@ def get_bookings(user: User) -> BookingsResponse:
             )
         ],
     )
+    # TODO: remove this once the booking.stock.offer.url = booking.completedUrl hack in serialization is removed
+    db.session.rollback()
+    return result
 
 
 def is_ended_booking(booking: Booking) -> bool:

--- a/src/pcapi/routes/native/v1/serialization/bookings.py
+++ b/src/pcapi/routes/native/v1/serialization/bookings.py
@@ -8,7 +8,6 @@ from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offers.models import Offer
-from pcapi.models.db import db
 from pcapi.routes.native.utils import convert_to_cent
 from pcapi.routes.native.v1.serialization.common_models import Coordinates
 from pcapi.routes.native.v1.serialization.offers import OfferCategoryResponse
@@ -114,11 +113,8 @@ class BookingReponse(BaseModel):
         # Therefore the API will override `booking.stock.offer.url` with
         # `booking.completedUrl`.
         # Unfortunate side-effect, the offer object has its url modified and
-        # should be either commited or rolledback.
-        # Alternatively, we detach the offer from the session to evade weird
-        # commit/rollbacks in read-only endpoints.
+        # needs to be rolledback.
         booking.stock.offer.url = booking.completedUrl
-        db.session.expunge(booking.stock.offer)
         return super().from_orm(booking)
 
     class Config:

--- a/tests/routes/native/v1/bookings_test.py
+++ b/tests/routes/native/v1/bookings_test.py
@@ -144,7 +144,8 @@ class GetBookingsTest:
         # 1: get the user
         # 1: get the bookings
         # 1: get AUTO_ACTIVATE_DIGITAL_BOOKINGS feature
-        with assert_num_queries(3):
+        # 1: rollback
+        with assert_num_queries(4):
             response = test_client.get("/native/v1/bookings")
 
         assert response.status_code == 200


### PR DESCRIPTION
Since we modify the offer's url to fix an issue with the native
application, we need to rollback the changes to ensure they are
neither in an intermediate state nor commited.
session.expunge should have let us do that but somehow it does not
seem to work in all the cases