### PR TITLE
Pc 8503 phone number id check

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -146,6 +146,7 @@ def create_account(
     is_email_validated: bool = False,
     send_activation_mail: bool = True,
     postal_code: str = None,
+    phone_number: str = None,
 ) -> User:
     email = sanitize_email(email)
     if find_user_by_email(email):
@@ -162,6 +163,7 @@ def create_account(
         notificationSubscriptions=asdict(NotificationSubscriptions(marketing_email=marketing_email_subscription)),
         postalCode=postal_code,
         departementCode=departementCode,
+        phoneNumber=phone_number,
     )
 
     if not user.age or user.age < constants.ACCOUNT_CREATION_MINIMUM_AGE:

--- a/src/pcapi/domain/user_activation.py
+++ b/src/pcapi/domain/user_activation.py
@@ -23,7 +23,6 @@ def create_beneficiary_from_application(application_detail: dict, user: Optional
     beneficiary.lastName = application_detail["last_name"]
     beneficiary.firstName = application_detail["first_name"]
     beneficiary.publicName = "%s %s" % (application_detail["first_name"], application_detail["last_name"])
-    beneficiary.phoneNumber = application_detail["phone"]
     beneficiary.departementCode = application_detail["department"]
     beneficiary.postalCode = application_detail["postal_code"]
     beneficiary.address = application_detail["address"]
@@ -31,6 +30,9 @@ def create_beneficiary_from_application(application_detail: dict, user: Optional
     beneficiary.activity = application_detail["activity"]
     beneficiary.isAdmin = False
     beneficiary.hasSeenTutorials = False
+
+    if not beneficiary.phoneNumber:
+        beneficiary.phoneNumber = application_detail["phone"]
 
     return beneficiary
 

--- a/src/pcapi/infrastructure/repository/beneficiary/beneficiary_pre_subscription_sql_converter.py
+++ b/src/pcapi/infrastructure/repository/beneficiary/beneficiary_pre_subscription_sql_converter.py
@@ -27,9 +27,11 @@ def to_model(beneficiary_pre_subscription: BeneficiaryPreSubscription, user: Opt
     beneficiary.hasSeenTutorials = False
     beneficiary.isAdmin = False
     beneficiary.lastName = beneficiary_pre_subscription.last_name
-    beneficiary.phoneNumber = beneficiary_pre_subscription.phone_number
     beneficiary.postalCode = beneficiary_pre_subscription.postal_code
     beneficiary.publicName = beneficiary_pre_subscription.public_name
+
+    if not beneficiary.phoneNumber:
+        beneficiary.phoneNumber = beneficiary_pre_subscription.phone_number
 
     users_api.attach_beneficiary_import_details(beneficiary, beneficiary_pre_subscription)
     if not users_api.steps_to_become_beneficiary(beneficiary):

--- a/tests/scripts/beneficiary/remote_import_test.py
+++ b/tests/scripts/beneficiary/remote_import_test.py
@@ -671,11 +671,15 @@ class RunIntegrationTest:
 
         # then
         assert User.query.count() == 1
+
         user = User.query.first()
         assert user.firstName == "john"
         assert user.postalCode == "93450"
         assert user.address == "11 Rue du Test"
+        assert user.phoneNumber == "0102030405"
+
         assert BeneficiaryImport.query.count() == 1
+
         beneficiary_import = BeneficiaryImport.query.first()
         assert beneficiary_import.source == "demarches_simplifiees"
         assert beneficiary_import.applicationId == 123
@@ -773,6 +777,7 @@ class RunIntegrationTest:
         assert user.postalCode == "93450"
         assert user.address == "11 Rue du Test"
         assert user.isBeneficiary
+        assert user.phoneNumber == "0102030405"
 
         assert BeneficiaryImport.query.count() == 1
         beneficiary_import = BeneficiaryImport.query.first()
@@ -829,6 +834,7 @@ class RunIntegrationTest:
             birthdate=self.BENEFICIARY_BIRTH_DATE,
             is_email_validated=True,
             send_activation_mail=False,
+            phone_number="0607080900",
         )
         push_testing.reset_requests()
 
@@ -841,15 +847,23 @@ class RunIntegrationTest:
 
         # then
         assert User.query.count() == 1
+
         user = User.query.first()
         assert user.firstName == "john"
         assert user.postalCode == "93450"
+
+        # Since the User already exists, the phone number should not be updated
+        # during the import process
+        assert user.phoneNumber == "0607080900"
+
         assert BeneficiaryImport.query.count() == 1
+
         beneficiary_import = BeneficiaryImport.query.first()
         assert beneficiary_import.source == "demarches_simplifiees"
         assert beneficiary_import.applicationId == 123
         assert beneficiary_import.beneficiary == user
         assert beneficiary_import.currentStatus == ImportStatus.CREATED
+
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0].sent_data["Mj-TemplateID"] == 2016025
 

--- a/tests/use_cases/create_beneficiary_from_application_test.py
+++ b/tests/use_cases/create_beneficiary_from_application_test.py
@@ -135,6 +135,7 @@ def test_application_for_native_app_user(mocked_send_accepted_as_beneficiary_ema
         is_email_validated=True,
         send_activation_mail=False,
         marketing_email_subscription=False,
+        phone_number="0607080900",
     )
     push_testing.reset_requests()
 
@@ -145,6 +146,12 @@ def test_application_for_native_app_user(mocked_send_accepted_as_beneficiary_ema
     mocked_send_accepted_as_beneficiary_email.assert_called_once()
 
     beneficiary = User.query.one()
+
+    # the fake Jouve backend returns a default phone number. Since a User
+    # alredy exists, the phone number should not be updated during the import
+    # process.
+    assert beneficiary.phoneNumber == "0607080900"
+
     deposit = Deposit.query.one()
     assert deposit.amount == 300
     assert deposit.source == "dossier jouve [35]"


### PR DESCRIPTION
Ne pas mettre à jour le numéro de téléphone de l'utilisateur lors de l'import ID-Check s'il en a déjà un.

**Au passage**

Ajout de `**kwargs` à `create_user` pour faciliter la création d'utilisateurs. Ici : passer le paramètre `phoneNumber` dans des tests.

**Note**

Aucun test n'a été ajouté dans `tests/use_cases/create_beneficiary_from_application_test.py` pour le cas où l'utilisateur n'existe pas, car il est déjà pris en compte : on vérifie que le numéro de téléphone est bien celui d'ID-Check (backend de test).