### PR TITLE
(PC-9326) : Raise error on id_check_token if already beneficiary

### DIFF
--- a/src/pcapi/routes/native/v1/account.py
+++ b/src/pcapi/routes/native/v1/account.py
@@ -151,7 +151,7 @@ def resend_email_validation(body: serializers.ResendEmailValidationRequest) -> N
 @spectree_serialize(api=blueprint.api, response_model=serializers.GetIdCheckTokenResponse)
 @authenticated_user_required
 def get_id_check_token(user: User) -> serializers.GetIdCheckTokenResponse:
-    if not user.is_eligible:
+    if not user.is_eligible or user.isBeneficiary:
         raise ApiErrors({"code": "USER_NOT_ELIGIBLE"})
     try:
         id_check_token = api.create_id_check_token(user)


### PR DESCRIPTION
If - for some reasons - a user already beneficiary tries to call
/id_check_token, let's just return an error to tell the user that
he can't do that.