### PR TITLE
(PC-8076) : mail newly created user script after ID-Check outage

### DIFF
--- a/src/pcapi/scripts/beneficiary/send_mail_after_idcheck_outage.py
+++ b/src/pcapi/scripts/beneficiary/send_mail_after_idcheck_outage.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+import logging
+from typing import Optional
+
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import not_
+from sqlalchemy.orm import Query
+
+from pcapi.core.users import constants
+from pcapi.core.users.models import User
+from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_validator import ELIGIBLE_DEPARTMENTS
+from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_validator import EXCLUDED_DEPARTMENTS
+from pcapi.domain.user_emails import send_newly_eligible_user_email
+from pcapi.models import UserOfferer
+from pcapi.models.feature import FeatureToggle
+from pcapi.repository import feature_queries
+
+
+logger = logging.getLogger(__name__)
+
+
+# Basically, this is _is_postal_code_eligible refactored for queries
+def _filter_by_eligible_postal_code(query: Query) -> Query:
+    if not feature_queries.is_active(FeatureToggle.WHOLE_FRANCE_OPENING):
+        eligible_departments_arg = "(%s)%%" % ("|".join(ELIGIBLE_DEPARTMENTS))
+        return query.filter(User.postalCode.op("SIMILAR TO")(eligible_departments_arg))
+
+    # New behaviour: all departments are eligible, except a few.
+    excluded_departments_arg = "(%s)%%" % ("|".join(EXCLUDED_DEPARTMENTS))
+    return query.filter(not_(User.postalCode.op("SIMILAR TO")(excluded_departments_arg)))
+
+
+def _get_eligible_users_created_between(
+    start_date: datetime, end_date: datetime, max_number: Optional[int] = None
+) -> list[User]:
+    today = datetime.combine(datetime.today(), datetime.min.time())
+    query = User.query.outerjoin(UserOfferer).filter(
+        User.dateCreated.between(start_date, end_date),
+        User.isBeneficiary == False,  # not already beneficiary
+        User.isAdmin == False,  # not an admin
+        UserOfferer.userId.is_(None),  # not a pro
+        User.dateOfBirth > today - relativedelta(years=(constants.ELIGIBILITY_AGE + 1)),  # less than 19yo
+        User.dateOfBirth <= today - relativedelta(years=constants.ELIGIBILITY_AGE),  # more than or 18yo
+    )
+    query = _filter_by_eligible_postal_code(query)
+    if max_number:
+        query = query.limit(max_number)
+    return query.order_by(User.dateCreated).all()
+
+
+def send_mail_to_potential_beneficiaries(
+    start_date: datetime, end_date: datetime, max_number: Optional[int] = None
+) -> None:
+    # BEWARE: start_date and end_date are expected to be in UTC
+    logger.info(
+        (
+            "Sending IDCheck mails to %s new users created between %s and %s "
+            "to notify them they can start the idcheck process - if they eligible"
+        ),
+        (max_number or ""),
+        start_date,
+        end_date,
+    )
+    user = None
+    try:
+        for i, user in enumerate(_get_eligible_users_created_between(start_date, end_date, max_number)):
+            if user.is_eligible:
+                if not send_newly_eligible_user_email(user):
+                    print(f"Could not send mail to user {user.id}")
+            if i % 100:
+                print(f"Processed {i} users")
+    finally:
+        if user:
+            print("Last user creation datetime: %s" % user.dateCreated)
+        else:
+            print("No user found within the timeframe")

--- a/tests/scripts/beneficiary/send_mail_after_idcheck_outage_test.py
+++ b/tests/scripts/beneficiary/send_mail_after_idcheck_outage_test.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+from datetime import timedelta
+
+from freezegun import freeze_time
+import pytest
+
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.testing import override_features
+from pcapi.core.users import factories
+from pcapi.scripts.beneficiary.send_mail_after_idcheck_outage import _get_eligible_users_created_between
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class SendMailAfterIdcheckOutageTest:
+    @override_features(WHOLE_FRANCE_OPENING=True)
+    @freeze_time("2018-01-01 01:00:00")
+    def test_get_eligible_users_created_between(self, app):
+        ELIGIBLE_CONDTIONS = {
+            "dateCreated": datetime.now(),
+            "postalCode": "93000",
+            "isBeneficiary": False,
+        }
+        # 19 yo
+        factories.UserFactory(dateOfBirth=datetime(1999, 1, 1), **ELIGIBLE_CONDTIONS)
+        user_just_18_in_eligible_area = factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), **ELIGIBLE_CONDTIONS)
+        # User just 18 but in an ineligible area
+        factories.UserFactory(
+            dateOfBirth=datetime(2000, 1, 1),
+            isBeneficiary=False,
+            dateCreated=datetime.now(),
+            postalCode="98712",
+        )
+        # Beneficiary
+        factories.UserFactory(
+            dateOfBirth=datetime(2000, 1, 1),
+            isBeneficiary=True,
+            dateCreated=datetime.now(),
+            postalCode="93000",
+        )
+        # Admin
+        factories.UserFactory(isAdmin=True, dateOfBirth=datetime(2000, 1, 1), **ELIGIBLE_CONDTIONS)
+        # Pro
+        pro_user = factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), **ELIGIBLE_CONDTIONS)
+        offers_factories.UserOffererFactory(user=pro_user)
+        # User not yet 18
+        factories.UserFactory(dateOfBirth=datetime(2000, 1, 2), **ELIGIBLE_CONDTIONS)
+
+        result = _get_eligible_users_created_between(
+            datetime.now() - timedelta(days=1), datetime.now() + timedelta(minutes=1)
+        )
+
+        assert {u.id for u in result} == {user_just_18_in_eligible_area.id}


### PR DESCRIPTION
script to send a mail to newly created users that should have
been able to start the ID-Check process but were not able to due
to ID-Check being turned off.

Note that the script DOES NOT conttact users that were already created.