### PR TITLE
(PC-8919) : Add a IDCheck fraud control feature flag

### DIFF
--- a/src/pcapi/alembic/versions/20210523_0fe847be8089_feature_enable_idcheck_fraud_control.py
+++ b/src/pcapi/alembic/versions/20210523_0fe847be8089_feature_enable_idcheck_fraud_control.py
@@ -1,0 +1,26 @@
+"""feature enable idcheck fraud control
+
+Revision ID: 0fe847be8089
+Revises: 6999a11484ba
+Create Date: 2021-05-23 15:49:25.049504
+
+"""
+from pcapi.models import feature
+
+
+# revision identifiers, used by Alembic.
+revision = "0fe847be8089"
+down_revision = "6999a11484ba"
+branch_labels = None
+depends_on = None
+
+
+FLAG = feature.FeatureToggle.ENABLE_IDCHECK_FRAUD_CONTROLS
+
+
+def upgrade() -> None:
+    feature.add_feature_to_database(FLAG)
+
+
+def downgrade() -> None:
+    feature.add_feature_to_database(FLAG)

--- a/src/pcapi/connectors/beneficiaries/jouve_backend.py
+++ b/src/pcapi/connectors/beneficiaries/jouve_backend.py
@@ -8,6 +8,8 @@ import requests
 from pcapi import settings
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription import BeneficiaryPreSubscription
 from pcapi.models import BeneficiaryImportSources
+from pcapi.models.feature import FeatureToggle
+from pcapi.repository import feature_queries
 
 
 logger = logging.getLogger(__name__)
@@ -114,6 +116,12 @@ def get_threshold_fraud_detetction_item(content: dict, key: str, threshold: int)
 
 
 def get_fraud_fields(content: dict) -> dict:
+    if not feature_queries.is_active(FeatureToggle.ENABLE_IDCHECK_FRAUD_CONTROLS):
+        return {
+            "strict_controls": [],
+            "non_blocking_controls": [],
+        }
+
     return {
         "strict_controls": [
             get_boolean_fraud_detetction_item(content, "posteCodeCtrl"),

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -55,6 +55,7 @@ class FeatureToggle(enum.Enum):
     USE_NEW_BATCH_INDEX_OFFERS_BEHAVIOUR = "Utilise une boucle dans le cron de réindexation Algolia"
     ENABLE_NATIVE_ID_CHECK_VERSION = "Utilise la version d'ID-Check intégrée à l'application native"
     ENABLE_NEW_VENUE_PAGES = "Utiliser la nouvelle version des pages d'edition et de creation de lieux"
+    ENABLE_IDCHECK_FRAUD_CONTROLS = "Active les contrôles de sécurité en sortie du process ID Check"
 
 
 class Feature(PcObject, Model, DeactivableMixin):

--- a/tests/connectors/beneficiaries/beneficiary_jouve_repository_test.py
+++ b/tests/connectors/beneficiaries/beneficiary_jouve_repository_test.py
@@ -11,6 +11,10 @@ from pcapi.connectors.beneficiaries.jouve_backend import BeneficiaryJouveBackend
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription import BeneficiaryPreSubscription
 
 
+# Required by the feature flag...
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
 def get_application_by_detail_response(application_id: int = 2, birth_date: str = "09/08/1995", **kwargs) -> dict:
     return {
         "id": application_id,


### PR DESCRIPTION
In order to bypass security checks on staging to run the
IDCheck process, let's add a feature flag to skip it.