### PR TITLE
(PC-5091): Validate isbn on LIVRE_EDITION offer creation and associate it to existing product

### DIFF
--- a/src/pcapi/routes/serialization/offers_serialize.py
+++ b/src/pcapi/routes/serialization/offers_serialize.py
@@ -10,6 +10,7 @@ from pydantic import validator
 
 from pcapi.core.bookings.api import compute_confirmation_date
 from pcapi.core.offers.models import OfferStatus
+from pcapi.models import ThingType
 from pcapi.serialization.utils import cast_optional_field_str_to_int
 from pcapi.serialization.utils import dehumanize_field
 from pcapi.serialization.utils import dehumanize_list_field
@@ -17,6 +18,7 @@ from pcapi.serialization.utils import humanize_field
 from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import DateTimes
 from pcapi.utils.date import format_into_utc_date
+from pcapi.validation.routes.offers import check_offer_isbn_is_valid
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
 from pcapi.validation.routes.offers import check_offer_type_is_valid
 
@@ -61,6 +63,12 @@ class PostOfferBodyModel(BaseModel):
         if not values["product_id"]:
             check_offer_type_is_valid(type_field)
         return type_field
+
+    @validator("extra_data", pre=True)
+    def validate_isbn(cls, extra_data_field, values):  # pylint: disable=no-self-argument
+        if not values["product_id"] and values["type"] == str(ThingType.LIVRE_EDITION):
+            check_offer_isbn_is_valid(extra_data_field["isbn"])
+        return extra_data_field
 
     class Config:
         alias_generator = to_camel

--- a/src/pcapi/validation/routes/offers.py
+++ b/src/pcapi/validation/routes/offers.py
@@ -24,3 +24,11 @@ def check_offer_id_is_present_in_request(offer_id: str):
         errors.add_error("global", "Le paramètre offerId est obligatoire")
         errors.maybe_raise()
         raise errors
+
+
+def check_offer_isbn_is_valid(isbn: str):
+    isbn_length = 13
+    if not (isbn and isbn.isnumeric() and len(isbn) == isbn_length):
+        api_errors = ApiErrors()
+        api_errors.add_error("isbn", "Format d’ISBN incorrect. Exemple de format correct : 9782020427852")
+        raise api_errors

--- a/tests/validation/routes/offers_test.py
+++ b/tests/validation/routes/offers_test.py
@@ -3,6 +3,7 @@ import pytest
 from pcapi.models import ApiErrors
 from pcapi.models import EventType
 from pcapi.models import ThingType
+from pcapi.validation.routes.offers import check_offer_isbn_is_valid
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
 from pcapi.validation.routes.offers import check_offer_type_is_valid
 
@@ -43,3 +44,34 @@ class CheckOfferNameIsValidTest:
 
         # The the following should not raise
         check_offer_name_length_is_valid(offer_title_less_than_90_characters)
+
+
+class CheckOfferIsbnIsValidTest:
+    def test_raises_api_error_when_offer_isbn_is_too_long(self):
+        isbn_too_long = "123456789123456789"
+
+        with pytest.raises(ApiErrors) as error:
+            check_offer_isbn_is_valid(isbn_too_long)
+
+        assert error.value.errors["isbn"] == ["Format d’ISBN incorrect. Exemple de format correct : 9782020427852"]
+
+    def test_raises_api_error_when_offer_isbn_is_too_short(self):
+        isbn_too_short = "123"
+
+        with pytest.raises(ApiErrors) as error:
+            check_offer_isbn_is_valid(isbn_too_short)
+
+        assert error.value.errors["isbn"] == ["Format d’ISBN incorrect. Exemple de format correct : 9782020427852"]
+
+    def test_raises_api_error_when_offer_isbn_is_with_alphabets(self):
+        isbn_with_alphabets = "12ab45cd67ef8"
+
+        with pytest.raises(ApiErrors) as error:
+            check_offer_isbn_is_valid(isbn_with_alphabets)
+
+        assert error.value.errors["isbn"] == ["Format d’ISBN incorrect. Exemple de format correct : 9782020427852"]
+
+    def test_raises_api_with_valid_isbn(self):
+        valid_isbn = "9782221247884"
+
+        check_offer_isbn_is_valid(valid_isbn)


### PR DESCRIPTION
# Objectif
Importer les informations d'un livre depuis un ISBN13 lors de la création d'offre.
Avoir qu'un seul `product` pour un isbn.

# Implémentation
Validation du champs `isbn` qui devient obligatoire pour la création d'offre de type LIVRE_EDITION.
Vérification si le livre est éligible au pass Culture.
Création de l'offre.

PR [front](https://github.com/pass-culture/pass-culture-pro/pull/1338) 