### PR TITLE
(PC-8440): Automaticaly grant wallet to new pro users after sign-up on integration

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -567,6 +567,11 @@ def create_pro_user(pro_user: ProUserCreationBodyModel) -> User:
     if pro_user.postal_code:
         new_pro_user.departementCode = PostalCode(pro_user.postal_code).get_departement_code()
 
+    if settings.IS_INTEGRATION:
+        new_pro_user.isBeneficiary = True
+        deposit = payment_api.create_deposit(new_pro_user, "integration_signup")
+        new_pro_user.deposits = [deposit]
+
     return new_pro_user
 
 


### PR DESCRIPTION
Créditer automatiquement les comptes PRO crées sur intégration.

Dans `create_pro_user()`
- Passer `isBeneficiary` à `True`
- Créer un `deposit` et l'associer à l'utilisateur pro