### PR TITLE
PC-8943: add index on the Validation column from the Offer table

### DIFF
--- a/src/pcapi/alembic/versions/20210524_9908a2709641_add_idx_offer_validation.py
+++ b/src/pcapi/alembic/versions/20210524_9908a2709641_add_idx_offer_validation.py
@@ -1,0 +1,32 @@
+"""add_idx_offer_validation
+
+Revision ID: 9908a2709641
+Revises: 0fe847be8089
+Create Date: 2021-05-24 10:12:35.543128
+
+"""
+from alembic import op
+
+
+revision = "9908a2709641"
+down_revision = "0fe847be8089"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_offer_validation" ON offer ("validation")
+        """
+    )
+
+
+def downgrade():
+    op.execute("COMMIT")
+    op.execute(
+        """
+        DROP INDEX CONCURRENTLY IF EXISTS "ix_offer_validation"
+        """
+    )

--- a/src/pcapi/core/offers/models.py
+++ b/src/pcapi/core/offers/models.py
@@ -321,6 +321,7 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin, ProvidableMixin):
         default=OfferValidationStatus.APPROVED,
         # changing the server_default will cost an UPDATE migration on all existing null rows
         server_default="APPROVED",
+        index=True,
     )
 
     authorId = Column(BigInteger, ForeignKey("user.id"), nullable=True)


### PR DESCRIPTION
This is especially necessary for the FA Validation section