### PR TITLE
Pc 8502 phone numbers black list

### DIFF
--- a/helm/pcapi/values.integration.yaml
+++ b/helm/pcapi/values.integration.yaml
@@ -319,3 +319,5 @@ secrets:
     version: 2
   - name: SUPPORT_EMAIL_ADDRESS
     version: 2
+  - name: BLOCKED_PHONE_NUMBERS
+    version: 1

--- a/helm/pcapi/values.perf.yaml
+++ b/helm/pcapi/values.perf.yaml
@@ -364,3 +364,5 @@ secrets:
     version: 1
   - name: WHITELISTED_SMS_RECIPIENTS
     version: 1
+  - name: BLOCKED_PHONE_NUMBERS
+    version: 1

--- a/helm/pcapi/values.production.yaml
+++ b/helm/pcapi/values.production.yaml
@@ -384,3 +384,5 @@ secrets:
     version: 2
   - name: WALLET_BALANCES_RECIPIENTS
     version: 2
+  - name: BLOCKED_PHONE_NUMBERS
+    version: 1

--- a/helm/pcapi/values.staging.yaml
+++ b/helm/pcapi/values.staging.yaml
@@ -369,3 +369,5 @@ secrets:
     version: 3
   - name: WHITELISTED_SMS_RECIPIENTS
     version: 1
+  - name: BLOCKED_PHONE_NUMBERS
+    version: 1

--- a/helm/pcapi/values.testing.yaml
+++ b/helm/pcapi/values.testing.yaml
@@ -372,4 +372,5 @@ secrets:
     version: 1
   - name: WHITELISTED_SMS_RECIPIENTS
     version: 1
-    
+  - name: BLOCKED_PHONE_NUMBERS
+    version: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,3 +70,4 @@ SQLAlchemy==1.3.*
 Werkzeug==1.0.1
 wheel==0.35.1
 WTForms-SQLAlchemy
+phonenumberslite==8.12.23

--- a/src/pcapi/core/users/exceptions.py
+++ b/src/pcapi/core/users/exceptions.py
@@ -64,3 +64,11 @@ class NotValidCode(PhoneVerificationException):
 
 class ExpiredCode(NotValidCode):
     pass
+
+
+class BlockedPhoneNumber(PhoneVerificationException):
+    pass
+
+
+class InvalidPhoneNumber(PhoneVerificationException):
+    pass

--- a/src/pcapi/routes/native/v1/account.py
+++ b/src/pcapi/routes/native/v1/account.py
@@ -154,6 +154,14 @@ def send_phone_validation_code(user: User, body: serializers.SendPhoneValidation
         raise ApiErrors(
             {"message": "Le numéro de téléphone est invalide", "code": "INVALID_PHONE_NUMBER"}, status_code=400
         )
+    except exceptions.BlockedPhoneNumber:
+        raise ApiErrors(
+            {"message": "Le numéro de téléphone n'est pas autorisé", "code": "BLOCKED_PHONE_NUMBER"}, status_code=400
+        )
+    except exceptions.InvalidPhoneNumber:
+        raise ApiErrors(
+            {"message": "Le numéro de téléphone est invalide", "code": "MALFORMED_PHONE_NUMBER"}, status_code=400
+        )
     except exceptions.PhoneVerificationException:
         raise ApiErrors({"message": "L'envoi du code a échoué", "code": "CODE_SENDING_FAILURE"}, status_code=400)
 
@@ -172,5 +180,15 @@ def validate_phone_number(user: User, body: serializers.ValidatePhoneNumberReque
             )
         except exceptions.ExpiredCode:
             raise ApiErrors({"message": "Le code saisi a expiré", "code": "EXPIRED_VALIDATION_CODE"}, status_code=400)
+        except exceptions.BlockedPhoneNumber:
+            raise ApiErrors(
+                {"message": "Le numéro de téléphone utilisé n'est pas autorisé", "code": "BLOCKED_PHONE_NUMBER"},
+                status_code=400,
+            )
+        except exceptions.InvalidPhoneNumber:
+            raise ApiErrors(
+                {"message": "Le numéro de téléphone utilisé est invalide", "code": "MALFORMED_PHONE_NUMBER"},
+                status_code=400,
+            )
         except exceptions.NotValidCode:
             raise ApiErrors({"message": "Le code est invalide", "code": "INVALID_VALIDATION_CODE"}, status_code=400)

--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -263,3 +263,6 @@ RATE_LIMIT_BY_IP = os.environ.get("RATE_LIMIT_BY_IP", "10/minute")
 
 # DEBUG
 DEBUG_ACTIVATED = os.environ.get("DEBUG_ACTIVATED") == "True"
+
+# PHONE NUMBERS
+BLOCKED_PHONE_NUMBERS = set(os.environ.get("BLOCKED_PHONE_NUMBERS", []))

--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -265,4 +265,4 @@ RATE_LIMIT_BY_IP = os.environ.get("RATE_LIMIT_BY_IP", "10/minute")
 DEBUG_ACTIVATED = os.environ.get("DEBUG_ACTIVATED") == "True"
 
 # PHONE NUMBERS
-BLOCKED_PHONE_NUMBERS = set(os.environ.get("BLOCKED_PHONE_NUMBERS", []))
+BLOCKED_PHONE_NUMBERS = set(os.environ.get("BLOCKED_PHONE_NUMBERS", []).replace(" ", "").split(","))

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -674,7 +674,7 @@ class ShowEligibleCardTest:
 
 class SendPhoneValidationCodeTest:
     def test_send_phone_validation_code(self, app):
-        user = users_factories.UserFactory(departementCode="93", isBeneficiary=False, phoneNumber="060102030405")
+        user = users_factories.UserFactory(departementCode="93", isBeneficiary=False, phoneNumber="0601020304")
         access_token = create_access_token(identity=user.email)
 
         test_client = TestClient(app.test_client())
@@ -692,7 +692,7 @@ class SendPhoneValidationCodeTest:
         assert token.expirationDate < datetime.now() + timedelta(minutes=30)
 
         assert sms_testing.requests == [
-            {"recipient": "3360102030405", "content": f"{token.value} est ton code de confirmation pass Culture"}
+            {"recipient": "33601020304", "content": f"{token.value} est ton code de confirmation pass Culture"}
         ]
         assert len(token.value) == 6
         assert 0 <= int(token.value) < 1000000
@@ -706,7 +706,7 @@ class SendPhoneValidationCodeTest:
 
     @override_settings(MAX_SMS_SENT_FOR_PHONE_VALIDATION=1)
     def test_send_phone_validation_code_too_many_attempts(self, app):
-        user = users_factories.UserFactory(departementCode="93", isBeneficiary=False, phoneNumber="060102030405")
+        user = users_factories.UserFactory(departementCode="93", isBeneficiary=False, phoneNumber="0601020304")
         access_token = create_access_token(identity=user.email)
 
         test_client = TestClient(app.test_client())
@@ -720,7 +720,7 @@ class SendPhoneValidationCodeTest:
         assert response.json["code"] == "TOO_MANY_SMS_SENT"
 
     def test_send_phone_validation_code_already_beneficiary(self, app):
-        user = users_factories.UserFactory(isEmailValidated=True, isBeneficiary=True, phoneNumber="060102030405")
+        user = users_factories.UserFactory(isEmailValidated=True, isBeneficiary=True, phoneNumber="0601020304")
         access_token = create_access_token(identity=user.email)
 
         test_client = TestClient(app.test_client())
@@ -733,7 +733,7 @@ class SendPhoneValidationCodeTest:
         assert not Token.query.filter_by(userId=user.id).first()
 
     def test_send_phone_validation_code_for_new_phone_with_already_beneficiary(self, app):
-        user = users_factories.UserFactory(isEmailValidated=True, isBeneficiary=True, phoneNumber="060102030405")
+        user = users_factories.UserFactory(isEmailValidated=True, isBeneficiary=True, phoneNumber="0601020304")
         access_token = create_access_token(identity=user.email)
 
         test_client = TestClient(app.test_client())
@@ -745,10 +745,10 @@ class SendPhoneValidationCodeTest:
 
         assert not Token.query.filter_by(userId=user.id).first()
         db.session.refresh(user)
-        assert user.phoneNumber == "060102030405"
+        assert user.phoneNumber == "0601020304"
 
     def test_send_phone_validation_code_for_new_phone_updates_phone(self, app):
-        user = users_factories.UserFactory(isEmailValidated=True, isBeneficiary=False, phoneNumber="060102030405")
+        user = users_factories.UserFactory(isEmailValidated=True, isBeneficiary=False, phoneNumber="0601020304")
         access_token = create_access_token(identity=user.email)
 
         test_client = TestClient(app.test_client())
@@ -765,7 +765,7 @@ class SendPhoneValidationCodeTest:
 
 class ValidatePhoneNumberTest:
     def test_validate_phone_number(self, app):
-        user = users_factories.UserFactory(isBeneficiary=False)
+        user = users_factories.UserFactory(isBeneficiary=False, phoneNumber="0607080900")
         access_token = create_access_token(identity=user.email)
         token = create_phone_validation_token(user)
 
@@ -788,7 +788,7 @@ class ValidatePhoneNumberTest:
 
     @override_settings(MAX_PHONE_VALIDATION_ATTEMPTS=1)
     def test_validate_phone_number_too_many_attempts(self, app):
-        user = users_factories.UserFactory(isBeneficiary=False)
+        user = users_factories.UserFactory(isBeneficiary=False, phoneNumber="0607080900")
         access_token = create_access_token(identity=user.email)
         token = create_phone_validation_token(user)
 
@@ -807,7 +807,7 @@ class ValidatePhoneNumberTest:
         assert int(app.redis_client.get(f"phone_validation_attempts_user_{user.id}")) == 1
 
     def test_wrong_code(self, app):
-        user = users_factories.UserFactory(isBeneficiary=False)
+        user = users_factories.UserFactory(isBeneficiary=False, phoneNumber="0607080900")
         access_token = create_access_token(identity=user.email)
         create_phone_validation_token(user)
 
@@ -823,7 +823,7 @@ class ValidatePhoneNumberTest:
         assert Token.query.filter_by(userId=user.id, type=TokenType.PHONE_VALIDATION).first()
 
     def test_expired_code(self, app):
-        user = users_factories.UserFactory(isBeneficiary=False)
+        user = users_factories.UserFactory(isBeneficiary=False, phoneNumber="0607080900")
         token = create_phone_validation_token(user)
 
         with freeze_time(datetime.now() + timedelta(minutes=20)):

--- a/tests/routes/webapp/phone_validation_test.py
+++ b/tests/routes/webapp/phone_validation_test.py
@@ -12,7 +12,7 @@ from tests.conftest import TestClient
 @pytest.mark.usefixtures("db_session")
 def test_send_phone_validation(app):
     app.redis_client = redis.Redis()
-    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="060102030405")
+    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="0601020304")
 
     client = TestClient(app.test_client()).with_auth(email=user.email)
 


### PR DESCRIPTION
Bloquer les opérations suivantes si le numéro de téléphone utilisé fait partie d'une blacklist : 

* envoi du code de validation ;
* changement du numéro (pour l'envoi du code) ;
* validation du code.

Pour y arriver, le numéro de téléphone utilisé dans chacune de ses opérations est analysé à l'aide de [`phonenumbers`](https://github.com/daviddrysdale/python-phonenumbers) (concrètement, la version _lite_ est utilisée puisqu'on n'a pas besoin des fonctionnalités avancées).

L'idée est d'avoir une blacklist de numéro de téléphone normalisés (préfixe +33 pour la France métropolitaine par exemple), et de vérifier la présence du numéro de téléphone à vérifier dans cette liste. Le problème est de normaliser les numéros de téléphone des utilisateurs pour la comparaison.