### PR TITLE
(PC-9264) : Save the ID piece number during DMS process

### DIFF
--- a/src/pcapi/domain/user_activation.py
+++ b/src/pcapi/domain/user_activation.py
@@ -30,6 +30,7 @@ def create_beneficiary_from_application(application_detail: dict, user: Optional
     beneficiary.activity = application_detail["activity"]
     beneficiary.isAdmin = False
     beneficiary.hasSeenTutorials = False
+    beneficiary.idPieceNumber = application_detail.get("id_piece_number")
 
     if not beneficiary.phoneNumber:
         beneficiary.phoneNumber = application_detail["phone"]

--- a/src/pcapi/scripts/beneficiary/remote_import.py
+++ b/src/pcapi/scripts/beneficiary/remote_import.py
@@ -155,6 +155,8 @@ def parse_beneficiary_information(application_detail: dict) -> dict:
             information["activity"] = value
         if label == "Quelle est votre adresse de résidence":
             information["address"] = value
+        if label == "Quel est le numéro de la pièce que vous venez de saisir ?":
+            information["id_piece_number"] = value
 
     return information
 

--- a/tests/scripts/beneficiary/fixture_dms_with_selfie.py
+++ b/tests/scripts/beneficiary/fixture_dms_with_selfie.py
@@ -86,6 +86,22 @@ APPLICATION_DETAIL_STANDARD_RESPONSE_AFTER_GENERALISATION = {
                 },
             },
             {
+                "type_de_champ": {
+                    "description": "Indiquez ici ton "
+                    "numéro de la pièce "
+                    "que vous avez "
+                    "envoyée "
+                    "(généralement "
+                    "située en haut à "
+                    "droite du recto)",
+                    "id": 1873743,
+                    "libelle": "Quel est le numéro de " "la pièce que vous venez " "de saisir ?",
+                    "order_place": None,
+                    "type_champ": "text",
+                },
+                "value": "123456789012",
+            },
+            {
                 "value": "0123456789",
                 "type_de_champ": {
                     "id": 582219,

--- a/tests/scripts/beneficiary/remote_import_test.py
+++ b/tests/scripts/beneficiary/remote_import_test.py
@@ -681,6 +681,10 @@ class RunIntegrationTest:
                         "value": "11 Rue du Test",
                     },
                     {"type_de_champ": {"libelle": "Veuillez indiquer votre statut"}, "value": "Etudiant"},
+                    {
+                        "type_de_champ": {"libelle": "Quel est le numéro de la pièce que vous venez de saisir ?"},
+                        "value": "121314",
+                    },
                 ],
             }
         }
@@ -810,6 +814,7 @@ class RunIntegrationTest:
         assert user.address == "11 Rue du Test"
         assert user.isBeneficiary
         assert user.phoneNumber == "0102030405"
+        assert user.idPieceNumber == "121314"
 
         assert BeneficiaryImport.query.count() == 1
         beneficiary_import = BeneficiaryImport.query.first()


### PR DESCRIPTION
The beneficiairy creation now saves the ID card number - or the
other piece that was used - along with the user if it is available.