### PR TITLE
(PC-9311) admin: Fix over-escaping of suspend/reactivate link in user lists

### DIFF
--- a/src/pcapi/admin/custom_views/mixins/suspension_mixin.py
+++ b/src/pcapi/admin/custom_views/mixins/suspension_mixin.py
@@ -39,10 +39,10 @@ def _action_links(view, context, model, name):
 
     if model.isActive:
         url = url_for(".suspend_user_view")
-        text = "Suspendre&hellip;"
+        text = "Suspendre…"
     else:
         url = url_for(".unsuspend_user_view")
-        text = "Réactiver&hellip;"
+        text = "Réactiver…"
 
     return Markup('<a href="{url}?user_id={model_id}">{text}</a>').format(
         url=url,


### PR DESCRIPTION
The text was escaped by `Markup.format()`, which caused this to be
displayed in the browser:

    Suspendre&hellip;

The bug was introduced in aa10f18a0adfa2dc82a05148027bf2e899c0a2bb.