### PR TITLE
Correctoin ALGOLIA_API_KEY + fix typo dans une migration

### DIFF
--- a/helm/pcapi/values.integration.yaml
+++ b/helm/pcapi/values.integration.yaml
@@ -291,7 +291,7 @@ secrets:
   - name: ADMINISTRATION_EMAIL_ADDRESS
     version: 2
   - name: ALGOLIA_API_KEY
-    version: 3
+    version: 2
   - name: ALGOLIA_APPLICATION_ID
     version: 2
   - name: BATCH_SECRET_API_KEY

--- a/src/pcapi/alembic/versions/20210523_0fe847be8089_feature_enable_idcheck_fraud_control.py
+++ b/src/pcapi/alembic/versions/20210523_0fe847be8089_feature_enable_idcheck_fraud_control.py
@@ -23,4 +23,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    feature.add_feature_to_database(FLAG)
+    feature.remove_feature_from_database(FLAG)


### PR DESCRIPTION
Commits à relire séparément.