### PR TITLE
(PC-7143) fix ValidationView access

### DIFF
--- a/src/pcapi/admin/custom_views/offer_view.py
+++ b/src/pcapi/admin/custom_views/offer_view.py
@@ -259,6 +259,9 @@ class ValidationView(BaseAdminView):
     column_default_sort = ("id", True)
     page_size = 100
 
+    def is_accessible(self):
+        return super().is_accessible() and self.check_super_admins()
+
     @property
     def column_formatters(self):
         formatters = super().column_formatters

--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -671,7 +671,7 @@ def set_offer_status_based_on_fraud_criteria(offer: Offer) -> OfferValidationSta
 def update_pending_offer_validation(offer: Offer, validation_status: OfferValidationStatus) -> bool:
     offer = offer_queries.get_offer_by_id(offer.id)
     if offer.validation != OfferValidationStatus.PENDING:
-        logger.exception(
+        logger.info(
             "Offer validation status cannot be updated, initial validation status is not PENDING. %s",
             extra={"offer": offer.id},
         )

--- a/tests/admin/custom_views/offer_view_test.py
+++ b/tests/admin/custom_views/offer_view_test.py
@@ -401,6 +401,25 @@ class OfferValidationViewTest:
         assert offer.isActive is False
         assert offer.lastValidationDate == datetime.datetime(2020, 11, 17, 15)
 
+    @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES="super_admin@example.com")
+    def test_access_to_validation_page_with_super_admin_user_on_prod_env(self, app):
+        users_factories.UserFactory(email="super_admin@example.com", isAdmin=True)
+        client = TestClient(app.test_client()).with_auth("super_admin@example.com")
+
+        response = client.get("/pc/back-office/validation/")
+
+        assert response.status_code == 200
+
+    @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES="super_admin@example.com")
+    def test_access_to_validation_page_with_none_super_admin_user_on_prod_env(self, app):
+        users_factories.UserFactory(email="simple_admin@example.com", isAdmin=True)
+        client = TestClient(app.test_client()).with_auth("simple_admin@example.com")
+
+        response = client.get("/pc/back-office/validation/")
+
+        assert response.status_code == 302
+        assert response.headers["location"] == "http://localhost/pc/back-office/"
+
 
 class GetOfferValidationViewTest:
     @clean_database


### PR DESCRIPTION
##  Objectif

Limiter l'accès à la vue admin de validation des offres aux utilisateur _super admin_

##  Implémentation

- ajout de `is_accessible()` à la `ValidationView`

##  Informations supplémentaires

En bonus, une correction de niveau de log dont le relecteur pardonnera l'ajout cavalier.