### PR TITLE
(PC-8960) unique validated phone number

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -31,7 +31,7 @@ from pcapi.core.users.models import Token
 from pcapi.core.users.models import TokenType
 from pcapi.core.users.models import User
 from pcapi.core.users.models import VOID_PUBLIC_NAME
-from pcapi.core.users.repository import does_phone_exists
+from pcapi.core.users.repository import does_validated_phone_exists
 from pcapi.core.users.repository import get_beneficiary_import_for_beneficiary
 from pcapi.core.users.utils import decode_jwt_token
 from pcapi.core.users.utils import encode_jwt_payload
@@ -560,7 +560,7 @@ def change_user_phone_number(user: User, phone_number: str):
     if not formatted_phone_number:
         raise exceptions.InvalidPhoneNumber(phone_number)
 
-    if does_phone_exists(formatted_phone_number):
+    if does_validated_phone_exists(formatted_phone_number):
         raise exceptions.PhoneAlreadyExists()
 
     user.phoneNumber = formatted_phone_number

--- a/src/pcapi/core/users/models.py
+++ b/src/pcapi/core/users/models.py
@@ -24,6 +24,7 @@ from sqlalchemy import UniqueConstraint
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.dialects.postgresql.json import JSONB
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import joinedload
@@ -355,9 +356,13 @@ class User(PcObject, Model, NeedsValidationMixin):
             return None
         return eligibility_stop
 
-    @property
+    @hybrid_property
     def is_phone_validated(self):
         return self.phoneValidationStatus == PhoneValidationStatusType.VALIDATED
+
+    @is_phone_validated.expression
+    def is_phone_validated(cls):  # pylint: disable=no-self-argument
+        return cls.phoneValidationStatus == PhoneValidationStatusType.VALIDATED
 
     def get_notification_subscriptions(self) -> NotificationSubscriptions:
         return NotificationSubscriptions(**self.notificationSubscriptions or {})

--- a/src/pcapi/core/users/repository.py
+++ b/src/pcapi/core/users/repository.py
@@ -153,5 +153,5 @@ def get_beneficiary_import_for_beneficiary(user: User) -> Optional[BeneficiaryIm
     )
 
 
-def does_validated_phone_exists(phone_number: str):
+def does_validated_phone_exist(phone_number: str):
     return bool(User.query.filter(User.phoneNumber == phone_number, User.is_phone_validated).count())

--- a/src/pcapi/core/users/repository.py
+++ b/src/pcapi/core/users/repository.py
@@ -153,5 +153,5 @@ def get_beneficiary_import_for_beneficiary(user: User) -> Optional[BeneficiaryIm
     )
 
 
-def does_phone_exists(phone_number: str):
-    return bool(User.query.filter(User.phoneNumber == phone_number).count())
+def does_validated_phone_exists(phone_number: str):
+    return bool(User.query.filter(User.phoneNumber == phone_number, User.is_phone_validated).count())

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -1063,6 +1063,29 @@ class ValidatePhoneNumberTest:
         assert not User.query.get(user.id).is_phone_validated
         assert Token.query.filter_by(userId=user.id, type=TokenType.PHONE_VALIDATION).first()
 
+    def test_validate_phone_number_with_already_validated_phone(self, app):
+        users_factories.UserFactory(
+            isBeneficiary=False, phoneValidationStatus=PhoneValidationStatusType.VALIDATED, phoneNumber="+33607080900"
+        )
+        user = users_factories.UserFactory(isBeneficiary=False, phoneNumber="+33607080900")
+        access_token = create_access_token(identity=user.email)
+        token = create_phone_validation_token(user)
+
+        test_client = TestClient(app.test_client())
+        test_client.auth_header = {"Authorization": f"Bearer {access_token}"}
+
+        # try one attempt with wrong code
+        response = test_client.post("/native/v1/validate_phone_number", {"code": token.value})
+
+        assert response.status_code == 400
+        user = User.query.get(user.id)
+        assert not user.is_phone_validated
+
+        token = Token.query.filter_by(userId=user.id, type=TokenType.PHONE_VALIDATION).first()
+        assert not token
+
+        assert int(app.redis_client.get(f"phone_validation_attempts_user_{user.id}")) == 1
+
 
 def test_suspend_account(app):
     booking = BookingFactory()

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -822,8 +822,28 @@ class SendPhoneValidationCodeTest:
         db.session.refresh(user)
         assert user.phoneNumber == "+33102030405"
 
-    def test_send_phone_validation_code_for_new_duplicated_phone_number(self, app):
+    def test_send_phone_validation_code_for_new_unvalidated_duplicated_phone_number(self, app):
         users_factories.UserFactory(isEmailValidated=True, isBeneficiary=False, phoneNumber="+33102030405")
+        user = users_factories.UserFactory(isEmailValidated=True, isBeneficiary=False, phoneNumber="+33601020304")
+        access_token = create_access_token(identity=user.email)
+
+        test_client = TestClient(app.test_client())
+        test_client.auth_header = {"Authorization": f"Bearer {access_token}"}
+
+        response = test_client.post("/native/v1/send_phone_validation_code", json={"phoneNumber": "+33102030405"})
+
+        assert response.status_code == 204
+
+        db.session.refresh(user)
+        assert user.phoneNumber == "+33102030405"
+
+    def test_send_phone_validation_code_for_new_validated_duplicated_phone_number(self, app):
+        users_factories.UserFactory(
+            isEmailValidated=True,
+            phoneValidationStatus=PhoneValidationStatusType.VALIDATED,
+            isBeneficiary=False,
+            phoneNumber="+33102030405",
+        )
         user = users_factories.UserFactory(isEmailValidated=True, isBeneficiary=False, phoneNumber="+33601020304")
         access_token = create_access_token(identity=user.email)
 


### PR DESCRIPTION
- Allow duplicated phone number if they are not validated
In order not to forbid a user to set its phone number if someone
else also entered it, we will restrict the phone number uniqueness
if the phone number is validated.

- don't validate an already validated phone number 
Do not allow a user to validate a phone number that is already validated.
This may happen if several users used the same unvalidated number and start validating it.