### PR TITLE
[PC-8995] : return 400 on non eligible user asking for id check

### DIFF
--- a/src/pcapi/routes/native/v1/account.py
+++ b/src/pcapi/routes/native/v1/account.py
@@ -135,6 +135,8 @@ def resend_email_validation(body: serializers.ResendEmailValidationRequest) -> N
 @spectree_serialize(api=blueprint.api, response_model=serializers.GetIdCheckTokenResponse)
 @authenticated_user_required
 def get_id_check_token(user: User) -> serializers.GetIdCheckTokenResponse:
+    if not user.is_eligible:
+        raise ApiErrors({"code": "USER_NOT_ELIGIBLE"})
     try:
         id_check_token = api.create_id_check_token(user)
         return serializers.GetIdCheckTokenResponse(

--- a/src/pcapi/routes/native/v1/serialization/account.py
+++ b/src/pcapi/routes/native/v1/serialization/account.py
@@ -159,8 +159,8 @@ class ResendEmailValidationRequest(BaseModel):
 
 
 class GetIdCheckTokenResponse(BaseModel):
-    token: Optional[str]
-    token_timestamp: Optional[datetime.datetime]
+    token: str
+    token_timestamp: datetime.datetime
 
 
 class ValidatePhoneNumberRequest(BaseModel):

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -664,8 +664,8 @@ class GetIdCheckTokenTest:
         test_client.auth_header = {"Authorization": f"Bearer {access_token}"}
         response = test_client.get("/native/v1/id_check_token")
 
-        assert response.status_code == 200
-        assert not response.json["token"]
+        assert response.status_code == 400
+        assert response.json == {"code": "USER_NOT_ELIGIBLE"}
 
     def test_get_id_check_token_limit_reached(self, app):
         user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), departementCode="93")


### PR DESCRIPTION
To make easier for the native app to track non eligible users
the backend will now return a specific error code when a
non eligible user tries to get an IDCheck token.