### PR TITLE
(PC-8729): Avoid error on missing context

### DIFF
--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -107,7 +107,12 @@ def before_request() -> None:
 
 @app.after_request
 def log_request_details(response: flask.wrappers.Response) -> flask.wrappers.Response:
-    duration = round((time.perf_counter() - g.request_start) * 1000)  # milliseconds
+    if "request_start" in g:
+        duration = round((time.perf_counter() - g.request_start) * 1000)  # milliseconds
+    else:
+        logger.warning("No request_start in flask context", extra={"route": str(request.url_rule)})
+        duration = 0
+
     extra = {
         "statusCode": response.status_code,
         "method": request.method,


### PR DESCRIPTION
A priori le `g.request_start` ne devrait pas fail parce que cet attribut est rempli dans le before_request et utilisé dans le after_request
Je n'ai trouvé aucun indice sur des cas où le before_request ne s'exécute pas, ni d'indication explicite comme quoi ils ne s'exécutent pas en parallèle (ce qui est peut être le cas et qui expliquerait pourquoi ça fail pour ces requêtes trop rapide = api booking non authentifié)

Je ne sais pas si on peut retracer la call stack entière en prod, ou on pourrait creuser le code source
Pour l'instant je propose de transformer l'erreur en warning dans nos logs pour éviter de renvoyer une 500