### PR TITLE
(PC-8909) : fix email validation when user has no idcheck token left

### DIFF
--- a/src/pcapi/routes/native/v1/authentication.py
+++ b/src/pcapi/routes/native/v1/authentication.py
@@ -134,7 +134,10 @@ def validate_email(body: ValidateEmailRequest) -> ValidateEmailResponse:
     user.isEmailValidated = True
     repository.save(user)
 
-    id_check_token = users_api.create_id_check_token(user)
+    try:
+        id_check_token = users_api.create_id_check_token(user)
+    except users_exceptions.IdCheckTokenLimitReached:
+        id_check_token = None
 
     response = ValidateEmailResponse(
         access_token=create_user_access_token(user),


### PR DESCRIPTION
When adding the limitation on IdCheck token quantity for a given
user, the email validation route was forgotten and had sometime
an uncaught exception when trying to create a new token and the
user is not allowed to create one anymore.
Let's catch that exception and return an empty token just like
a non eligible user.