### PR TITLE
[Besoin à clarifier] (PC-8935) send notification regarding account activation

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -62,6 +62,7 @@ from pcapi.routes.serialization.users import ProUserCreationBodyModel
 logger = logging.getLogger(__name__)
 
 from pcapi.utils.mailing import MailServiceException
+from pcapi.workers.push_notification_job import send_account_activation_notification_job
 from pcapi.workers.push_notification_job import update_user_attributes_job
 
 from . import constants
@@ -239,6 +240,8 @@ def attach_beneficiary_import_details(
 def request_email_confirmation(user: User) -> None:
     token = create_email_validation_token(user)
     user_emails.send_activation_email(user, native_version=True, token=token)
+
+    send_account_activation_notification_job.delay(user.id)
 
 
 def request_password_reset(user: User) -> None:

--- a/src/pcapi/notifications/push/transactional_notifications.py
+++ b/src/pcapi/notifications/push/transactional_notifications.py
@@ -13,6 +13,7 @@ class GroupId(Enum):
     CANCEL_BOOKING = "Cancel_booking"
     TOMORROW_STOCK = "Tomorrow_stock"
     OFFER_LINK = "Offer_link"
+    ACCOUNT_ACTIVATION = "Account_activation"
 
 
 @dataclass
@@ -74,4 +75,15 @@ def get_offer_notification_data(user_id: int, offer: Offer) -> TransactionalNoti
             body="Pour réserver, c'est par ici !",
         ),
         extra={"deeplink": offer_webapp_link(offer)},
+    )
+
+
+def get_account_activation_notification_data(user_id: int) -> TransactionalNotificationData:
+    return TransactionalNotificationData(
+        group_id=GroupId.ACCOUNT_ACTIVATION.value,
+        user_ids=[user_id],
+        message=TransactionalNotificationMessage(
+            title="Ton compte est créé !",
+            body="Clique ici pour découvrir le pass Culture !",
+        ),
     )

--- a/src/pcapi/workers/push_notification_job.py
+++ b/src/pcapi/workers/push_notification_job.py
@@ -7,6 +7,7 @@ from pcapi.core.offers.models import Offer
 from pcapi.core.users.models import User
 from pcapi.notifications.push import send_transactional_notification
 from pcapi.notifications.push import update_user_attributes
+from pcapi.notifications.push.transactional_notifications import get_account_activation_notification_data
 from pcapi.notifications.push.transactional_notifications import get_bookings_cancellation_notification_data
 from pcapi.notifications.push.transactional_notifications import get_offer_notification_data
 from pcapi.notifications.push.transactional_notifications import get_tomorrow_stock_notification_data
@@ -68,4 +69,12 @@ def send_tomorrow_stock_notification(stock_id: int) -> None:
 def send_offer_link_by_push_job(user_id: int, offer_id: int) -> None:
     offer = Offer.query.get(offer_id)
     notification_data = get_offer_notification_data(user_id, offer)
+    send_transactional_notification(notification_data)
+
+
+@job(worker.default_queue, connection=worker.conn)
+@job_context
+@log_job
+def send_account_activation_notification_job(user_id: int) -> None:
+    notification_data = get_account_activation_notification_data(user_id)
     send_transactional_notification(notification_data)


### PR DESCRIPTION
Envoyer une notification à l'utilisateur pour l'informer que sont compte a bien été créé. Cette notification fait doublon avec l'email qui est aussi envoyé une fois celui-ci confirmé mais que certains utilisateurs ne reçoivent pas.