### PR TITLE
(FIX) : reorder migration after v137.0.2

### DIFF
--- a/src/pcapi/alembic/versions/20210526_3605366e5ded_add_validation_date_to_offer.py
+++ b/src/pcapi/alembic/versions/20210526_3605366e5ded_add_validation_date_to_offer.py
@@ -1,7 +1,7 @@
 """add_validation_date_to_offer
 
 Revision ID: 3605366e5ded
-Revises: e8199ef92975
+Revises: 8bdc4dd58856
 Create Date: 2021-05-26 09:30:13.290019
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "3605366e5ded"
-down_revision = "e8199ef92975"
+down_revision = "8bdc4dd58856"
 branch_labels = None
 depends_on = None
 

--- a/src/pcapi/alembic/versions/20210531_8bdc4dd58856_feature_enable_native_id_check_verbose_debugging.py
+++ b/src/pcapi/alembic/versions/20210531_8bdc4dd58856_feature_enable_native_id_check_verbose_debugging.py
@@ -1,7 +1,7 @@
 """Add ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING feature flag
 
 Revision ID: 8bdc4dd58856
-Revises: 5bca073597c4
+Revises: e8199ef92975
 Create Date: 2021-05-31 09:54:01.457723
 
 """
@@ -10,7 +10,7 @@ from pcapi.models import feature
 
 # revision identifiers, used by Alembic.
 revision = "8bdc4dd58856"
-down_revision = "5bca073597c4"
+down_revision = "e8199ef92975"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Since we added a new migration in v137.0.2 (8bdc4dd58856) and
it was added in master after migrations that were not part of
v137.0.2, we need to reorder them to get them applied in the
upcoming version.

`alembic history` diff (v137.0.2 on the left, master on the right) after the PR:
```
							      >	77d29ab6c382 -> 5bca073597c4, add_feature_flipping_for_bookin
							      >	3605366e5ded -> 77d29ab6c382, add_index_for_last_validation_d
							      >	8bdc4dd58856 -> 3605366e5ded, add_validation_date_to_offer
e8199ef92975 -> 8bdc4dd58856, Add ENABLE_NATIVE_ID_CHECK_VERB	e8199ef92975 -> 8bdc4dd58856, Add ENABLE_NATIVE_ID_CHECK_VERB
20290f0b5d4f -> e8199ef92975, migrate_id_at_provider_part_2	20290f0b5d4f -> e8199ef92975, migrate_id_at_provider_part_2
9908a2709641 -> 20290f0b5d4f, migrate_id_at_provider_part_1	9908a2709641 -> 20290f0b5d4f, migrate_id_at_provider_part_1
8bdc4df58856 -> 9908a2709641, add_idx_offer_validation		8bdc4df58856 -> 9908a2709641, add_idx_offer_validation
ae87394773a0 -> 8bdc4df58856, Add ENABLE_NEW_VENUE_PAGES feat	ae87394773a0 -> 8bdc4df58856, Add ENABLE_NEW_VENUE_PAGES feat
e63d336e9da8 -> ae87394773a0, remove_WEBAPP_PROFILE_PAGE_feat	e63d336e9da8 -> ae87394773a0, remove_WEBAPP_PROFILE_PAGE_feat
e7a7fdd9c4e1 -> e63d336e9da8, populate_provider_prices_in_cen	e7a7fdd9c4e1 -> e63d336e9da8, populate_provider_prices_in_cen
40afbb732e70 -> e7a7fdd9c4e1, Add `Provider.pricesInCents`	40afbb732e70 -> e7a7fdd9c4e1, Add `Provider.pricesInCents`
97553c40978d -> 40afbb732e70, Remove activity-related _trigge	97553c40978d -> 40afbb732e70, Remove activity-related _trigge
963e6e163cf0 -> 97553c40978d, drop_if_exists_User_canBookFree	963e6e163cf0 -> 97553c40978d, drop_if_exists_User_canBookFree
2c062a40154e -> 963e6e163cf0, add feature flag DISPLAY_DMS_RE	2c062a40154e -> 963e6e163cf0, add feature flag DISPLAY_DMS_RE
865dbe4bec27 -> 2c062a40154e, add_author_to_offer		865dbe4bec27 -> 2c062a40154e, add_author_to_offer
0fe847be8089 -> 865dbe4bec27, add_feature_flag			0fe847be8089 -> 865dbe4bec27, add_feature_flag
6999a11484ba -> 0fe847be8089, feature enable idcheck fraud co	6999a11484ba -> 0fe847be8089, feature enable idcheck fraud co
5d6f3407546c -> 6999a11484ba, has_completed_id_check		5d6f3407546c -> 6999a11484ba, has_completed_id_check
c83abec806af -> 5d6f3407546c, add_is_used_to_token		c83abec806af -> 5d6f3407546c, add_is_used_to_token
e442fb5ac4e6 -> c83abec806af, Add offer.rankingWeight column	e442fb5ac4e6 -> c83abec806af, Add offer.rankingWeight column
8824ce692699 -> e442fb5ac4e6, feature_disable_booking_recap	8824ce692699 -> e442fb5ac4e6, feature_disable_booking_recap
58df8264fe50 -> 8824ce692699, booking.displayAsEnded		58df8264fe50 -> 8824ce692699, booking.displayAsEnded
c2e2425fbac6 -> 58df8264fe50, Enable native id check version	c2e2425fbac6 -> 58df8264fe50, Enable native id check version
```