### PR TITLE
(PC-8283) add admin views for OfferCategoryGroup and OfferCategory

### DIFF
--- a/src/pcapi/admin/custom_views/offer_category_view.py
+++ b/src/pcapi/admin/custom_views/offer_category_view.py
@@ -1,0 +1,65 @@
+from pcapi.admin.base_configuration import BaseAdminView
+
+
+class OfferCategoryView(BaseAdminView):
+    list_template = "admin/offer_categories_list.html"
+    can_create = True
+    can_edit = True
+    can_delete = False
+    column_list = ["name", "proLabel", "appLabel"]
+    column_sortable_list = None
+    column_filters = ["name", "proLabel", "appLabel"]
+    column_default_sort = ("name", True)
+    column_labels = {
+        "name": "Nom",
+        "isActive": "Visible",
+        "proLabel": "Nom affiché sur le portail pro",
+        "appLabel": "Nom affiché sur l'app",
+    }
+    form_excluded_columns = ["subcategories"]
+
+    def is_accessible(self):
+        return super().is_accessible() and self.check_super_admins()
+
+
+class OfferSubcategoryView(BaseAdminView):
+    list_template = "admin/offer_subcategories_list.html"
+    can_create = True
+    can_edit = True
+    can_delete = False
+    column_list = ["name", "category.name", "proLabel", "appLabel"]
+    column_sortable_list = ["name", "category.name", "proLabel", "appLabel"]
+    column_filters = ["name", "category.name", "proLabel", "appLabel", "isActive"]
+    column_default_sort = ("name", True)
+    column_labels = {
+        "name": "Nom",
+        "isActive": "Visible",
+        "proLabel": "Nom affiché sur le portail pro",
+        "appLabel": "Nom affiché sur l'app",
+        "category.name": "Catégorie",
+        "category": "Catégorie",
+        "isEvent": "Evénement",
+        "canBeDuo": "Offre duo",
+        "canExpire": "Avec date limite de retrait",
+        "isDigital": "Offre numérique",
+        "isDigitalDeposit": "Plafond numérique",
+        "isPhysicalDeposit": "Plafond physique",
+        "conditionalFields": "Champs additionnels",
+    }
+    form_columns = [
+        "name",
+        "isActive",
+        "category",
+        "proLabel",
+        "appLabel",
+        "isEvent",
+        "canBeDuo",
+        "canExpire",
+        "isDigital",
+        "isDigitalDeposit",
+        "isPhysicalDeposit",
+        "conditionalFields",
+    ]
+
+    def is_accessible(self):
+        return super().is_accessible() and self.check_super_admins()

--- a/src/pcapi/admin/install.py
+++ b/src/pcapi/admin/install.py
@@ -14,6 +14,8 @@ from pcapi.admin.custom_views.booking_view import BookingView
 from pcapi.admin.custom_views.criteria_view import CriteriaView
 from pcapi.admin.custom_views.feature_view import FeatureView
 from pcapi.admin.custom_views.many_offers_operations_view import ManyOffersOperationsView
+from pcapi.admin.custom_views.offer_category_view import OfferCategoryView
+from pcapi.admin.custom_views.offer_category_view import OfferSubcategoryView
 from pcapi.admin.custom_views.offerer_view import OffererView
 from pcapi.admin.custom_views.partner_user_view import PartnerUserView
 from pcapi.admin.custom_views.pro_user_view import ProUserView
@@ -145,6 +147,26 @@ def install_admin_views(admin: Admin, session: Session) -> None:
         SuspendFraudulentUsersView(
             name="Suspension d'utilisateurs via noms de domaine",
             endpoint="/suspend_fraud_users",
+            category=Category.CUSTOM_OPERATIONS,
+        )
+    )
+
+    admin.add_view(
+        OfferCategoryView(
+            models.OfferCategory,
+            session,
+            name="Catégories d'offres",
+            endpoint="/offer_categoriess",
+            category=Category.CUSTOM_OPERATIONS,
+        )
+    )
+
+    admin.add_view(
+        OfferSubcategoryView(
+            models.OfferSubcategory,
+            session,
+            name="Sous-catégories d'offres",
+            endpoint="/offer_subcategories",
             category=Category.CUSTOM_OPERATIONS,
         )
     )

--- a/src/pcapi/admin/install.py
+++ b/src/pcapi/admin/install.py
@@ -3,6 +3,8 @@ from enum import Enum
 from flask_admin.base import Admin
 from sqlalchemy.orm.session import Session
 
+from pcapi import models
+from pcapi.admin.custom_views import offer_view
 from pcapi.admin.custom_views.admin_user_view import AdminUserView
 from pcapi.admin.custom_views.allocine_pivot_view import AllocinePivotView
 from pcapi.admin.custom_views.api_key_view import ApiKeyView
@@ -12,10 +14,6 @@ from pcapi.admin.custom_views.booking_view import BookingView
 from pcapi.admin.custom_views.criteria_view import CriteriaView
 from pcapi.admin.custom_views.feature_view import FeatureView
 from pcapi.admin.custom_views.many_offers_operations_view import ManyOffersOperationsView
-from pcapi.admin.custom_views.offer_view import ImportConfigValidationOfferView
-from pcapi.admin.custom_views.offer_view import OfferForVenueSubview
-from pcapi.admin.custom_views.offer_view import OfferView
-from pcapi.admin.custom_views.offer_view import ValidationView
 from pcapi.admin.custom_views.offerer_view import OffererView
 from pcapi.admin.custom_views.partner_user_view import PartnerUserView
 from pcapi.admin.custom_views.pro_user_view import ProUserView
@@ -27,14 +25,6 @@ from pcapi.core.offerers.models import Offerer
 from pcapi.core.offers.models import OfferValidationConfig
 from pcapi.core.providers.models import VenueProvider
 from pcapi.core.users.models import User
-from pcapi.models import AllocinePivot
-from pcapi.models import ApiKey
-from pcapi.models import BeneficiaryImport
-from pcapi.models import Criterion
-from pcapi.models import Feature
-from pcapi.models import Offer
-from pcapi.models import UserOfferer
-from pcapi.models import Venue
 
 
 class Category(Enum):
@@ -47,21 +37,25 @@ class Category(Enum):
 
 
 def install_admin_views(admin: Admin, session: Session) -> None:
-    admin.add_view(OfferView(Offer, session, name="Offres", category=Category.OFFRES_STRUCTURES_LIEUX))
     admin.add_view(
-        OfferForVenueSubview(
-            Offer,
+        offer_view.OfferView(models.Offer, session, name="Offres", category=Category.OFFRES_STRUCTURES_LIEUX)
+    )
+    admin.add_view(
+        offer_view.OfferForVenueSubview(
+            models.Offer,
             session,
             name="Offres pour un lieu",
             endpoint="offer_for_venue",
         )
     )
-    admin.add_view(CriteriaView(Criterion, session, name="Tags des offres", category=Category.OFFRES_STRUCTURES_LIEUX))
+    admin.add_view(
+        CriteriaView(models.Criterion, session, name="Tags des offres", category=Category.OFFRES_STRUCTURES_LIEUX)
+    )
     admin.add_view(OffererView(Offerer, session, name="Structures", category=Category.OFFRES_STRUCTURES_LIEUX))
-    admin.add_view(VenueView(Venue, session, name="Lieux", category=Category.OFFRES_STRUCTURES_LIEUX))
+    admin.add_view(VenueView(models.Venue, session, name="Lieux", category=Category.OFFRES_STRUCTURES_LIEUX))
     admin.add_view(
         UserOffererView(
-            UserOfferer, session, name="Lien Utilisateurs/Structures", category=Category.OFFRES_STRUCTURES_LIEUX
+            models.UserOfferer, session, name="Lien Utilisateurs/Structures", category=Category.OFFRES_STRUCTURES_LIEUX
         )
     )
     admin.add_view(
@@ -103,11 +97,15 @@ def install_admin_views(admin: Admin, session: Session) -> None:
     admin.add_view(
         PartnerUserView(User, session, name="Comptes Partenaires", category=Category.USERS, endpoint="/partner_users")
     )
-    admin.add_view(FeatureView(Feature, session, name="Feature Flipping", category=None))
-    admin.add_view(BeneficiaryImportView(BeneficiaryImport, session, name="Imports DMS", category=Category.USERS))
-    admin.add_view(ApiKeyView(ApiKey, session, name="Clés API", category=Category.USERS))
+    admin.add_view(FeatureView(models.Feature, session, name="Feature Flipping", category=None))
     admin.add_view(
-        AllocinePivotView(AllocinePivot, session, name="Pivot Allocine", category=Category.OFFRES_STRUCTURES_LIEUX)
+        BeneficiaryImportView(models.BeneficiaryImport, session, name="Imports DMS", category=Category.USERS)
+    )
+    admin.add_view(ApiKeyView(models.ApiKey, session, name="Clés API", category=Category.USERS))
+    admin.add_view(
+        AllocinePivotView(
+            models.AllocinePivot, session, name="Pivot Allocine", category=Category.OFFRES_STRUCTURES_LIEUX
+        )
     )
     admin.add_view(
         ManyOffersOperationsView(
@@ -124,8 +122,8 @@ def install_admin_views(admin: Admin, session: Session) -> None:
         )
     )
     admin.add_view(
-        ValidationView(
-            Offer,
+        offer_view.ValidationView(
+            models.Offer,
             session,
             name="Validation",
             endpoint="/validation",
@@ -134,7 +132,7 @@ def install_admin_views(admin: Admin, session: Session) -> None:
     )
 
     admin.add_view(
-        ImportConfigValidationOfferView(
+        offer_view.ImportConfigValidationOfferView(
             OfferValidationConfig,
             session,
             name="Configuration des règles de fraude",

--- a/src/pcapi/templates/admin/offer_categories_list.html
+++ b/src/pcapi/templates/admin/offer_categories_list.html
@@ -1,0 +1,6 @@
+{% extends 'admin/model/list.html' %}
+
+{% block body %}
+    <h2>Catégories d'offres</h2>
+    {{ super() }}
+{% endblock %}

--- a/src/pcapi/templates/admin/offer_subcategories_list.html
+++ b/src/pcapi/templates/admin/offer_subcategories_list.html
@@ -1,0 +1,6 @@
+{% extends 'admin/model/list.html' %}
+
+{% block body %}
+    <h2>Sous-catégories d'offres</h2>
+    {{ super() }}
+{% endblock %}


### PR DESCRIPTION
##  Objectif

Ajouter des vues _FlaskAdmin_ pour `OfferCategoryGroup` et `OfferCategory`


##  Informations supplémentaires

Un réarrangement des imports de `src/pcapi/admin/install.py` a été fait au passage, afin d'éviter les imports de nombreuses classes du même module.
Cette PR devra être fusionnée APRES https://github.com/pass-culture/pass-culture-api/pull/2601 (renommage de modèles)

Un grand dilemme m'a saisi: `subcategory` ou `sub-category` ? Si l'orthographe avec trait d'union (_hyphenated_) est souvent acceptée en anglais UK ou CA, elle est en revanche déconseillée en anglais US. J'ai donc choisi de conserver l'orthographe sans trait d'union, qui fait l'économie de bosses de chameau au passage.