### PR TITLE
Pc 9003 send phone validation code accepts phone prefix

### DIFF
--- a/src/pcapi/alembic/versions/20210526_a587787c8be7_add_phoneprefix_to_user.py
+++ b/src/pcapi/alembic/versions/20210526_a587787c8be7_add_phoneprefix_to_user.py
@@ -1,0 +1,24 @@
+"""add_phonePrefix_to_user
+
+Revision ID: a587787c8be7
+Revises: 963e6e163cf0
+Create Date: 2021-05-26 13:47:55.391134
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a587787c8be7"
+down_revision = "963e6e163cf0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("user", sa.Column("phonePrefix", sa.String(length=10), nullable=True))
+
+
+def downgrade():
+    op.drop_column("user", "phonePrefix")

--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -552,13 +552,15 @@ def set_pro_tuto_as_seen(user: User) -> None:
     repository.save(user)
 
 
-def change_user_phone_number(user: User, phone_number: str):
+def change_user_phone_number(user: User, phone_number: str, phone_prefix: str):
     _check_phone_number_validation_is_authorized(user)
 
     if does_phone_exists(phone_number):
         raise exceptions.PhoneAlreadyExists()
 
+    user.phonePrefix = phone_prefix
     user.phoneNumber = phone_number
+
     Token.query.filter(Token.user == user, Token.type == TokenType.PHONE_VALIDATION).delete()
     repository.save(user)
 

--- a/src/pcapi/core/users/models.py
+++ b/src/pcapi/core/users/models.py
@@ -170,6 +170,8 @@ class User(PcObject, Model, NeedsValidationMixin):
 
     password = Column(LargeBinary(60), nullable=False)
 
+    phonePrefix = Column(String(10), nullable=True)
+
     phoneNumber = Column(String(20), nullable=True)
 
     postalCode = Column(String(5), nullable=True)

--- a/src/pcapi/core/users/utils.py
+++ b/src/pcapi/core/users/utils.py
@@ -50,6 +50,8 @@ def format_phone_number_with_country_code(user: User) -> str:
             extra={"departementCode": user.departementCode, "postalCode": user.postalCode},
         )
 
-    phone_prefix = PHONE_PREFIX_BY_DEPARTEMENT_CODE.get(user.departementCode, METROPOLE_PHONE_PREFIX)
+    if user.phonePrefix:
+        return user.phonePrefix + user.phoneNumber[1:]
 
+    phone_prefix = PHONE_PREFIX_BY_DEPARTEMENT_CODE.get(user.departementCode, METROPOLE_PHONE_PREFIX)
     return phone_prefix + user.phoneNumber[1:]

--- a/src/pcapi/routes/native/v1/account.py
+++ b/src/pcapi/routes/native/v1/account.py
@@ -160,7 +160,7 @@ def get_id_check_token(user: User) -> serializers.GetIdCheckTokenResponse:
 def send_phone_validation_code(user: User, body: serializers.SendPhoneValidationRequest) -> None:
     try:
         if body.phoneNumber:
-            api.change_user_phone_number(user, body.phoneNumber)
+            api.change_user_phone_number(user, body.phoneNumber, body.phonePrefix)
 
         api.send_phone_validation_code(user)
 

--- a/src/pcapi/routes/native/v1/serialization/account.py
+++ b/src/pcapi/routes/native/v1/serialization/account.py
@@ -168,4 +168,5 @@ class ValidatePhoneNumberRequest(BaseModel):
 
 
 class SendPhoneValidationRequest(BaseModel):
+    phonePrefix: Optional[str]
     phoneNumber: Optional[str]

--- a/src/pcapi/routes/serialization/beneficiaries.py
+++ b/src/pcapi/routes/serialization/beneficiaries.py
@@ -132,7 +132,8 @@ class PatchBeneficiaryBodyModel(BaseModel):
 
 
 class SendPhoneValidationRequest(BaseModel):
-    phone_number: Optional[str]
+    phonePrefix: Optional[str]
+    phoneNumber: Optional[str]
 
     class Config:
         alias_generator = to_camel

--- a/src/pcapi/routes/webapp/beneficiaries.py
+++ b/src/pcapi/routes/webapp/beneficiaries.py
@@ -169,8 +169,8 @@ def id_check_application_update(
 def send_phone_validation_code(body: serialization_beneficiaries.SendPhoneValidationRequest) -> None:
     user = current_user._get_current_object()
     try:
-        if body.phone_number:
-            users_api.change_user_phone_number(user, body.phoneNumber)
+        if body.phoneNumber:
+            users_api.change_user_phone_number(user, body.phoneNumber, body.phonePrefix)
         users_api.send_phone_validation_code(user)
     except users_exceptions.UserPhoneNumberAlreadyValidated:
         raise ApiErrors({"message": "Le numéro de téléphone est déjà validé"}, status_code=400)

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -804,13 +804,15 @@ class SendPhoneValidationCodeTest:
         test_client = TestClient(app.test_client())
         test_client.auth_header = {"Authorization": f"Bearer {access_token}"}
 
-        response = test_client.post("/native/v1/send_phone_validation_code", json={"phoneNumber": "0102030405"})
+        phone_number_data = {"phoneNumber": "102030405", "phonePrefix": "+33"}
+        response = test_client.post("/native/v1/send_phone_validation_code", json=phone_number_data)
 
         assert response.status_code == 204
 
         assert Token.query.filter_by(userId=user.id).first()
         db.session.refresh(user)
-        assert user.phoneNumber == "0102030405"
+        assert user.phonePrefix == "+33"
+        assert user.phoneNumber == "102030405"
 
     def test_send_phone_validation_code_for_new_duplicated_phone_number(self, app):
         users_factories.UserFactory(isEmailValidated=True, isBeneficiary=False, phoneNumber="0102030405")

--- a/tests/routes/shared/get_user_profile_test.py
+++ b/tests/routes/shared/get_user_profile_test.py
@@ -62,6 +62,7 @@ class Get:
                 "lastName": "Smisse",
                 "needsToFillCulturalSurvey": False,
                 "notificationSubscriptions": {"marketing_email": True, "marketing_push": True},
+                "phonePrefix": None,
                 "phoneNumber": "0612345678",
                 "phoneValidationStatus": None,
                 "postalCode": "93020",


### PR DESCRIPTION
* Ajouter d'une colonne `phonePrefix` à `User` 
* Permettre au front d'envoyer un numéro de téléphone avec son préfix (via `/send_phone_validation_code`)
* Utiliser ce préfixe pour construire le numéro de téléphone, s'il est présent.

:heavy_plus_sign:   avoir des corps de requêtes avec les mêmes variables (pas `body.phone_number` côté webapp et `body.phoneNumer` côté app native)