### PR TITLE
providers: Fix price comparison in _get_stocks_to_upsert

### DIFF
--- a/src/pcapi/core/providers/api.py
+++ b/src/pcapi/core/providers/api.py
@@ -237,12 +237,12 @@ def _get_stocks_to_upsert(
             # sent a specific price before. Should we keep the
             # possibly specific price that we have received before? Or
             # should we override with the (generic) product price?
-            if not stock_detail.get("price") and stock["price"] != book_price:
+            if not stock_detail.get("price") and float(stock["price"]) != book_price:
                 logger.warning(
                     "Stock specific price has been overriden by product price because provider price is missing",
                     extra={
                         "stock": stock["id"],
-                        "previous_stock_price": stock["price"],
+                        "previous_stock_price": float(stock["price"]),
                         "new_price": book_price,
                     },
                 )


### PR DESCRIPTION
Here `stock["price"]` is a Decimal. We must convert it to a float to
compare it to the product price and JSON-serialize it in the logx.