### PR TITLE
(PC-9015) eligible email: no more idcheck token

### DIFF
--- a/src/pcapi/domain/user_emails.py
+++ b/src/pcapi/domain/user_emails.py
@@ -220,14 +220,7 @@ def send_fraud_suspicion_email(
 
 
 def send_newly_eligible_user_email(user: User) -> bool:
-    try:
-        token = users_api.create_id_check_token(user)
-    except Exception:  # pylint: disable=broad-except
-        token = None
-    if not token:
-        logger.warning("Could not create token for user %s to notify its elibility", user.id)
-        return False
-    data = beneficiary_activation.get_newly_eligible_user_email_data(user, token)
+    data = beneficiary_activation.get_newly_eligible_user_email_data(user)
     return mails.send(recipients=[user.email], data=data)
 
 

--- a/src/pcapi/emails/beneficiary_activation.py
+++ b/src/pcapi/emails/beneficiary_activation.py
@@ -58,11 +58,10 @@ def get_accepted_as_beneficiary_email_data() -> dict:
     }
 
 
-def get_newly_eligible_user_email_data(user: users_models.User, token: users_models.Token) -> dict:
-    expiration_timestamp = int(token.expirationDate.timestamp())
+def get_newly_eligible_user_email_data(user: users_models.User) -> dict:
     email_link = generate_firebase_dynamic_link(
         path="id-check",
-        params={"licenceToken": token.value, "expirationTimestamp": expiration_timestamp, "email": user.email},
+        params={"email": user.email},
     )
     limit_configuration = conf.LIMIT_CONFIGURATIONS[conf.get_current_deposit_version()]
     deposit_amount = limit_configuration.TOTAL_CAP

--- a/tests/domain/user_emails_test.py
+++ b/tests/domain/user_emails_test.py
@@ -485,7 +485,6 @@ class SendNewlyEligibleUserEmailTest:
             mails_testing.outbox[0].sent_data["Vars"]["nativeAppLink"][:111]
             == "https://passcultureapptestauto.page.link/?link=https%3A%2F%2Fapp.passculture-testing.beta.gouv.fr%2Fid-check%3F"
         )
-        assert "licenceToken" in mails_testing.outbox[0].sent_data["Vars"]["nativeAppLink"]
         assert "email" in mails_testing.outbox[0].sent_data["Vars"]["nativeAppLink"]
         assert mails_testing.outbox[0].sent_data["Vars"]["depositAmount"] == 500
 
@@ -505,7 +504,6 @@ class SendNewlyEligibleUserEmailTest:
             mails_testing.outbox[0].sent_data["Vars"]["nativeAppLink"][:111]
             == "https://passcultureapptestauto.page.link/?link=https%3A%2F%2Fapp.passculture-testing.beta.gouv.fr%2Fid-check%3F"
         )
-        assert "licenceToken" in mails_testing.outbox[0].sent_data["Vars"]["nativeAppLink"]
         assert "email" in mails_testing.outbox[0].sent_data["Vars"]["nativeAppLink"]
         assert mails_testing.outbox[0].sent_data["Vars"]["depositAmount"] == 300
 


### PR DESCRIPTION
Ne pas créer de token id check pour l'envoi de l'email à un utilisateur qui devient éligible afin d'éviter le cas (minoritaire) où l'utilisateur clique sur le lien après l'expiration du token.