### PR TITLE
(PC-9076) remove id-check token from /validate_email response

### DIFF
--- a/src/pcapi/routes/native/v1/authentication.py
+++ b/src/pcapi/routes/native/v1/authentication.py
@@ -133,17 +133,9 @@ def validate_email(body: ValidateEmailRequest) -> ValidateEmailResponse:
     user.isEmailValidated = True
     repository.save(user)
 
-    try:
-        id_check_token = users_api.create_id_check_token(user)
-    except Exception:  # pylint: disable=broad-except:
-        id_check_token = None
-
     response = ValidateEmailResponse(
         access_token=create_user_access_token(user),
         refresh_token=create_refresh_token(identity=user.email),
-        # TODO (viconnex): remove id-check-token when phone-validation step is enforced in client
-        id_check_token=id_check_token.value if id_check_token else None,
-        id_check_token_timestamp=id_check_token.expirationDate if id_check_token else None,
     )
 
     return response

--- a/src/pcapi/routes/native/v1/serialization/authentication.py
+++ b/src/pcapi/routes/native/v1/serialization/authentication.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Optional
 
 from pcapi.serialization.utils import to_camel
@@ -61,8 +60,6 @@ class ValidateEmailRequest(BaseModel):
 class ValidateEmailResponse(BaseModel):
     access_token: str
     refresh_token: str
-    id_check_token: Optional[str]
-    id_check_token_timestamp: Optional[datetime]
 
     class Config:
         alias_generator = to_camel


### PR DESCRIPTION
Ne plus créer de token id check lors de la validation de l'email afin de n'avoir plus qu'un seul moyen de créer des tokens id check : lors d'un appel à `GET /id_check_token`. Ceci permet de ne pas consommer inutilement une tentative à l'utilisateur s'il ne bascule pas immédiatement sur le parcours id check.