### PR TITLE
Log User Profiling calls duration and errors using pcapi.utils.requests

### DIFF
--- a/src/pcapi/connectors/user_profiling.py
+++ b/src/pcapi/connectors/user_profiling.py
@@ -4,9 +4,9 @@ import logging
 import typing
 
 import pydantic
-import requests
 
 from pcapi import settings
+import pcapi.utils.requests as requests
 
 
 logger = logging.getLogger(__name__)

--- a/src/pcapi/utils/requests.py
+++ b/src/pcapi/utils/requests.py
@@ -24,9 +24,13 @@ REQUEST_TIMEOUT_IN_SECOND = 10
 
 
 def _wrapper(request_func: Callable, method: str, url: str, **kwargs: Any) -> Response:
+    timeout = kwargs.pop("timeout", REQUEST_TIMEOUT_IN_SECOND)
     try:
-        timeout = kwargs.pop("timeout", REQUEST_TIMEOUT_IN_SECOND)
         response = request_func(method=method, url=url, timeout=timeout, **kwargs)
+    except Exception as exc:
+        logger.exception("Call to external service failed with %s", exc, extra={"method": method, "url": url})
+        raise exc
+    else:
         logger.info(
             "External service called",
             extra={
@@ -35,9 +39,6 @@ def _wrapper(request_func: Callable, method: str, url: str, **kwargs: Any) -> Re
                 "duration": response.elapsed.total_seconds(),
             },
         )
-    except Exception as exc:
-        logger.exception("Call to external service failed with %s", exc, extra={"method": method, "url": url})
-        raise exc
 
     return response
 

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -1383,4 +1383,6 @@ class ProfilingFraudScoreTest:
             response = client.post("/native/v1/user_profiling", json={"session_id": "random-session-id"})
         assert response.status_code == 204
         assert matcher.call_count == 1
-        assert caplog.record_tuples[0][-1].startswith("Success when profiling user:")
+        assert len(caplog.records) == 2
+        assert caplog.record_tuples[0][-1] == "External service called"
+        assert caplog.record_tuples[1][-1].startswith("Success when profiling user:")


### PR DESCRIPTION
As every call, we want to have the same harmonised logs on external api calls.

And a quick cleanup of the try/except to only wrapps the actual request call