### PR TITLE
PC-8821: correct bug KeyError in check validation configuration file format

### DIFF
--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -701,6 +701,7 @@ def import_offer_validation_config(config_as_yaml: str, user: User = None) -> Of
     except (KeyError, ValueError, ScannerError) as error:
         logger.exception(
             "Wrong configuration file format: %s",
+            error,
             extra={"exc": str(error)},
         )
         raise WrongFormatInFraudConfigurationFile(str(error))

--- a/src/pcapi/core/offers/validation.py
+++ b/src/pcapi/core/offers/validation.py
@@ -292,6 +292,9 @@ def check_user_can_load_config(user: User) -> None:
 
 def check_validation_config_parameters(config_as_dict: dict, valid_keys: list) -> None:
     for key, value in config_as_dict.items():
+        if key not in valid_keys:
+            raise KeyError(f"Wrong key: {key}")
+
         if isinstance(value, list) and key in KEY_VALIDATION_CONFIG:
             for item in value:
                 check_validation_config_parameters(item, KEY_VALIDATION_CONFIG[key])
@@ -300,5 +303,3 @@ def check_validation_config_parameters(config_as_dict: dict, valid_keys: list) -
         # Note that these are case-senstive
         elif not (value in VALUE_VALIDATION_CONFIG[key] or type(value) in VALUE_VALIDATION_CONFIG[key]):
             raise ValueError(f"{value} of type {type(value)} not in: {VALUE_VALIDATION_CONFIG[key]}")
-        if key not in valid_keys:
-            raise KeyError(f"Wrong key: {key}")

--- a/tests/core/offers/test_api.py
+++ b/tests/core/offers/test_api.py
@@ -1325,7 +1325,7 @@ class ImportOfferValidationConfigTest:
         """
         with pytest.raises(WrongFormatInFraudConfigurationFile) as error:
             import_offer_validation_config(config_yaml)
-        assert "WRONG_KEY" in str(error.value)
+        assert str(error.value) == "\"'Wrong key: WRONG_KEY'\""
 
     @override_features(OFFER_VALIDATION_MOCK_COMPUTATION=False)
     def test_raise_a_WrongFormatInFraudConfigurationFile_error_for_wrong_type(self):


### PR DESCRIPTION
Une KeyError python était levée avant de passer dans notre if.