### PR TITLE
(PC-8771) phone number: validate and normalize

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,3 +70,4 @@ SQLAlchemy==1.3.*
 Werkzeug==1.0.1
 wheel==0.35.1
 WTForms-SQLAlchemy
+phonenumberslite==8.12.23

--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -23,8 +23,6 @@ from pcapi.core import mails
 from pcapi.core.bookings.conf import LIMIT_CONFIGURATIONS
 import pcapi.core.bookings.repository as bookings_repository
 from pcapi.core.payments import api as payment_api
-from pcapi.core.users.constants import METROPOLE_PHONE_PREFIX
-from pcapi.core.users.constants import PHONE_PREFIX_BY_DEPARTEMENT_CODE
 from pcapi.core.users.models import Credit
 from pcapi.core.users.models import DomainsCredit
 from pcapi.core.users.models import NotificationSubscriptions
@@ -37,6 +35,8 @@ from pcapi.core.users.repository import does_phone_exists
 from pcapi.core.users.repository import get_beneficiary_import_for_beneficiary
 from pcapi.core.users.utils import decode_jwt_token
 from pcapi.core.users.utils import encode_jwt_payload
+from pcapi.core.users.utils import get_formatted_phone_number
+from pcapi.core.users.utils import parse_phone_number
 from pcapi.core.users.utils import sanitize_email
 from pcapi.domain import user_emails
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription import BeneficiaryPreSubscription
@@ -556,14 +556,14 @@ def set_pro_tuto_as_seen(user: User) -> None:
 def change_user_phone_number(user: User, phone_number: str):
     _check_phone_number_validation_is_authorized(user)
 
-    formatted_phone_number = get_formatted_phone_number(user.departementCode, phone_number)
-    if not is_phone_number_legit(formatted_phone_number):
-        raise exceptions.InvalidPhoneNumber()
+    formatted_phone_number = get_legit_phone_number(phone_number)
+    if not formatted_phone_number:
+        raise exceptions.InvalidPhoneNumber(phone_number)
 
-    if does_phone_exists(phone_number):
+    if does_phone_exists(formatted_phone_number):
         raise exceptions.PhoneAlreadyExists()
 
-    user.phoneNumber = phone_number
+    user.phoneNumber = formatted_phone_number
     Token.query.filter(Token.user == user, Token.type == TokenType.PHONE_VALIDATION).delete()
     repository.save(user)
 
@@ -571,9 +571,9 @@ def change_user_phone_number(user: User, phone_number: str):
 def send_phone_validation_code(user: User) -> None:
     _check_phone_number_validation_is_authorized(user)
 
-    phone_number = get_formatted_phone_number(user.postalCode, user.phoneNumber)
-    if not is_phone_number_legit(phone_number):
-        raise exceptions.InvalidPhoneNumber()
+    formatted_phone_number = get_legit_phone_number(user.phoneNumber)
+    if not formatted_phone_number:
+        raise exceptions.InvalidPhoneNumber(user.phoneNumber)
 
     if not is_SMS_sending_allowed(app.redis_client, user):
         raise exceptions.SMSSendingLimitReached()
@@ -581,7 +581,7 @@ def send_phone_validation_code(user: User) -> None:
     phone_validation_token = create_phone_validation_token(user)
     content = f"{phone_validation_token.value} est ton code de confirmation pass Culture"
 
-    if not send_transactional_sms(phone_number, content):
+    if not send_transactional_sms(formatted_phone_number, content):
         raise exceptions.PhoneVerificationCodeSendingException()
 
     update_sent_SMS_counter(app.redis_client, user)
@@ -591,9 +591,8 @@ def validate_phone_number(user: User, code: str) -> None:
     _check_phone_number_validation_is_authorized(user)
     _check_and_update_phone_validation_attempts(app.redis_client, user)
 
-    phone_number = get_formatted_phone_number(user.postalCode, user.phoneNumber)
-    if not is_phone_number_legit(phone_number):
-        raise exceptions.InvalidPhoneNumber()
+    if not get_legit_phone_number(user.phoneNumber):
+        raise exceptions.InvalidPhoneNumber(user.phoneNumber)
 
     token = Token.query.filter(
         Token.user == user, Token.value == code, Token.type == TokenType.PHONE_VALIDATION
@@ -611,13 +610,23 @@ def validate_phone_number(user: User, code: str) -> None:
     repository.save(user)
 
 
-def is_phone_number_legit(phone_number: Optional[str]) -> bool:
-    return phone_number and phone_number not in settings.BLACKLISTED_SMS_RECIPIENTS
+def get_legit_phone_number(phone_number: Optional[str]) -> Optional[str]:
+    try:
+        parsed_phone_number = parse_phone_number(phone_number)
+        formatted_phone_number = get_formatted_phone_number(parsed_phone_number)
+    except exceptions.InvalidPhoneNumber:
+        return None
+
+    if is_phone_number_legit(formatted_phone_number, parsed_phone_number.country_code):
+        return formatted_phone_number
+    return None
 
 
-def get_formatted_phone_number(departement_code: str, phone_number: str) -> Optional[str]:
-    country_code = PHONE_PREFIX_BY_DEPARTEMENT_CODE.get(departement_code, METROPOLE_PHONE_PREFIX)
-    return country_code + phone_number[1:]
+def is_phone_number_legit(phone_number: str, country_code) -> bool:
+    return (
+        phone_number not in settings.BLACKLISTED_SMS_RECIPIENTS
+        and country_code in constants.WHITELISTED_COUNTRY_PHONE_CODES
+    )
 
 
 def _check_phone_number_validation_is_authorized(user: User) -> None:

--- a/src/pcapi/core/users/constants.py
+++ b/src/pcapi/core/users/constants.py
@@ -14,6 +14,21 @@ PHONE_VALIDATION_TOKEN_LIFE_TIME = timedelta(minutes=10)
 ELIGIBILITY_AGE = 18
 ACCOUNT_CREATION_MINIMUM_AGE = 16
 
+WHITELISTED_COUNTRY_PHONE_CODES = {
+    33,  # France métropolitaine
+    590,  # Guadeloupe
+    596,  # Martinique
+    594,  # Guyane
+    262,  # Réunion
+    508,  # Saint-Pierre-et-Miquelon
+    262,  # Mayotte
+    590,  # Saint-Barthélémy
+    590,  # Saint-Martin
+    681,  # Wallis-et-Futuna
+    689,  # Tahiti
+    687,  # Nouvelle-Calédonie
+}
+
 
 class SuspensionReason(Enum):
     def __str__(self) -> str:

--- a/src/pcapi/core/users/utils.py
+++ b/src/pcapi/core/users/utils.py
@@ -3,10 +3,14 @@ import logging
 from typing import Optional
 
 import jwt
+import phonenumbers
+from phonenumbers import PhoneNumber
+from phonenumbers.phonenumberutil import NumberParseException
 
 from pcapi import settings
 from pcapi.core.users.constants import METROPOLE_PHONE_PREFIX
 from pcapi.core.users.constants import PHONE_PREFIX_BY_DEPARTEMENT_CODE
+from pcapi.core.users.exceptions import InvalidPhoneNumber
 from pcapi.core.users.exceptions import UserWithoutPhoneNumberException
 from pcapi.core.users.models import ALGORITHM_HS_256
 from pcapi.core.users.models import User
@@ -56,3 +60,28 @@ def format_phone_number_with_country_code(user: User) -> str:
         )
 
     return build_internationalized_phone_number(user, user.phoneNumber)
+
+
+def parse_phone_number(phone_number: Optional[str]) -> PhoneNumber:
+    """
+    Phone number must be correctly formatted in international format (E.164)
+    and be valid (number of digits, digit sequence)
+
+    Raises:
+        InvalidPhoneNumber
+    """
+    try:
+        parsed_phone_number = phonenumbers.parse(phone_number)
+    except NumberParseException as error:
+        raise InvalidPhoneNumber(str(phone_number)) from error
+    except TypeError as error:
+        raise InvalidPhoneNumber(str(phone_number)) from error
+
+    if not phonenumbers.is_valid_number(parsed_phone_number):
+        raise InvalidPhoneNumber(str(phone_number))
+
+    return parsed_phone_number
+
+
+def get_formatted_phone_number(phone_number: PhoneNumber) -> str:
+    return phonenumbers.format_number(phone_number, phonenumbers.PhoneNumberFormat.E164)

--- a/src/pcapi/notifications/sms/backends/sendinblue.py
+++ b/src/pcapi/notifications/sms/backends/sendinblue.py
@@ -19,7 +19,7 @@ class SendinblueBackend:
     def send_transactional_sms(self, recipient: str, content: str) -> bool:
         send_transac_sms = sib_api_v3_sdk.SendTransacSms(
             sender="PassCulture",
-            recipient=recipient,
+            recipient=self._format_recipient(recipient),
             content=content,
             type="transactional",
             tag="phone-validation",
@@ -31,6 +31,12 @@ class SendinblueBackend:
         except ApiException as e:
             logger.exception("Exception when calling TransactionalSMSApi->send_transac_sms: %s\n", e)
             return False
+
+    def _format_recipient(self, recipient: str):
+        """Sendinblue does not accept phone numbers with a leading '+'"""
+        if recipient.startswith("+"):
+            return recipient[1:]
+        return recipient
 
 
 class ToDevSendinblueBackend(SendinblueBackend):

--- a/tests/routes/webapp/phone_validation_test.py
+++ b/tests/routes/webapp/phone_validation_test.py
@@ -21,7 +21,7 @@ def test_send_phone_validation(app):
     + ensure that a user that has no import operation does not become
     beneficiary.
     """
-    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="060102030405")
+    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="+33601020304")
 
     client = TestClient(app.test_client()).with_auth(email=user.email)
 
@@ -47,7 +47,7 @@ def test_send_phone_validation_and_become_beneficiary(app):
     Test that a user with a CREATED import becomes a beneficiary once its phone
     number is vaidated.
     """
-    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="060102030405")
+    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="+33601020304")
     beneficiary_import = BeneficiaryImportFactory(beneficiary=user)
     beneficiary_import.setStatus(ImportStatus.CREATED)
 
@@ -70,9 +70,9 @@ def test_send_phone_validation_and_become_beneficiary(app):
 
 
 @pytest.mark.usefixtures("db_session")
-@override_settings(BLACKLISTED_SMS_RECIPIENTS={"33607080900"})
+@override_settings(BLACKLISTED_SMS_RECIPIENTS={"+33607080900"})
 def test_send_phone_validation_blocked_number(app):
-    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="0607080900")
+    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="+33607080900")
 
     client = TestClient(app.test_client()).with_auth(email=user.email)
 
@@ -85,25 +85,25 @@ def test_send_phone_validation_blocked_number(app):
 
 
 @pytest.mark.usefixtures("db_session")
-@override_settings(BLACKLISTED_SMS_RECIPIENTS={"33607080900"})
+@override_settings(BLACKLISTED_SMS_RECIPIENTS={"+33607080900"})
 def test_update_phone_number_with_blocked_phone_number(app):
-    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="0601020304")
+    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="+33601020304")
 
     client = TestClient(app.test_client()).with_auth(email=user.email)
-    response = client.post("/send_phone_validation_code", json={"phoneNumber": "0607080900"})
+    response = client.post("/send_phone_validation_code", json={"phoneNumber": "+33607080900"})
 
     assert response.status_code == 400
     assert response.json["code"] == "INVALID_PHONE_NUMBER"
 
     assert not Token.query.filter_by(userId=user.id).first()
     db.session.refresh(user)
-    assert user.phoneNumber == "0601020304"
+    assert user.phoneNumber == "+33601020304"
 
 
 @pytest.mark.usefixtures("db_session")
-@override_settings(BLACKLISTED_SMS_RECIPIENTS={"33607080900"})
+@override_settings(BLACKLISTED_SMS_RECIPIENTS={"+33607080900"})
 def test_validate_phone_validation_with_blocked_number(app):
-    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="0607080900")
+    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="+33607080900")
 
     token = create_phone_validation_token(user)
     client = TestClient(app.test_client()).with_auth(email=user.email)
@@ -114,3 +114,62 @@ def test_validate_phone_validation_with_blocked_number(app):
 
     assert not User.query.get(user.id).is_phone_validated
     assert Token.query.filter_by(userId=user.id, type=TokenType.PHONE_VALIDATION).first()
+
+
+@pytest.mark.usefixtures("db_session")
+def test_send_phone_validation_with_malformed_number(app):
+    # user's phone number should be in international format (E.164): +33601020304
+    user = UserFactory(isEmailValidated=True, isBeneficiary=False, phoneNumber="0601020304")
+
+    token = create_phone_validation_token(user)
+    client = TestClient(app.test_client()).with_auth(email=user.email)
+    response = client.post("/send_phone_validation_code", {"code": token.value})
+
+    assert response.status_code == 400
+    assert response.json["code"] == "INVALID_PHONE_NUMBER"
+
+    assert not User.query.get(user.id).is_phone_validated
+    assert Token.query.filter_by(userId=user.id, type=TokenType.PHONE_VALIDATION).first()
+
+
+@pytest.mark.usefixtures("db_session")
+def test_validate_phone_with_non_french_number(app):
+    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="+46766123456")
+
+    token = create_phone_validation_token(user)
+    client = TestClient(app.test_client()).with_auth(email=user.email)
+    response = client.post("/validate_phone_number", {"code": token.value})
+
+    assert response.status_code == 400
+    assert response.json["code"] == "INVALID_PHONE_NUMBER"
+
+    assert not User.query.get(user.id).is_phone_validated
+    assert Token.query.filter_by(userId=user.id, type=TokenType.PHONE_VALIDATION).first()
+
+
+@pytest.mark.usefixtures("db_session")
+def test_send_phone_validation_with_non_french_number(app):
+    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="+46766123456")
+
+    client = TestClient(app.test_client()).with_auth(email=user.email)
+    response = client.post("/send_phone_validation_code")
+
+    assert response.status_code == 400
+    assert response.json["code"] == "INVALID_PHONE_NUMBER"
+    assert not sms_testing.requests
+    assert not Token.query.filter_by(userId=user.id, type="PHONE_VALIDATION").first()
+
+
+@pytest.mark.usefixtures("db_session")
+def test_update_phone_number_with_non_french_number(app):
+    user = UserFactory(isBeneficiary=False, isEmailValidated=True, phoneNumber="+46766123456")
+
+    client = TestClient(app.test_client()).with_auth(email=user.email)
+    response = client.post("/send_phone_validation_code", json={"phoneNumber": "+46766987654"})
+
+    assert response.status_code == 400
+    assert response.json["code"] == "INVALID_PHONE_NUMBER"
+
+    assert not Token.query.filter_by(userId=user.id).first()
+    db.session.refresh(user)
+    assert user.phoneNumber == "+46766123456"


### PR DESCRIPTION
Valider et normaliser les numéros de téléphone des utilisateurs : 

1. vérifier que le numéro est valide (nombre de chiffre correct, format général cohérent) ;
2. vérifier que le code de pays du numéro correspond bien à un numéro français (métropole + dom-tom)
3. normaliser le format des numéros de téléphone des utilisateurs en base de données (format E.164)

Renvoyer une erreur si le numéro de téléphone n'est pas conforme lors des opérations suivantes : 

* changer le numéro de téléphone de l'utilisateur (`/send_phone_validation_code`)
* envoyer un code de validation à l'utilisateur (`/send_phone_validation_code`)
* valider le code envoyé précédemment (`/validate_phone_number`)

:heavy_plus_sign:  Mettre à jour les versions des secrets BLACKLISTED_SMS_RECIPIENTS (version 1 à 2)