### PR TITLE
[PC-8398] : Limit the number of SMS sent to verify a phone number

### DIFF
--- a/src/pcapi/core/users/exceptions.py
+++ b/src/pcapi/core/users/exceptions.py
@@ -34,6 +34,10 @@ class PhoneVerificationCodeSendingException(PhoneVerificationException):
     pass
 
 
+class SMSSendingLimitReached(PhoneVerificationException):
+    pass
+
+
 class UnvalidatedEmail(PhoneVerificationException):
     pass
 

--- a/src/pcapi/notifications/sms/sending_limit.py
+++ b/src/pcapi/notifications/sms/sending_limit.py
@@ -1,0 +1,21 @@
+from redis import Redis
+
+from pcapi import settings
+from pcapi.models import User
+
+
+def _sent_SMS_counter_key_name(user: User):
+    return f"sent_SMS_counter_user_{user.id}"
+
+
+def update_sent_SMS_counter(redis: Redis, user: User):
+    key_name = _sent_SMS_counter_key_name(user)
+    count = redis.incr(key_name)
+    if count == 1:
+        redis.expire(key_name, settings.SENT_SMS_COUNTER_TTL)
+
+
+def is_SMS_sending_allowed(redis: Redis, user: User):
+    sent_SMS_count = redis.get(_sent_SMS_counter_key_name(user))
+
+    return not sent_SMS_count or int(sent_SMS_count) < settings.MAX_SMS_SENT_FOR_PHONE_VALIDATION

--- a/src/pcapi/routes/native/v1/account.py
+++ b/src/pcapi/routes/native/v1/account.py
@@ -137,7 +137,14 @@ def send_phone_validation_code(user: User, body: serializers.SendPhoneValidation
     try:
         if body.phoneNumber:
             api.change_user_phone_number(user, body.phoneNumber)
+
         api.send_phone_validation_code(user)
+
+    except exceptions.SMSSendingLimitReached:
+        raise ApiErrors(
+            {"code": "TOO_MANY_SMS_SENT", "message": "Nombre de tentatives maximal dépassé"},
+            status_code=400,
+        )
     except exceptions.UserPhoneNumberAlreadyValidated:
         raise ApiErrors({"message": "Le numéro de téléphone est déjà validé"}, status_code=400)
     except exceptions.UserWithoutPhoneNumberException:

--- a/src/pcapi/routes/native/v1/account.py
+++ b/src/pcapi/routes/native/v1/account.py
@@ -146,11 +146,16 @@ def send_phone_validation_code(user: User, body: serializers.SendPhoneValidation
             status_code=400,
         )
     except exceptions.UserPhoneNumberAlreadyValidated:
-        raise ApiErrors({"message": "Le numéro de téléphone est déjà validé"}, status_code=400)
+        raise ApiErrors(
+            {"message": "Le numéro de téléphone est déjà validé", "code": "PHONE_NUMBER_ALREADY_VALIDATED"},
+            status_code=400,
+        )
     except exceptions.UserWithoutPhoneNumberException:
-        raise ApiErrors({"message": "Le numéro de téléphone est invalide"}, status_code=400)
+        raise ApiErrors(
+            {"message": "Le numéro de téléphone est invalide", "code": "INVALID_PHONE_NUMBER"}, status_code=400
+        )
     except exceptions.PhoneVerificationException:
-        raise ApiErrors({"message": "L'envoi du code a échoué"}, status_code=400)
+        raise ApiErrors({"message": "L'envoi du code a échoué", "code": "CODE_SENDING_FAILURE"}, status_code=400)
 
 
 @blueprint.native_v1.route("/validate_phone_number", methods=["POST"])

--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -117,6 +117,8 @@ WHITELISTED_SMS_RECIPIENTS = utils.parse_phone_numbers(os.environ.get("WHITELIST
 # NOTIFICATIONS
 PUSH_NOTIFICATION_BACKEND = os.environ.get("PUSH_NOTIFICATION_BACKEND", _default_push_notification_backend)
 SMS_NOTIFICATION_BACKEND = os.environ.get("SMS_NOTIFICATION_BACKEND", _default_sms_notification_backend)
+MAX_SMS_SENT_FOR_PHONE_VALIDATION = int(os.environ.get("MAX_SMS_SENT_FOR_PHONE_VALIDATION", 3))
+SENT_SMS_COUNTER_TTL = int(os.environ.get("SENT_SMS_COUNTER_TTL", 30 * 24 * 60 * 60))
 
 # ALGOLIA
 ALGOLIA_API_KEY = os.environ.get("ALGOLIA_API_KEY")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from functools import wraps
 from pathlib import Path
 from pprint import pprint
-from unittest.mock import Mock
 
 from alembic import command
 from alembic.config import Config
@@ -10,6 +9,7 @@ from flask.testing import FlaskClient
 from flask_jwt_extended import JWTManager
 from flask_login import LoginManager
 import pytest
+import redis
 from requests import Response
 from requests.auth import _basic_auth_str
 
@@ -76,7 +76,7 @@ def app():
     admin.init_app(app)
     install_admin_views(admin, db.session)
 
-    app.redis_client = Mock()
+    app.redis_client = redis.Redis()
     app.register_blueprint(native_v1, url_prefix="/native/v1")
     app.register_blueprint(pro_api_v2, url_prefix="/v2")
 

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -12,6 +12,7 @@ import pytest
 from pcapi.core.bookings.factories import BookingFactory
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.testing import override_features
+from pcapi.core.testing import override_settings
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users.api import create_phone_validation_token
 from pcapi.core.users.models import Token
@@ -645,6 +646,8 @@ class SendPhoneValidationCodeTest:
 
         assert response.status_code == 204
 
+        assert int(app.redis_client.get(f"sent_SMS_counter_user_{user.id}")) == 1
+
         token = Token.query.filter_by(userId=user.id, type=TokenType.PHONE_VALIDATION).first()
 
         assert token.expirationDate >= datetime.now() + timedelta(minutes=2)
@@ -653,6 +656,7 @@ class SendPhoneValidationCodeTest:
         assert sms_testing.requests == [
             {"recipient": "3360102030405", "content": f"{token.value} est ton code de confirmation pass Culture"}
         ]
+        assert len(token.value) == 6
         assert 0 <= int(token.value) < 1000000
 
         # validate phone number with generated code
@@ -661,6 +665,21 @@ class SendPhoneValidationCodeTest:
         assert response.status_code == 204
         user = User.query.get(user.id)
         assert user.is_phone_validated
+
+    @override_settings(MAX_SMS_SENT_FOR_PHONE_VALIDATION=1)
+    def test_send_phone_validation_code_too_many_attempts(self, app):
+        user = users_factories.UserFactory(departementCode="93", isBeneficiary=False, phoneNumber="060102030405")
+        access_token = create_access_token(identity=user.email)
+
+        test_client = TestClient(app.test_client())
+        test_client.auth_header = {"Authorization": f"Bearer {access_token}"}
+
+        response = test_client.post("/native/v1/send_phone_validation_code")
+        assert response.status_code == 204
+
+        response = test_client.post("/native/v1/send_phone_validation_code")
+        assert response.status_code == 400
+        assert response.json["code"] == "TOO_MANY_SMS_SENT"
 
     def test_send_phone_validation_code_already_beneficiary(self, app):
         user = users_factories.UserFactory(isEmailValidated=True, isBeneficiary=True, phoneNumber="060102030405")

--- a/tests/routes/webapp/phone_validation_test.py
+++ b/tests/routes/webapp/phone_validation_test.py
@@ -1,4 +1,5 @@
 import pytest
+import redis
 
 from pcapi.core.users.factories import UserFactory
 from pcapi.core.users.models import Token
@@ -10,6 +11,7 @@ from tests.conftest import TestClient
 
 @pytest.mark.usefixtures("db_session")
 def test_send_phone_validation(app):
+    app.redis_client = redis.Redis()
     user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="060102030405")
 
     client = TestClient(app.test_client()).with_auth(email=user.email)


### PR DESCRIPTION
In order to limit fraud we want to limit the number of SMS a user
can send to check its phone number.