### PR TITLE
(PC-8765) + (PC-8813): Gestion du fournisseur qui envoie les prix en centimes

### DIFF
--- a/src/pcapi/alembic/versions/20210519_e63d336e9da8_populate_provider_prices_in_cents.py
+++ b/src/pcapi/alembic/versions/20210519_e63d336e9da8_populate_provider_prices_in_cents.py
@@ -1,0 +1,26 @@
+"""populate_provider_prices_in_cents
+
+Revision ID: e63d336e9da8
+Revises: e7a7fdd9c4e1
+Create Date: 2021-05-19 14:05:25.182178
+
+"""
+from alembic import op
+from sqlalchemy.sql import text
+
+
+# revision identifiers, used by Alembic.
+revision = "e63d336e9da8"
+down_revision = "e7a7fdd9c4e1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    statement = text('UPDATE provider SET "pricesInCents" = true WHERE name = :name')
+    statement = statement.bindparams(name="TiteLive Stocks (Epagine / Place des libraires.com)")
+    op.execute(statement)
+
+
+def downgrade():
+    pass

--- a/src/pcapi/alembic/versions/20210519_e7a7fdd9c4e1_add_provider_prices_in_cents.py
+++ b/src/pcapi/alembic/versions/20210519_e7a7fdd9c4e1_add_provider_prices_in_cents.py
@@ -1,0 +1,24 @@
+"""Add `Provider.pricesInCents`
+
+Revision ID: e7a7fdd9c4e1
+Revises: 40afbb732e70
+Create Date: 2021-05-19 14:02:45.358481
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e7a7fdd9c4e1"
+down_revision = "40afbb732e70"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("provider", sa.Column("pricesInCents", sa.Boolean(), server_default=sa.text("false"), nullable=False))
+
+
+def downgrade():
+    op.drop_column("provider", "pricesInCents")

--- a/src/pcapi/core/providers/models.py
+++ b/src/pcapi/core/providers/models.py
@@ -52,6 +52,14 @@ class Provider(PcObject, Model, DeactivableMixin):
 
     requireProviderIdentifier = Column(Boolean, nullable=False, default=True, server_default=expression.true())
 
+    # FIXME (dbaty, 2021-05-19): this is very ugly and brittle. We
+    # should probably store this information on the Provider model as
+    # `Provider.pricesInCents`. But we want this in production quickly
+    # and adding a database schema migration would be cumbersome.
+    @property
+    def pricesInCents(self):
+        return self.name == "TiteLive Stocks (Epagine / Place des libraires.com)"
+
     @property
     def isAllocine(self) -> bool:
         from pcapi import local_providers  # avoid import loop

--- a/src/pcapi/core/providers/models.py
+++ b/src/pcapi/core/providers/models.py
@@ -52,13 +52,7 @@ class Provider(PcObject, Model, DeactivableMixin):
 
     requireProviderIdentifier = Column(Boolean, nullable=False, default=True, server_default=expression.true())
 
-    # FIXME (dbaty, 2021-05-19): this is very ugly and brittle. We
-    # should probably store this information on the Provider model as
-    # `Provider.pricesInCents`. But we want this in production quickly
-    # and adding a database schema migration would be cumbersome.
-    @property
-    def pricesInCents(self):
-        return self.name == "TiteLive Stocks (Epagine / Place des libraires.com)"
+    pricesInCents = Column(Boolean, nullable=False, default=False, server_default=expression.false())
 
     @property
     def isAllocine(self) -> bool:

--- a/src/pcapi/routes/pro/providers.py
+++ b/src/pcapi/routes/pro/providers.py
@@ -27,5 +27,6 @@ def get_providers_by_venue(venue_id: str):
         provider_dict = as_dict(provider)
         del provider_dict["apiUrl"]
         del provider_dict["authToken"]
+        del provider_dict["pricesInCents"]
         result.append(provider_dict)
     return jsonify(result)

--- a/src/pcapi/routes/pro/stocks.py
+++ b/src/pcapi/routes/pro/stocks.py
@@ -86,6 +86,7 @@ def update_stocks(venue_id: int, body: UpdateVenueStocksBodyModel) -> None:
     Only books, pre existing on the pass Culture database and whitelisted by pass Culture's cgu will be taken, all other stocks are filtered.
     Stocks are referenced by their isbn format EAN13.
     The 'available' quantity is the number of items that could be bought at the library.
+    If provided, the 'price' must be in euros (not cents).
     """
     offerer_id = current_api_key.offererId
     venue = Venue.query.join(Offerer).filter(Venue.id == venue_id, Offerer.id == offerer_id).first_or_404()

--- a/tests/core/providers/test_api.py
+++ b/tests/core/providers/test_api.py
@@ -71,7 +71,8 @@ class SynchronizeStocksTest:
         provider = offerers_factories.APIProviderFactory(apiUrl="https://provider_url", authToken="fake_token")
         venue = VenueFactory()
         siret = venue.siret
-        stock_details = synchronize_provider_api._build_stock_details_from_raw_stocks(spec, siret)
+        provider = offerers_factories.ProviderFactory()
+        stock_details = synchronize_provider_api._build_stock_details_from_raw_stocks(spec, siret, provider)
 
         stock = create_stock(
             spec[0]["ref"],

--- a/tests/local_providers/synchronize_provider_api_test.py
+++ b/tests/local_providers/synchronize_provider_api_test.py
@@ -242,7 +242,7 @@ class ProviderAPICronTest:
             ]
 
             # When
-            provider = offerers_factories.ProviderFactory(name="TiteLive Stocks (Epagine / Place des libraires.com)")
+            provider = offerers_factories.ProviderFactory(pricesInCents=True)
             result = synchronize_provider_api._build_stock_details_from_raw_stocks(raw_stocks, "siret", provider)
 
             # Then


### PR DESCRIPTION
Commits à relire séparément. Pourquoi 2 commits ?

1. On veut hotfix la prod aujourd'hui ou demain **avec le premier commit seulement**.
2. Le second commit ne sera **pas** déployé en hotfix sur la prod, car il contient une migration.

Inclure la migration dans le hotfix aurait nécessité de ré-ordonner les migrations qui sont sur master mais pas encore en prod.