### PR TITLE
native: Lower log level on unknown user authentication

### DIFF
--- a/src/pcapi/routes/native/security.py
+++ b/src/pcapi/routes/native/security.py
@@ -25,7 +25,7 @@ def authenticated_user_required(route_function):  # type: ignore
         email = get_jwt_identity()
         user = find_user_by_email(email)
         if user is None or not user.isActive:
-            logger.error("Authenticated user with email %s not found or inactive", email)
+            logger.info("Authenticated user with email %s not found or inactive", email)
             raise ForbiddenError({"email": ["Utilisateur introuvable"]})
 
         # push the user to the current context - similar to flask-login


### PR DESCRIPTION
Logging an error pollutes Sentry, while we don't have anything to do
about it. An info log is enough.

---

Le log en question dans Sentry : https://logs.passculture.app/organizations/sentry/issues/2545