### PR TITLE
(PC-8796) : Fix double favorite creation

### DIFF
--- a/src/pcapi/routes/native/v1/favorites.py
+++ b/src/pcapi/routes/native/v1/favorites.py
@@ -133,14 +133,16 @@ def create_favorite(user: User, body: serializers.FavoriteRequest) -> serializer
             raise ApiErrors({"code": "MAX_FAVORITES_REACHED"})
     with transaction():
         offer = Offer.query.filter_by(id=body.offerId).first_or_404()
+        favorite = Favorite.query.filter(Favorite.offerId == body.offerId, Favorite.userId == user.id).one_or_none()
 
-        favorite = Favorite(
-            mediation=offer.activeMediation,
-            offer=offer,
-            user=user,
-        )
-        db.session.add(favorite)
-        db.session.flush()
+        if not favorite:
+            favorite = Favorite(
+                mediation=offer.activeMediation,
+                offer=offer,
+                user=user,
+            )
+            db.session.add(favorite)
+            db.session.flush()
         return serializers.FavoriteResponse.from_orm(favorite)
 
 

--- a/tests/routes/native/v1/favorites_test.py
+++ b/tests/routes/native/v1/favorites_test.py
@@ -299,6 +299,23 @@ class Post:
             assert response.json["id"] == favorite.id
             assert response.json["offer"]
 
+        def when_user_creates_a_favorite_twice(self, app):
+            # Given
+            _, test_client = utils.create_user_and_test_client(app)
+            offerer = offers_factories.OffererFactory()
+            venue = offers_factories.VenueFactory(managingOfferer=offerer)
+            offer1 = offers_factories.EventOfferFactory(venue=venue)
+            assert Favorite.query.count() == 0
+
+            # When
+            response = test_client.post(FAVORITES_URL, json={"offerId": offer1.id})
+            assert response.status_code == 200
+            response = test_client.post(FAVORITES_URL, json={"offerId": offer1.id})
+
+            # Then
+            assert response.status_code == 200
+            assert Favorite.query.count() == 1
+
     class Returns400:
         @override_settings(MAX_FAVORITES=1)
         def when_user_creates_one_favorite_above_the_limit(self, app):


### PR DESCRIPTION
This should fix most concurent requests when creating a favorite.
Returns the existing favorite if it was already created and act
as if it was just created - might be because the client missed
a request or though it missed it.