### PR TITLE
Create id-check token only if allow id-check-registration

### DIFF
--- a/src/pcapi/routes/native/v1/authentication.py
+++ b/src/pcapi/routes/native/v1/authentication.py
@@ -134,7 +134,11 @@ def validate_email(body: ValidateEmailRequest) -> ValidateEmailResponse:
     user.isEmailValidated = True
     repository.save(user)
 
-    id_check_token = users_api.create_id_check_token(user)
+    id_check_token = (
+        users_api.create_id_check_token(user)
+        if feature_queries.is_active(FeatureToggle.ALLOW_IDCHECK_REGISTRATION)
+        else None
+    )
 
     response = ValidateEmailResponse(
         access_token=create_user_access_token(user),


### PR DESCRIPTION
otherwise the token would be created and useless because the front will not use it ; now that the number of alive token is limited