### PR TITLE
(PC-9147) jouve: add birthLocationCtrl as fraud detection method

### DIFF
--- a/src/pcapi/connectors/beneficiaries/jouve_backend.py
+++ b/src/pcapi/connectors/beneficiaries/jouve_backend.py
@@ -133,10 +133,10 @@ def get_fraud_fields(content: dict) -> dict:
         "strict_controls": [
             get_boolean_fraud_detection_item(content, "posteCodeCtrl"),
             get_boolean_fraud_detection_item(content, "serviceCodeCtrl"),
+            get_boolean_fraud_detection_item(content, "birthLocationCtrl"),
         ],
         "non_blocking_controls": [
             get_threshold_fraud_detection_item(content, "bodyBirthDateLevel", 100),
-            get_boolean_fraud_detection_item(content, "birthLocationCtrl"),
             get_threshold_fraud_detection_item(content, "bodyNameLevel", 50),
             get_boolean_fraud_detection_item(content, "bodyBirthDateCtrl"),
             get_boolean_fraud_detection_item(content, "bodyFirstNameCtrl"),

--- a/tests/use_cases/create_beneficiary_from_application_test.py
+++ b/tests/use_cases/create_beneficiary_from_application_test.py
@@ -57,9 +57,8 @@ class FakeBeneficiaryJouveBackend:
 @override_features(FORCE_PHONE_VALIDATION=False)
 @patch("pcapi.use_cases.create_beneficiary_from_application.send_activation_email")
 @patch("pcapi.domain.password.random_token")
-@patch(
-    "pcapi.settings.JOUVE_APPLICATION_BACKEND",
-    "tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
+@override_settings(
+    JOUVE_APPLICATION_BACKEND="tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
 )
 @freeze_time("2013-05-15 09:00:00")
 @pytest.mark.usefixtures("db_session")
@@ -124,9 +123,8 @@ def test_saved_a_beneficiary_from_application(stubed_random_token, mocked_send_a
 
 @override_features(FORCE_PHONE_VALIDATION=False)
 @patch("pcapi.use_cases.create_beneficiary_from_application.send_accepted_as_beneficiary_email")
-@patch(
-    "pcapi.settings.JOUVE_APPLICATION_BACKEND",
-    "tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
+@override_settings(
+    JOUVE_APPLICATION_BACKEND="tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
 )
 @freeze_time("2013-05-15 09:00:00")
 @pytest.mark.usefixtures("db_session")
@@ -184,9 +182,8 @@ def test_application_for_native_app_user(mocked_send_accepted_as_beneficiary_ema
 
 
 @override_features(FORCE_PHONE_VALIDATION=False)
-@patch(
-    "pcapi.settings.JOUVE_APPLICATION_BACKEND",
-    "tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
+@override_settings(
+    JOUVE_APPLICATION_BACKEND="tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
 )
 @pytest.mark.usefixtures("db_session")
 def test_cannot_save_beneficiary_if_email_is_already_taken(app):
@@ -212,9 +209,8 @@ def test_cannot_save_beneficiary_if_email_is_already_taken(app):
     assert push_testing.requests == []
 
 
-@patch(
-    "pcapi.settings.JOUVE_APPLICATION_BACKEND",
-    "tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
+@override_settings(
+    JOUVE_APPLICATION_BACKEND="tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
 )
 @pytest.mark.usefixtures("db_session")
 def test_cannot_save_beneficiary_if_duplicate(app):
@@ -293,9 +289,8 @@ def test_cannot_save_beneficiary_if_department_is_not_eligible(app):
 
 @patch("pcapi.use_cases.create_beneficiary_from_application.validate")
 @patch("pcapi.use_cases.create_beneficiary_from_application.send_rejection_email_to_beneficiary_pre_subscription")
-@patch(
-    "pcapi.settings.JOUVE_APPLICATION_BACKEND",
-    "tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
+@override_settings(
+    JOUVE_APPLICATION_BACKEND="tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
 )
 @pytest.mark.usefixtures("db_session")
 def test_calls_send_rejection_mail_with_validation_error(

--- a/tests/use_cases/create_beneficiary_from_application_test.py
+++ b/tests/use_cases/create_beneficiary_from_application_test.py
@@ -344,25 +344,32 @@ BASE_JOUVE_CONTENT = {
 }
 
 
+@pytest.mark.parametrize(
+    "fraud_strict_detection_parameter",
+    [{"serviceCodeCtrl": "KO"}, {"posteCodeCtrl": "KO"}, {"birthLocationCtrl": "KO"}],
+)
 @patch("pcapi.connectors.beneficiaries.jouve_backend.BeneficiaryJouveBackend._get_application_content")
 @pytest.mark.usefixtures("db_session")
 def test_cannot_save_beneficiary_when_fraud_is_detected(
     mocked_get_content,
+    fraud_strict_detection_parameter,
     app,
 ):
     # Given
     mocked_get_content.return_value = BASE_JOUVE_CONTENT | {
-        "posteCodeCtrl": "KO",
         "bodyNameLevel": 30,
     }
+    # updates mocked return value from parametrized test
+    mocked_get_content.return_value.update(fraud_strict_detection_parameter)
 
     # When
     create_beneficiary_from_application.execute(BASE_APPLICATION_ID)
 
     # Then
+    fraud_strict_detection_cause = list(fraud_strict_detection_parameter.keys())[0]
     beneficiary_import = BeneficiaryImport.query.one()
     assert beneficiary_import.currentStatus == ImportStatus.REJECTED
-    assert beneficiary_import.detail == "Fraud controls triggered: posteCodeCtrl, bodyNameLevel"
+    assert beneficiary_import.detail == f"Fraud controls triggered: {fraud_strict_detection_cause}, bodyNameLevel"
 
     assert len(mails_testing.outbox) == 0
 


### PR DESCRIPTION

Use a pytest parametrize to test the whole strict fraud detection checks