### PR TITLE
(PC-9333) : Returns gracefully if concurrent favorite creation

### DIFF
--- a/src/pcapi/routes/native/v1/favorites.py
+++ b/src/pcapi/routes/native/v1/favorites.py
@@ -1,4 +1,5 @@
 from sqlalchemy import and_
+from sqlalchemy import exc
 from sqlalchemy import func
 from sqlalchemy import not_
 from sqlalchemy.orm import Load
@@ -131,18 +132,22 @@ def create_favorite(user: User, body: serializers.FavoriteRequest) -> serializer
     if settings.MAX_FAVORITES:
         if Favorite.query.filter_by(user=user).count() >= settings.MAX_FAVORITES:
             raise ApiErrors({"code": "MAX_FAVORITES_REACHED"})
-    with transaction():
-        offer = Offer.query.filter_by(id=body.offerId).first_or_404()
-        favorite = Favorite.query.filter(Favorite.offerId == body.offerId, Favorite.userId == user.id).one_or_none()
+    try:
+        with transaction():
+            offer = Offer.query.filter_by(id=body.offerId).first_or_404()
+            favorite = Favorite.query.filter(Favorite.offerId == body.offerId, Favorite.userId == user.id).one_or_none()
 
-        if not favorite:
-            favorite = Favorite(
-                mediation=offer.activeMediation,
-                offer=offer,
-                user=user,
-            )
-            db.session.add(favorite)
-            db.session.flush()
+            if not favorite:
+                favorite = Favorite(
+                    mediation=offer.activeMediation,
+                    offer=offer,
+                    user=user,
+                )
+                db.session.add(favorite)
+                db.session.flush()
+            return serializers.FavoriteResponse.from_orm(favorite)
+    except exc.IntegrityError:
+        favorite = Favorite.query.filter(Favorite.offerId == body.offerId, Favorite.userId == user.id).one_or_none()
         return serializers.FavoriteResponse.from_orm(favorite)
 
 


### PR DESCRIPTION
On a regular basis, the native application sends favorite creation
request on a very short time interval, like in less than 5ms.
This gracefully handles integrity errors whenever one happens.