### PR TITLE
(PC-9250) providers: Stop using Provider.requireProviderIdentifier

### DIFF
--- a/src/pcapi/alembic/versions/20210604_25468af34cb8_make_require_provider_identifier.py
+++ b/src/pcapi/alembic/versions/20210604_25468af34cb8_make_require_provider_identifier.py
@@ -1,0 +1,36 @@
+"""make_require_provider_identifier_nullable
+
+Revision ID: 25468af34cb8
+Revises: e85a73abc5a7
+Create Date: 2021-06-04 18:05:43.310800
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "25468af34cb8"
+down_revision = "e85a73abc5a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "provider",
+        "requireProviderIdentifier",
+        existing_type=sa.BOOLEAN(),
+        nullable=True,
+        existing_server_default=sa.text("true"),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "provider",
+        "requireProviderIdentifier",
+        existing_type=sa.BOOLEAN(),
+        nullable=False,
+        existing_server_default=sa.text("true"),
+    )

--- a/src/pcapi/core/providers/models.py
+++ b/src/pcapi/core/providers/models.py
@@ -50,7 +50,9 @@ class Provider(PcObject, Model, DeactivableMixin):
 
     enabledForPro = Column(Boolean, nullable=False, default=False, server_default=expression.false())
 
-    requireProviderIdentifier = Column(Boolean, nullable=False, default=True, server_default=expression.true())
+    # FIXME (dbaty, 2021-06-04): remove this field once v139 has been
+    # deployed on prod.
+    requireProviderIdentifier = Column(Boolean, nullable=True, default=True, server_default=expression.true())
 
     pricesInCents = Column(Boolean, nullable=False, default=False, server_default=expression.false())
 

--- a/src/pcapi/model_creators/generic_creators.py
+++ b/src/pcapi/model_creators/generic_creators.py
@@ -352,7 +352,6 @@ def create_provider(
     provider.isActive = is_active
     provider.localClass = local_class
     provider.name = name
-    provider.requireProviderIdentifier = require_provider_identifier
 
     return provider
 

--- a/src/pcapi/routes/pro/providers.py
+++ b/src/pcapi/routes/pro/providers.py
@@ -28,5 +28,6 @@ def get_providers_by_venue(venue_id: str):
         del provider_dict["apiUrl"]
         del provider_dict["authToken"]
         del provider_dict["pricesInCents"]
+        del provider_dict["requireProviderIdentifier"]
         result.append(provider_dict)
     return jsonify(result)

--- a/src/pcapi/routes/serialization/offers_serialize.py
+++ b/src/pcapi/routes/serialization/offers_serialize.py
@@ -377,7 +377,6 @@ class GetOfferLastProviderResponseModel(BaseModel):
     isActive: bool
     localClass: Optional[str]
     name: str
-    requireProviderIdentifier: bool
 
     _humanize_id = humanize_field("id")
 

--- a/src/pcapi/routes/serialization/venue_provider_serialize.py
+++ b/src/pcapi/routes/serialization/venue_provider_serialize.py
@@ -23,7 +23,6 @@ class ProviderResponse(BaseModel):
     name: str
     enabledForPro: bool
     id: str
-    requireProviderIdentifier: str
     isActive: bool
     localClass: Optional[str]
 

--- a/tests/routes/pro/get_providers_by_venue_test.py
+++ b/tests/routes/pro/get_providers_by_venue_test.py
@@ -36,7 +36,6 @@ class Get:
                     "isActive": True,
                     "localClass": "AllocineStocks",
                     "name": "Allociné",
-                    "requireProviderIdentifier": True,
                 },
                 {
                     "enabledForPro": True,
@@ -44,7 +43,6 @@ class Get:
                     "isActive": True,
                     "localClass": "TiteLiveStocks",
                     "name": "TiteLive Stocks (Epagine / Place des libraires.com)",
-                    "requireProviderIdentifier": True,
                 },
             ]
 
@@ -72,7 +70,6 @@ class Get:
                     "isActive": True,
                     "localClass": "TiteLiveStocks",
                     "name": "TiteLive Stocks (Epagine / Place des libraires.com)",
-                    "requireProviderIdentifier": True,
                 }
             ]
 

--- a/tests/routes/pro/post_venue_provider_test.py
+++ b/tests/routes/pro/post_venue_provider_test.py
@@ -187,7 +187,6 @@ class Returns201:
             "isActive",
             "localClass",
             "name",
-            "requireProviderIdentifier",
         }
 
     @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
This field is not used by the pro portal anymore. Here we stop exporting it
and set it as nullable. Once this commit is deployed, we will finally
delete the column.

---

PR liée côté portail pro : pass-culture/pass-culture-pro/pull/1340