### PR TITLE
[PC-8667] Show activation code expiration in native offer's API

### DIFF
--- a/src/pcapi/routes/native/v1/offers.py
+++ b/src/pcapi/routes/native/v1/offers.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import joinedload
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offers.models import Offer
+from pcapi.core.offers.models import Stock
 from pcapi.core.users.models import User
 from pcapi.domain.user_emails import send_user_webapp_offer_link_email
 from pcapi.models.product import Product
@@ -20,7 +21,7 @@ from .serialization import offers as serializers
 )  # type: ignore
 def get_offer(offer_id: str) -> serializers.OfferResponse:
     offer = (
-        Offer.query.options(joinedload(Offer.stocks))
+        Offer.query.options(joinedload(Offer.stocks).joinedload(Stock.activationCodes))
         .options(
             joinedload(Offer.venue)
             .joinedload(Venue.managingOfferer)

--- a/tests/core/bookings/test_validation.py
+++ b/tests/core/bookings/test_validation.py
@@ -536,7 +536,7 @@ class CheckHasAvailableActivationCodeTest:
         stock = offers_factories.ThingStockFactory()
         booking = factories.BookingFactory(isUsed=True, token="ABCDEF")
         activation_codes = offers_factories.ActivationCodeFactory.create_batch(
-            size=1, expirationDate=datetime(2000, 1, 1), stock=stock, booking=booking
+            size=1, expirationDate=datetime(2050, 1, 1), stock=stock, booking=booking
         )
 
         # When


### PR DESCRIPTION
In order to display the activation code's expiration date during
the booking process, the offer on native API should return the
information if available.