### PR TITLE
(PC-8910) : Don't let expired tokens be tested as recaptchas

### DIFF
--- a/src/pcapi/core/users/repository.py
+++ b/src/pcapi/core/users/repository.py
@@ -63,8 +63,6 @@ def get_id_check_token(token_value: str) -> models.Token:
     return models.Token.query.filter(
         models.Token.value == token_value,
         models.Token.type == models.TokenType.ID_CHECK,
-        models.Token.isUsed == False,
-        models.Token.expirationDate > datetime.now(),
     ).one_or_none()
 
 

--- a/src/pcapi/routes/webapp/beneficiaries.py
+++ b/src/pcapi/routes/webapp/beneficiaries.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 
 from flask import abort
@@ -128,9 +129,11 @@ def verify_id_check_licence_token(
 ) -> serialization_beneficiaries.VerifyIdCheckLicenceResponse:
     token = users_repo.get_id_check_token(body.token)
     if token:
-        token.isUsed = True
-        repository.save(token)
-        return serialization_beneficiaries.VerifyIdCheckLicenceResponse()
+        if not token.isUsed and token.expirationDate > datetime.now():
+            token.isUsed = True
+            repository.save(token)
+            return serialization_beneficiaries.VerifyIdCheckLicenceResponse()
+        raise ApiErrors(errors={"token": "Le token renseigné n'est pas valide"})
 
     # Let's try with the legacy webapp tokens
     check_webapp_recaptcha_token(


### PR DESCRIPTION
licence_verify was trying to get an active and valid token before
falling back to recaptcha.
However it creates false warning about broken recaptcha.
Therefore the API will now try to sort out whether it's a token
or a recaptcha and then will check the token is valid in a second
step.