### PR TITLE
(PC-fix) set pylint and astroid versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ Il existe une ancienne api très incomplète et non utilisable (A décommissione
     
     Configurer le working directory par défaut pour être toujours à la racine de ce projet
     ![pycharm-test-config][pycharm-test-configuration]
-    
+
+## Dépendances
+
+- La combinaison pylint-astroid a parfois quelques soucis : elle est pour
+l'instant figée à 2.8.3 pour pylint et 2.5.6 pour astroid. Ceci pourra être
+modifié quand ces problèmes seront réglés côté pylint/astroid.
 
 ## Démarrage du serveur back api
 - Option 1 : Lancement du serveur back api depuis le script pc présent dans le dossier parent

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alembic==1.4.3
 algoliasearch==2.4.0
-# astroid is required by pylint and version 2.5.7 crashes
-astroid!=2.5.7
+# astroid is required by pylint and version 2.5.7 and 2.5.8 crashes
+astroid==2.5.6
 APScheduler==3.6.3
 Babel==2.8.0
 bcrypt==3.2.0
@@ -43,7 +43,7 @@ pgcli==2.2.0
 Pillow>=8.1.1
 pydantic[email]==1.7.3
 PyJWT==1.7.1
-pylint
+pylint==2.8.3
 pylint-strict-informational
 pytest-cov==2.10.1
 pytest-flask==1.0.0


### PR DESCRIPTION
Pylint 2.8.3 + astroid 2.5.8 :arrow_right: :boom: 

`AttributeError: 'ListComp' object has no attribute 'name'`

Ce n'est pas la première fois qu'on a ce type d'incompatibilité, autant être serein avec deux versions dont on sait qu'elles fonctionnent ensemble.