### PR TITLE
(PC-9375) edit pytest class collection directive

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,17 +3,7 @@ addopts=-v --tb=short
 testpaths=tests
 norecursedirs=.git venv/ .pytest_cache/
 python_files=*_test.py test_*.py tests.py
-# FIXME (dbaty, 2020-10-21): we should remove prefixes such as Get,
-# Post, Patch, etc. because pytest complains, for example:
-#     PytestCollectionWarning: cannot collect test class 'GetVenueLabels'
-#     because it has a __init__ constructor
-#
-# ... even though the mentioned class is not in the tests (but is
-# imported by tests).
-# As far as I can tell, these prefixes are only used in tests of
-# routes, where they could be removed because the test filename
-# already contains the HTTP verb...
-python_classes=Post Patch Put Get Delete Returns* When* *Test
+python_classes=*Test
 python_functions=test_* when_* expect_* should_*
 env_files=local_test_env_file
 mocked-sessions=pcapi.models.db.session

--- a/tests/core/offers/test_repository.py
+++ b/tests/core/offers/test_repository.py
@@ -226,7 +226,7 @@ class PaginatedOfferForFiltersTest:
         assert offer_in_mayotte.id in offers_id
         assert paginated_offers.total_offers == 2
 
-    class WhenUserIsAdmin:
+    class WhenUserIsAdminTest:
         @pytest.mark.usefixtures("db_session")
         def should_return_offers_of_given_venue_when_user_is_not_attached_to_its_offerer(self, app):
             # given
@@ -326,7 +326,7 @@ class PaginatedOfferForFiltersTest:
             assert offer_for_other_offerer.id not in offers_id
             assert paginated_offers.total_offers == 1
 
-    class WhenUserIsPro:
+    class WhenUserIsProTest:
         @pytest.mark.usefixtures("db_session")
         def should_not_return_offers_of_given_venue_when_user_is_not_attached_to_its_offerer(self, app):
             # given

--- a/tests/core/providers/connect_provider_to_venue_test.py
+++ b/tests/core/providers/connect_provider_to_venue_test.py
@@ -54,7 +54,7 @@ def test_use_siret_as_default(can_be_synchronized, app):
     can_be_synchronized.assert_called_once_with("12345678912345")
 
 
-class WhenProviderIsLibraires:
+class WhenProviderIsLibrairesTest:
     def setup_class(self):
         self.find_by_id = MagicMock()
 
@@ -129,7 +129,7 @@ class WhenProviderIsLibraires:
         ]
 
 
-class WhenProviderIsTiteLive:
+class WhenProviderIsTiteLiveTest:
     def setup_class(self):
         self.find_by_id = MagicMock()
 
@@ -206,7 +206,7 @@ class WhenProviderIsTiteLive:
         ]
 
 
-class WhenProviderImplementsProviderAPI:
+class WhenProviderImplementsProviderAPITest:
     def setup_class(self):
         self.find_by_id = MagicMock()
 
@@ -282,7 +282,7 @@ class WhenProviderImplementsProviderAPI:
         ]
 
 
-class WhenProviderIsPraxiel:
+class WhenProviderIsPraxielTest:
     def setup_class(self):
         self.find_by_id = MagicMock()
 
@@ -357,7 +357,7 @@ class WhenProviderIsPraxiel:
         ]
 
 
-class WhenProviderIsSomethingElse:
+class WhenProviderIsSomethingElseTest:
     def setup_class(self):
         self.find_by_id = MagicMock()
 

--- a/tests/domain/demarches_simplifiees_test.py
+++ b/tests/domain/demarches_simplifiees_test.py
@@ -179,7 +179,7 @@ class GetClosedApplicationIdsForBeneficiaryImportTest:
 
 
 @patch("pcapi.domain.demarches_simplifiees.get_application_details")
-class GetOffererBankInformation_applicationDetailsByApplicationId:
+class GetOffererBankInformation_applicationDetailsByApplicationIdTest:
     def test_retrieve_and_format_all_fields(self, get_application_details):
         # Given
         updated_at = datetime(2020, 1, 3)
@@ -227,7 +227,7 @@ class GetOffererBankInformation_applicationDetailsByApplicationId:
 
 
 @patch("pcapi.domain.demarches_simplifiees.get_application_details")
-class GetVenueBankInformation_applicationDetailsByApplicationId:
+class GetVenueBankInformation_applicationDetailsByApplicationIdTest:
     def test_retrieve_and_format_all_fields_when_with_siret(self, get_application_details):
         # Given
         updated_at = datetime(2020, 1, 3)
@@ -320,7 +320,7 @@ class GetVenueBankInformation_applicationDetailsByApplicationId:
         mock_format_raw_iban_and_bic.assert_has_calls([call("F R763000 700011123 45 67890144"), call("SOGeferp")])
 
 
-class GetStatusFromDemarchesSimplifieesApplicationState:
+class GetStatusFromDemarchesSimplifieesApplicationStateTest:
     def test_correctly_infer_status_from_state(self):
         # Given
         states = ["closed", "initiated", "refused", "received", "without_continuation"]

--- a/tests/local_providers/allocine_stocks_test.py
+++ b/tests/local_providers/allocine_stocks_test.py
@@ -1322,7 +1322,7 @@ class UpdateObjectsTest:
         assert third_stock.beginningDatetime == datetime(2019, 12, 3, 19, 0)
         assert third_stock.bookingLimitDatetime == datetime(2019, 12, 3, 19, 0)
 
-    class WhenAllocineStockAreSynchronizedTwice:
+    class WhenAllocineStockAreSynchronizedTwiceTest:
         @patch("pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes")
         @patch("pcapi.local_providers.allocine.allocine_stocks.get_movie_poster")
         @patch("pcapi.settings.ALLOCINE_API_KEY", "token")
@@ -1787,7 +1787,7 @@ class UpdateObjectsTest:
             assert second_stock.price == 10
             assert second_stock.bookingLimitDatetime == datetime(2019, 12, 4, 15, 0)
 
-    class WhenOfferHasBeenManuallyUpdated:
+    class WhenOfferHasBeenManuallyUpdatedTest:
         @patch("pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes")
         @patch("pcapi.local_providers.allocine.allocine_stocks.get_movie_poster")
         @patch("pcapi.settings.ALLOCINE_API_KEY", "token")
@@ -1957,7 +1957,7 @@ class UpdateObjectsTest:
             created_offer = Offer.query.one()
             assert created_offer.isDuo is True
 
-    class WhenStockHasBeenManuallyDeleted:
+    class WhenStockHasBeenManuallyDeletedTest:
         @patch("pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes")
         @patch("pcapi.local_providers.allocine.allocine_stocks.get_movie_poster")
         @patch("pcapi.settings.ALLOCINE_API_KEY", "token")
@@ -2111,7 +2111,7 @@ class UpdateObjectsTest:
             created_stock = Stock.query.one()
             assert created_stock.isSoftDeleted is True
 
-    class WhenSettingDefaultValuesAtImport:
+    class WhenSettingDefaultValuesAtImportTest:
         @patch("pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes")
         @patch("pcapi.local_providers.allocine.allocine_stocks.get_movie_poster")
         @patch("pcapi.settings.ALLOCINE_API_KEY", "token")

--- a/tests/routes/external/post_update_offerer_demarches_simplifiees_application_test.py
+++ b/tests/routes/external/post_update_offerer_demarches_simplifiees_application_test.py
@@ -5,61 +5,62 @@ import pytest
 from tests.conftest import TestClient
 
 
-class Post:
-    class Returns202:
-        @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
-        @pytest.mark.usefixtures("db_session")
-        def when_has_valid_provider_name_and_dossier_id(self, mock_bank_information_job, app):
-            # Given
-            data = {"dossier_id": "666"}
+class Returns202Test:
+    @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
+    @pytest.mark.usefixtures("db_session")
+    def when_has_valid_provider_name_and_dossier_id(self, mock_bank_information_job, app):
+        # Given
+        data = {"dossier_id": "666"}
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/bank_informations/offerer/application_update?token=good_token", form=data
-            )
+        # When
+        response = TestClient(app.test_client()).post(
+            "/bank_informations/offerer/application_update?token=good_token", form=data
+        )
 
-            # Then
-            assert response.status_code == 202
-            mock_bank_information_job.assert_called_once_with("666", "offerer")
+        # Then
+        assert response.status_code == 202
+        mock_bank_information_job.assert_called_once_with("666", "offerer")
 
-    class Returns400:
-        @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
-        @pytest.mark.usefixtures("db_session")
-        def when_has_not_dossier_in_request_form_data(self, mock_bank_information_job, app):
-            # Given
-            data = {"fake_key": "666"}
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/bank_informations/offerer/application_update?token=good_token", form=data
-            )
+class Returns400Test:
+    @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
+    @pytest.mark.usefixtures("db_session")
+    def when_has_not_dossier_in_request_form_data(self, mock_bank_information_job, app):
+        # Given
+        data = {"fake_key": "666"}
 
-            # Then
-            assert response.status_code == 400
+        # When
+        response = TestClient(app.test_client()).post(
+            "/bank_informations/offerer/application_update?token=good_token", form=data
+        )
 
-    class Returns403:
-        @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
-        @pytest.mark.usefixtures("db_session")
-        def when_has_not_a_token_in_url_params(self, mock_bank_information_job, app):
-            # Given
-            data = {"dossier_id": "666"}
+        # Then
+        assert response.status_code == 400
 
-            # When
-            response = TestClient(app.test_client()).post("/bank_informations/offerer/application_update", form=data)
 
-            # Then
-            assert response.status_code == 403
+class Returns403Test:
+    @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
+    @pytest.mark.usefixtures("db_session")
+    def when_has_not_a_token_in_url_params(self, mock_bank_information_job, app):
+        # Given
+        data = {"dossier_id": "666"}
 
-        @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
-        @pytest.mark.usefixtures("db_session")
-        def when_token_in_url_params_is_not_good(self, mock_bank_information_job, app):
-            # Given
-            data = {"dossier_id": "666"}
+        # When
+        response = TestClient(app.test_client()).post("/bank_informations/offerer/application_update", form=data)
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/bank_informations/offerer/application_update?token=ABCD", form=data
-            )
+        # Then
+        assert response.status_code == 403
 
-            # Then
-            assert response.status_code == 403
+    @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
+    @pytest.mark.usefixtures("db_session")
+    def when_token_in_url_params_is_not_good(self, mock_bank_information_job, app):
+        # Given
+        data = {"dossier_id": "666"}
+
+        # When
+        response = TestClient(app.test_client()).post(
+            "/bank_informations/offerer/application_update?token=ABCD", form=data
+        )
+
+        # Then
+        assert response.status_code == 403

--- a/tests/routes/external/post_update_venue_demarches_simplifiees_application_test.py
+++ b/tests/routes/external/post_update_venue_demarches_simplifiees_application_test.py
@@ -5,61 +5,62 @@ import pytest
 from tests.conftest import TestClient
 
 
-class Post:
-    class Returns202:
-        @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
-        @pytest.mark.usefixtures("db_session")
-        def when_has_valid_provider_name_and_dossier_id(self, mock_bank_information_job, app):
-            # Given
-            data = {"dossier_id": "666"}
+class Returns202Test:
+    @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
+    @pytest.mark.usefixtures("db_session")
+    def when_has_valid_provider_name_and_dossier_id(self, mock_bank_information_job, app):
+        # Given
+        data = {"dossier_id": "666"}
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/bank_informations/venue/application_update?token=good_token", form=data
-            )
+        # When
+        response = TestClient(app.test_client()).post(
+            "/bank_informations/venue/application_update?token=good_token", form=data
+        )
 
-            # Then
-            assert response.status_code == 202
-            mock_bank_information_job.assert_called_once_with("666", "venue")
+        # Then
+        assert response.status_code == 202
+        mock_bank_information_job.assert_called_once_with("666", "venue")
 
-    class Returns400:
-        @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
-        @pytest.mark.usefixtures("db_session")
-        def when_has_not_dossier_in_request_form_data(self, mock_bank_information_job, app):
-            # Given
-            data = {"fake_key": "666"}
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/bank_informations/venue/application_update?token=good_token", form=data
-            )
+class Returns400Test:
+    @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
+    @pytest.mark.usefixtures("db_session")
+    def when_has_not_dossier_in_request_form_data(self, mock_bank_information_job, app):
+        # Given
+        data = {"fake_key": "666"}
 
-            # Then
-            assert response.status_code == 400
+        # When
+        response = TestClient(app.test_client()).post(
+            "/bank_informations/venue/application_update?token=good_token", form=data
+        )
 
-    class Returns403:
-        @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
-        @pytest.mark.usefixtures("db_session")
-        def when_has_not_a_token_in_url_params(self, mock_bank_information_job, app):
-            # Given
-            data = {"dossier_id": "666"}
+        # Then
+        assert response.status_code == 400
 
-            # When
-            response = TestClient(app.test_client()).post("/bank_informations/venue/application_update", form=data)
 
-            # Then
-            assert response.status_code == 403
+class Returns403Test:
+    @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
+    @pytest.mark.usefixtures("db_session")
+    def when_has_not_a_token_in_url_params(self, mock_bank_information_job, app):
+        # Given
+        data = {"dossier_id": "666"}
 
-        @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
-        @pytest.mark.usefixtures("db_session")
-        def when_token_in_url_params_is_not_good(self, mock_bank_information_job, app):
-            # Given
-            data = {"dossier_id": "666"}
+        # When
+        response = TestClient(app.test_client()).post("/bank_informations/venue/application_update", form=data)
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/bank_informations/venue/application_update?token=ABCD", form=data
-            )
+        # Then
+        assert response.status_code == 403
 
-            # Then
-            assert response.status_code == 403
+    @patch("pcapi.routes.external.bank_informations.bank_information_job.delay")
+    @pytest.mark.usefixtures("db_session")
+    def when_token_in_url_params_is_not_good(self, mock_bank_information_job, app):
+        # Given
+        data = {"dossier_id": "666"}
+
+        # When
+        response = TestClient(app.test_client()).post(
+            "/bank_informations/venue/application_update?token=ABCD", form=data
+        )
+
+        # Then
+        assert response.status_code == 403

--- a/tests/routes/internal/get_health_test.py
+++ b/tests/routes/internal/get_health_test.py
@@ -3,45 +3,45 @@ from unittest.mock import patch
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @patch("pcapi.routes.internal.health_check.read_version_from_file")
-        def when_api_is_available(self, mock_read_version_from_file, app):
-            # Given
-            mock_read_version_from_file.return_value = "v69.0.0"
+class Returns200Test:
+    @patch("pcapi.routes.internal.health_check.read_version_from_file")
+    def when_api_is_available(self, mock_read_version_from_file, app):
+        # Given
+        mock_read_version_from_file.return_value = "v69.0.0"
 
-            # When
-            response = TestClient(app.test_client()).get("/health/api")
+        # When
+        response = TestClient(app.test_client()).get("/health/api")
 
-            # Then
-            assert response.status_code == 200
-            assert str(response.data, "utf-8") == "v69.0.0"
+        # Then
+        assert response.status_code == 200
+        assert str(response.data, "utf-8") == "v69.0.0"
 
-        @patch("pcapi.routes.internal.health_check.read_version_from_file")
-        @patch("pcapi.routes.internal.health_check.check_database_connection")
-        def when_database_is_available(self, mock_check_database_connection, mock_read_version_from_file, app):
-            # Given
-            mock_check_database_connection.return_value = True
-            mock_read_version_from_file.return_value = "v69.0.0"
+    @patch("pcapi.routes.internal.health_check.read_version_from_file")
+    @patch("pcapi.routes.internal.health_check.check_database_connection")
+    def when_database_is_available(self, mock_check_database_connection, mock_read_version_from_file, app):
+        # Given
+        mock_check_database_connection.return_value = True
+        mock_read_version_from_file.return_value = "v69.0.0"
 
-            # When
-            response = TestClient(app.test_client()).get("/health/database")
+        # When
+        response = TestClient(app.test_client()).get("/health/database")
 
-            # Then
-            assert response.status_code == 200
-            assert str(response.data, "utf-8") == "v69.0.0"
+        # Then
+        assert response.status_code == 200
+        assert str(response.data, "utf-8") == "v69.0.0"
 
-    class Returns500:
-        @patch("pcapi.routes.internal.health_check.read_version_from_file")
-        @patch("pcapi.routes.internal.health_check.check_database_connection")
-        def when_database_is_not_available(self, mock_check_database_connection, mock_read_version_from_file, app):
-            # Given
-            mock_check_database_connection.return_value = False
-            mock_read_version_from_file.return_value = "v69.0.0"
 
-            # when
-            response = TestClient(app.test_client()).get("/health/database")
+class Returns500Test:
+    @patch("pcapi.routes.internal.health_check.read_version_from_file")
+    @patch("pcapi.routes.internal.health_check.check_database_connection")
+    def when_database_is_not_available(self, mock_check_database_connection, mock_read_version_from_file, app):
+        # Given
+        mock_check_database_connection.return_value = False
+        mock_read_version_from_file.return_value = "v69.0.0"
 
-            # then
-            assert response.status_code == 500
-            assert str(response.data, "utf-8") == "v69.0.0"
+        # when
+        response = TestClient(app.test_client()).get("/health/database")
+
+        # then
+        assert response.status_code == 500
+        assert str(response.data, "utf-8") == "v69.0.0"

--- a/tests/routes/native/v1/favorites_test.py
+++ b/tests/routes/native/v1/favorites_test.py
@@ -22,8 +22,8 @@ FAVORITES_URL = "/native/v1/me/favorites"
 FAVORITES_COUNT_URL = "/native/v1/me/favorites/count"
 
 
-class Get:
-    class Returns200:
+class GetTest:
+    class Returns200Test:
         def when_user_is_logged_in_but_has_no_favorites(self, app):
             # Given
             _, test_client = utils.create_user_and_test_client(app)
@@ -268,7 +268,7 @@ class Get:
                 True,
             ]
 
-    class Returns401:
+    class Returns401Test:
         def when_user_is_not_logged_in(self, app):
             # When
             response = TestClient(app.test_client()).get(FAVORITES_URL)
@@ -277,8 +277,8 @@ class Get:
             assert response.status_code == 401
 
 
-class Post:
-    class Returns200:
+class PostTest:
+    class Returns200Test:
         def when_user_creates_a_favorite(self, app):
             # Given
             user, test_client = utils.create_user_and_test_client(app)
@@ -316,7 +316,7 @@ class Post:
             assert response.status_code == 200
             assert Favorite.query.count() == 1
 
-    class Returns400:
+    class Returns400Test:
         @override_settings(MAX_FAVORITES=1)
         def when_user_creates_one_favorite_above_the_limit(self, app):
             _, test_client = utils.create_user_and_test_client(app)
@@ -335,8 +335,8 @@ class Post:
             assert Favorite.query.count() == 1
 
 
-class Delete:
-    class Returns204:
+class DeleteTest:
+    class Returns204Test:
         def when_user_delete_its_favorite(self, app):
             # Given
             user, test_client = utils.create_user_and_test_client(app)
@@ -381,8 +381,8 @@ class Delete:
             assert response.status_code == 404
 
 
-class GetCount:
-    class Returns200:
+class GetCountTest:
+    class Returns200Test:
         def when_user_is_logged_in_but_has_no_favorites(self, app):
             # Given
             _, test_client = utils.create_user_and_test_client(app)

--- a/tests/routes/pro/delete_stock_test.py
+++ b/tests/routes/pro/delete_stock_test.py
@@ -9,7 +9,7 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Returns200:
+class Returns200Test:
     def when_current_user_has_rights_on_offer(self, app, db_session):
         # given
         offer = offers_factories.OfferFactory()
@@ -38,7 +38,7 @@ class Returns200:
         }
 
 
-class Returns400:
+class Returns400Test:
     def when_stock_is_on_an_offer_from_titelive_provider(self, app, db_session):
         # given
         provider = offerers_factories.ProviderFactory(localClass="TiteLiveThings")
@@ -67,7 +67,7 @@ class Returns400:
         assert response.json["global"] == ["Les offres refusées ou en attente de validation ne sont pas modifiables"]
 
 
-class Returns403:
+class Returns403Test:
     def when_current_user_has_no_rights_on_offer(self, app, db_session):
         # given
         user = users_factories.UserFactory(email="notadmin@example.com")

--- a/tests/routes/pro/get_all_bookings_test.py
+++ b/tests/routes/pro/get_all_bookings_test.py
@@ -70,152 +70,155 @@ class GetAllBookingsTest:
 
 
 @pytest.mark.usefixtures("db_session")
-class GetTest:
-    class Returns200Test:
-        def when_user_is_linked_to_a_valid_offerer(self, app):
-            booking = bookings_factories.BookingFactory(
-                dateCreated=datetime(2020, 4, 3, 12, 0, 0),
-                isUsed=True,
-                dateUsed=datetime(2020, 5, 3, 12, 0, 0),
-                token="ABCDEF",
-                user__email="beneficiary@example.com",
-                user__firstName="Hermione",
-                user__lastName="Granger",
-            )
-            pro_user = users_factories.UserFactory(email="pro@example.com")
-            offerer = booking.stock.offer.venue.managingOfferer
-            offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+class Returns200Test:
+    def when_user_is_linked_to_a_valid_offerer(self, app):
+        booking = bookings_factories.BookingFactory(
+            dateCreated=datetime(2020, 4, 3, 12, 0, 0),
+            isUsed=True,
+            dateUsed=datetime(2020, 5, 3, 12, 0, 0),
+            token="ABCDEF",
+            user__email="beneficiary@example.com",
+            user__firstName="Hermione",
+            user__lastName="Granger",
+        )
+        pro_user = users_factories.UserFactory(email="pro@example.com")
+        offerer = booking.stock.offer.venue.managingOfferer
+        offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
 
-            client = TestClient(app.test_client()).with_auth(pro_user.email)
-            with assert_num_queries(testing.AUTHENTICATION_QUERIES + 3):
-                response = client.get("/bookings/pro")
-
-            expected_bookings_recap = [
-                {
-                    "stock": {
-                        "type": "thing",
-                        "offer_name": booking.stock.offer.name,
-                        "offer_identifier": humanize(booking.stock.offer.id),
-                    },
-                    "beneficiary": {
-                        "email": "beneficiary@example.com",
-                        "firstname": "Hermione",
-                        "lastname": "Granger",
-                    },
-                    "booking_date": format_into_timezoned_date(
-                        booking.dateCreated.astimezone(tz.gettz("Europe/Paris")),
-                    ),
-                    "booking_amount": 10.0,
-                    "booking_token": "ABCDEF",
-                    "booking_status": "validated",
-                    "booking_is_duo": False,
-                    "booking_status_history": [
-                        {
-                            "status": "booked",
-                            "date": format_into_timezoned_date(
-                                booking.dateCreated.astimezone(tz.gettz("Europe/Paris")),
-                            ),
-                        },
-                        {
-                            "status": "validated",
-                            "date": format_into_timezoned_date(
-                                booking.dateUsed.astimezone(tz.gettz("Europe/Paris")),
-                            ),
-                        },
-                    ],
-                    "offerer": {
-                        "name": offerer.name,
-                    },
-                    "venue": {
-                        "identifier": humanize(booking.stock.offer.venue.id),
-                        "is_virtual": booking.stock.offer.venue.isVirtual,
-                        "name": booking.stock.offer.venue.name,
-                    },
-                }
-            ]
-            assert response.status_code == 200
-            assert response.json["bookings_recap"] == expected_bookings_recap
-            assert response.json["page"] == 1
-            assert response.json["pages"] == 1
-            assert response.json["total"] == 1
-
-        def when_requested_event_date_is_iso_format(self, app):
-            requested_date = datetime(2020, 8, 12, 20, 00)
-            requested_date_iso_format = "2020-08-12T00:00:00Z"
-            stock = offers_factories.EventStockFactory(beginningDatetime=requested_date)
-            booking = bookings_factories.BookingFactory(stock=stock, token="AAAAAA")
-            bookings_factories.BookingFactory(stock=offers_factories.EventStockFactory(), token="BBBBBB")
-            pro_user = users_factories.UserFactory(email="pro@example.com")
-            offerer = stock.offer.venue.managingOfferer
-            offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-
-            client = TestClient(app.test_client()).with_auth(pro_user.email)
-            with assert_num_queries(testing.AUTHENTICATION_QUERIES + 3):
-                response = client.get("/bookings/pro?eventDate=%s" % requested_date_iso_format)
-
-            assert response.status_code == 200
-            assert len(response.json["bookings_recap"]) == 1
-            assert response.json["bookings_recap"][0]["booking_token"] == booking.token
-            assert response.json["page"] == 1
-            assert response.json["pages"] == 1
-            assert response.json["total"] == 1
-
-        def when_requested_booking_period_dates_are_iso_format(self, app):
-            booking_date = datetime(2020, 8, 12, 20, 00, tzinfo=timezone.utc)
-            booking_period_beginning_date_iso = "2020-08-10T00:00:00Z"
-            booking_period_ending_date_iso = "2020-08-12T00:00:00Z"
-            booking = bookings_factories.BookingFactory(dateCreated=booking_date, token="AAAAAA")
-            bookings_factories.BookingFactory(token="BBBBBB")
-            pro_user = users_factories.UserFactory(email="pro@example.com")
-            offerer = booking.stock.offer.venue.managingOfferer
-            offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-
-            client = TestClient(app.test_client()).with_auth(pro_user.email)
-            with assert_num_queries(testing.AUTHENTICATION_QUERIES + 3):
-                response = client.get(
-                    "/bookings/pro?bookingPeriodBeginningDate=%s&bookingPeriodEndingDate=%s"
-                    % (booking_period_beginning_date_iso, booking_period_ending_date_iso)
-                )
-
-            assert response.status_code == 200
-            assert len(response.json["bookings_recap"]) == 1
-            assert response.json["bookings_recap"][0]["booking_date"] == datetime.isoformat(
-                utc_datetime_to_department_timezone(booking.dateCreated, booking.stock.offer.venue.departementCode)
-            )
-            assert response.json["page"] == 1
-            assert response.json["pages"] == 1
-            assert response.json["total"] == 1
-
-    class Returns400Test:
-        def when_page_number_is_not_a_number(self, app):
-            user = users_factories.UserFactory()
-
-            client = TestClient(app.test_client()).with_auth(user.email)
-            response = client.get("/bookings/pro?page=not-a-number")
-
-            assert response.status_code == 400
-            assert response.json["global"] == ["L'argument 'page' not-a-number n'est pas valide"]
-
-    class Returns401Test:
-        def when_user_is_admin(self, app):
-            user = users_factories.UserFactory(isAdmin=True)
-
-            client = TestClient(app.test_client()).with_auth(user.email)
+        client = TestClient(app.test_client()).with_auth(pro_user.email)
+        with assert_num_queries(testing.AUTHENTICATION_QUERIES + 3):
             response = client.get("/bookings/pro")
 
-            assert response.status_code == 401
-            assert response.json == {
-                "global": ["Le statut d'administrateur ne permet pas d'accéder au suivi des réservations"]
+        expected_bookings_recap = [
+            {
+                "stock": {
+                    "type": "thing",
+                    "offer_name": booking.stock.offer.name,
+                    "offer_identifier": humanize(booking.stock.offer.id),
+                },
+                "beneficiary": {
+                    "email": "beneficiary@example.com",
+                    "firstname": "Hermione",
+                    "lastname": "Granger",
+                },
+                "booking_date": format_into_timezoned_date(
+                    booking.dateCreated.astimezone(tz.gettz("Europe/Paris")),
+                ),
+                "booking_amount": 10.0,
+                "booking_token": "ABCDEF",
+                "booking_status": "validated",
+                "booking_is_duo": False,
+                "booking_status_history": [
+                    {
+                        "status": "booked",
+                        "date": format_into_timezoned_date(
+                            booking.dateCreated.astimezone(tz.gettz("Europe/Paris")),
+                        ),
+                    },
+                    {
+                        "status": "validated",
+                        "date": format_into_timezoned_date(
+                            booking.dateUsed.astimezone(tz.gettz("Europe/Paris")),
+                        ),
+                    },
+                ],
+                "offerer": {
+                    "name": offerer.name,
+                },
+                "venue": {
+                    "identifier": humanize(booking.stock.offer.venue.id),
+                    "is_virtual": booking.stock.offer.venue.isVirtual,
+                    "name": booking.stock.offer.venue.name,
+                },
             }
+        ]
+        assert response.status_code == 200
+        assert response.json["bookings_recap"] == expected_bookings_recap
+        assert response.json["page"] == 1
+        assert response.json["pages"] == 1
+        assert response.json["total"] == 1
 
-        @override_features(DISABLE_BOOKINGS_RECAP_FOR_SOME_PROS=True)
-        def when_user_is_blacklisted(self, app):
-            user = users_factories.UserFactory(offerers=[offers_factories.OffererFactory(siren="334473352")])
+    def when_requested_event_date_is_iso_format(self, app):
+        requested_date = datetime(2020, 8, 12, 20, 00)
+        requested_date_iso_format = "2020-08-12T00:00:00Z"
+        stock = offers_factories.EventStockFactory(beginningDatetime=requested_date)
+        booking = bookings_factories.BookingFactory(stock=stock, token="AAAAAA")
+        bookings_factories.BookingFactory(stock=offers_factories.EventStockFactory(), token="BBBBBB")
+        pro_user = users_factories.UserFactory(email="pro@example.com")
+        offerer = stock.offer.venue.managingOfferer
+        offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
 
-            client = TestClient(app.test_client()).with_auth(user.email)
-            response = client.get("/bookings/pro")
+        client = TestClient(app.test_client()).with_auth(pro_user.email)
+        with assert_num_queries(testing.AUTHENTICATION_QUERIES + 3):
+            response = client.get("/bookings/pro?eventDate=%s" % requested_date_iso_format)
 
-            assert response.status_code == 401
-            assert response.json == {
-                "global": ["Le statut d'administrateur ne permet pas d'accéder au suivi des réservations"]
-            }
+        assert response.status_code == 200
+        assert len(response.json["bookings_recap"]) == 1
+        assert response.json["bookings_recap"][0]["booking_token"] == booking.token
+        assert response.json["page"] == 1
+        assert response.json["pages"] == 1
+        assert response.json["total"] == 1
+
+    def when_requested_booking_period_dates_are_iso_format(self, app):
+        booking_date = datetime(2020, 8, 12, 20, 00, tzinfo=timezone.utc)
+        booking_period_beginning_date_iso = "2020-08-10T00:00:00Z"
+        booking_period_ending_date_iso = "2020-08-12T00:00:00Z"
+        booking = bookings_factories.BookingFactory(dateCreated=booking_date, token="AAAAAA")
+        bookings_factories.BookingFactory(token="BBBBBB")
+        pro_user = users_factories.UserFactory(email="pro@example.com")
+        offerer = booking.stock.offer.venue.managingOfferer
+        offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+
+        client = TestClient(app.test_client()).with_auth(pro_user.email)
+        with assert_num_queries(testing.AUTHENTICATION_QUERIES + 3):
+            response = client.get(
+                "/bookings/pro?bookingPeriodBeginningDate=%s&bookingPeriodEndingDate=%s"
+                % (booking_period_beginning_date_iso, booking_period_ending_date_iso)
+            )
+
+        assert response.status_code == 200
+        assert len(response.json["bookings_recap"]) == 1
+        assert response.json["bookings_recap"][0]["booking_date"] == datetime.isoformat(
+            utc_datetime_to_department_timezone(booking.dateCreated, booking.stock.offer.venue.departementCode)
+        )
+        assert response.json["page"] == 1
+        assert response.json["pages"] == 1
+        assert response.json["total"] == 1
+
+
+@pytest.mark.usefixtures("db_session")
+class Returns400Test:
+    def when_page_number_is_not_a_number(self, app):
+        user = users_factories.UserFactory()
+
+        client = TestClient(app.test_client()).with_auth(user.email)
+        response = client.get("/bookings/pro?page=not-a-number")
+
+        assert response.status_code == 400
+        assert response.json["global"] == ["L'argument 'page' not-a-number n'est pas valide"]
+
+
+@pytest.mark.usefixtures("db_session")
+class Returns401Test:
+    def when_user_is_admin(self, app):
+        user = users_factories.UserFactory(isAdmin=True)
+
+        client = TestClient(app.test_client()).with_auth(user.email)
+        response = client.get("/bookings/pro")
+
+        assert response.status_code == 401
+        assert response.json == {
+            "global": ["Le statut d'administrateur ne permet pas d'accéder au suivi des réservations"]
+        }
+
+    @override_features(DISABLE_BOOKINGS_RECAP_FOR_SOME_PROS=True)
+    def when_user_is_blacklisted(self, app):
+        user = users_factories.UserFactory(offerers=[offers_factories.OffererFactory(siren="334473352")])
+
+        client = TestClient(app.test_client()).with_auth(user.email)
+        response = client.get("/bookings/pro")
+
+        assert response.status_code == 401
+        assert response.json == {
+            "global": ["Le statut d'administrateur ne permet pas d'accéder au suivi des réservations"]
+        }

--- a/tests/routes/pro/get_booking_by_token_test.py
+++ b/tests/routes/pro/get_booking_by_token_test.py
@@ -25,346 +25,349 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_has_rights_and_regular_offer(self, app):
-            # Given
-            user = create_user(email="user@example.com", public_name="John Doe")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(admin_user, offerer)
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name", event_type=EventType.CINEMA)
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(user_offerer, booking)
-            url = f"/bookings/token/{booking.token}"
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_has_rights_and_regular_offer(self, app):
+        # Given
+        user = create_user(email="user@example.com", public_name="John Doe")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(admin_user, offerer)
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name", event_type=EventType.CINEMA)
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(user_offerer, booking)
+        url = f"/bookings/token/{booking.token}"
 
-            # When
-            response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
+        # When
+        response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
 
-            # Then
-            assert response.status_code == 200
-            response_json = response.json
-            assert response_json == {
-                "bookingId": humanize(booking.id),
-                "date": serialize(booking.stock.beginningDatetime),
-                "email": "user@example.com",
-                "isUsed": False,
-                "offerName": "Event Name",
-                "userName": "John Doe",
-                "venueDepartementCode": "93",
-            }
+        # Then
+        assert response.status_code == 200
+        response_json = response.json
+        assert response_json == {
+            "bookingId": humanize(booking.id),
+            "date": serialize(booking.stock.beginningDatetime),
+            "email": "user@example.com",
+            "isUsed": False,
+            "offerName": "Event Name",
+            "userName": "John Doe",
+            "venueDepartementCode": "93",
+        }
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_has_rights_and_regular_offer_and_token_in_lower_case(self, app):
-            # Given
-            user = create_user(email="user@example.com", public_name="John Doe")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(admin_user, offerer)
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name", event_type=EventType.CINEMA)
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(user_offerer, booking)
-            booking_token = booking.token.lower()
-            url = f"/bookings/token/{booking_token}"
+    @pytest.mark.usefixtures("db_session")
+    def when_user_has_rights_and_regular_offer_and_token_in_lower_case(self, app):
+        # Given
+        user = create_user(email="user@example.com", public_name="John Doe")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(admin_user, offerer)
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name", event_type=EventType.CINEMA)
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(user_offerer, booking)
+        booking_token = booking.token.lower()
+        url = f"/bookings/token/{booking_token}"
 
-            # When
-            response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
+        # When
+        response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
 
-            # Then
-            assert response.status_code == 200
-            response_json = response.json
-            assert response_json == {
-                "bookingId": humanize(booking.id),
-                "date": serialize(booking.stock.beginningDatetime),
-                "email": "user@example.com",
-                "isUsed": False,
-                "offerName": "Event Name",
-                "userName": "John Doe",
-                "venueDepartementCode": "93",
-            }
+        # Then
+        assert response.status_code == 200
+        response_json = response.json
+        assert response_json == {
+            "bookingId": humanize(booking.id),
+            "date": serialize(booking.stock.beginningDatetime),
+            "email": "user@example.com",
+            "isUsed": False,
+            "offerName": "Event Name",
+            "userName": "John Doe",
+            "venueDepartementCode": "93",
+        }
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_has_rights_and_email_with_special_characters_url_encoded(self, app):
-            # Given
-            user = create_user(email="user+plus@example.com")
-            user_admin = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(user_admin, offerer)
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name")
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(user_offerer, booking)
-            url_email = urlencode({"email": "user+plus@example.com"})
-            url = f"/bookings/token/{booking.token}?{url_email}"
+    @pytest.mark.usefixtures("db_session")
+    def when_user_has_rights_and_email_with_special_characters_url_encoded(self, app):
+        # Given
+        user = create_user(email="user+plus@example.com")
+        user_admin = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(user_admin, offerer)
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name")
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(user_offerer, booking)
+        url_email = urlencode({"email": "user+plus@example.com"})
+        url = f"/bookings/token/{booking.token}?{url_email}"
 
-            # When
-            response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
+        # When
+        response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
 
-            # Then
-            assert response.status_code == 200
+        # Then
+        assert response.status_code == 200
 
-    class Returns204:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_not_logged_in_and_gives_right_email(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name")
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(admin_user, booking)
-            url = f"/bookings/token/{booking.token}?email=user@example.com"
 
-            # When
-            response = TestClient(app.test_client()).get(url)
+class Returns204Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_not_logged_in_and_gives_right_email(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name")
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(admin_user, booking)
+        url = f"/bookings/token/{booking.token}?email=user@example.com"
 
-            # Then
-            assert response.status_code == 204
+        # When
+        response = TestClient(app.test_client()).get(url)
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_not_logged_in_and_give_right_email_and_event_offer_id(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name")
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(admin_user, booking)
-            url = f"/bookings/token/{booking.token}?email=user@example.com&offer_id={humanize(offer.id)}"
+        # Then
+        assert response.status_code == 204
 
-            # When
-            response = TestClient(app.test_client()).get(url)
+    @pytest.mark.usefixtures("db_session")
+    def when_user_not_logged_in_and_give_right_email_and_event_offer_id(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name")
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(admin_user, booking)
+        url = f"/bookings/token/{booking.token}?email=user@example.com&offer_id={humanize(offer.id)}"
 
-            # Then
-            assert response.status_code == 204
+        # When
+        response = TestClient(app.test_client()).get(url)
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_not_logged_in_and_give_right_email_and_offer_id_thing(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(admin_user, booking)
-            url = f"/bookings/token/{booking.token}?email=user@example.com&offer_id={humanize(stock.offerId)}"
+        # Then
+        assert response.status_code == 204
 
-            # When
-            response = TestClient(app.test_client()).get(url)
+    @pytest.mark.usefixtures("db_session")
+    def when_user_not_logged_in_and_give_right_email_and_offer_id_thing(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(admin_user, booking)
+        url = f"/bookings/token/{booking.token}?email=user@example.com&offer_id={humanize(stock.offerId)}"
 
-            # Then
-            assert response.status_code == 204
+        # When
+        response = TestClient(app.test_client()).get(url)
 
-    class Returns404:
-        @pytest.mark.usefixtures("db_session")
-        def when_token_user_has_rights_but_token_not_found(self, app):
-            # Given
-            admin_user = create_user(email="admin@example.com")
-            repository.save(admin_user)
-            url = "/bookings/token/12345"
+        # Then
+        assert response.status_code == 204
 
-            # When
-            response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
 
-            # Then
-            assert response.status_code == 404
-            assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
+class Returns404Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_token_user_has_rights_but_token_not_found(self, app):
+        # Given
+        admin_user = create_user(email="admin@example.com")
+        repository.save(admin_user)
+        url = "/bookings/token/12345"
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_not_logged_in_and_wrong_email(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name")
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(admin_user, booking)
-            url = f"/bookings/token/{booking.token}?email=toto@example.com"
+        # When
+        response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
 
-            # When
-            response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
+        # Then
+        assert response.status_code == 404
+        assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
 
-            # Then
-            assert response.status_code == 404
-            assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
+    @pytest.mark.usefixtures("db_session")
+    def when_user_not_logged_in_and_wrong_email(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name")
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(admin_user, booking)
+        url = f"/bookings/token/{booking.token}?email=toto@example.com"
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_not_logged_in_right_email_and_wrong_offer(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(admin_user, booking)
-            url = f"/bookings/token/{booking.token}?email=user@example.com&offer_id={humanize(123)}"
+        # When
+        response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
 
-            # When
-            response = TestClient(app.test_client()).get(url)
+        # Then
+        assert response.status_code == 404
+        assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
 
-            # Then
-            assert response.status_code == 404
-            assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
+    @pytest.mark.usefixtures("db_session")
+    def when_user_not_logged_in_right_email_and_wrong_offer(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(admin_user, booking)
+        url = f"/bookings/token/{booking.token}?email=user@example.com&offer_id={humanize(123)}"
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_has_rights_and_email_with_special_characters_not_url_encoded(self, app):
-            # Given
-            user = create_user(email="user+plus@example.com")
-            user_admin = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(user_admin, offerer)
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name")
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(user_offerer, booking)
-            url = f"/bookings/token/{booking.token}?email={user.email}"
+        # When
+        response = TestClient(app.test_client()).get(url)
 
-            # When
-            response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
+        # Then
+        assert response.status_code == 404
+        assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
 
-            # Then
-            assert response.status_code == 404
+    @pytest.mark.usefixtures("db_session")
+    def when_user_has_rights_and_email_with_special_characters_not_url_encoded(self, app):
+        # Given
+        user = create_user(email="user+plus@example.com")
+        user_admin = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(user_admin, offerer)
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name")
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(user_offerer, booking)
+        url = f"/bookings/token/{booking.token}?email={user.email}"
 
-    class Returns400:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_not_logged_in_and_doesnt_give_email(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name")
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(admin_user, booking)
-            url = f"/bookings/token/{booking.token}"
+        # When
+        response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
 
-            # When
-            response = TestClient(app.test_client()).get(url)
+        # Then
+        assert response.status_code == 404
 
-            # Then
-            assert response.status_code == 400
-            error_message = response.json
-            assert error_message["email"] == [
-                "Vous devez préciser l'email de l'utilisateur quand vous n'êtes pas connecté(e)"
-            ]
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_doesnt_have_rights_and_token_exists(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            querying_user = create_user(email="querying@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name")
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(querying_user, booking)
-            url = f"/bookings/token/{booking.token}"
+class Returns400Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_not_logged_in_and_doesnt_give_email(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name")
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(admin_user, booking)
+        url = f"/bookings/token/{booking.token}"
 
-            # When
-            response = TestClient(app.test_client()).with_auth("querying@example.com").get(url)
+        # When
+        response = TestClient(app.test_client()).get(url)
 
-            # Then
-            assert response.status_code == 400
-            assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
+        # Then
+        assert response.status_code == 400
+        error_message = response.json
+        assert error_message["email"] == [
+            "Vous devez préciser l'email de l'utilisateur quand vous n'êtes pas connecté(e)"
+        ]
 
-    class Returns403:
-        @mock.patch("pcapi.core.bookings.validation.check_is_usable")
-        @pytest.mark.usefixtures("db_session")
-        def when_booking_not_confirmed(self, mocked_check_is_usable, app):
-            # Given
-            next_week = datetime.utcnow() + timedelta(weeks=1)
-            unconfirmed_booking = BookingFactory(stock__beginningDatetime=next_week)
-            url = (
-                f"/bookings/token/{unconfirmed_booking.token}?email={unconfirmed_booking.user.email}"
-                f"&offer_id={humanize(unconfirmed_booking.stock.offerId)}"
-            )
-            mocked_check_is_usable.side_effect = api_errors.ForbiddenError(errors={"booking": ["Not confirmed"]})
+    @pytest.mark.usefixtures("db_session")
+    def when_user_doesnt_have_rights_and_token_exists(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        querying_user = create_user(email="querying@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name")
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(querying_user, booking)
+        url = f"/bookings/token/{booking.token}"
 
-            # When
-            response = TestClient(app.test_client()).get(url)
+        # When
+        response = TestClient(app.test_client()).with_auth("querying@example.com").get(url)
 
-            # Then
-            assert response.status_code == 403
-            assert response.json["booking"] == ["Not confirmed"]
+        # Then
+        assert response.status_code == 400
+        assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
 
-        @pytest.mark.usefixtures("db_session")
-        def when_booking_is_cancelled(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
-            booking = create_booking(user=user, stock=stock, is_cancelled=True, venue=venue)
-            repository.save(admin_user, booking)
-            url = f"/bookings/token/{booking.token}?email=user@example.com&offer_id={humanize(stock.offerId)}"
 
-            # When
-            response = TestClient(app.test_client()).get(url)
+class Returns403Test:
+    @mock.patch("pcapi.core.bookings.validation.check_is_usable")
+    @pytest.mark.usefixtures("db_session")
+    def when_booking_not_confirmed(self, mocked_check_is_usable, app):
+        # Given
+        next_week = datetime.utcnow() + timedelta(weeks=1)
+        unconfirmed_booking = BookingFactory(stock__beginningDatetime=next_week)
+        url = (
+            f"/bookings/token/{unconfirmed_booking.token}?email={unconfirmed_booking.user.email}"
+            f"&offer_id={humanize(unconfirmed_booking.stock.offerId)}"
+        )
+        mocked_check_is_usable.side_effect = api_errors.ForbiddenError(errors={"booking": ["Not confirmed"]})
 
-            # Then
-            assert response.status_code == 403
-            assert response.json["booking"] == ["Cette réservation a été annulée"]
+        # When
+        response = TestClient(app.test_client()).get(url)
 
-        @pytest.mark.usefixtures("db_session")
-        def when_booking_is_refunded(self, app):
-            # Given
-            booking = BookingFactory()
-            PaymentFactory(booking=booking)
-            url = (
-                f"/bookings/token/{booking.token}?"
-                f"email={booking.user.email}&offer_id={humanize(booking.stock.offerId)}"
-            )
+        # Then
+        assert response.status_code == 403
+        assert response.json["booking"] == ["Not confirmed"]
 
-            # When
-            response = TestClient(app.test_client()).get(url)
+    @pytest.mark.usefixtures("db_session")
+    def when_booking_is_cancelled(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
+        booking = create_booking(user=user, stock=stock, is_cancelled=True, venue=venue)
+        repository.save(admin_user, booking)
+        url = f"/bookings/token/{booking.token}?email=user@example.com&offer_id={humanize(stock.offerId)}"
 
-            # Then
-            assert response.status_code == 403
-            assert response.json["payment"] == ["Cette réservation a été remboursée"]
+        # When
+        response = TestClient(app.test_client()).get(url)
 
-    class Returns410:
-        @pytest.mark.usefixtures("db_session")
-        def when_booking_is_already_validated(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
-            booking = create_booking(user=user, stock=stock, is_used=True, venue=venue)
-            repository.save(admin_user, booking)
-            url = f"/bookings/token/{booking.token}?email=user@example.com&offer_id={humanize(stock.offerId)}"
+        # Then
+        assert response.status_code == 403
+        assert response.json["booking"] == ["Cette réservation a été annulée"]
 
-            # When
-            response = TestClient(app.test_client()).get(url)
+    @pytest.mark.usefixtures("db_session")
+    def when_booking_is_refunded(self, app):
+        # Given
+        booking = BookingFactory()
+        PaymentFactory(booking=booking)
+        url = (
+            f"/bookings/token/{booking.token}?" f"email={booking.user.email}&offer_id={humanize(booking.stock.offerId)}"
+        )
 
-            # Then
-            assert response.status_code == 410
-            assert response.json["booking"] == ["Cette réservation a déjà été validée"]
+        # When
+        response = TestClient(app.test_client()).get(url)
+
+        # Then
+        assert response.status_code == 403
+        assert response.json["payment"] == ["Cette réservation a été remboursée"]
+
+
+class Returns410Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_booking_is_already_validated(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
+        booking = create_booking(user=user, stock=stock, is_used=True, venue=venue)
+        repository.save(admin_user, booking)
+        url = f"/bookings/token/{booking.token}?email=user@example.com&offer_id={humanize(stock.offerId)}"
+
+        # When
+        response = TestClient(app.test_client()).get(url)
+
+        # Then
+        assert response.status_code == 410
+        assert response.json["booking"] == ["Cette réservation a déjà été validée"]

--- a/tests/routes/pro/get_booking_by_token_v2_test.py
+++ b/tests/routes/pro/get_booking_by_token_v2_test.py
@@ -32,391 +32,394 @@ from tests.conftest import TestClient
 API_KEY_VALUE = "A_MOCKED_API_KEY"
 
 
-class Get:
-    class Returns200:
-        @freeze_time("2019-11-26 18:29:20.891028")
-        @pytest.mark.usefixtures("db_session")
-        def when_user_has_rights_and_regular_offer(self, app):
-            # Given
-            user = users_factories.UserFactory(email="user@example.com", publicName="John Doe")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            create_user_offerer(admin_user, offerer)
-            venue = create_venue(offerer, name="Venue name", address="Venue address")
-            offer = create_offer_with_event_product(
-                venue=venue,
-                event_name="Event Name",
-                event_type=EventType.CINEMA,
-                extra_data={
-                    "theater": {
-                        "allocine_movie_id": 165,
-                        "allocine_room_id": 987,
-                    }
-                },
-            )
-            four_days_from_now = datetime.utcnow() + timedelta(days=4)
-            event_occurrence = create_event_occurrence(offer, beginning_datetime=four_days_from_now)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=12)
-            unconfirmed_booking = create_booking(
-                user=user, quantity=3, stock=stock, venue=venue, date_created=datetime.utcnow() - timedelta(hours=48)
-            )
-            repository.save(unconfirmed_booking)
-            url = f"/v2/bookings/token/{unconfirmed_booking.token}"
-
-            # When
-            response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
-
-            # Then
-            assert response.headers["Content-type"] == "application/json"
-            assert response.status_code == 200
-            assert response.json == {
-                "bookingId": humanize(unconfirmed_booking.id),
-                "dateOfBirth": "",
-                "datetime": format_into_utc_date(stock.beginningDatetime),
-                "ean13": "",
-                "email": "user@example.com",
-                "formula": "PLACE",
-                "isUsed": False,
-                "offerId": offer.id,
-                "offerName": "Event Name",
-                "offerType": "EVENEMENT",
-                "phoneNumber": "",
-                "price": 12.0,
-                "publicOfferId": humanize(offer.id),
-                "quantity": 3,
+class Returns200Test:
+    @freeze_time("2019-11-26 18:29:20.891028")
+    @pytest.mark.usefixtures("db_session")
+    def when_user_has_rights_and_regular_offer(self, app):
+        # Given
+        user = users_factories.UserFactory(email="user@example.com", publicName="John Doe")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        create_user_offerer(admin_user, offerer)
+        venue = create_venue(offerer, name="Venue name", address="Venue address")
+        offer = create_offer_with_event_product(
+            venue=venue,
+            event_name="Event Name",
+            event_type=EventType.CINEMA,
+            extra_data={
                 "theater": {
                     "allocine_movie_id": 165,
                     "allocine_room_id": 987,
-                },
-                "userName": "John Doe",
-                "venueAddress": "Venue address",
-                "venueDepartementCode": "93",
-                "venueName": "Venue name",
-            }
+                }
+            },
+        )
+        four_days_from_now = datetime.utcnow() + timedelta(days=4)
+        event_occurrence = create_event_occurrence(offer, beginning_datetime=four_days_from_now)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=12)
+        unconfirmed_booking = create_booking(
+            user=user, quantity=3, stock=stock, venue=venue, date_created=datetime.utcnow() - timedelta(hours=48)
+        )
+        repository.save(unconfirmed_booking)
+        url = f"/v2/bookings/token/{unconfirmed_booking.token}"
 
-        @pytest.mark.usefixtures("db_session")
-        def when_api_key_is_provided_and_rights_and_regular_offer(self, app):
-            # Given
-            user = create_user(email="user@example.com", public_name="John Doe")
-            user2 = create_user(email="user2@example.com", public_name="Jane Doe")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(user2, offerer)
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name", event_type=EventType.CINEMA)
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(user_offerer, booking)
-            offererApiKey = create_api_key(offerer_id=offerer.id)
-            repository.save(offererApiKey)
-            user2ApiKey = f"Bearer {offererApiKey.value}"
-            booking_token = booking.token.lower()
-            url = f"/v2/bookings/token/{booking_token}"
+        # When
+        response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
 
-            # When
-            response = TestClient(app.test_client()).get(
-                url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-            )
+        # Then
+        assert response.headers["Content-type"] == "application/json"
+        assert response.status_code == 200
+        assert response.json == {
+            "bookingId": humanize(unconfirmed_booking.id),
+            "dateOfBirth": "",
+            "datetime": format_into_utc_date(stock.beginningDatetime),
+            "ean13": "",
+            "email": "user@example.com",
+            "formula": "PLACE",
+            "isUsed": False,
+            "offerId": offer.id,
+            "offerName": "Event Name",
+            "offerType": "EVENEMENT",
+            "phoneNumber": "",
+            "price": 12.0,
+            "publicOfferId": humanize(offer.id),
+            "quantity": 3,
+            "theater": {
+                "allocine_movie_id": 165,
+                "allocine_room_id": 987,
+            },
+            "userName": "John Doe",
+            "venueAddress": "Venue address",
+            "venueDepartementCode": "93",
+            "venueName": "Venue name",
+        }
 
-            # Then
-            assert response.status_code == 200
+    @pytest.mark.usefixtures("db_session")
+    def when_api_key_is_provided_and_rights_and_regular_offer(self, app):
+        # Given
+        user = create_user(email="user@example.com", public_name="John Doe")
+        user2 = create_user(email="user2@example.com", public_name="Jane Doe")
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(user2, offerer)
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name", event_type=EventType.CINEMA)
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(user_offerer, booking)
+        offererApiKey = create_api_key(offerer_id=offerer.id)
+        repository.save(offererApiKey)
+        user2ApiKey = f"Bearer {offererApiKey.value}"
+        booking_token = booking.token.lower()
+        url = f"/v2/bookings/token/{booking_token}"
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_has_rights_and_regular_offer_and_token_in_lower_case(self, app):
-            # Given
-            user = create_user(email="user@example.com", public_name="John Doe")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(admin_user, offerer)
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name", event_type=EventType.CINEMA)
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(user_offerer, booking)
-            booking_token = booking.token.lower()
-            url = f"/v2/bookings/token/{booking_token}"
+        # When
+        response = TestClient(app.test_client()).get(
+            url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
+        )
 
-            # When
-            response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
+        # Then
+        assert response.status_code == 200
 
-            # Then
-            assert response.status_code == 200
+    @pytest.mark.usefixtures("db_session")
+    def when_user_has_rights_and_regular_offer_and_token_in_lower_case(self, app):
+        # Given
+        user = create_user(email="user@example.com", public_name="John Doe")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(admin_user, offerer)
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name", event_type=EventType.CINEMA)
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(user_offerer, booking)
+        booking_token = booking.token.lower()
+        url = f"/v2/bookings/token/{booking_token}"
 
-        @pytest.mark.usefixtures("db_session")
-        def when_non_standard_origin_header(self, app):
-            # Given
-            user = create_user()
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(admin_user, offerer)
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(
-                offerer,
-                venue,
-                price=0,
-                beginning_datetime=datetime.utcnow() + timedelta(hours=46),
-                booking_limit_datetime=datetime.utcnow() + timedelta(hours=24),
-            )
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking, user_offerer)
-            url = f"/v2/bookings/token/{booking.token}"
+        # When
+        response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
 
-            # When
-            response = (
-                TestClient(app.test_client())
-                .with_auth("admin@example.com")
-                .get(url, headers={"origin": "http://random_header.fr"})
-            )
+        # Then
+        assert response.status_code == 200
 
-            # Then
-            assert response.status_code == 200
+    @pytest.mark.usefixtures("db_session")
+    def when_non_standard_origin_header(self, app):
+        # Given
+        user = create_user()
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(admin_user, offerer)
+        venue = create_venue(offerer)
+        stock = create_stock_with_event_offer(
+            offerer,
+            venue,
+            price=0,
+            beginning_datetime=datetime.utcnow() + timedelta(hours=46),
+            booking_limit_datetime=datetime.utcnow() + timedelta(hours=24),
+        )
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(booking, user_offerer)
+        url = f"/v2/bookings/token/{booking.token}"
 
-    class Returns401:
-        def when_user_not_logged_in_and_doesnt_give_api_key(self, app):
-            # Given
-            url = "/v2/bookings/token/MOCKED_TOKEN"
+        # When
+        response = (
+            TestClient(app.test_client())
+            .with_auth("admin@example.com")
+            .get(url, headers={"origin": "http://random_header.fr"})
+        )
 
-            # When
-            response = TestClient(app.test_client()).get(url)
+        # Then
+        assert response.status_code == 200
 
-            # Then
-            assert response.status_code == 401
 
-        def when_user_not_logged_in_and_given_api_key_does_not_exist(self, app):
-            # Given
-            url = "/v2/bookings/token/FAKETOKEN"
+class Returns401Test:
+    def when_user_not_logged_in_and_doesnt_give_api_key(self, app):
+        # Given
+        url = "/v2/bookings/token/MOCKED_TOKEN"
 
-            # When
-            response = TestClient(app.test_client()).get(
-                url, headers={"Authorization": "Bearer WrongApiKey1234567", "Origin": "http://localhost"}
-            )
+        # When
+        response = TestClient(app.test_client()).get(url)
 
-            # Then
-            assert response.status_code == 401
+        # Then
+        assert response.status_code == 401
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_not_logged_in_and_existing_api_key_given_with_no_bearer_prefix(self, app):
-            # Given
-            pro = create_user(email="offerer@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(pro, offerer)
-            repository.save(user_offerer)
-            offerer_api_key = create_api_key(offerer_id=offerer.id)
-            repository.save(offerer_api_key)
-            url = "/v2/bookings/token/FAKETOKEN"
+    def when_user_not_logged_in_and_given_api_key_does_not_exist(self, app):
+        # Given
+        url = "/v2/bookings/token/FAKETOKEN"
 
-            # When
-            response = TestClient(app.test_client()).get(
-                url, headers={"Authorization": API_KEY_VALUE, "Origin": "http://localhost"}
-            )
+        # When
+        response = TestClient(app.test_client()).get(
+            url, headers={"Authorization": "Bearer WrongApiKey1234567", "Origin": "http://localhost"}
+        )
 
-            # Then
-            assert response.status_code == 401
+        # Then
+        assert response.status_code == 401
 
-    class Returns403:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_doesnt_have_rights_and_token_exists(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            querying_user = create_user(email="querying@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name")
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(querying_user, booking)
-            url = f"/v2/bookings/token/{booking.token}"
+    @pytest.mark.usefixtures("db_session")
+    def when_user_not_logged_in_and_existing_api_key_given_with_no_bearer_prefix(self, app):
+        # Given
+        pro = create_user(email="offerer@example.com")
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(pro, offerer)
+        repository.save(user_offerer)
+        offerer_api_key = create_api_key(offerer_id=offerer.id)
+        repository.save(offerer_api_key)
+        url = "/v2/bookings/token/FAKETOKEN"
 
-            # When
-            response = TestClient(app.test_client()).with_auth("querying@example.com").get(url)
+        # When
+        response = TestClient(app.test_client()).get(
+            url, headers={"Authorization": API_KEY_VALUE, "Origin": "http://localhost"}
+        )
 
-            # Then
-            assert response.status_code == 403
-            assert response.json["user"] == ["Vous n'avez pas les droits suffisants pour valider cette contremarque."]
+        # Then
+        assert response.status_code == 401
 
-        @pytest.mark.usefixtures("db_session")
-        def when_given_api_key_not_related_to_booking_offerer(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            offerer2 = create_offerer(siren="987654321")
-            user_offerer = create_user_offerer(admin_user, offerer)
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name")
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(admin_user, booking, user_offerer, offerer2)
-            offerer2ApiKey = create_api_key(offerer_id=offerer2.id)
-            repository.save(offerer2ApiKey)
-            user2ApiKey = f"Bearer {offerer2ApiKey.value}"
-            url = f"/v2/bookings/token/{booking.token}"
 
-            # When
-            response = TestClient(app.test_client()).get(
-                url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-            )
+class Returns403Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_doesnt_have_rights_and_token_exists(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        querying_user = create_user(email="querying@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name")
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(querying_user, booking)
+        url = f"/v2/bookings/token/{booking.token}"
 
-            # Then
-            assert response.status_code == 403
-            assert response.json["user"] == ["Vous n'avez pas les droits suffisants pour valider cette contremarque."]
+        # When
+        response = TestClient(app.test_client()).with_auth("querying@example.com").get(url)
 
-        @mock.patch("pcapi.core.bookings.validation.check_is_usable")
-        @pytest.mark.usefixtures("db_session")
-        def when_booking_not_confirmed(self, mocked_check_is_usable, app):
-            # Given
-            next_week = datetime.utcnow() + timedelta(weeks=1)
-            unconfirmed_booking = bookings_factories.BookingFactory(stock__beginningDatetime=next_week)
-            pro_user = users_factories.UserFactory(email="pro@example.com")
-            offerer = unconfirmed_booking.stock.offer.venue.managingOfferer
-            offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-            url = f"/v2/bookings/token/{unconfirmed_booking.token}"
-            mocked_check_is_usable.side_effect = api_errors.ForbiddenError(errors={"booking": ["Not confirmed"]})
+        # Then
+        assert response.status_code == 403
+        assert response.json["user"] == ["Vous n'avez pas les droits suffisants pour valider cette contremarque."]
 
-            # When
-            response = TestClient(app.test_client()).with_auth("pro@example.com").get(url)
+    @pytest.mark.usefixtures("db_session")
+    def when_given_api_key_not_related_to_booking_offerer(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        offerer2 = create_offerer(siren="987654321")
+        user_offerer = create_user_offerer(admin_user, offerer)
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name")
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(admin_user, booking, user_offerer, offerer2)
+        offerer2ApiKey = create_api_key(offerer_id=offerer2.id)
+        repository.save(offerer2ApiKey)
+        user2ApiKey = f"Bearer {offerer2ApiKey.value}"
+        url = f"/v2/bookings/token/{booking.token}"
 
-            # Then
-            assert response.status_code == 403
-            assert response.json["booking"] == ["Not confirmed"]
+        # When
+        response = TestClient(app.test_client()).get(
+            url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
+        )
 
-        @pytest.mark.usefixtures("db_session")
-        def when_booking_is_cancelled(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(admin_user, offerer)
-            venue = create_venue(offerer)
-            stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
-            booking = create_booking(user=user, stock=stock, is_cancelled=True, venue=venue)
-            repository.save(admin_user, booking, user_offerer)
-            offererApiKey = create_api_key(offerer_id=offerer.id)
-            repository.save(offererApiKey)
-            user2ApiKey = f"Bearer {offererApiKey.value}"
-            url = f"/v2/bookings/token/{booking.token}"
+        # Then
+        assert response.status_code == 403
+        assert response.json["user"] == ["Vous n'avez pas les droits suffisants pour valider cette contremarque."]
 
-            # When
-            response = TestClient(app.test_client()).get(
-                url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-            )
+    @mock.patch("pcapi.core.bookings.validation.check_is_usable")
+    @pytest.mark.usefixtures("db_session")
+    def when_booking_not_confirmed(self, mocked_check_is_usable, app):
+        # Given
+        next_week = datetime.utcnow() + timedelta(weeks=1)
+        unconfirmed_booking = bookings_factories.BookingFactory(stock__beginningDatetime=next_week)
+        pro_user = users_factories.UserFactory(email="pro@example.com")
+        offerer = unconfirmed_booking.stock.offer.venue.managingOfferer
+        offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+        url = f"/v2/bookings/token/{unconfirmed_booking.token}"
+        mocked_check_is_usable.side_effect = api_errors.ForbiddenError(errors={"booking": ["Not confirmed"]})
 
-            # Then
-            assert response.status_code == 403
-            assert response.json["booking"] == ["Cette réservation a été annulée"]
+        # When
+        response = TestClient(app.test_client()).with_auth("pro@example.com").get(url)
 
-        @pytest.mark.usefixtures("db_session")
-        def when_booking_is_refunded(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(admin_user, offerer)
-            venue = create_venue(offerer)
-            stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
-            booking = create_booking(user=user, stock=stock, is_used=True, venue=venue)
-            payment = create_payment(booking=booking, offerer=offerer)
-            repository.save(admin_user, payment, user_offerer)
-            offererApiKey = create_api_key(offerer_id=offerer.id)
-            repository.save(offererApiKey)
-            user2ApiKey = f"Bearer {offererApiKey.value}"
-            url = f"/v2/bookings/token/{booking.token}"
+        # Then
+        assert response.status_code == 403
+        assert response.json["booking"] == ["Not confirmed"]
 
-            # When
-            response = TestClient(app.test_client()).get(
-                url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-            )
+    @pytest.mark.usefixtures("db_session")
+    def when_booking_is_cancelled(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(admin_user, offerer)
+        venue = create_venue(offerer)
+        stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
+        booking = create_booking(user=user, stock=stock, is_cancelled=True, venue=venue)
+        repository.save(admin_user, booking, user_offerer)
+        offererApiKey = create_api_key(offerer_id=offerer.id)
+        repository.save(offererApiKey)
+        user2ApiKey = f"Bearer {offererApiKey.value}"
+        url = f"/v2/bookings/token/{booking.token}"
 
-            # Then
-            assert response.status_code == 403
-            assert response.json["payment"] == ["Cette réservation a été remboursée"]
+        # When
+        response = TestClient(app.test_client()).get(
+            url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
+        )
 
-    class Returns404:
-        @pytest.mark.usefixtures("db_session")
-        def when_booking_is_not_provided_at_all(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name")
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking)
-            url = "/v2/bookings/token/"
+        # Then
+        assert response.status_code == 403
+        assert response.json["booking"] == ["Cette réservation a été annulée"]
 
-            # When
-            response = TestClient(app.test_client()).get(url)
+    @pytest.mark.usefixtures("db_session")
+    def when_booking_is_refunded(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(admin_user, offerer)
+        venue = create_venue(offerer)
+        stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
+        booking = create_booking(user=user, stock=stock, is_used=True, venue=venue)
+        payment = create_payment(booking=booking, offerer=offerer)
+        repository.save(admin_user, payment, user_offerer)
+        offererApiKey = create_api_key(offerer_id=offerer.id)
+        repository.save(offererApiKey)
+        user2ApiKey = f"Bearer {offererApiKey.value}"
+        url = f"/v2/bookings/token/{booking.token}"
 
-            # Then
-            assert response.status_code == 404
+        # When
+        response = TestClient(app.test_client()).get(
+            url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
+        )
 
-        @pytest.mark.usefixtures("db_session")
-        def when_token_user_has_rights_but_token_not_found(self, app):
-            # Given
-            admin_user = create_user(email="admin@example.com")
-            repository.save(admin_user)
-            url = "/v2/bookings/token/12345"
+        # Then
+        assert response.status_code == 403
+        assert response.json["payment"] == ["Cette réservation a été remboursée"]
 
-            # When
-            response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
 
-            # Then
-            assert response.status_code == 404
-            assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
+class Returns404Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_booking_is_not_provided_at_all(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name")
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(booking)
+        url = "/v2/bookings/token/"
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_has_api_key_but_token_not_found(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(admin_user, offerer)
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name")
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(admin_user, booking, user_offerer)
-            offererApiKey = create_api_key(offerer_id=offerer.id)
-            repository.save(offererApiKey)
-            user2ApiKey = f"Bearer {offererApiKey.value}"
-            url = "/v2/bookings/token/12345"
+        # When
+        response = TestClient(app.test_client()).get(url)
 
-            # When
-            response = TestClient(app.test_client()).get(
-                url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-            )
+        # Then
+        assert response.status_code == 404
 
-            # Then
-            assert response.status_code == 404
-            assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
+    @pytest.mark.usefixtures("db_session")
+    def when_token_user_has_rights_but_token_not_found(self, app):
+        # Given
+        admin_user = create_user(email="admin@example.com")
+        repository.save(admin_user)
+        url = "/v2/bookings/token/12345"
 
-    class Returns410:
-        @pytest.mark.usefixtures("db_session")
-        def when_booking_is_already_validated(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            admin_user = create_user(email="admin@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(admin_user, offerer)
-            venue = create_venue(offerer)
-            stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
-            booking = create_booking(user=user, stock=stock, is_used=True, venue=venue)
-            repository.save(admin_user, booking, user_offerer)
-            offererApiKey = create_api_key(offerer_id=offerer.id)
-            repository.save(offererApiKey)
-            user2ApiKey = f"Bearer {offererApiKey.value}"
-            url = f"/v2/bookings/token/{booking.token}"
+        # When
+        response = TestClient(app.test_client()).with_auth("admin@example.com").get(url)
 
-            # When
-            response = TestClient(app.test_client()).get(
-                url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-            )
+        # Then
+        assert response.status_code == 404
+        assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
 
-            # Then
-            assert response.status_code == 410
-            assert response.json["booking"] == ["Cette réservation a déjà été validée"]
+    @pytest.mark.usefixtures("db_session")
+    def when_user_has_api_key_but_token_not_found(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(admin_user, offerer)
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue, event_name="Event Name")
+        event_occurrence = create_event_occurrence(offer)
+        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(admin_user, booking, user_offerer)
+        offererApiKey = create_api_key(offerer_id=offerer.id)
+        repository.save(offererApiKey)
+        user2ApiKey = f"Bearer {offererApiKey.value}"
+        url = "/v2/bookings/token/12345"
+
+        # When
+        response = TestClient(app.test_client()).get(
+            url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
+        )
+
+        # Then
+        assert response.status_code == 404
+        assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
+
+
+class Returns410Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_booking_is_already_validated(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        admin_user = create_user(email="admin@example.com")
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(admin_user, offerer)
+        venue = create_venue(offerer)
+        stock = create_stock_with_thing_offer(offerer, venue, offer=None, price=0)
+        booking = create_booking(user=user, stock=stock, is_used=True, venue=venue)
+        repository.save(admin_user, booking, user_offerer)
+        offererApiKey = create_api_key(offerer_id=offerer.id)
+        repository.save(offererApiKey)
+        user2ApiKey = f"Bearer {offererApiKey.value}"
+        url = f"/v2/bookings/token/{booking.token}"
+
+        # When
+        response = TestClient(app.test_client()).get(
+            url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
+        )
+
+        # Then
+        assert response.status_code == 410
+        assert response.json["booking"] == ["Cette réservation a déjà été validée"]

--- a/tests/routes/pro/get_categories_test.py
+++ b/tests/routes/pro/get_categories_test.py
@@ -5,7 +5,7 @@ import pcapi.core.offers.factories as offers_factories
 from tests.conftest import TestClient
 
 
-class Returns200:
+class Returns200Test:
     @pytest.mark.usefixtures("db_session")
     def should_return_categories_and_sub_categories(self, app):
         # Given

--- a/tests/routes/pro/get_offer_test.py
+++ b/tests/routes/pro/get_offer_test.py
@@ -12,7 +12,7 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns200:
+class Returns200Test:
     def test_access_by_beneficiary(self, app):
         # Given
         beneficiary = users_factories.UserFactory()

--- a/tests/routes/pro/get_offerer_test.py
+++ b/tests/routes/pro/get_offerer_test.py
@@ -10,7 +10,7 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Returns404:
+class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_offerer_does_not_exist(self, app):
         # Given
@@ -25,7 +25,7 @@ class Returns404:
         assert response.json["global"] == ["La page que vous recherchez n'existe pas"]
 
 
-class Returns200:
+class Returns200Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_has_rights_on_offerer(self, app):
         # given

--- a/tests/routes/pro/get_offerers_names_test.py
+++ b/tests/routes/pro/get_offerers_names_test.py
@@ -7,7 +7,7 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Returns200ForProUser:
+class Returns200ForProUserTest:
     def _setup_offerers_for_pro_user(self, user):
         offerer = offers_factories.OffererFactory()
         offers_factories.UserOffererFactory(user=user, offerer=offerer)
@@ -153,7 +153,7 @@ class Returns200ForProUser:
         assert humanize(offerers["owned_offerer_not_validated_for_user"].id) in offerer_ids
 
 
-class Returns200ForAdmin:
+class Returns200ForAdminTest:
     def _setup_offerers_for_users(self):
         offerer = offers_factories.OffererFactory()
         user_offerer = offers_factories.UserOffererFactory(offerer=offerer)

--- a/tests/routes/pro/get_offerers_test.py
+++ b/tests/routes/pro/get_offerers_test.py
@@ -10,352 +10,352 @@ from pcapi.repository import repository
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_logged_in_and_return_an_offerer_with_one_managed_venue(self, app):
-            # given
-            offerer1 = create_offerer(siren="123456781", name="offreur C")
-            venue = create_venue(offerer1)
-            repository.save(offerer1, venue)
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_logged_in_and_return_an_offerer_with_one_managed_venue(self, app):
+        # given
+        offerer1 = create_offerer(siren="123456781", name="offreur C")
+        venue = create_venue(offerer1)
+        repository.save(offerer1, venue)
 
-            user = create_user()
-            user.offerers = [offerer1]
-            repository.save(user)
+        user = create_user()
+        user.offerers = [offerer1]
+        repository.save(user)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/offerers")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/offerers")
 
-            # then
-            assert response.status_code == 200
-            offerer_response = response.json[0]
-            managed_venues_response = offerer_response["managedVenues"][0]
-            assert "validationToken" not in managed_venues_response
+        # then
+        assert response.status_code == 200
+        offerer_response = response.json[0]
+        managed_venues_response = offerer_response["managedVenues"][0]
+        assert "validationToken" not in managed_venues_response
 
-        @pytest.mark.usefixtures("db_session")
-        def when_logged_in_and_return_a_list_of_offerers_sorted_alphabetically(self, app):
-            # given
-            offerer1 = create_offerer(siren="123456781", name="offreur C")
-            offerer2 = create_offerer(siren="123456782", name="offreur A")
-            offerer3 = create_offerer(siren="123456783", name="offreur B")
-            repository.save(offerer1, offerer3, offerer2)
+    @pytest.mark.usefixtures("db_session")
+    def when_logged_in_and_return_a_list_of_offerers_sorted_alphabetically(self, app):
+        # given
+        offerer1 = create_offerer(siren="123456781", name="offreur C")
+        offerer2 = create_offerer(siren="123456782", name="offreur A")
+        offerer3 = create_offerer(siren="123456783", name="offreur B")
+        repository.save(offerer1, offerer3, offerer2)
 
-            user = create_user()
-            user.offerers = [offerer1, offerer2, offerer3]
-            repository.save(user)
+        user = create_user()
+        user.offerers = [offerer1, offerer2, offerer3]
+        repository.save(user)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/offerers")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/offerers")
 
-            # then
-            assert response.status_code == 200
-            offerers = response.json
-            assert len(offerers) == 3
-            names = [offerer["name"] for offerer in offerers]
-            assert names == ["offreur A", "offreur B", "offreur C"]
+        # then
+        assert response.status_code == 200
+        offerers = response.json
+        assert len(offerers) == 3
+        names = [offerer["name"] for offerer in offerers]
+        assert names == ["offreur A", "offreur B", "offreur C"]
 
-        @pytest.mark.usefixtures("db_session")
-        def when_logged_in_and_return_a_list_of_offerers_including_non_validated_structures(self, app):
-            # given
-            user = create_user()
-            offerer1 = create_offerer(siren="123456781", name="offreur A")
-            offerer2 = create_offerer(siren="123456782", name="offreur B")
-            offerer3 = create_offerer(siren="123456783", name="offreur C")
-            user_offerer1 = create_user_offerer(user, offerer1, validation_token=None)
-            user_offerer2 = create_user_offerer(user, offerer2, validation_token="AZE123")
-            user_offerer3 = create_user_offerer(user, offerer3, validation_token=None)
-            repository.save(user_offerer1, user_offerer2, user_offerer3)
+    @pytest.mark.usefixtures("db_session")
+    def when_logged_in_and_return_a_list_of_offerers_including_non_validated_structures(self, app):
+        # given
+        user = create_user()
+        offerer1 = create_offerer(siren="123456781", name="offreur A")
+        offerer2 = create_offerer(siren="123456782", name="offreur B")
+        offerer3 = create_offerer(siren="123456783", name="offreur C")
+        user_offerer1 = create_user_offerer(user, offerer1, validation_token=None)
+        user_offerer2 = create_user_offerer(user, offerer2, validation_token="AZE123")
+        user_offerer3 = create_user_offerer(user, offerer3, validation_token=None)
+        repository.save(user_offerer1, user_offerer2, user_offerer3)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/offerers")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/offerers")
 
-            # then
-            assert response.status_code == 200
-            offerers = response.json
-            assert len(offerers) == 3
-            names = [offerer["name"] for offerer in offerers]
-            assert names == ["offreur A", "offreur B", "offreur C"]
+        # then
+        assert response.status_code == 200
+        offerers = response.json
+        assert len(offerers) == 3
+        names = [offerer["name"] for offerer in offerers]
+        assert names == ["offreur A", "offreur B", "offreur C"]
 
-            assert offerers[0]["userHasAccess"] is True
-            assert offerers[1]["userHasAccess"] is False
-            assert offerers[2]["userHasAccess"] is True
+        assert offerers[0]["userHasAccess"] is True
+        assert offerers[1]["userHasAccess"] is False
+        assert offerers[2]["userHasAccess"] is True
 
-        @pytest.mark.usefixtures("db_session")
-        def when_current_user_is_not_admin_and_returns_only_offers_managed_by_him(self, app):
-            # given
-            offerer1 = create_offerer(siren="123456781", name="offreur C")
-            offerer2 = create_offerer(siren="123456782", name="offreur A")
-            offerer3 = create_offerer(siren="123456783", name="offreur B")
-            repository.save(offerer1, offerer3, offerer2)
+    @pytest.mark.usefixtures("db_session")
+    def when_current_user_is_not_admin_and_returns_only_offers_managed_by_him(self, app):
+        # given
+        offerer1 = create_offerer(siren="123456781", name="offreur C")
+        offerer2 = create_offerer(siren="123456782", name="offreur A")
+        offerer3 = create_offerer(siren="123456783", name="offreur B")
+        repository.save(offerer1, offerer3, offerer2)
 
-            user = create_user(is_beneficiary=True, is_admin=False)
-            user.offerers = [offerer1, offerer2]
-            repository.save(user)
+        user = create_user(is_beneficiary=True, is_admin=False)
+        user.offerers = [offerer1, offerer2]
+        repository.save(user)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/offerers")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/offerers")
 
-            # then
-            assert response.status_code == 200
-            assert len(response.json) == 2
+        # then
+        assert response.status_code == 200
+        assert len(response.json) == 2
 
-        @pytest.mark.usefixtures("db_session")
-        def when_current_user_is_admin_and_returns_all_offerers(self, app):
-            # given
-            offerer1 = create_offerer(siren="123456781", name="offreur C")
-            offerer2 = create_offerer(siren="123456782", name="offreur A")
-            offerer3 = create_offerer(siren="123456783", name="offreur B")
-            repository.save(offerer1, offerer3, offerer2)
+    @pytest.mark.usefixtures("db_session")
+    def when_current_user_is_admin_and_returns_all_offerers(self, app):
+        # given
+        offerer1 = create_offerer(siren="123456781", name="offreur C")
+        offerer2 = create_offerer(siren="123456782", name="offreur A")
+        offerer3 = create_offerer(siren="123456783", name="offreur B")
+        repository.save(offerer1, offerer3, offerer2)
 
-            user = create_user(is_beneficiary=False, is_admin=True)
-            user.offerers = [offerer1, offerer2]
-            repository.save(user)
+        user = create_user(is_beneficiary=False, is_admin=True)
+        user.offerers = [offerer1, offerer2]
+        repository.save(user)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/offerers")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/offerers")
 
-            # then
-            assert response.status_code == 200
-            assert len(response.json) == 3
+        # then
+        assert response.status_code == 200
+        assert len(response.json) == 3
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_admin_and_param_validated_is_false_and_returns_all_info_of_all_offerers(self, app):
-            # given
-            offerer1 = create_offerer(siren="123456781", name="offreur A", validation_token="F1TVYSGV")
-            offerer2 = create_offerer(siren="123456782", name="offreur B")
-            bank_information1 = create_bank_information(application_id=1, offerer=offerer1)
-            bank_information2 = create_bank_information(application_id=2, offerer=offerer2)
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_admin_and_param_validated_is_false_and_returns_all_info_of_all_offerers(self, app):
+        # given
+        offerer1 = create_offerer(siren="123456781", name="offreur A", validation_token="F1TVYSGV")
+        offerer2 = create_offerer(siren="123456782", name="offreur B")
+        bank_information1 = create_bank_information(application_id=1, offerer=offerer1)
+        bank_information2 = create_bank_information(application_id=2, offerer=offerer2)
 
-            user = create_user(is_beneficiary=False, is_admin=True)
-            user.offerers = [offerer1, offerer2]
-            repository.save(user, bank_information1, bank_information2)
+        user = create_user(is_beneficiary=False, is_admin=True)
+        user.offerers = [offerer1, offerer2]
+        repository.save(user, bank_information1, bank_information2)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=false")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=false")
 
-            # then
-            assert response.status_code == 200
-            assert len(response.json) == 1
-            offerer_response = response.json[0]
-            assert offerer_response["name"] == "offreur A"
-            assert set(offerer_response.keys()) == {
-                "address",
-                "bic",
-                "city",
-                "dateCreated",
-                "dateModifiedAtLastProvider",
-                "demarchesSimplifieesApplicationId",
-                "fieldsUpdated",
-                "iban",
-                "id",
-                "idAtProviders",
-                "isActive",
-                "isValidated",
-                "lastProviderId",
-                "managedVenues",
-                "nOffers",
-                "name",
-                "postalCode",
-                "siren",
-                "thumbCount",
-                "userHasAccess",
-            }
+        # then
+        assert response.status_code == 200
+        assert len(response.json) == 1
+        offerer_response = response.json[0]
+        assert offerer_response["name"] == "offreur A"
+        assert set(offerer_response.keys()) == {
+            "address",
+            "bic",
+            "city",
+            "dateCreated",
+            "dateModifiedAtLastProvider",
+            "demarchesSimplifieesApplicationId",
+            "fieldsUpdated",
+            "iban",
+            "id",
+            "idAtProviders",
+            "isActive",
+            "isValidated",
+            "lastProviderId",
+            "managedVenues",
+            "nOffers",
+            "name",
+            "postalCode",
+            "siren",
+            "thumbCount",
+            "userHasAccess",
+        }
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_admin_and_param_validated_is_true_and_returns_only_validated_offerer(self, app):
-            # given
-            offerer1 = create_offerer(siren="123456781", name="offreur C", validation_token=None)
-            offerer2 = create_offerer(siren="123456782", name="offreur A", validation_token="AFYDAA")
-            bank_information1 = create_bank_information(application_id=1, offerer=offerer1)
-            bank_information2 = create_bank_information(application_id=2, offerer=offerer2)
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_admin_and_param_validated_is_true_and_returns_only_validated_offerer(self, app):
+        # given
+        offerer1 = create_offerer(siren="123456781", name="offreur C", validation_token=None)
+        offerer2 = create_offerer(siren="123456782", name="offreur A", validation_token="AFYDAA")
+        bank_information1 = create_bank_information(application_id=1, offerer=offerer1)
+        bank_information2 = create_bank_information(application_id=2, offerer=offerer2)
 
-            user = create_user(is_beneficiary=False, is_admin=True)
-            user.offerers = [offerer1, offerer2]
-            repository.save(user, bank_information1, bank_information2)
+        user = create_user(is_beneficiary=False, is_admin=True)
+        user.offerers = [offerer1, offerer2]
+        repository.save(user, bank_information1, bank_information2)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=true")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=true")
 
-            # then
-            assert response.status_code == 200
-            assert len(response.json) == 1
-            offerer_response = response.json[0]
-            assert offerer_response["name"] == "offreur C"
+        # then
+        assert response.status_code == 200
+        assert len(response.json) == 1
+        offerer_response = response.json[0]
+        assert offerer_response["name"] == "offreur C"
 
-        @pytest.mark.usefixtures("db_session")
-        def when_param_validated_is_false_and_returns_only_not_validated_offerers(self, app):
-            # given
-            user = create_user()
-            offerer1 = create_offerer(siren="123456781", name="offreur C", validation_token=None)
-            offerer2 = create_offerer(siren="123456782", name="offreur A", validation_token="AZE123")
-            offerer3 = create_offerer(siren="123456783", name="offreur B", validation_token=None)
-            user_offerer1 = create_user_offerer(user, offerer1)
-            user_offerer2 = create_user_offerer(user, offerer2)
-            user_offerer3 = create_user_offerer(user, offerer3)
-            repository.save(user_offerer1, user_offerer2, user_offerer3)
+    @pytest.mark.usefixtures("db_session")
+    def when_param_validated_is_false_and_returns_only_not_validated_offerers(self, app):
+        # given
+        user = create_user()
+        offerer1 = create_offerer(siren="123456781", name="offreur C", validation_token=None)
+        offerer2 = create_offerer(siren="123456782", name="offreur A", validation_token="AZE123")
+        offerer3 = create_offerer(siren="123456783", name="offreur B", validation_token=None)
+        user_offerer1 = create_user_offerer(user, offerer1)
+        user_offerer2 = create_user_offerer(user, offerer2)
+        user_offerer3 = create_user_offerer(user, offerer3)
+        repository.save(user_offerer1, user_offerer2, user_offerer3)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=false")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=false")
 
-            # then
-            assert response.status_code == 200
-            assert len(response.json) == 1
+        # then
+        assert response.status_code == 200
+        assert len(response.json) == 1
 
-        @pytest.mark.usefixtures("db_session")
-        def when_param_validated_is_true_and_returns_only_validated_offerers(self, app):
-            # given
-            user = create_user()
-            offerer1 = create_offerer(siren="123456781", name="offreur C", validation_token=None)
-            offerer2 = create_offerer(siren="123456782", name="offreur A", validation_token="AZE123")
-            offerer3 = create_offerer(siren="123456783", name="offreur B", validation_token=None)
-            user_offerer1 = create_user_offerer(user, offerer1)
-            user_offerer2 = create_user_offerer(user, offerer2)
-            user_offerer3 = create_user_offerer(user, offerer3)
-            repository.save(user_offerer1, user_offerer2, user_offerer3)
+    @pytest.mark.usefixtures("db_session")
+    def when_param_validated_is_true_and_returns_only_validated_offerers(self, app):
+        # given
+        user = create_user()
+        offerer1 = create_offerer(siren="123456781", name="offreur C", validation_token=None)
+        offerer2 = create_offerer(siren="123456782", name="offreur A", validation_token="AZE123")
+        offerer3 = create_offerer(siren="123456783", name="offreur B", validation_token=None)
+        user_offerer1 = create_user_offerer(user, offerer1)
+        user_offerer2 = create_user_offerer(user, offerer2)
+        user_offerer3 = create_user_offerer(user, offerer3)
+        repository.save(user_offerer1, user_offerer2, user_offerer3)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=true")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=true")
 
-            # then
-            assert response.status_code == 200
-            assert len(response.json) == 2
-            assert response.json[0]["name"] == "offreur B"
-            assert response.json[1]["name"] == "offreur C"
+        # then
+        assert response.status_code == 200
+        assert len(response.json) == 2
+        assert response.json[0]["name"] == "offreur B"
+        assert response.json[1]["name"] == "offreur C"
 
-        @pytest.mark.usefixtures("db_session")
-        def when_param_validated_is_true_returns_all_info_of_validated_offerers(self, app):
-            # given
-            user = create_user()
-            offerer1 = create_offerer(siren="123456781", name="offreur C", validation_token=None)
-            offerer2 = create_offerer(siren="123456782", name="offreur A", validation_token="AZE123")
-            offerer3 = create_offerer(siren="123456783", name="offreur B", validation_token=None)
-            user_offerer1 = create_user_offerer(user, offerer1)
-            user_offerer2 = create_user_offerer(user, offerer2)
-            user_offerer3 = create_user_offerer(user, offerer3)
-            bank_information1 = create_bank_information(application_id=1, offerer=offerer1)
-            bank_information2 = create_bank_information(application_id=2, offerer=offerer2)
-            bank_information3 = create_bank_information(application_id=3, offerer=offerer3)
-            repository.save(
-                bank_information1, bank_information2, bank_information3, user_offerer1, user_offerer2, user_offerer3
-            )
+    @pytest.mark.usefixtures("db_session")
+    def when_param_validated_is_true_returns_all_info_of_validated_offerers(self, app):
+        # given
+        user = create_user()
+        offerer1 = create_offerer(siren="123456781", name="offreur C", validation_token=None)
+        offerer2 = create_offerer(siren="123456782", name="offreur A", validation_token="AZE123")
+        offerer3 = create_offerer(siren="123456783", name="offreur B", validation_token=None)
+        user_offerer1 = create_user_offerer(user, offerer1)
+        user_offerer2 = create_user_offerer(user, offerer2)
+        user_offerer3 = create_user_offerer(user, offerer3)
+        bank_information1 = create_bank_information(application_id=1, offerer=offerer1)
+        bank_information2 = create_bank_information(application_id=2, offerer=offerer2)
+        bank_information3 = create_bank_information(application_id=3, offerer=offerer3)
+        repository.save(
+            bank_information1, bank_information2, bank_information3, user_offerer1, user_offerer2, user_offerer3
+        )
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=true")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=true")
 
-            # then
-            assert response.status_code == 200
-            assert len(response.json) == 2
-            assert list(response.json[0].keys()) == [
-                "address",
-                "bic",
-                "city",
-                "dateCreated",
-                "dateModifiedAtLastProvider",
-                "demarchesSimplifieesApplicationId",
-                "fieldsUpdated",
-                "iban",
-                "id",
-                "idAtProviders",
-                "isActive",
-                "isValidated",
-                "lastProviderId",
-                "managedVenues",
-                "nOffers",
-                "name",
-                "postalCode",
-                "siren",
-                "thumbCount",
-                "userHasAccess",
-            ]
+        # then
+        assert response.status_code == 200
+        assert len(response.json) == 2
+        assert list(response.json[0].keys()) == [
+            "address",
+            "bic",
+            "city",
+            "dateCreated",
+            "dateModifiedAtLastProvider",
+            "demarchesSimplifieesApplicationId",
+            "fieldsUpdated",
+            "iban",
+            "id",
+            "idAtProviders",
+            "isActive",
+            "isValidated",
+            "lastProviderId",
+            "managedVenues",
+            "nOffers",
+            "name",
+            "postalCode",
+            "siren",
+            "thumbCount",
+            "userHasAccess",
+        ]
 
-        @pytest.mark.usefixtures("db_session")
-        def when_no_bank_information_for_offerer(self, app):
-            # given
-            user = create_user()
-            offerer1 = create_offerer(siren="123456781", name="offreur C")
-            user_offerer1 = create_user_offerer(user, offerer1)
-            repository.save(user_offerer1)
+    @pytest.mark.usefixtures("db_session")
+    def when_no_bank_information_for_offerer(self, app):
+        # given
+        user = create_user()
+        offerer1 = create_offerer(siren="123456781", name="offreur C")
+        user_offerer1 = create_user_offerer(user, offerer1)
+        repository.save(user_offerer1)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=true")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=true")
 
-            # then
-            assert response.status_code == 200
-            assert len(response.json) == 1
-            assert response.json[0]["bic"] is None
-            assert response.json[0]["iban"] is None
+        # then
+        assert response.status_code == 200
+        assert len(response.json) == 1
+        assert response.json[0]["bic"] is None
+        assert response.json[0]["iban"] is None
 
-        @pytest.mark.usefixtures("db_session")
-        def test_returns_metadata(self, app):
-            # given
-            user = create_user(email="user@test.com")
-            offerer = create_offerer(name="offreur C")
-            user_offerer = create_user_offerer(user, offerer)
-            repository.save(user_offerer)
-            auth_request = TestClient(app.test_client()).with_auth(email="user@test.com")
+    @pytest.mark.usefixtures("db_session")
+    def test_returns_metadata(self, app):
+        # given
+        user = create_user(email="user@test.com")
+        offerer = create_offerer(name="offreur C")
+        user_offerer = create_user_offerer(user, offerer)
+        repository.save(user_offerer)
+        auth_request = TestClient(app.test_client()).with_auth(email="user@test.com")
 
-            # when
-            response = auth_request.get("/offerers")
+        # when
+        response = auth_request.get("/offerers")
 
-            # then
-            assert response.status_code == 200
-            assert response.headers["Total-Data-Count"] == "1"
+        # then
+        assert response.status_code == 200
+        assert response.headers["Total-Data-Count"] == "1"
 
-        @pytest.mark.usefixtures("db_session")
-        def test_returns_proper_data_count_by_counting_distinct_offerers(self, app):
-            # given
-            user = create_user(email="user@test.com")
-            offerer1 = create_offerer(name="offreur")
-            user_offerer1 = create_user_offerer(user, offerer1)
-            offerer2 = create_offerer(name="offreur 2", siren="123456781")
-            user_offerer2 = create_user_offerer(user, offerer2)
-            venue1 = create_venue(offerer1)
-            venue2 = create_venue(siret="12345678912346", offerer=offerer1)
-            repository.save(user_offerer1, user_offerer2, venue1, venue2)
-            auth_request = TestClient(app.test_client()).with_auth(email="user@test.com")
+    @pytest.mark.usefixtures("db_session")
+    def test_returns_proper_data_count_by_counting_distinct_offerers(self, app):
+        # given
+        user = create_user(email="user@test.com")
+        offerer1 = create_offerer(name="offreur")
+        user_offerer1 = create_user_offerer(user, offerer1)
+        offerer2 = create_offerer(name="offreur 2", siren="123456781")
+        user_offerer2 = create_user_offerer(user, offerer2)
+        venue1 = create_venue(offerer1)
+        venue2 = create_venue(siret="12345678912346", offerer=offerer1)
+        repository.save(user_offerer1, user_offerer2, venue1, venue2)
+        auth_request = TestClient(app.test_client()).with_auth(email="user@test.com")
 
-            # when
-            response = auth_request.get("/offerers")
+        # when
+        response = auth_request.get("/offerers")
 
-            # then
-            assert response.status_code == 200
-            assert response.headers["Total-Data-Count"] == "2"
+        # then
+        assert response.status_code == 200
+        assert response.headers["Total-Data-Count"] == "2"
 
-        @pytest.mark.usefixtures("db_session")
-        def test_returns_only_active_offerers(self, app):
-            # given
-            pro_user = create_user(email="user@test.com")
-            active_offerer = create_offerer(name="active_offerer", siren="1", is_active=True)
-            active_user_offerer = create_user_offerer(pro_user, active_offerer)
-            inactive_offerer = create_offerer(name="inactive_offerer", siren="2", is_active=False)
-            inactive_user_offerer = create_user_offerer(pro_user, inactive_offerer)
-            repository.save(active_user_offerer, inactive_user_offerer)
+    @pytest.mark.usefixtures("db_session")
+    def test_returns_only_active_offerers(self, app):
+        # given
+        pro_user = create_user(email="user@test.com")
+        active_offerer = create_offerer(name="active_offerer", siren="1", is_active=True)
+        active_user_offerer = create_user_offerer(pro_user, active_offerer)
+        inactive_offerer = create_offerer(name="inactive_offerer", siren="2", is_active=False)
+        inactive_user_offerer = create_user_offerer(pro_user, inactive_offerer)
+        repository.save(active_user_offerer, inactive_user_offerer)
 
-            # when
-            request = TestClient(app.test_client()).with_auth(email=pro_user.email)
-            response = request.get("/offerers?is_active=true")
+        # when
+        request = TestClient(app.test_client()).with_auth(email=pro_user.email)
+        response = request.get("/offerers?is_active=true")
 
-            # then
-            assert response.status_code == 200
-            assert len(response.json) == 1
-            assert response.json[0]["name"] == active_offerer.name
+        # then
+        assert response.status_code == 200
+        assert len(response.json) == 1
+        assert response.json[0]["name"] == active_offerer.name
 
-    class Returns400:
-        @pytest.mark.usefixtures("db_session")
-        def when_param_validated_is_not_true_nor_false(self, app):
-            # given
-            offerer1 = create_offerer(siren="123456781", name="offreur C")
-            offerer2 = create_offerer(siren="123456782", name="offreur A")
-            offerer3 = create_offerer(siren="123456783", name="offreur B")
-            repository.save(offerer1, offerer3, offerer2)
 
-            user = create_user(is_beneficiary=False, is_admin=True)
-            user.offerers = [offerer1, offerer2]
-            repository.save(user)
+class Returns400Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_param_validated_is_not_true_nor_false(self, app):
+        # given
+        offerer1 = create_offerer(siren="123456781", name="offreur C")
+        offerer2 = create_offerer(siren="123456782", name="offreur A")
+        offerer3 = create_offerer(siren="123456783", name="offreur B")
+        repository.save(offerer1, offerer3, offerer2)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=blabla")
+        user = create_user(is_beneficiary=False, is_admin=True)
+        user.offerers = [offerer1, offerer2]
+        repository.save(user)
 
-            # then
-            assert response.status_code == 400
-            assert response.json["validated"] == ["Le paramètre 'validated' doit être 'true' ou 'false'"]
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/offerers?validated=blabla")
+
+        # then
+        assert response.status_code == 400
+        assert response.json["validated"] == ["Le paramètre 'validated' doit être 'true' ou 'false'"]

--- a/tests/routes/pro/get_offers_test.py
+++ b/tests/routes/pro/get_offers_test.py
@@ -10,7 +10,7 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Returns200:
+class Returns200Test:
     def should_filter_by_venue_when_user_is_admin_and_request_specific_venue_with_no_rights_on_it(
         self, app, db_session, assert_num_queries
     ):
@@ -330,7 +330,7 @@ class Returns200:
         )
 
 
-class Returns404:
+class Returns404Test:
     def when_requested_venue_does_not_exist(self, app, db_session):
         # Given
         user = users_factories.UserFactory()

--- a/tests/routes/pro/get_providers_by_venue_test.py
+++ b/tests/routes/pro/get_providers_by_venue_test.py
@@ -9,92 +9,91 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_venue_has_known_allocine_id(self, app):
+        # Given
+        UserFactory(email="user@test.com")
+        venue = VenueFactory(siret="12345678912345")
+        AllocinePivotFactory(siret="12345678912345")
+
+        titelive_stocks = activate_provider("TiteLiveStocks")
+        allocine_stocks = activate_provider("AllocineStocks")
+
+        # When
+        response = (
+            TestClient(app.test_client()).with_auth(email="user@test.com").get(f"/providers/{humanize(venue.id)}")
+        )
+
+        # Then
+        assert response.status_code == 200
+        response_json = response.json
+        assert response_json == [
+            {
+                "enabledForPro": True,
+                "id": humanize(allocine_stocks.id),
+                "isActive": True,
+                "localClass": "AllocineStocks",
+                "name": "Allociné",
+            },
+            {
+                "enabledForPro": True,
+                "id": humanize(titelive_stocks.id),
+                "isActive": True,
+                "localClass": "TiteLiveStocks",
+                "name": "TiteLive Stocks (Epagine / Place des libraires.com)",
+            },
+        ]
+
+    @pytest.mark.usefixtures("db_session")
+    def when_venue_has_no_allocine_id(self, app):
+        # Given
+        UserFactory(email="user@test.com")
+        venue = VenueFactory()
+
+        titelive_stocks = activate_provider("TiteLiveStocks")
+        activate_provider("AllocineStocks")
+
+        # When
+        response = (
+            TestClient(app.test_client()).with_auth(email="user@test.com").get(f"/providers/{humanize(venue.id)}")
+        )
+
+        # Then
+        assert response.status_code == 200
+        response_json = response.json
+        assert response_json == [
+            {
+                "enabledForPro": True,
+                "id": humanize(titelive_stocks.id),
+                "isActive": True,
+                "localClass": "TiteLiveStocks",
+                "name": "TiteLive Stocks (Epagine / Place des libraires.com)",
+            }
+        ]
+
+    class Returns404Test:
         @pytest.mark.usefixtures("db_session")
-        def when_venue_has_known_allocine_id(self, app):
+        def when_venue_does_not_exists(self, app):
             # Given
             UserFactory(email="user@test.com")
-            venue = VenueFactory(siret="12345678912345")
-            AllocinePivotFactory(siret="12345678912345")
+            VenueFactory()
+            AllocinePivotFactory()
 
-            titelive_stocks = activate_provider("TiteLiveStocks")
-            allocine_stocks = activate_provider("AllocineStocks")
-
-            # When
-            response = (
-                TestClient(app.test_client()).with_auth(email="user@test.com").get(f"/providers/{humanize(venue.id)}")
-            )
-
-            # Then
-            assert response.status_code == 200
-            response_json = response.json
-            assert response_json == [
-                {
-                    "enabledForPro": True,
-                    "id": humanize(allocine_stocks.id),
-                    "isActive": True,
-                    "localClass": "AllocineStocks",
-                    "name": "Allociné",
-                },
-                {
-                    "enabledForPro": True,
-                    "id": humanize(titelive_stocks.id),
-                    "isActive": True,
-                    "localClass": "TiteLiveStocks",
-                    "name": "TiteLive Stocks (Epagine / Place des libraires.com)",
-                },
-            ]
-
-        @pytest.mark.usefixtures("db_session")
-        def when_venue_has_no_allocine_id(self, app):
-            # Given
-            UserFactory(email="user@test.com")
-            venue = VenueFactory()
-
-            titelive_stocks = activate_provider("TiteLiveStocks")
+            activate_provider("TiteLiveStocks")
             activate_provider("AllocineStocks")
 
             # When
-            response = (
-                TestClient(app.test_client()).with_auth(email="user@test.com").get(f"/providers/{humanize(venue.id)}")
-            )
+            response = TestClient(app.test_client()).with_auth(email="user@test.com").get("/providers/AZER")
 
             # Then
-            assert response.status_code == 200
-            response_json = response.json
-            assert response_json == [
-                {
-                    "enabledForPro": True,
-                    "id": humanize(titelive_stocks.id),
-                    "isActive": True,
-                    "localClass": "TiteLiveStocks",
-                    "name": "TiteLive Stocks (Epagine / Place des libraires.com)",
-                }
-            ]
+            assert response.status_code == 404
 
-        class Returns404:
-            @pytest.mark.usefixtures("db_session")
-            def when_venue_does_not_exists(self, app):
-                # Given
-                UserFactory(email="user@test.com")
-                VenueFactory()
-                AllocinePivotFactory()
+    class Returns401Test:
+        @pytest.mark.usefixtures("db_session")
+        def when_user_is_not_logged_in(self, app):
+            # when
+            response = TestClient(app.test_client()).get("/providers/AZER")
 
-                activate_provider("TiteLiveStocks")
-                activate_provider("AllocineStocks")
-
-                # When
-                response = TestClient(app.test_client()).with_auth(email="user@test.com").get("/providers/AZER")
-
-                # Then
-                assert response.status_code == 404
-
-        class Returns401:
-            @pytest.mark.usefixtures("db_session")
-            def when_user_is_not_logged_in(self, app):
-                # when
-                response = TestClient(app.test_client()).get("/providers/AZER")
-
-                # then
-                assert response.status_code == 401
+            # then
+            assert response.status_code == 401

--- a/tests/routes/pro/get_stocks_test.py
+++ b/tests/routes/pro/get_stocks_test.py
@@ -13,7 +13,7 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns200:
+class Returns200Test:
     @freeze_time("2020-10-15 00:00:00")
     def test_returns_an_event_stock(self, app):
         # Given
@@ -186,7 +186,7 @@ class Returns200:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403:
+class Returns403Test:
     def test_returns_an_event_stock(self, app):
         # Given
         now = datetime.utcnow()

--- a/tests/routes/pro/get_types_test.py
+++ b/tests/routes/pro/get_types_test.py
@@ -6,77 +6,77 @@ from pcapi.repository import repository
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns401:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_anonymous(self, app):
-            # when
-            response = TestClient(app.test_client()).get("/types")
+class Returns401Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_anonymous(self, app):
+        # when
+        response = TestClient(app.test_client()).get("/types")
 
-            # then
-            assert response.status_code == 401
+        # then
+        assert response.status_code == 401
 
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_logged(self, app):
-            # given
-            user = create_user(email="test@email.com")
-            repository.save(user)
 
-            # when
-            response = TestClient(app.test_client()).with_auth("test@email.com").get("/types")
-            types = response.json
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_logged(self, app):
+        # given
+        user = create_user(email="test@email.com")
+        repository.save(user)
 
-            # then
-            assert response.status_code == 200
-            types_values = [type["value"] for type in types]
-            assert "ThingType.ACTIVATION" not in types_values
-            assert "EventType.ACTIVATION" not in types_values
-            assert "ThingType.OEUVRE_ART" in types_values
-            assert "ThingType.INSTRUMENT" in types_values
-            assert "ThingType.LIVRE_AUDIO" in types_values
+        # when
+        response = TestClient(app.test_client()).with_auth("test@email.com").get("/types")
+        types = response.json
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_admin(self, app):
-            # given
-            admin_user = create_user(is_beneficiary=False, email="pctest.admin93.0@example.com", is_admin=True)
-            repository.save(admin_user)
+        # then
+        assert response.status_code == 200
+        types_values = [type["value"] for type in types]
+        assert "ThingType.ACTIVATION" not in types_values
+        assert "EventType.ACTIVATION" not in types_values
+        assert "ThingType.OEUVRE_ART" in types_values
+        assert "ThingType.INSTRUMENT" in types_values
+        assert "ThingType.LIVRE_AUDIO" in types_values
 
-            # when
-            response = TestClient(app.test_client()).with_auth("pctest.admin93.0@example.com").get("/types")
-            types = response.json
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_admin(self, app):
+        # given
+        admin_user = create_user(is_beneficiary=False, email="pctest.admin93.0@example.com", is_admin=True)
+        repository.save(admin_user)
 
-            # then
-            assert response.status_code == 200
-            types_values = [type["value"] for type in types]
-            assert "ThingType.ACTIVATION" not in types_values
-            assert "EventType.ACTIVATION" not in types_values
+        # when
+        response = TestClient(app.test_client()).with_auth("pctest.admin93.0@example.com").get("/types")
+        types = response.json
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_returns_types_labels(self, app):
-            # given
-            user = create_user(email="test@email.com")
+        # then
+        assert response.status_code == 200
+        types_values = [type["value"] for type in types]
+        assert "ThingType.ACTIVATION" not in types_values
+        assert "EventType.ACTIVATION" not in types_values
 
-            repository.save(user)
+    @pytest.mark.usefixtures("db_session")
+    def when_user_returns_types_labels(self, app):
+        # given
+        user = create_user(email="test@email.com")
 
-            # when
-            response = TestClient(app.test_client()).with_auth("test@email.com").get("/types")
-            types = response.json
+        repository.save(user)
 
-            # then
-            assert response.status_code == 200
-            pro_labels = [type["proLabel"] for type in types]
-            app_labels = [type["appLabel"] for type in types]
+        # when
+        response = TestClient(app.test_client()).with_auth("test@email.com").get("/types")
+        types = response.json
 
-            assert "Livres papier ou numérique, abonnements lecture" in pro_labels
-            assert "Conférences, rencontres et découverte des métiers" in pro_labels
-            assert "Musées, galeries, patrimoine - entrées libres, abonnements" in pro_labels
-            assert "Pratique artistique - séances d'essai et stages ponctuels" in pro_labels
-            assert "Livres papier ou numérique, abonnements lecture" in pro_labels
-            assert "Livres audio numériques" in pro_labels
-            assert "Vente et location d’instruments de musique" in pro_labels
-            assert "Vente d'œuvres d'art" in pro_labels
+        # then
+        assert response.status_code == 200
+        pro_labels = [type["proLabel"] for type in types]
+        app_labels = [type["appLabel"] for type in types]
 
-            assert "Œuvre d’art" in app_labels
-            assert "Instrument de musique" in app_labels
-            assert "Livre ou carte lecture" in app_labels
+        assert "Livres papier ou numérique, abonnements lecture" in pro_labels
+        assert "Conférences, rencontres et découverte des métiers" in pro_labels
+        assert "Musées, galeries, patrimoine - entrées libres, abonnements" in pro_labels
+        assert "Pratique artistique - séances d'essai et stages ponctuels" in pro_labels
+        assert "Livres papier ou numérique, abonnements lecture" in pro_labels
+        assert "Livres audio numériques" in pro_labels
+        assert "Vente et location d’instruments de musique" in pro_labels
+        assert "Vente d'œuvres d'art" in pro_labels
+
+        assert "Œuvre d’art" in app_labels
+        assert "Instrument de musique" in app_labels
+        assert "Livre ou carte lecture" in app_labels

--- a/tests/routes/pro/get_user_offerer_test.py
+++ b/tests/routes/pro/get_user_offerer_test.py
@@ -9,47 +9,44 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def test_get_user_offerer_should_return_only_user_offerer_from_current_user(self, app):
-            # given
-            user1 = create_user(email="patrick.fiori@test.com")
-            user2 = create_user(email="celine.dion@test.com")
-            offerer = create_offerer(siren="123456781")
-            user_offerer1 = create_user_offerer(user1, offerer)
-            user_offerer2 = create_user_offerer(user2, offerer)
-            repository.save(user_offerer1, user_offerer2)
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def test_get_user_offerer_should_return_only_user_offerer_from_current_user(self, app):
+        # given
+        user1 = create_user(email="patrick.fiori@test.com")
+        user2 = create_user(email="celine.dion@test.com")
+        offerer = create_offerer(siren="123456781")
+        user_offerer1 = create_user_offerer(user1, offerer)
+        user_offerer2 = create_user_offerer(user2, offerer)
+        repository.save(user_offerer1, user_offerer2)
 
-            # when
-            response = (
-                TestClient(app.test_client()).with_auth(email=user1.email).get("/userOfferers/" + humanize(offerer.id))
-            )
+        # when
+        response = (
+            TestClient(app.test_client()).with_auth(email=user1.email).get("/userOfferers/" + humanize(offerer.id))
+        )
 
-            # then
-            assert response.status_code == 200
-            user_offerer_response = response.json[0]
-            assert user_offerer_response["userId"] == humanize(user1.id)
-            assert "validationToken" not in user_offerer_response
+        # then
+        assert response.status_code == 200
+        user_offerer_response = response.json[0]
+        assert user_offerer_response["userId"] == humanize(user1.id)
+        assert "validationToken" not in user_offerer_response
 
-        @pytest.mark.usefixtures("db_session")
-        def when_offerer_id_does_not_exist(self, app):
-            # given
-            user1 = create_user(email="patrick.fiori@test.com")
-            user2 = create_user(email="celine.dion@test.com")
-            offerer = create_offerer(siren="123456781")
-            user_offerer1 = create_user_offerer(user1, offerer)
-            user_offerer2 = create_user_offerer(user2, offerer)
-            repository.save(user_offerer1, user_offerer2)
-            non_existing_offerer_id = "B9"
+    @pytest.mark.usefixtures("db_session")
+    def when_offerer_id_does_not_exist(self, app):
+        # given
+        user1 = create_user(email="patrick.fiori@test.com")
+        user2 = create_user(email="celine.dion@test.com")
+        offerer = create_offerer(siren="123456781")
+        user_offerer1 = create_user_offerer(user1, offerer)
+        user_offerer2 = create_user_offerer(user2, offerer)
+        repository.save(user_offerer1, user_offerer2)
+        non_existing_offerer_id = "B9"
 
-            # when
-            response = (
-                TestClient(app.test_client())
-                .with_auth(email=user1.email)
-                .get("/userOfferers/" + non_existing_offerer_id)
-            )
+        # when
+        response = (
+            TestClient(app.test_client()).with_auth(email=user1.email).get("/userOfferers/" + non_existing_offerer_id)
+        )
 
-            # then
-            assert response.status_code == 200
-            assert response.json == []
+        # then
+        assert response.status_code == 200
+        assert response.json == []

--- a/tests/routes/pro/get_venue_labels_test.py
+++ b/tests/routes/pro/get_venue_labels_test.py
@@ -7,31 +7,31 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns401:
-        @pytest.mark.usefixtures("db_session")
-        def when_the_user_is_not_authenticated(self, app):
-            # When
-            response = TestClient(app.test_client()).get("/venue-labels")
+class Returns401Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_the_user_is_not_authenticated(self, app):
+        # When
+        response = TestClient(app.test_client()).get("/venue-labels")
 
-            # then
-            assert response.status_code == 401
+        # then
+        assert response.status_code == 401
 
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_the_user_is_authenticated(self, app):
-            # Given
-            user = UserFactory(isAdmin=False, isBeneficiary=False)
-            venue_label_1 = VenueLabelFactory(label="Maison des illustres")
-            venue_label_2 = VenueLabelFactory(label="Monuments historiques")
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).get("/venue-labels")
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_the_user_is_authenticated(self, app):
+        # Given
+        user = UserFactory(isAdmin=False, isBeneficiary=False)
+        venue_label_1 = VenueLabelFactory(label="Maison des illustres")
+        venue_label_2 = VenueLabelFactory(label="Monuments historiques")
 
-            # then
-            assert response.status_code == 200
-            assert len(response.json) == 2
-            assert response.json == [
-                {"id": humanize(venue_label_1.id), "label": venue_label_1.label},
-                {"id": humanize(venue_label_2.id), "label": venue_label_2.label},
-            ]
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).get("/venue-labels")
+
+        # then
+        assert response.status_code == 200
+        assert len(response.json) == 2
+        assert response.json == [
+            {"id": humanize(venue_label_1.id), "label": venue_label_1.label},
+            {"id": humanize(venue_label_2.id), "label": venue_label_2.label},
+        ]

--- a/tests/routes/pro/get_venue_providers_test.py
+++ b/tests/routes/pro/get_venue_providers_test.py
@@ -8,60 +8,60 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def test_get_list_with_valid_venue_id(self, app):
-            # given
-            user = users_factories.UserFactory(isAdmin=False, isBeneficiary=False)
-            titelive_things_provider = get_provider_by_local_class("TiteLiveThings")
-            venue_provider = offerers_factories.VenueProviderFactory(
-                venue__name="Librairie Titelive",
-                provider=titelive_things_provider,
-            )
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def test_get_list_with_valid_venue_id(self, app):
+        # given
+        user = users_factories.UserFactory(isAdmin=False, isBeneficiary=False)
+        titelive_things_provider = get_provider_by_local_class("TiteLiveThings")
+        venue_provider = offerers_factories.VenueProviderFactory(
+            venue__name="Librairie Titelive",
+            provider=titelive_things_provider,
+        )
 
-            # when
-            auth_request = TestClient(app.test_client()).with_auth(email=user.email)
-            response = auth_request.get("/venueProviders?venueId=" + humanize(venue_provider.venue.id))
+        # when
+        auth_request = TestClient(app.test_client()).with_auth(email=user.email)
+        response = auth_request.get("/venueProviders?venueId=" + humanize(venue_provider.venue.id))
 
-            # then
-            assert response.status_code == 200
-            assert response.json["venue_providers"][0].get("id") == humanize(venue_provider.id)
-            assert response.json["venue_providers"][0].get("venueId") == humanize(venue_provider.venue.id)
+        # then
+        assert response.status_code == 200
+        assert response.json["venue_providers"][0].get("id") == humanize(venue_provider.id)
+        assert response.json["venue_providers"][0].get("venueId") == humanize(venue_provider.venue.id)
 
-        @pytest.mark.usefixtures("db_session")
-        def test_get_list_that_include_allocine_with_valid_venue_id(self, app):
-            # given
-            user = users_factories.UserFactory(isAdmin=False, isBeneficiary=False)
-            allocine_stocks_provider = get_provider_by_local_class("AllocineStocks")
-            allocine_venue_provider = offerers_factories.VenueProviderFactory(
-                venue__name="Whatever cinema",
-                provider=allocine_stocks_provider,
-            )
+    @pytest.mark.usefixtures("db_session")
+    def test_get_list_that_include_allocine_with_valid_venue_id(self, app):
+        # given
+        user = users_factories.UserFactory(isAdmin=False, isBeneficiary=False)
+        allocine_stocks_provider = get_provider_by_local_class("AllocineStocks")
+        allocine_venue_provider = offerers_factories.VenueProviderFactory(
+            venue__name="Whatever cinema",
+            provider=allocine_stocks_provider,
+        )
 
-            # when
-            auth_request = TestClient(app.test_client()).with_auth(email=user.email)
-            response = auth_request.get("/venueProviders?venueId=" + humanize(allocine_venue_provider.venue.id))
+        # when
+        auth_request = TestClient(app.test_client()).with_auth(email=user.email)
+        response = auth_request.get("/venueProviders?venueId=" + humanize(allocine_venue_provider.venue.id))
 
-            # then
-            assert response.status_code == 200
-            assert response.json["venue_providers"][0].get("id") == humanize(allocine_venue_provider.id)
-            assert response.json["venue_providers"][0].get("venueId") == humanize(allocine_venue_provider.venue.id)
+        # then
+        assert response.status_code == 200
+        assert response.json["venue_providers"][0].get("id") == humanize(allocine_venue_provider.id)
+        assert response.json["venue_providers"][0].get("venueId") == humanize(allocine_venue_provider.venue.id)
 
-    class Returns400:
-        @pytest.mark.usefixtures("db_session")
-        def when_listing_all_venues_without_venue_id_argument(self, app):
-            # given
-            user = users_factories.UserFactory(isAdmin=False, isBeneficiary=False)
-            titelive_things_provider = get_provider_by_local_class("TiteLiveThings")
-            offerers_factories.VenueProviderFactory(
-                venue__name="Librairie Titelive",
-                provider=titelive_things_provider,
-            )
 
-            # when
-            auth_request = TestClient(app.test_client()).with_auth(email=user.email)
-            response = auth_request.get("/venueProviders")
+class Returns400Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_listing_all_venues_without_venue_id_argument(self, app):
+        # given
+        user = users_factories.UserFactory(isAdmin=False, isBeneficiary=False)
+        titelive_things_provider = get_provider_by_local_class("TiteLiveThings")
+        offerers_factories.VenueProviderFactory(
+            venue__name="Librairie Titelive",
+            provider=titelive_things_provider,
+        )
 
-            # then
-            assert response.status_code == 400
+        # when
+        auth_request = TestClient(app.test_client()).with_auth(email=user.email)
+        response = auth_request.get("/venueProviders")
+
+        # then
+        assert response.status_code == 400

--- a/tests/routes/pro/get_venue_stats_test.py
+++ b/tests/routes/pro/get_venue_stats_test.py
@@ -8,43 +8,43 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_pro_user_has_rights_on_managing_offerer(self, app):
-            # given
-            booking = bookings_factories.BookingFactory()
-            bookings_factories.BookingFactory(isUsed=True, stock=booking.stock)
-            venue = booking.stock.offer.venue
-            venue_owner = offers_factories.UserOffererFactory(offerer=venue.managingOfferer).user
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_pro_user_has_rights_on_managing_offerer(self, app):
+        # given
+        booking = bookings_factories.BookingFactory()
+        bookings_factories.BookingFactory(isUsed=True, stock=booking.stock)
+        venue = booking.stock.offer.venue
+        venue_owner = offers_factories.UserOffererFactory(offerer=venue.managingOfferer).user
 
-            auth_request = TestClient(app.test_client()).with_auth(email=venue_owner.email)
+        auth_request = TestClient(app.test_client()).with_auth(email=venue_owner.email)
 
-            # when
-            response = auth_request.get("/venues/%s/stats" % humanize(venue.id))
+        # when
+        response = auth_request.get("/venues/%s/stats" % humanize(venue.id))
 
-            # then
-            assert response.status_code == 200
-            response_json = response.json
-            assert response_json["activeBookingsQuantity"] == 1
-            assert response_json["validatedBookingsQuantity"] == 1
-            assert response_json["activeOffersCount"] == 1
-            assert response_json["soldOutOffersCount"] == 0
+        # then
+        assert response.status_code == 200
+        response_json = response.json
+        assert response_json["activeBookingsQuantity"] == 1
+        assert response_json["validatedBookingsQuantity"] == 1
+        assert response_json["activeOffersCount"] == 1
+        assert response_json["soldOutOffersCount"] == 0
 
-    class Returns403:
-        @pytest.mark.usefixtures("db_session")
-        def when_pro_user_does_not_have_rights(self, app):
-            # given
-            pro_user = users_factories.UserFactory()
-            venue = offers_factories.VenueFactory()
 
-            auth_request = TestClient(app.test_client()).with_auth(email=pro_user.email)
+class Returns403Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_pro_user_does_not_have_rights(self, app):
+        # given
+        pro_user = users_factories.UserFactory()
+        venue = offers_factories.VenueFactory()
 
-            # when
-            response = auth_request.get("/venues/%s/stats" % humanize(venue.id))
+        auth_request = TestClient(app.test_client()).with_auth(email=pro_user.email)
 
-            # then
-            assert response.status_code == 403
-            assert response.json["global"] == [
-                "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
-            ]
+        # when
+        response = auth_request.get("/venues/%s/stats" % humanize(venue.id))
+
+        # then
+        assert response.status_code == 403
+        assert response.json["global"] == [
+            "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
+        ]

--- a/tests/routes/pro/get_venue_test.py
+++ b/tests/routes/pro/get_venue_test.py
@@ -8,83 +8,81 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_has_rights_on_managing_offerer(self, app):
-            # given
-            user_offerer = offers_factories.UserOffererFactory(user__email="user.pro@test.com")
-            venue = offers_factories.VenueFactory(name="L'encre et la plume", managingOfferer=user_offerer.offerer)
-            bank_information = offers_factories.BankInformationFactory(venue=venue)
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_has_rights_on_managing_offerer(self, app):
+        # given
+        user_offerer = offers_factories.UserOffererFactory(user__email="user.pro@test.com")
+        venue = offers_factories.VenueFactory(name="L'encre et la plume", managingOfferer=user_offerer.offerer)
+        bank_information = offers_factories.BankInformationFactory(venue=venue)
 
-            expected_serialized_venue = {
-                "address": venue.address,
-                "bic": bank_information.bic,
-                "bookingEmail": venue.bookingEmail,
-                "city": venue.city,
-                "comment": venue.comment,
-                "dateCreated": format_into_utc_date(venue.dateCreated),
-                "dateModifiedAtLastProvider": format_into_utc_date(venue.dateModifiedAtLastProvider),
-                "demarchesSimplifieesApplicationId": str(venue.demarchesSimplifieesApplicationId),
-                "departementCode": venue.departementCode,
-                "fieldsUpdated": venue.fieldsUpdated,
-                "iban": bank_information.iban,
-                "id": humanize(venue.id),
-                "idAtProviders": venue.idAtProviders,
-                "isValidated": venue.isValidated,
-                "isVirtual": venue.isVirtual,
-                "latitude": float(venue.latitude),
-                "lastProviderId": venue.lastProviderId,
-                "longitude": float(venue.longitude),
-                "managingOfferer": {
-                    "address": venue.managingOfferer.address,
-                    "bic": venue.managingOfferer.bic,
-                    "city": venue.managingOfferer.city,
-                    "dateCreated": format_into_utc_date(venue.managingOfferer.dateCreated),
-                    "dateModifiedAtLastProvider": format_into_utc_date(
-                        venue.managingOfferer.dateModifiedAtLastProvider
-                    ),
-                    "demarchesSimplifieesApplicationId": venue.managingOfferer.demarchesSimplifieesApplicationId,
-                    "fieldsUpdated": venue.managingOfferer.fieldsUpdated,
-                    "iban": venue.managingOfferer.iban,
-                    "id": humanize(venue.managingOfferer.id),
-                    "idAtProviders": venue.managingOfferer.idAtProviders,
-                    "isValidated": venue.managingOfferer.isValidated,
-                    "lastProviderId": venue.managingOfferer.lastProviderId,
-                    "name": venue.managingOfferer.name,
-                    "postalCode": venue.managingOfferer.postalCode,
-                    "siren": venue.managingOfferer.siren,
-                },
-                "managingOffererId": humanize(venue.managingOffererId),
-                "name": venue.name,
-                "postalCode": venue.postalCode,
-                "publicName": venue.publicName,
-                "siret": venue.siret,
-                "venueLabelId": humanize(venue.venueLabelId),
-                "venueTypeId": humanize(venue.venueTypeId),
-            }
+        expected_serialized_venue = {
+            "address": venue.address,
+            "bic": bank_information.bic,
+            "bookingEmail": venue.bookingEmail,
+            "city": venue.city,
+            "comment": venue.comment,
+            "dateCreated": format_into_utc_date(venue.dateCreated),
+            "dateModifiedAtLastProvider": format_into_utc_date(venue.dateModifiedAtLastProvider),
+            "demarchesSimplifieesApplicationId": str(venue.demarchesSimplifieesApplicationId),
+            "departementCode": venue.departementCode,
+            "fieldsUpdated": venue.fieldsUpdated,
+            "iban": bank_information.iban,
+            "id": humanize(venue.id),
+            "idAtProviders": venue.idAtProviders,
+            "isValidated": venue.isValidated,
+            "isVirtual": venue.isVirtual,
+            "latitude": float(venue.latitude),
+            "lastProviderId": venue.lastProviderId,
+            "longitude": float(venue.longitude),
+            "managingOfferer": {
+                "address": venue.managingOfferer.address,
+                "bic": venue.managingOfferer.bic,
+                "city": venue.managingOfferer.city,
+                "dateCreated": format_into_utc_date(venue.managingOfferer.dateCreated),
+                "dateModifiedAtLastProvider": format_into_utc_date(venue.managingOfferer.dateModifiedAtLastProvider),
+                "demarchesSimplifieesApplicationId": venue.managingOfferer.demarchesSimplifieesApplicationId,
+                "fieldsUpdated": venue.managingOfferer.fieldsUpdated,
+                "iban": venue.managingOfferer.iban,
+                "id": humanize(venue.managingOfferer.id),
+                "idAtProviders": venue.managingOfferer.idAtProviders,
+                "isValidated": venue.managingOfferer.isValidated,
+                "lastProviderId": venue.managingOfferer.lastProviderId,
+                "name": venue.managingOfferer.name,
+                "postalCode": venue.managingOfferer.postalCode,
+                "siren": venue.managingOfferer.siren,
+            },
+            "managingOffererId": humanize(venue.managingOffererId),
+            "name": venue.name,
+            "postalCode": venue.postalCode,
+            "publicName": venue.publicName,
+            "siret": venue.siret,
+            "venueLabelId": humanize(venue.venueLabelId),
+            "venueTypeId": humanize(venue.venueTypeId),
+        }
 
-            # when
-            auth_request = TestClient(app.test_client()).with_auth(email=user_offerer.user.email)
-            response = auth_request.get("/venues/%s" % humanize(venue.id))
+        # when
+        auth_request = TestClient(app.test_client()).with_auth(email=user_offerer.user.email)
+        response = auth_request.get("/venues/%s" % humanize(venue.id))
 
-            # then
-            assert response.status_code == 200
-            assert response.json == expected_serialized_venue
+        # then
+        assert response.status_code == 200
+        assert response.json == expected_serialized_venue
 
-    class Returns403:
-        @pytest.mark.usefixtures("db_session")
-        def when_current_user_doesnt_have_rights(self, app):
-            # given
-            user = users_factories.UserFactory(email="user.pro@test.com")
-            venue = offers_factories.VenueFactory(name="L'encre et la plume")
 
-            # when
-            auth_request = TestClient(app.test_client()).with_auth(email=user.email)
-            response = auth_request.get("/venues/%s" % humanize(venue.id))
+class Returns403Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_current_user_doesnt_have_rights(self, app):
+        # given
+        user = users_factories.UserFactory(email="user.pro@test.com")
+        venue = offers_factories.VenueFactory(name="L'encre et la plume")
 
-            # then
-            assert response.status_code == 403
-            assert response.json["global"] == [
-                "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
-            ]
+        # when
+        auth_request = TestClient(app.test_client()).with_auth(email=user.email)
+        response = auth_request.get("/venues/%s" % humanize(venue.id))
+
+        # then
+        assert response.status_code == 403
+        assert response.json["global"] == [
+            "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
+        ]

--- a/tests/routes/pro/get_venue_types_test.py
+++ b/tests/routes/pro/get_venue_types_test.py
@@ -6,28 +6,28 @@ from pcapi.core.users.factories import UserFactory
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns401:
-        @pytest.mark.usefixtures("db_session")
-        def when_the_user_is_not_authenticated(self, app):
-            # When
-            response = TestClient(app.test_client()).get("/venue-types")
+class Returns401Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_the_user_is_not_authenticated(self, app):
+        # When
+        response = TestClient(app.test_client()).get("/venue-types")
 
-            # then
-            assert response.status_code == 401
+        # then
+        assert response.status_code == 401
 
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_the_user_is_authenticated(self, app):
-            # Given
-            user = UserFactory()
-            VenueTypeFactory(label="Centre culturel", id=1)
-            VenueTypeFactory(label="Musée", id=2)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).get("/venue-types")
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_the_user_is_authenticated(self, app):
+        # Given
+        user = UserFactory()
+        VenueTypeFactory(label="Centre culturel", id=1)
+        VenueTypeFactory(label="Musée", id=2)
 
-            # then
-            assert response.status_code == 200
-            assert len(response.json) == 2
-            assert response.json == [{"id": "AE", "label": "Centre culturel"}, {"id": "A9", "label": "Musée"}]
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).get("/venue-types")
+
+        # then
+        assert response.status_code == 200
+        assert len(response.json) == 2
+        assert response.json == [{"id": "AE", "label": "Centre culturel"}, {"id": "A9", "label": "Musée"}]

--- a/tests/routes/pro/patch_all_offers_active_status_test.py
+++ b/tests/routes/pro/patch_all_offers_active_status_test.py
@@ -11,7 +11,7 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns204:
+class Returns204Test:
     def when_activating_all_existing_offers(self, app):
         # Given
         offer1 = offers_factories.OfferFactory(isActive=False)

--- a/tests/routes/pro/patch_booking_by_token_test.py
+++ b/tests/routes/pro/patch_booking_by_token_test.py
@@ -22,8 +22,8 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns204:
-    class WhenUserIsAnonymous:
+class Returns204Test:
+    class WhenUserIsAnonymousTest:
         def expect_booking_to_be_used(self, app):
             booking = BookingFactory(token="ABCDEF")
 
@@ -37,7 +37,7 @@ class Returns204:
             booking = Booking.query.one()
             assert booking.isUsed
 
-    class WhenUserIsLoggedIn:
+    class WhenUserIsLoggedInTest:
         def expect_booking_to_be_used(self, app):
             booking = BookingFactory(token="ABCDEF")
             pro_user = UserFactory(email="pro@example.com")
@@ -97,8 +97,8 @@ class Returns204:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns400:
-    class WhenUserIsAnonymous:
+class Returns400Test:
+    class WhenUserIsAnonymousTest:
         def when_email_is_missing(self, app):
             # Given
             user = create_user()
@@ -157,7 +157,7 @@ class Returns400:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403:  # Forbidden
+class Returns403Test:  # Forbidden
     def when_user_is_not_attached_to_linked_offerer(self, app):
         # Given
         user = create_user()
@@ -196,8 +196,8 @@ class Returns403:  # Forbidden
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns404:
-    class WhenUserIsAnonymous:
+class Returns404Test:
+    class WhenUserIsAnonymousTest:
         def when_booking_does_not_exist(self, app):
             # Given
             user = create_user()
@@ -217,7 +217,7 @@ class Returns404:
             assert response.status_code == 404
             assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
 
-    class WhenUserIsLoggedIn:
+    class WhenUserIsLoggedInTest:
         def when_user_is_not_editor_and_email_does_not_match(self, app):
             # Given
             user = create_user()

--- a/tests/routes/pro/patch_booking_keep_by_token_test.py
+++ b/tests/routes/pro/patch_booking_keep_by_token_test.py
@@ -27,7 +27,7 @@ API_KEY_VALUE = random_token(64)
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns204:
+class Returns204Test:
     class WithApiKeyAuthTest:
         def when_api_key_provided_is_related_to_regular_offer_with_rights(self, app):
             booking = BookingFactory(isUsed=True, token="ABCDEF")
@@ -116,7 +116,7 @@ class Returns204:
             assert booking.dateUsed is None
 
 
-class Returns401:
+class Returns401Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_not_logged_in_and_doesnt_give_api_key(self, app):
         # Given
@@ -161,7 +161,7 @@ class Returns401:
         assert response.status_code == 401
 
 
-class Returns403:
+class Returns403Test:
     class WithApiKeyAuthTest:
         @pytest.mark.usefixtures("db_session")
         def when_the_api_key_is_not_linked_to_the_right_offerer(self, app):
@@ -258,7 +258,7 @@ class Returns403:
             assert Booking.query.get(booking.id).isUsed is True
 
 
-class Returns404:
+class Returns404Test:
     class WithApiKeyAuthTest:
         @pytest.mark.usefixtures("db_session")
         def when_booking_is_not_provided_at_all(self, app):
@@ -358,7 +358,7 @@ class Returns404:
             assert response.status_code == 404
 
 
-class Returns410:
+class Returns410Test:
     class WithBasicAuthTest:
         @pytest.mark.usefixtures("db_session")
         def when_user_is_logged_in_and_booking_has_not_been_validated_already(self, app):

--- a/tests/routes/pro/patch_booking_use_by_token_test.py
+++ b/tests/routes/pro/patch_booking_use_by_token_test.py
@@ -24,7 +24,7 @@ API_KEY_VALUE = random_token(64)
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns204:
+class Returns204Test:
     class WithApiKeyAuthTest:
         def when_api_key_is_provided_and_rights_and_regular_offer(self, app):
             booking = BookingFactory(token="ABCDEF")
@@ -90,7 +90,7 @@ class Returns204:
             assert booking.isUsed
 
 
-class Returns401:
+class Returns401Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_not_logged_in_and_doesnt_give_api_key(self, app):
         # Given
@@ -132,7 +132,7 @@ class Returns401:
         assert response.status_code == 401
 
 
-class Returns403:
+class Returns403Test:
     class WithApiKeyAuthTest:
         @pytest.mark.usefixtures("db_session")
         def when_api_key_given_not_related_to_booking_offerer(self, app):
@@ -222,7 +222,7 @@ class Returns403:
             assert Booking.query.get(booking.id).isUsed is False
 
 
-class Returns404:
+class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     def when_booking_is_not_provided_at_all(self, app):
         # Given

--- a/tests/routes/pro/patch_cancel_booking_by_token_test.py
+++ b/tests/routes/pro/patch_cancel_booking_by_token_test.py
@@ -25,10 +25,201 @@ def create_api_key_for_offerer(offerer, token):
     return offerer_api_key
 
 
-class Patch:
-    class Returns204:
+class Returns204Test:
+    @pytest.mark.usefixtures("db_session")
+    def test_should_returns_204_with_cancellation_allowed(self, app):
+        # Given
+        pro_user = create_user(email="Mr Books@example.net", public_name="Mr Books")
+        offerer = create_offerer(siren="793875030")
+        user_offerer = create_user_offerer(pro_user, offerer)
+        venue = create_venue(offerer)
+        book_offer = create_offer_with_event_product(venue)
+        stock = create_stock(offer=book_offer)
+
+        user = users_factories.UserFactory()
+        booking = create_booking(user=user, stock=stock, venue=venue)
+
+        repository.save(booking, user_offerer)
+        api_key = random_token(64)
+        offerer_api_key = create_api_key_for_offerer(offerer, api_key)
+        repository.save(offerer_api_key)
+
+        # When
+        response = TestClient(app.test_client()).patch(
+            "/v2/bookings/cancel/token/{}".format(booking.token),
+            headers={"Authorization": "Bearer " + api_key, "Origin": "http://localhost"},
+        )
+
+        # cancellation can trigger more than one request to Batch
+        assert len(push_testing.requests) >= 1
+
+        # Then
+        assert response.status_code == 204
+        updated_booking = Booking.query.first()
+        assert updated_booking.isCancelled
+
+        assert push_testing.requests[-1] == {
+            "group_id": "Cancel_booking",
+            "message": {
+                "body": 'Ta réservation "Test event" a été annulée par l\'offreur.',
+                "title": "Réservation annulée",
+            },
+            "user_ids": [user.id],
+        }
+
+    @pytest.mark.usefixtures("db_session")
+    def test_should_returns_204_with_lowercase_token(self, app):
+        # Given
+        pro_user = create_user(email="Mr Books@example.net", public_name="Mr Books")
+        offerer = create_offerer(siren="793875030")
+        user_offerer = create_user_offerer(pro_user, offerer)
+        venue = create_venue(offerer)
+        book_offer = create_offer_with_event_product(venue)
+        stock = create_stock(offer=book_offer)
+
+        user = users_factories.UserFactory()
+        booking = create_booking(user=user, stock=stock, venue=venue)
+
+        repository.save(booking, user_offerer)
+        api_key = random_token(64)
+        offerer_api_key = create_api_key_for_offerer(offerer, api_key)
+        repository.save(offerer_api_key)
+
+        # When
+        token = booking.token.lower()
+        response = TestClient(app.test_client()).patch(
+            "/v2/bookings/cancel/token/{}".format(token),
+            headers={"Authorization": "Bearer " + api_key, "Origin": "http://localhost"},
+        )
+
+        # cancellation can trigger more than one request to Batch
+        assert len(push_testing.requests) >= 1
+
+        # Then
+        assert response.status_code == 204
+        updated_booking = Booking.query.first()
+        assert updated_booking.isCancelled
+
+
+class Returns401Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_not_authenticated_used_api_key_or_login(self, app):
+        # Given
+        user = users_factories.UserFactory()
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(user, offerer)
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue)
+        stock = create_stock(offer=offer)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(user_offerer, booking)
+
+        # When
+        url = "/v2/bookings/cancel/token/{}".format(booking.token)
+        response = TestClient(app.test_client()).patch(url)
+
+        # Then
+        assert response.status_code == 401
+        assert push_testing.requests == []
+
+    @pytest.mark.usefixtures("db_session")
+    def when_giving_an_api_key_that_does_not_exists(self, app):
+        # Given
+        user = users_factories.UserFactory()
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(user, offerer)
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue)
+        stock = create_stock(offer=offer)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(user_offerer, booking)
+
+        # When
+        url = "/v2/bookings/cancel/token/{}".format(booking.token)
+        wrong_api_key = "Bearer WrongApiKey1234567"
+        response = TestClient(app.test_client()).patch(
+            url, headers={"Authorization": wrong_api_key, "Origin": "http://localhost"}
+        )
+
+        assert response.status_code == 401
+        assert push_testing.requests == []
+
+
+class Returns403Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_the_api_key_is_not_linked_to_the_right_offerer(self, app):
+        # Given
+        pro_user = create_user(email="Mr Books@example.net", public_name="Mr Books")
+        offerer = create_offerer(siren="793875030")
+        user_offerer = create_user_offerer(pro_user, offerer)
+        venue = create_venue(offerer)
+        book_offer = create_offer_with_event_product(venue)
+        stock = create_stock(offer=book_offer)
+
+        user = users_factories.UserFactory()
+        booking = create_booking(user=user, stock=stock, venue=venue)
+
+        repository.save(booking, user_offerer)
+
+        offerer_with_api_key = create_offerer()
+        repository.save(offerer_with_api_key)
+
+        api_key = random_token(64)
+        offerer_api_key = create_api_key_for_offerer(offerer_with_api_key, api_key)
+
+        repository.save(offerer_api_key)
+
+        # When
+        response = TestClient(app.test_client()).patch(
+            "/v2/bookings/cancel/token/{}".format(booking.token),
+            headers={"Authorization": "Bearer " + api_key, "Origin": "http://localhost"},
+        )
+
+        # Then
+        assert response.status_code == 403
+        assert response.json["user"] == ["Vous n'avez pas les droits suffisants pour annuler cette réservation."]
+        assert push_testing.requests == []
+
+    @pytest.mark.usefixtures("db_session")
+    def when_the_logged_user_has_not_rights_on_offerer(self, app):
+        # Given
+        pro_user = create_user(email="mr.book@example.net", public_name="Mr Books")
+        offerer = create_offerer(siren="793875030")
+        user_offerer = create_user_offerer(pro_user, offerer)
+        venue = create_venue(offerer)
+        book_offer = create_offer_with_event_product(venue)
+        stock = create_stock(offer=book_offer)
+
+        user = users_factories.UserFactory()
+        booking = create_booking(user=user, stock=stock, venue=venue)
+
+        repository.save(booking, user_offerer)
+
+        offerer_with_api_key = create_offerer()
+        repository.save(offerer_with_api_key)
+
+        api_key = random_token(64)
+        offerer_api_key = create_api_key_for_offerer(offerer_with_api_key, api_key)
+
+        repository.save(offerer_api_key)
+
+        # When
+        response = (
+            TestClient(app.test_client())
+            .with_auth(user.email)
+            .patch("/v2/bookings/cancel/token/{}".format(booking.token))
+        )
+
+        # Then
+        assert response.status_code == 403
+        assert response.json["global"] == [
+            "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
+        ]
+        assert push_testing.requests == []
+
+    class WhenTheBookingIsUsedTest:
         @pytest.mark.usefixtures("db_session")
-        def test_should_returns_204_with_cancellation_allowed(self, app):
+        def test_should_prevent_a_used_booking_from_being_cancelled(self, app):
             # Given
             pro_user = create_user(email="Mr Books@example.net", public_name="Mr Books")
             offerer = create_offerer(siren="793875030")
@@ -38,134 +229,11 @@ class Patch:
             stock = create_stock(offer=book_offer)
 
             user = users_factories.UserFactory()
-            booking = create_booking(user=user, stock=stock, venue=venue)
+            booking = create_booking(user=user, stock=stock, is_used=True, venue=venue)
 
             repository.save(booking, user_offerer)
             api_key = random_token(64)
             offerer_api_key = create_api_key_for_offerer(offerer, api_key)
-            repository.save(offerer_api_key)
-
-            # When
-            response = TestClient(app.test_client()).patch(
-                "/v2/bookings/cancel/token/{}".format(booking.token),
-                headers={"Authorization": "Bearer " + api_key, "Origin": "http://localhost"},
-            )
-
-            # cancellation can trigger more than one request to Batch
-            assert len(push_testing.requests) >= 1
-
-            # Then
-            assert response.status_code == 204
-            updated_booking = Booking.query.first()
-            assert updated_booking.isCancelled
-
-            assert push_testing.requests[-1] == {
-                "group_id": "Cancel_booking",
-                "message": {
-                    "body": 'Ta réservation "Test event" a été annulée par l\'offreur.',
-                    "title": "Réservation annulée",
-                },
-                "user_ids": [user.id],
-            }
-
-        @pytest.mark.usefixtures("db_session")
-        def test_should_returns_204_with_lowercase_token(self, app):
-            # Given
-            pro_user = create_user(email="Mr Books@example.net", public_name="Mr Books")
-            offerer = create_offerer(siren="793875030")
-            user_offerer = create_user_offerer(pro_user, offerer)
-            venue = create_venue(offerer)
-            book_offer = create_offer_with_event_product(venue)
-            stock = create_stock(offer=book_offer)
-
-            user = users_factories.UserFactory()
-            booking = create_booking(user=user, stock=stock, venue=venue)
-
-            repository.save(booking, user_offerer)
-            api_key = random_token(64)
-            offerer_api_key = create_api_key_for_offerer(offerer, api_key)
-            repository.save(offerer_api_key)
-
-            # When
-            token = booking.token.lower()
-            response = TestClient(app.test_client()).patch(
-                "/v2/bookings/cancel/token/{}".format(token),
-                headers={"Authorization": "Bearer " + api_key, "Origin": "http://localhost"},
-            )
-
-            # cancellation can trigger more than one request to Batch
-            assert len(push_testing.requests) >= 1
-
-            # Then
-            assert response.status_code == 204
-            updated_booking = Booking.query.first()
-            assert updated_booking.isCancelled
-
-    class Returns401:
-        @pytest.mark.usefixtures("db_session")
-        def when_not_authenticated_used_api_key_or_login(self, app):
-            # Given
-            user = users_factories.UserFactory()
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(user, offerer)
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue)
-            stock = create_stock(offer=offer)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(user_offerer, booking)
-
-            # When
-            url = "/v2/bookings/cancel/token/{}".format(booking.token)
-            response = TestClient(app.test_client()).patch(url)
-
-            # Then
-            assert response.status_code == 401
-            assert push_testing.requests == []
-
-        @pytest.mark.usefixtures("db_session")
-        def when_giving_an_api_key_that_does_not_exists(self, app):
-            # Given
-            user = users_factories.UserFactory()
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(user, offerer)
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue)
-            stock = create_stock(offer=offer)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(user_offerer, booking)
-
-            # When
-            url = "/v2/bookings/cancel/token/{}".format(booking.token)
-            wrong_api_key = "Bearer WrongApiKey1234567"
-            response = TestClient(app.test_client()).patch(
-                url, headers={"Authorization": wrong_api_key, "Origin": "http://localhost"}
-            )
-
-            assert response.status_code == 401
-            assert push_testing.requests == []
-
-    class Returns403:
-        @pytest.mark.usefixtures("db_session")
-        def when_the_api_key_is_not_linked_to_the_right_offerer(self, app):
-            # Given
-            pro_user = create_user(email="Mr Books@example.net", public_name="Mr Books")
-            offerer = create_offerer(siren="793875030")
-            user_offerer = create_user_offerer(pro_user, offerer)
-            venue = create_venue(offerer)
-            book_offer = create_offer_with_event_product(venue)
-            stock = create_stock(offer=book_offer)
-
-            user = users_factories.UserFactory()
-            booking = create_booking(user=user, stock=stock, venue=venue)
-
-            repository.save(booking, user_offerer)
-
-            offerer_with_api_key = create_offerer()
-            repository.save(offerer_with_api_key)
-
-            api_key = random_token(64)
-            offerer_api_key = create_api_key_for_offerer(offerer_with_api_key, api_key)
-
             repository.save(offerer_api_key)
 
             # When
@@ -176,133 +244,68 @@ class Patch:
 
             # Then
             assert response.status_code == 403
-            assert response.json["user"] == ["Vous n'avez pas les droits suffisants pour annuler cette réservation."]
+            assert response.json["global"] == ["Impossible d'annuler une réservation consommée"]
+            updated_booking = Booking.query.first()
+            assert updated_booking.isUsed
+            assert updated_booking.isCancelled is False
             assert push_testing.requests == []
 
-        @pytest.mark.usefixtures("db_session")
-        def when_the_logged_user_has_not_rights_on_offerer(self, app):
-            # Given
-            pro_user = create_user(email="mr.book@example.net", public_name="Mr Books")
-            offerer = create_offerer(siren="793875030")
-            user_offerer = create_user_offerer(pro_user, offerer)
-            venue = create_venue(offerer)
-            book_offer = create_offer_with_event_product(venue)
-            stock = create_stock(offer=book_offer)
 
-            user = users_factories.UserFactory()
-            booking = create_booking(user=user, stock=stock, venue=venue)
+class Returns404Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_the_booking_does_not_exists(self, app):
+        # Given
+        user = users_factories.UserFactory()
+        offerer = create_offerer()
+        user_offerer = create_user_offerer(user, offerer)
+        venue = create_venue(offerer)
+        offer = create_offer_with_event_product(venue)
+        stock = create_stock(offer=offer)
+        booking = create_booking(user=user, stock=stock, venue=venue)
+        repository.save(user_offerer, booking)
 
-            repository.save(booking, user_offerer)
+        api_key = "A_MOCKED_API_KEY"
+        offerer_api_key = create_api_key_for_offerer(offerer, api_key)
+        repository.save(offerer_api_key)
 
-            offerer_with_api_key = create_offerer()
-            repository.save(offerer_with_api_key)
+        # When
+        response = TestClient(app.test_client()).patch(
+            "/v2/bookings/cancel/token/FAKETOKEN",
+            headers={"Authorization": f"Bearer {api_key}", "Origin": "http://localhost"},
+        )
 
-            api_key = random_token(64)
-            offerer_api_key = create_api_key_for_offerer(offerer_with_api_key, api_key)
+        # Then
+        assert response.status_code == 404
+        assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
+        assert push_testing.requests == []
 
-            repository.save(offerer_api_key)
 
-            # When
-            response = (
-                TestClient(app.test_client())
-                .with_auth(user.email)
-                .patch("/v2/bookings/cancel/token/{}".format(booking.token))
-            )
+class Returns410Test:
+    @pytest.mark.usefixtures("db_session")
+    def test_cancel_a_booking_already_cancelled(self, app):
+        # Given
+        pro_user = create_user(email="Mr Books@example.net", public_name="Mr Books")
+        offerer = create_offerer(siren="793875030")
+        user_offerer = create_user_offerer(pro_user, offerer)
+        venue = create_venue(offerer)
+        book_offer = create_offer_with_thing_product(venue)
+        stock = create_stock(offer=book_offer)
 
-            # Then
-            assert response.status_code == 403
-            assert response.json["global"] == [
-                "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
-            ]
-            assert push_testing.requests == []
+        user = users_factories.UserFactory()
+        booking = create_booking(user=user, stock=stock, is_cancelled=True, venue=venue)
 
-        class WhenTheBookingIsUsed:
-            @pytest.mark.usefixtures("db_session")
-            def test_should_prevent_a_used_booking_from_being_cancelled(self, app):
-                # Given
-                pro_user = create_user(email="Mr Books@example.net", public_name="Mr Books")
-                offerer = create_offerer(siren="793875030")
-                user_offerer = create_user_offerer(pro_user, offerer)
-                venue = create_venue(offerer)
-                book_offer = create_offer_with_event_product(venue)
-                stock = create_stock(offer=book_offer)
+        repository.save(booking, user_offerer)
+        api_key = random_token(64)
+        offerer_api_key = create_api_key_for_offerer(offerer, api_key)
+        repository.save(offerer_api_key)
 
-                user = users_factories.UserFactory()
-                booking = create_booking(user=user, stock=stock, is_used=True, venue=venue)
+        # When
+        response = TestClient(app.test_client()).patch(
+            "/v2/bookings/cancel/token/{}".format(booking.token),
+            headers={"Authorization": "Bearer " + api_key, "Origin": "http://localhost"},
+        )
 
-                repository.save(booking, user_offerer)
-                api_key = random_token(64)
-                offerer_api_key = create_api_key_for_offerer(offerer, api_key)
-                repository.save(offerer_api_key)
-
-                # When
-                response = TestClient(app.test_client()).patch(
-                    "/v2/bookings/cancel/token/{}".format(booking.token),
-                    headers={"Authorization": "Bearer " + api_key, "Origin": "http://localhost"},
-                )
-
-                # Then
-                assert response.status_code == 403
-                assert response.json["global"] == ["Impossible d'annuler une réservation consommée"]
-                updated_booking = Booking.query.first()
-                assert updated_booking.isUsed
-                assert updated_booking.isCancelled is False
-                assert push_testing.requests == []
-
-    class Returns404:
-        @pytest.mark.usefixtures("db_session")
-        def when_the_booking_does_not_exists(self, app):
-            # Given
-            user = users_factories.UserFactory()
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(user, offerer)
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue)
-            stock = create_stock(offer=offer)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(user_offerer, booking)
-
-            api_key = "A_MOCKED_API_KEY"
-            offerer_api_key = create_api_key_for_offerer(offerer, api_key)
-            repository.save(offerer_api_key)
-
-            # When
-            response = TestClient(app.test_client()).patch(
-                "/v2/bookings/cancel/token/FAKETOKEN",
-                headers={"Authorization": f"Bearer {api_key}", "Origin": "http://localhost"},
-            )
-
-            # Then
-            assert response.status_code == 404
-            assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
-            assert push_testing.requests == []
-
-    class Returns410:
-        @pytest.mark.usefixtures("db_session")
-        def test_cancel_a_booking_already_cancelled(self, app):
-            # Given
-            pro_user = create_user(email="Mr Books@example.net", public_name="Mr Books")
-            offerer = create_offerer(siren="793875030")
-            user_offerer = create_user_offerer(pro_user, offerer)
-            venue = create_venue(offerer)
-            book_offer = create_offer_with_thing_product(venue)
-            stock = create_stock(offer=book_offer)
-
-            user = users_factories.UserFactory()
-            booking = create_booking(user=user, stock=stock, is_cancelled=True, venue=venue)
-
-            repository.save(booking, user_offerer)
-            api_key = random_token(64)
-            offerer_api_key = create_api_key_for_offerer(offerer, api_key)
-            repository.save(offerer_api_key)
-
-            # When
-            response = TestClient(app.test_client()).patch(
-                "/v2/bookings/cancel/token/{}".format(booking.token),
-                headers={"Authorization": "Bearer " + api_key, "Origin": "http://localhost"},
-            )
-
-            # Then
-            assert response.status_code == 410
-            assert response.json["global"] == ["Cette contremarque a déjà été annulée"]
-            assert push_testing.requests == []
+        # Then
+        assert response.status_code == 410
+        assert response.json["global"] == ["Cette contremarque a déjà été annulée"]
+        assert push_testing.requests == []

--- a/tests/routes/pro/patch_offer_test.py
+++ b/tests/routes/pro/patch_offer_test.py
@@ -13,7 +13,7 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns200:
+class Returns200Test:
     def test_patch_offer(self, app):
         # Given
         offer = offers_factories.OfferFactory()
@@ -43,7 +43,7 @@ class Returns200:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns400:
+class Returns400Test:
     def when_trying_to_patch_forbidden_attributes(self, app):
         # Given
         offer = offers_factories.OfferFactory()
@@ -182,7 +182,7 @@ class Returns400:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403:
+class Returns403Test:
     def when_user_is_not_attached_to_offerer(self, app):
         # Given
         offer = offers_factories.OfferFactory(name="Old name")
@@ -201,7 +201,7 @@ class Returns403:
         assert Offer.query.get(offer.id).name == "Old name"
 
 
-class Returns404:
+class Returns404Test:
     def test_returns_404_if_offer_does_not_exist(self, app, db_session):
         # given
         user = users_factories.UserFactory()

--- a/tests/routes/pro/patch_offers_active_status_test.py
+++ b/tests/routes/pro/patch_offers_active_status_test.py
@@ -10,7 +10,7 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns204:
+class Returns204Test:
     def when_activating_existing_offers(self, app):
         # Given
         offer1 = offers_factories.OfferFactory(isActive=False)

--- a/tests/routes/pro/patch_user_has_seen_tuto_test.py
+++ b/tests/routes/pro/patch_user_has_seen_tuto_test.py
@@ -20,7 +20,7 @@ def test_mark_as_seen(app):
 
 class LegacyRouteTest:
     @pytest.mark.usefixtures("db_session")
-    class Returns204:
+    class Returns204Test:
         def when_user_is_logged_in(self, app):
             # given
             user = users_factories.UserFactory(hasSeenProTutorials=False)
@@ -35,7 +35,7 @@ class LegacyRouteTest:
             assert updated_user.hasSeenProTutorials == True
 
     @pytest.mark.usefixtures("db_session")
-    class Returns404:
+    class Returns404Test:
         def when_user_does_not_exist(self, app):
             # given
             user = users_factories.UserFactory(hasSeenProTutorials=False)
@@ -48,7 +48,7 @@ class LegacyRouteTest:
             assert response.status_code == 404
 
     @pytest.mark.usefixtures("db_session")
-    class Returns403:
+    class Returns403Test:
         def when_user_is_not_logged_in(self, app):
             # given
             user = users_factories.UserFactory(hasSeenProTutorials=False)

--- a/tests/routes/pro/patch_venue_test.py
+++ b/tests/routes/pro/patch_venue_test.py
@@ -24,7 +24,7 @@ def populate_missing_data_from_venue(venue_data, venue):
     }
 
 
-class Returns200:
+class Returns200Test:
     @pytest.mark.usefixtures("db_session")
     def test_should_update_venue(self, app) -> None:
         # given

--- a/tests/routes/pro/post_offer_test.py
+++ b/tests/routes/pro/post_offer_test.py
@@ -12,7 +12,7 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns200:
+class Returns200Test:
     def test_create_event_offer(self, app):
         # Given
         venue = offers_factories.VenueFactory()
@@ -97,7 +97,7 @@ class Returns200:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns400:
+class Returns400Test:
     def test_fail_if_venue_is_not_found(self, app):
         # Given
         offers_factories.UserOffererFactory(user__email="user@example.com")
@@ -267,7 +267,7 @@ class Returns400:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403:
+class Returns403Test:
     def when_user_is_not_attached_to_offerer(self, app):
         # Given
         users_factories.UserFactory(email="user@example.com")

--- a/tests/routes/pro/post_offerer_test.py
+++ b/tests/routes/pro/post_offerer_test.py
@@ -21,268 +21,267 @@ api_entreprise_json_mock = {
 DEFAULT_DIGITAL_VENUE_LABEL = "Offre numérique"
 
 
-class Post:
-    class Returns201:
-        @patch("pcapi.connectors.api_entreprises.requests.get")
-        @pytest.mark.usefixtures("db_session")
-        def when_creating_a_virtual_venue(self, mock_api_entreprise, app):
-            # given
-            mock_api_entreprise.return_value = MagicMock(
-                status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
-            )
+class Returns201Test:
+    @patch("pcapi.connectors.api_entreprises.requests.get")
+    @pytest.mark.usefixtures("db_session")
+    def when_creating_a_virtual_venue(self, mock_api_entreprise, app):
+        # given
+        mock_api_entreprise.return_value = MagicMock(
+            status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
+        )
 
-            user = UserFactory()
-            digital_venue_type = VirtualVenueTypeFactory()
-            body = {
-                "name": "Test Offerer",
-                "siren": "418166096",
-                "address": "123 rue de Paris",
-                "postalCode": "93100",
-                "city": "Montreuil",
-            }
+        user = UserFactory()
+        digital_venue_type = VirtualVenueTypeFactory()
+        body = {
+            "name": "Test Offerer",
+            "siren": "418166096",
+            "address": "123 rue de Paris",
+            "postalCode": "93100",
+            "city": "Montreuil",
+        }
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
 
-            # then
-            assert response.status_code == 201
-            assert response.json["siren"] == "418166096"
-            assert response.json["name"] == "Test Offerer"
-            virtual_venues = list(filter(lambda v: v["isVirtual"], response.json["managedVenues"]))
-            assert len(virtual_venues) == 1
-            assert virtual_venues[0]["venueTypeId"] == humanize(digital_venue_type.id)
+        # then
+        assert response.status_code == 201
+        assert response.json["siren"] == "418166096"
+        assert response.json["name"] == "Test Offerer"
+        virtual_venues = list(filter(lambda v: v["isVirtual"], response.json["managedVenues"]))
+        assert len(virtual_venues) == 1
+        assert virtual_venues[0]["venueTypeId"] == humanize(digital_venue_type.id)
 
-        @patch("pcapi.connectors.api_entreprises.requests.get")
-        @pytest.mark.usefixtures("db_session")
-        def when_no_address_is_provided(self, mock_api_entreprise, app):
-            # given
-            mock_api_entreprise.return_value = MagicMock(
-                status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
-            )
+    @patch("pcapi.connectors.api_entreprises.requests.get")
+    @pytest.mark.usefixtures("db_session")
+    def when_no_address_is_provided(self, mock_api_entreprise, app):
+        # given
+        mock_api_entreprise.return_value = MagicMock(
+            status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
+        )
 
-            user = UserFactory()
-            VirtualVenueTypeFactory()
-            body = {"name": "Test Offerer", "siren": "418166096", "postalCode": "93100", "city": "Montreuil"}
+        user = UserFactory()
+        VirtualVenueTypeFactory()
+        body = {"name": "Test Offerer", "siren": "418166096", "postalCode": "93100", "city": "Montreuil"}
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
 
-            # then
-            assert response.status_code == 201
-            assert response.json["siren"] == "418166096"
-            assert response.json["name"] == "Test Offerer"
+        # then
+        assert response.status_code == 201
+        assert response.json["siren"] == "418166096"
+        assert response.json["name"] == "Test Offerer"
 
-        @patch("pcapi.connectors.api_entreprises.requests.get")
-        @pytest.mark.usefixtures("db_session")
-        def when_current_user_is_admin(self, mock_api_entreprise, app):
-            # Given
-            mock_api_entreprise.return_value = MagicMock(
-                status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
-            )
+    @patch("pcapi.connectors.api_entreprises.requests.get")
+    @pytest.mark.usefixtures("db_session")
+    def when_current_user_is_admin(self, mock_api_entreprise, app):
+        # Given
+        mock_api_entreprise.return_value = MagicMock(
+            status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
+        )
 
-            user = UserFactory(isBeneficiary=False, isAdmin=True)
-            VirtualVenueTypeFactory()
-            body = {
-                "name": "Test Offerer",
-                "siren": "418166096",
-                "address": "123 rue de Paris",
-                "postalCode": "93100",
-                "city": "Montreuil",
-            }
+        user = UserFactory(isBeneficiary=False, isAdmin=True)
+        VirtualVenueTypeFactory()
+        body = {
+            "name": "Test Offerer",
+            "siren": "418166096",
+            "address": "123 rue de Paris",
+            "postalCode": "93100",
+            "city": "Montreuil",
+        }
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
 
-            # then
-            assert response.status_code == 201
+        # then
+        assert response.status_code == 201
 
-        @patch("pcapi.connectors.api_entreprises.requests.get")
-        @pytest.mark.usefixtures("db_session")
-        def expect_the_current_user_to_have_access_to_new_offerer(self, mock_api_entreprise, app):
-            # Given
-            mock_api_entreprise.return_value = MagicMock(
-                status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
-            )
+    @patch("pcapi.connectors.api_entreprises.requests.get")
+    @pytest.mark.usefixtures("db_session")
+    def expect_the_current_user_to_have_access_to_new_offerer(self, mock_api_entreprise, app):
+        # Given
+        mock_api_entreprise.return_value = MagicMock(
+            status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
+        )
 
-            user = UserFactory(isBeneficiary=False, isAdmin=False)
-            VirtualVenueTypeFactory()
-            body = {
-                "name": "Test Offerer",
-                "siren": "418166096",
-                "address": "123 rue de Paris",
-                "postalCode": "93100",
-                "city": "Montreuil",
-            }
+        user = UserFactory(isBeneficiary=False, isAdmin=False)
+        VirtualVenueTypeFactory()
+        body = {
+            "name": "Test Offerer",
+            "siren": "418166096",
+            "address": "123 rue de Paris",
+            "postalCode": "93100",
+            "city": "Montreuil",
+        }
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
 
-            # then
-            assert response.status_code == 201
-            offerer = Offerer.query.first()
-            assert offerer.UserOfferers[0].user == user
+        # then
+        assert response.status_code == 201
+        offerer = Offerer.query.first()
+        assert offerer.UserOfferers[0].user == user
 
-        @patch("pcapi.domain.admin_emails.make_validation_email_object")
-        @patch("pcapi.connectors.api_entreprises.requests.get")
-        @pytest.mark.usefixtures("db_session")
-        def when_offerer_already_have_user_offerer_new_user_offerer_has_validation_token(
-            self, mock_api_entreprise, make_validation_email_object, app
-        ):
-            # Given
-            make_validation_email_object.return_value = {"Html-part": None}
-            mock_api_entreprise.return_value = MagicMock(
-                status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
-            )
+    @patch("pcapi.domain.admin_emails.make_validation_email_object")
+    @patch("pcapi.connectors.api_entreprises.requests.get")
+    @pytest.mark.usefixtures("db_session")
+    def when_offerer_already_have_user_offerer_new_user_offerer_has_validation_token(
+        self, mock_api_entreprise, make_validation_email_object, app
+    ):
+        # Given
+        make_validation_email_object.return_value = {"Html-part": None}
+        mock_api_entreprise.return_value = MagicMock(
+            status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
+        )
 
-            user = UserFactory(isBeneficiary=False, isAdmin=False)
-            user_2 = UserFactory(email="other_offerer@mail.com", isAdmin=False)
-            offerer = OffererFactory()
-            UserOffererFactory(user=user_2, offerer=offerer, validationToken=None)
-            VirtualVenueTypeFactory()
-            body = {
-                "name": offerer.name,
-                "siren": offerer.siren,
-                "address": offerer.address,
-                "postalCode": offerer.postalCode,
-                "city": offerer.city,
-            }
+        user = UserFactory(isBeneficiary=False, isAdmin=False)
+        user_2 = UserFactory(email="other_offerer@mail.com", isAdmin=False)
+        offerer = OffererFactory()
+        UserOffererFactory(user=user_2, offerer=offerer, validationToken=None)
+        VirtualVenueTypeFactory()
+        body = {
+            "name": offerer.name,
+            "siren": offerer.siren,
+            "address": offerer.address,
+            "postalCode": offerer.postalCode,
+            "city": offerer.city,
+        }
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
 
-            # then
-            assert response.status_code == 201
-            offerer = Offerer.query.first()
-            created_user_offerer = (
-                UserOfferer.query.filter(UserOfferer.offerer == offerer).filter(UserOfferer.user == user).one()
-            )
-            assert created_user_offerer.validationToken is not None
+        # then
+        assert response.status_code == 201
+        offerer = Offerer.query.first()
+        created_user_offerer = (
+            UserOfferer.query.filter(UserOfferer.offerer == offerer).filter(UserOfferer.user == user).one()
+        )
+        assert created_user_offerer.validationToken is not None
 
-        @patch("pcapi.domain.admin_emails.make_validation_email_object")
-        @patch("pcapi.connectors.api_entreprises.requests.get")
-        @pytest.mark.usefixtures("db_session")
-        def expect_new_offerer_to_have_validation_token_but_user_offerer_dont(
-            self, mock_api_entreprise, make_validation_email_object, app
-        ):
-            # Given
-            make_validation_email_object.return_value = {"Html-part": None}
-            mock_api_entreprise.return_value = MagicMock(
-                status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
-            )
+    @patch("pcapi.domain.admin_emails.make_validation_email_object")
+    @patch("pcapi.connectors.api_entreprises.requests.get")
+    @pytest.mark.usefixtures("db_session")
+    def expect_new_offerer_to_have_validation_token_but_user_offerer_dont(
+        self, mock_api_entreprise, make_validation_email_object, app
+    ):
+        # Given
+        make_validation_email_object.return_value = {"Html-part": None}
+        mock_api_entreprise.return_value = MagicMock(
+            status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
+        )
 
-            user = UserFactory(isBeneficiary=False, isAdmin=False)
-            VirtualVenueTypeFactory()
-            body = {
-                "name": "Test Offerer",
-                "siren": "418166096",
-                "address": "123 rue de Paris",
-                "postalCode": "93100",
-                "city": "Montreuil",
-            }
+        user = UserFactory(isBeneficiary=False, isAdmin=False)
+        VirtualVenueTypeFactory()
+        body = {
+            "name": "Test Offerer",
+            "siren": "418166096",
+            "address": "123 rue de Paris",
+            "postalCode": "93100",
+            "city": "Montreuil",
+        }
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
 
-            # then
-            assert response.status_code == 201
-            offerer = Offerer.query.first()
-            assert offerer.validationToken is not None
-            assert offerer.UserOfferers[0].validationToken is None
+        # then
+        assert response.status_code == 201
+        offerer = Offerer.query.first()
+        assert offerer.validationToken is not None
+        assert offerer.UserOfferers[0].validationToken is None
 
-        @patch("pcapi.domain.admin_emails.make_validation_email_object")
-        @patch("pcapi.connectors.api_entreprises.requests.get")
-        @pytest.mark.usefixtures("db_session")
-        def when_offerer_already_in_base_just_create_user_offerer_with_validation_token(
-            self, mock_api_entreprise, make_validation_email_object, app
-        ):
-            # Given
-            make_validation_email_object.return_value = {"Html-part": None}
-            mock_api_entreprise.return_value = MagicMock(
-                status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
-            )
+    @patch("pcapi.domain.admin_emails.make_validation_email_object")
+    @patch("pcapi.connectors.api_entreprises.requests.get")
+    @pytest.mark.usefixtures("db_session")
+    def when_offerer_already_in_base_just_create_user_offerer_with_validation_token(
+        self, mock_api_entreprise, make_validation_email_object, app
+    ):
+        # Given
+        make_validation_email_object.return_value = {"Html-part": None}
+        mock_api_entreprise.return_value = MagicMock(
+            status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
+        )
 
-            user = UserFactory(isBeneficiary=False, isAdmin=False)
-            offerer = OffererFactory()
-            body = {
-                "name": offerer.name,
-                "siren": offerer.siren,
-                "address": offerer.address,
-                "postalCode": offerer.postalCode,
-                "city": offerer.city,
-            }
+        user = UserFactory(isBeneficiary=False, isAdmin=False)
+        offerer = OffererFactory()
+        body = {
+            "name": offerer.name,
+            "siren": offerer.siren,
+            "address": offerer.address,
+            "postalCode": offerer.postalCode,
+            "city": offerer.city,
+        }
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
 
-            # Then
-            assert response.status_code == 201
-            offerer = Offerer.query.first()
-            assert offerer.UserOfferers[0].user == user
-            assert offerer.UserOfferers[0].validationToken is not None
+        # Then
+        assert response.status_code == 201
+        offerer = Offerer.query.first()
+        assert offerer.UserOfferers[0].user == user
+        assert offerer.UserOfferers[0].validationToken is not None
 
-        @patch("pcapi.domain.admin_emails.make_validation_email_object")
-        @patch("pcapi.connectors.api_entreprises.requests.get")
-        @pytest.mark.usefixtures("db_session")
-        def expect_not_validated_offerer_to_keeps_validation_token_and_user_offerer_get_one(
-            self, mock_api_entreprise, make_validation_email_object, app
-        ):
-            # Given
-            make_validation_email_object.return_value = {"Html-part": None}
-            mock_api_entreprise.return_value = MagicMock(
-                status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
-            )
+    @patch("pcapi.domain.admin_emails.make_validation_email_object")
+    @patch("pcapi.connectors.api_entreprises.requests.get")
+    @pytest.mark.usefixtures("db_session")
+    def expect_not_validated_offerer_to_keeps_validation_token_and_user_offerer_get_one(
+        self, mock_api_entreprise, make_validation_email_object, app
+    ):
+        # Given
+        make_validation_email_object.return_value = {"Html-part": None}
+        mock_api_entreprise.return_value = MagicMock(
+            status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
+        )
 
-            user = UserFactory(isBeneficiary=False, isAdmin=False)
-            offerer = OffererFactory(validationToken="not_validated")
-            body = {
-                "name": offerer.name,
-                "siren": offerer.siren,
-                "address": offerer.address,
-                "postalCode": offerer.postalCode,
-                "city": offerer.city,
-            }
+        user = UserFactory(isBeneficiary=False, isAdmin=False)
+        offerer = OffererFactory(validationToken="not_validated")
+        body = {
+            "name": offerer.name,
+            "siren": offerer.siren,
+            "address": offerer.address,
+            "postalCode": offerer.postalCode,
+            "city": offerer.city,
+        }
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
 
-            # Then
-            assert response.status_code == 201
-            offerer = Offerer.query.first()
-            assert offerer.validationToken == "not_validated"
-            assert offerer.UserOfferers[0].validationToken is not None
-            user_offerer = UserOfferer.query.first()
-            make_validation_email_object.assert_called_once_with(offerer, user_offerer)
+        # Then
+        assert response.status_code == 201
+        offerer = Offerer.query.first()
+        assert offerer.validationToken == "not_validated"
+        assert offerer.UserOfferers[0].validationToken is not None
+        user_offerer = UserOfferer.query.first()
+        make_validation_email_object.assert_called_once_with(offerer, user_offerer)
 
-        @patch("pcapi.routes.pro.offerers.maybe_send_offerer_validation_email", return_value=True)
-        @patch("pcapi.connectors.api_entreprises.requests.get")
-        @pytest.mark.usefixtures("db_session")
-        def expect_maybe_send_offerer_validation_email_to_be_called(
-            self, mock_api_entreprise, mock_maybe_send_offerer_validation_email, app
-        ):
-            # Given
-            mock_api_entreprise.return_value = MagicMock(
-                status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
-            )
+    @patch("pcapi.routes.pro.offerers.maybe_send_offerer_validation_email", return_value=True)
+    @patch("pcapi.connectors.api_entreprises.requests.get")
+    @pytest.mark.usefixtures("db_session")
+    def expect_maybe_send_offerer_validation_email_to_be_called(
+        self, mock_api_entreprise, mock_maybe_send_offerer_validation_email, app
+    ):
+        # Given
+        mock_api_entreprise.return_value = MagicMock(
+            status_code=200, text="", json=MagicMock(return_value=copy.deepcopy(api_entreprise_json_mock))
+        )
 
-            user = UserFactory(isBeneficiary=False, isAdmin=False)
-            offerer = OffererFactory(validationToken="not_validated")
-            body = {
-                "name": offerer.name,
-                "siren": offerer.siren,
-                "address": offerer.address,
-                "postalCode": offerer.postalCode,
-                "city": offerer.city,
-            }
+        user = UserFactory(isBeneficiary=False, isAdmin=False)
+        offerer = OffererFactory(validationToken="not_validated")
+        body = {
+            "name": offerer.name,
+            "siren": offerer.siren,
+            "address": offerer.address,
+            "postalCode": offerer.postalCode,
+            "city": offerer.city,
+        }
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).post("/offerers", json=body)
 
-            # Then
-            assert response.status_code == 201
-            offerer = Offerer.query.first()
-            assert offerer.validationToken == "not_validated"
-            assert offerer.UserOfferers[0].validationToken is not None
+        # Then
+        assert response.status_code == 201
+        offerer = Offerer.query.first()
+        assert offerer.validationToken == "not_validated"
+        assert offerer.UserOfferers[0].validationToken is not None
 
-            user_offerer = UserOfferer.query.first()
+        user_offerer = UserOfferer.query.first()
 
-            mock_maybe_send_offerer_validation_email.assert_called_once_with(offerer, user_offerer)
+        mock_maybe_send_offerer_validation_email.assert_called_once_with(offerer, user_offerer)

--- a/tests/routes/pro/post_stocks_test.py
+++ b/tests/routes/pro/post_stocks_test.py
@@ -14,7 +14,7 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns201:
+class Returns201Test:
     def test_create_one_stock(self, app):
         # Given
         offer = offers_factories.ThingOfferFactory()
@@ -154,7 +154,7 @@ class Returns201:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns400:
+class Returns400Test:
     def when_missing_offer_id(self, app):
         # Given
         offer = offers_factories.ThingOfferFactory()
@@ -331,7 +331,7 @@ class Returns400:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403:
+class Returns403Test:
     def when_user_has_no_rights_and_creating_stock_from_offer_id(self, app, db_session):
         # Given
         user = users_factories.UserFactory(email="wrong@example.com")

--- a/tests/routes/pro/post_venue_provider_test.py
+++ b/tests/routes/pro/post_venue_provider_test.py
@@ -19,7 +19,7 @@ from tests.conftest import TestClient
 from tests.conftest import clean_database
 
 
-class Returns201:
+class Returns201Test:
     @pytest.mark.usefixtures("db_session")
     @override_features(SYNCHRONIZE_VENUE_PROVIDER_IN_WORKER=False)
     @patch("pcapi.core.providers.api.subprocess.Popen")
@@ -231,7 +231,7 @@ class Returns201:
         )
 
 
-class Returns400:
+class Returns400Test:
     @pytest.mark.usefixtures("db_session")
     def when_api_error_raise_when_missing_fields(self, app):
         # Given
@@ -321,7 +321,7 @@ class Returns400:
         assert VenueProvider.query.count() == 0
 
 
-class Returns401:
+class Returns401Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_is_not_logged_in(self, app):
         # when
@@ -331,7 +331,7 @@ class Returns401:
         assert response.status_code == 401
 
 
-class Returns404:
+class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     def when_venue_does_not_exist(self, app):
         # Given
@@ -375,7 +375,7 @@ class Returns404:
         assert VenueProvider.query.count() == 0
 
 
-class Returns422:
+class Returns422Test:
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.core.providers.api._check_venue_can_be_synchronized_with_provider")
     def when_provider_api_not_available(self, stubbed_check, app):

--- a/tests/routes/pro/post_venue_stocks_test.py
+++ b/tests/routes/pro/post_venue_stocks_test.py
@@ -11,119 +11,122 @@ from tests.conftest import TestClient
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-class Post:
-    @patch("pcapi.core.providers.api.synchronize_stocks")
-    def test_accepts_request(self, mock_synchronize_stocks, app):
-        offerer = offers_factories.OffererFactory(siren=123456789)
-        venue = offers_factories.VenueFactory(managingOfferer=offerer, id=3)
-        api_key = offers_factories.ApiKeyFactory(offerer=offerer)
+@patch("pcapi.core.providers.api.synchronize_stocks")
+def test_accepts_request(mock_synchronize_stocks, app):
+    offerer = offers_factories.OffererFactory(siren=123456789)
+    venue = offers_factories.VenueFactory(managingOfferer=offerer, id=3)
+    api_key = offers_factories.ApiKeyFactory(offerer=offerer)
 
-        mock_synchronize_stocks.return_value = {}
+    mock_synchronize_stocks.return_value = {}
 
-        test_client = TestClient(app.test_client())
-        test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
+    test_client = TestClient(app.test_client())
+    test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
 
-        response = test_client.post("/v2/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
+    response = test_client.post("/v2/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
 
-        assert response.status_code == 204
-        mock_synchronize_stocks.assert_called_once_with(
-            [
-                {
-                    "products_provider_reference": "123456789",
-                    "offers_provider_reference": "123456789@3",
-                    "stocks_provider_reference": "123456789@3",
-                    "available_quantity": 4,
-                    "price": None,
-                }
-            ],
-            venue,
-        )
-
-    @pytest.mark.parametrize(
-        "price,expected_price",
-        [(None, None), ("", None), ("0", None), (0, None), (1.23, Decimal("1.23")), ("1.23", Decimal("1.23"))],
+    assert response.status_code == 204
+    mock_synchronize_stocks.assert_called_once_with(
+        [
+            {
+                "products_provider_reference": "123456789",
+                "offers_provider_reference": "123456789@3",
+                "stocks_provider_reference": "123456789@3",
+                "available_quantity": 4,
+                "price": None,
+            }
+        ],
+        venue,
     )
-    @patch("pcapi.core.providers.api.synchronize_stocks")
-    def test_accepts_request_with_price(self, mock_synchronize_stocks, price, expected_price, app):
-        offerer = offers_factories.OffererFactory(siren=123456789)
-        venue = offers_factories.VenueFactory(managingOfferer=offerer, id=3)
-        api_key = offers_factories.ApiKeyFactory(offerer=offerer)
 
-        mock_synchronize_stocks.return_value = {}
 
-        test_client = TestClient(app.test_client())
-        test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
+@pytest.mark.parametrize(
+    "price,expected_price",
+    [(None, None), ("", None), ("0", None), (0, None), (1.23, Decimal("1.23")), ("1.23", Decimal("1.23"))],
+)
+@patch("pcapi.core.providers.api.synchronize_stocks")
+def test_accepts_request_with_price(mock_synchronize_stocks, price, expected_price, app):
+    offerer = offers_factories.OffererFactory(siren=123456789)
+    venue = offers_factories.VenueFactory(managingOfferer=offerer, id=3)
+    api_key = offers_factories.ApiKeyFactory(offerer=offerer)
 
-        response = test_client.post(
-            "/v2/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4, "price": price}]}
-        )
+    mock_synchronize_stocks.return_value = {}
 
-        assert response.status_code == 204
-        mock_synchronize_stocks.assert_called_once_with(
-            [
-                {
-                    "products_provider_reference": "123456789",
-                    "offers_provider_reference": "123456789@3",
-                    "stocks_provider_reference": "123456789@3",
-                    "available_quantity": 4,
-                    "price": expected_price,
-                }
-            ],
-            venue,
-        )
+    test_client = TestClient(app.test_client())
+    test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
 
-    @patch("pcapi.core.providers.api.synchronize_stocks")
-    def test_requires_an_api_key(self, mock_synchronize_stocks, app):
-        offerer = offers_factories.OffererFactory(siren=123456789)
-        offers_factories.VenueFactory(managingOfferer=offerer, id=3)
+    response = test_client.post(
+        "/v2/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4, "price": price}]}
+    )
 
-        mock_synchronize_stocks.return_value = {}
+    assert response.status_code == 204
+    mock_synchronize_stocks.assert_called_once_with(
+        [
+            {
+                "products_provider_reference": "123456789",
+                "offers_provider_reference": "123456789@3",
+                "stocks_provider_reference": "123456789@3",
+                "available_quantity": 4,
+                "price": expected_price,
+            }
+        ],
+        venue,
+    )
 
-        test_client = TestClient(app.test_client())
 
-        response = test_client.post("/v2/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
+@patch("pcapi.core.providers.api.synchronize_stocks")
+def test_requires_an_api_key(mock_synchronize_stocks, app):
+    offerer = offers_factories.OffererFactory(siren=123456789)
+    offers_factories.VenueFactory(managingOfferer=offerer, id=3)
 
-        assert response.status_code == 401
-        mock_synchronize_stocks.assert_not_called()
+    mock_synchronize_stocks.return_value = {}
 
-    @patch("pcapi.core.providers.api.synchronize_stocks")
-    def test_returns_404_if_api_key_cant_access_venue(self, mock_synchronize_stocks, app):
-        offerer = offers_factories.OffererFactory(siren=123456789)
-        offers_factories.VenueFactory(managingOfferer=offerer, id=3)
+    test_client = TestClient(app.test_client())
 
-        offerer2 = offers_factories.OffererFactory(siren=123456780)
-        api_key = offers_factories.ApiKeyFactory(offerer=offerer2)
+    response = test_client.post("/v2/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
 
-        mock_synchronize_stocks.return_value = {}
+    assert response.status_code == 401
+    mock_synchronize_stocks.assert_not_called()
 
-        test_client = TestClient(app.test_client())
-        test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
 
-        response1 = test_client.post("/v2/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
-        response2 = test_client.post("/v2/venue/123/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
+@patch("pcapi.core.providers.api.synchronize_stocks")
+def test_returns_404_if_api_key_cant_access_venue(mock_synchronize_stocks, app):
+    offerer = offers_factories.OffererFactory(siren=123456789)
+    offers_factories.VenueFactory(managingOfferer=offerer, id=3)
 
-        assert response1.status_code == 404
-        assert response2.status_code == 404
-        mock_synchronize_stocks.assert_not_called()
+    offerer2 = offers_factories.OffererFactory(siren=123456780)
+    api_key = offers_factories.ApiKeyFactory(offerer=offerer2)
 
-    @patch("pcapi.core.providers.api.synchronize_stocks")
-    def test_returns_comprehensive_errors(self, mock_synchronize_stocks, app):
-        api_key = offers_factories.ApiKeyFactory()
+    mock_synchronize_stocks.return_value = {}
 
-        mock_synchronize_stocks.return_value = {}
+    test_client = TestClient(app.test_client())
+    test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
 
-        test_client = TestClient(app.test_client())
-        test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
+    response1 = test_client.post("/v2/venue/3/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
+    response2 = test_client.post("/v2/venue/123/stocks", json={"stocks": [{"ref": "123456789", "available": 4}]})
 
-        response1 = test_client.post("/v2/venue/3/stocks", json={})
-        response2 = test_client.post(
-            "/v2/venue/3/stocks", json={"stocks": [{"ref": "123456789"}, {"wrong_key": "123456789"}]}
-        )
+    assert response1.status_code == 404
+    assert response2.status_code == 404
+    mock_synchronize_stocks.assert_not_called()
 
-        assert response1.status_code == 400
-        assert response1.json["stocks"] == ["Ce champ est obligatoire"]
-        assert response2.status_code == 400
-        assert response2.json["stocks.0.available"] == ["Ce champ est obligatoire"]
-        assert response2.json["stocks.1.available"] == ["Ce champ est obligatoire"]
-        assert response2.json["stocks.1.ref"] == ["Ce champ est obligatoire"]
-        mock_synchronize_stocks.assert_not_called()
+
+@patch("pcapi.core.providers.api.synchronize_stocks")
+def test_returns_comprehensive_errors(mock_synchronize_stocks, app):
+    api_key = offers_factories.ApiKeyFactory()
+
+    mock_synchronize_stocks.return_value = {}
+
+    test_client = TestClient(app.test_client())
+    test_client.auth_header = {"Authorization": f"Bearer {api_key.value}"}
+
+    response1 = test_client.post("/v2/venue/3/stocks", json={})
+    response2 = test_client.post(
+        "/v2/venue/3/stocks", json={"stocks": [{"ref": "123456789"}, {"wrong_key": "123456789"}]}
+    )
+
+    assert response1.status_code == 400
+    assert response1.json["stocks"] == ["Ce champ est obligatoire"]
+    assert response2.status_code == 400
+    assert response2.json["stocks.0.available"] == ["Ce champ est obligatoire"]
+    assert response2.json["stocks.1.available"] == ["Ce champ est obligatoire"]
+    assert response2.json["stocks.1.ref"] == ["Ce champ est obligatoire"]
+    mock_synchronize_stocks.assert_not_called()

--- a/tests/routes/pro/signup_pro_test.py
+++ b/tests/routes/pro/signup_pro_test.py
@@ -27,321 +27,322 @@ BASE_DATA_PRO = {
 
 
 @pytest.mark.usefixtures("db_session")
-class Post:
-    class Returns204:
-        def when_user_data_is_valid(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            venue_type = VirtualVenueTypeFactory()
+class Returns204Test:
+    def when_user_data_is_valid(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        venue_type = VirtualVenueTypeFactory()
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-            # Then
-            assert response.status_code == 204
-            assert "Set-Cookie" not in response.headers
+        # Then
+        assert response.status_code == 204
+        assert "Set-Cookie" not in response.headers
 
-            user = User.query.filter_by(email="toto_pro@example.com").first()
-            assert user is not None
-            assert user.isBeneficiary is False
-            assert user.departementCode == "92"
-            assert user.email == "toto_pro@example.com"
-            assert user.firstName == "Toto"
-            assert user.isAdmin is False
-            assert user.lastName == "Pro"
-            assert user.phoneNumber == "0102030405"
-            assert user.postalCode == "92000"
-            assert user.publicName == "Toto Pro"
-            assert user.dateOfBirth is None
-            assert user.dateCreated is not None
-            assert user.notificationSubscriptions == {"marketing_push": True, "marketing_email": False}
-            offerer = Offerer.query.filter_by(siren="349974931").first()
-            assert offerer is not None
-            assert offerer.validationToken is not None
-            assert len(offerer.managedVenues) == 1
-            assert offerer.managedVenues[0].isVirtual
-            assert offerer.managedVenues[0].venueTypeId == venue_type.id
-            user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).first()
-            assert user_offerer is not None
-            assert user_offerer.validationToken is None
+        user = User.query.filter_by(email="toto_pro@example.com").first()
+        assert user is not None
+        assert user.isBeneficiary is False
+        assert user.departementCode == "92"
+        assert user.email == "toto_pro@example.com"
+        assert user.firstName == "Toto"
+        assert user.isAdmin is False
+        assert user.lastName == "Pro"
+        assert user.phoneNumber == "0102030405"
+        assert user.postalCode == "92000"
+        assert user.publicName == "Toto Pro"
+        assert user.dateOfBirth is None
+        assert user.dateCreated is not None
+        assert user.notificationSubscriptions == {"marketing_push": True, "marketing_email": False}
+        offerer = Offerer.query.filter_by(siren="349974931").first()
+        assert offerer is not None
+        assert offerer.validationToken is not None
+        assert len(offerer.managedVenues) == 1
+        assert offerer.managedVenues[0].isVirtual
+        assert offerer.managedVenues[0].venueTypeId == venue_type.id
+        user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).first()
+        assert user_offerer is not None
+        assert user_offerer.validationToken is None
 
-        def test_creates_user_offerer_digital_venue_and_userOfferer_and_does_not_log_user_in(self, app):
-            # Given
-            data_pro = BASE_DATA_PRO.copy()
-            data_pro["contactOk"] = "true"
-            venue_type = VirtualVenueTypeFactory()
+    def test_creates_user_offerer_digital_venue_and_userOfferer_and_does_not_log_user_in(self, app):
+        # Given
+        data_pro = BASE_DATA_PRO.copy()
+        data_pro["contactOk"] = "true"
+        venue_type = VirtualVenueTypeFactory()
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data_pro)
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data_pro)
 
-            # Then
-            assert response.status_code == 204
-            assert "Set-Cookie" not in response.headers
-            user = User.query.filter_by(email="toto_pro@example.com").first()
-            assert user is not None
-            assert user.notificationSubscriptions == {"marketing_push": True, "marketing_email": True}
-            offerer = Offerer.query.filter_by(siren="349974931").first()
-            assert offerer is not None
-            assert offerer.validationToken is not None
-            assert len(offerer.managedVenues) == 1
-            assert offerer.managedVenues[0].isVirtual
-            assert offerer.managedVenues[0].venueTypeId == venue_type.id
-            user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).first()
-            assert user_offerer is not None
-            assert user_offerer.validationToken is None
+        # Then
+        assert response.status_code == 204
+        assert "Set-Cookie" not in response.headers
+        user = User.query.filter_by(email="toto_pro@example.com").first()
+        assert user is not None
+        assert user.notificationSubscriptions == {"marketing_push": True, "marketing_email": True}
+        offerer = Offerer.query.filter_by(siren="349974931").first()
+        assert offerer is not None
+        assert offerer.validationToken is not None
+        assert len(offerer.managedVenues) == 1
+        assert offerer.managedVenues[0].isVirtual
+        assert offerer.managedVenues[0].venueTypeId == venue_type.id
+        user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).first()
+        assert user_offerer is not None
+        assert user_offerer.validationToken is None
 
-        def when_successful_and_existing_offerer_creates_editor_user_offerer_and_does_not_log_in(self, app):
-            # Given
-            VirtualVenueTypeFactory()
-            offerer = OffererFactory(siren="349974931", validationToken="not_validated")
-            user = UserFactory(email="bobby@test.com", publicName="bobby")
-            UserOffererFactory(user=user, offerer=offerer)
+    def when_successful_and_existing_offerer_creates_editor_user_offerer_and_does_not_log_in(self, app):
+        # Given
+        VirtualVenueTypeFactory()
+        offerer = OffererFactory(siren="349974931", validationToken="not_validated")
+        user = UserFactory(email="bobby@test.com", publicName="bobby")
+        UserOffererFactory(user=user, offerer=offerer)
 
-            data = BASE_DATA_PRO.copy()
+        data = BASE_DATA_PRO.copy()
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-            # Then
-            assert response.status_code == 204
-            assert "Set-Cookie" not in response.headers
-            user = User.query.filter_by(email="toto_pro@example.com").first()
-            assert user is not None
-            offerer = Offerer.query.filter_by(siren="349974931").first()
-            assert offerer is not None
-            user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).first()
-            assert user_offerer is not None
-            assert user_offerer.validationToken is not None
+        # Then
+        assert response.status_code == 204
+        assert "Set-Cookie" not in response.headers
+        user = User.query.filter_by(email="toto_pro@example.com").first()
+        assert user is not None
+        offerer = Offerer.query.filter_by(siren="349974931").first()
+        assert offerer is not None
+        user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).first()
+        assert user_offerer is not None
+        assert user_offerer.validationToken is not None
 
-        def when_successful_and_existing_offerer_but_no_user_offerer_does_not_signin(self, app):
-            # Given
-            OffererFactory(siren="349974931")
+    def when_successful_and_existing_offerer_but_no_user_offerer_does_not_signin(self, app):
+        # Given
+        OffererFactory(siren="349974931")
 
-            data = BASE_DATA_PRO.copy()
+        data = BASE_DATA_PRO.copy()
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-            # Then
-            assert response.status_code == 204
-            assert "Set-Cookie" not in response.headers
-            user = User.query.filter_by(email="toto_pro@example.com").first()
-            assert user is not None
-            offerer = Offerer.query.filter_by(siren="349974931").first()
-            assert offerer is not None
-            user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).first()
-            assert user_offerer is not None
-            assert user_offerer.validationToken is not None
+        # Then
+        assert response.status_code == 204
+        assert "Set-Cookie" not in response.headers
+        user = User.query.filter_by(email="toto_pro@example.com").first()
+        assert user is not None
+        offerer = Offerer.query.filter_by(siren="349974931").first()
+        assert offerer is not None
+        user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).first()
+        assert user_offerer is not None
+        assert user_offerer.validationToken is not None
 
-        def when_successful_and_mark_pro_user_as_no_cultural_survey_needed(self, app):
-            # Given
-            OffererFactory(siren="349974931")
+    def when_successful_and_mark_pro_user_as_no_cultural_survey_needed(self, app):
+        # Given
+        OffererFactory(siren="349974931")
 
-            data = BASE_DATA_PRO.copy()
+        data = BASE_DATA_PRO.copy()
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-            # Then
-            assert response.status_code == 204
-            user = User.query.filter_by(email="toto_pro@example.com").first()
-            assert user.needsToFillCulturalSurvey == False
+        # Then
+        assert response.status_code == 204
+        user = User.query.filter_by(email="toto_pro@example.com").first()
+        assert user.needsToFillCulturalSurvey == False
 
-    class Returns400:
-        def when_email_is_missing(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            del data["email"]
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+@pytest.mark.usefixtures("db_session")
+class Returns400Test:
+    def when_email_is_missing(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        del data["email"]
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "email" in error
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-        def when_email_is_invalid(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            data["email"] = "toto"
-            VirtualVenueTypeFactory()
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "email" in error
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+    def when_email_is_invalid(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        data["email"] = "toto"
+        VirtualVenueTypeFactory()
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "email" in error
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-        def when_email_is_already_used(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            VirtualVenueTypeFactory()
-            TestClient(app.test_client()).post("/users/signup/pro", json=data)
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "email" in error
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+    def when_email_is_already_used(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        VirtualVenueTypeFactory()
+        TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "email" in error
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-        def when_public_name_is_missing(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            del data["publicName"]
-            VirtualVenueTypeFactory()
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "email" in error
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+    def when_public_name_is_missing(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        del data["publicName"]
+        VirtualVenueTypeFactory()
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "publicName" in error
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-        def when_public_name_is_too_long(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            data["publicName"] = "x" * 300
-            VirtualVenueTypeFactory()
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "publicName" in error
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+    def when_public_name_is_too_long(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        data["publicName"] = "x" * 300
+        VirtualVenueTypeFactory()
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "publicName" in error
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-        def when_password_is_missing(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            del data["password"]
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "publicName" in error
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+    def when_password_is_missing(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        del data["password"]
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "password" in error
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-        def when_password_is_invalid(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            data["password"] = "weakpassword"
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "password" in error
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+    def when_password_is_invalid(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        data["password"] = "weakpassword"
 
-            # Then
-            assert response.status_code == 400
-            response = response.json
-            assert response["password"] == [
-                "Ton mot de passe doit contenir au moins :\n"
-                "- 12 caractères\n"
-                "- Un chiffre\n"
-                "- Une majuscule et une minuscule\n"
-                "- Un caractère spécial"
-            ]
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-        def when_offerer_name_is_missing(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            del data["name"]
-            VirtualVenueTypeFactory()
+        # Then
+        assert response.status_code == 400
+        response = response.json
+        assert response["password"] == [
+            "Ton mot de passe doit contenir au moins :\n"
+            "- 12 caractères\n"
+            "- Un chiffre\n"
+            "- Une majuscule et une minuscule\n"
+            "- Un caractère spécial"
+        ]
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+    def when_offerer_name_is_missing(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        del data["name"]
+        VirtualVenueTypeFactory()
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "name" in error
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-        def when_offerer_city_is_missing(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            del data["city"]
-            VirtualVenueTypeFactory()
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "name" in error
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+    def when_offerer_city_is_missing(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        del data["city"]
+        VirtualVenueTypeFactory()
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "city" in error
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-        def when_postal_code_is_missing(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            del data["postalCode"]
-            VirtualVenueTypeFactory()
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "city" in error
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+    def when_postal_code_is_missing(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        del data["postalCode"]
+        VirtualVenueTypeFactory()
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "postalCode" in error
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-        def when_invalid_postal_code(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            data["postalCode"] = "111"
-            VirtualVenueTypeFactory()
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "postalCode" in error
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+    def when_invalid_postal_code(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        data["postalCode"] = "111"
+        VirtualVenueTypeFactory()
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "postalCode" in error
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
-        def when_extra_data_is_given(self, app):
-            # Given
-            user_json = {
-                "email": "toto_pro@example.com",
-                "publicName": "Toto Pro",
-                "firstName": "Toto",
-                "lastName": "Pro",
-                "password": "__v4l1d_P455sw0rd__",
-                "siren": "349974931",
-                "address": "12 boulevard de Pesaro",
-                "phoneNumber": "0102030405",
-                "postalCode": "92000",
-                "city": "Nanterre",
-                "name": "Crédit Coopératif",
-                "isAdmin": True,
-                "contactOk": "true",
-            }
-            VirtualVenueTypeFactory()
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "postalCode" in error
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=user_json)
+    def when_extra_data_is_given(self, app):
+        # Given
+        user_json = {
+            "email": "toto_pro@example.com",
+            "publicName": "Toto Pro",
+            "firstName": "Toto",
+            "lastName": "Pro",
+            "password": "__v4l1d_P455sw0rd__",
+            "siren": "349974931",
+            "address": "12 boulevard de Pesaro",
+            "phoneNumber": "0102030405",
+            "postalCode": "92000",
+            "city": "Nanterre",
+            "name": "Crédit Coopératif",
+            "isAdmin": True,
+            "contactOk": "true",
+        }
+        VirtualVenueTypeFactory()
 
-            # Then
-            assert response.status_code == 400
-            created_user = User.query.filter_by(email="toto_pro@example.com").first()
-            assert created_user is None
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=user_json)
 
-        def when_invalid_phone_number(self, app):
-            # Given
-            data = BASE_DATA_PRO.copy()
-            data["phoneNumber"] = "abc 123"
-            VirtualVenueTypeFactory()
+        # Then
+        assert response.status_code == 400
+        created_user = User.query.filter_by(email="toto_pro@example.com").first()
+        assert created_user is None
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+    def when_invalid_phone_number(self, app):
+        # Given
+        data = BASE_DATA_PRO.copy()
+        data["phoneNumber"] = "abc 123"
+        VirtualVenueTypeFactory()
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "phoneNumber" in error
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
+
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "phoneNumber" in error

--- a/tests/routes/pro/validate_bookings_test.py
+++ b/tests/routes/pro/validate_bookings_test.py
@@ -31,7 +31,7 @@ tomorrow_minus_one_hour = tomorrow - timedelta(hours=1)
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns204:  # No Content
+class Returns204Test:  # No Content
     def when_user_has_rights(self, app):
         booking = BookingFactory(token="ABCDEF")
         pro_user = UserFactory(email="pro@example.com")
@@ -81,7 +81,7 @@ class Returns204:  # No Content
         assert booking.isUsed
 
 
-class Returns403:
+class Returns403Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_not_editor_and_valid_email(self, app):
         # Given
@@ -142,7 +142,7 @@ class Returns403:
         assert not Booking.query.get(booking.id).isUsed
 
 
-class Returns404:
+class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_not_editor_and_invalid_email(self, app):
         # Given

--- a/tests/routes/pro/validate_offerer_attachment_test.py
+++ b/tests/routes/pro/validate_offerer_attachment_test.py
@@ -11,83 +11,81 @@ from pcapi.repository import repository
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns202:
-        @pytest.mark.usefixtures("db_session")
-        def expect_user_offerer_attachment_to_be_validated(self, app):
-            # Given
-            user_offerer_token = secrets.token_urlsafe(20)
-            offerer_token = secrets.token_urlsafe(20)
-            offerer = create_offerer(
-                siren="349974931",
-                address="12 boulevard de Pesaro",
-                city="Nanterre",
-                postal_code="92000",
-                name="Crédit Coopératif",
-                validation_token=offerer_token,
-            )
-            user = create_user()
-            user_offerer = create_user_offerer(user, offerer, validation_token=user_offerer_token)
-            repository.save(offerer, user_offerer)
-            user_offerer_id = offerer.id
+class Returns202Test:
+    @pytest.mark.usefixtures("db_session")
+    def expect_user_offerer_attachment_to_be_validated(self, app):
+        # Given
+        user_offerer_token = secrets.token_urlsafe(20)
+        offerer_token = secrets.token_urlsafe(20)
+        offerer = create_offerer(
+            siren="349974931",
+            address="12 boulevard de Pesaro",
+            city="Nanterre",
+            postal_code="92000",
+            name="Crédit Coopératif",
+            validation_token=offerer_token,
+        )
+        user = create_user()
+        user_offerer = create_user_offerer(user, offerer, validation_token=user_offerer_token)
+        repository.save(offerer, user_offerer)
+        user_offerer_id = offerer.id
 
-            # When
-            response = TestClient(app.test_client()).get(
-                "/validate/user-offerer/" + user_offerer_token, headers={"origin": "http://localhost:3000"}
-            )
+        # When
+        response = TestClient(app.test_client()).get(
+            "/validate/user-offerer/" + user_offerer_token, headers={"origin": "http://localhost:3000"}
+        )
 
-            # Then
-            assert response.status_code == 202
+        # Then
+        assert response.status_code == 202
 
-            user_offerer = UserOfferer.query.filter_by(offererId=user_offerer_id).first()
+        user_offerer = UserOfferer.query.filter_by(offererId=user_offerer_id).first()
 
-            assert user_offerer.isValidated
+        assert user_offerer.isValidated
 
-    class Returns404:
-        @pytest.mark.usefixtures("db_session")
-        def expect_user_offerer_attachment_not_to_be_validated_with_unknown_token(self, app):
-            # when
-            response = (
-                TestClient(app.test_client()).with_auth(email="bobby@example.net").get("/validate/user-offerer/123")
-            )
 
-            # then
-            assert response.status_code == 404
+class Returns404Test:
+    @pytest.mark.usefixtures("db_session")
+    def expect_user_offerer_attachment_not_to_be_validated_with_unknown_token(self, app):
+        # when
+        response = TestClient(app.test_client()).with_auth(email="bobby@example.net").get("/validate/user-offerer/123")
 
-        @pytest.mark.usefixtures("db_session")
-        def expect_user_offerer_attachment_not_to_be_validated_with_same_token(self, app):
-            user_offerer_token = secrets.token_urlsafe(20)
-            offerer_token = secrets.token_urlsafe(20)
+        # then
+        assert response.status_code == 404
 
-            offerer = create_offerer(
-                siren="349974931",
-                address="12 boulevard de Pesaro",
-                city="Nanterre",
-                postal_code="92000",
-                name="Crédit Coopératif",
-                validation_token=offerer_token,
-            )
-            user = create_user()
-            user_offerer = create_user_offerer(user, offerer, validation_token=user_offerer_token)
-            repository.save(offerer, user_offerer)
-            user_offerer_id = offerer.id
+    @pytest.mark.usefixtures("db_session")
+    def expect_user_offerer_attachment_not_to_be_validated_with_same_token(self, app):
+        user_offerer_token = secrets.token_urlsafe(20)
+        offerer_token = secrets.token_urlsafe(20)
 
-            # When
-            TestClient(app.test_client()).get(
-                "/validate/user-offerer/" + user_offerer_token, headers={"origin": "http://localhost:3000"}
-            )
+        offerer = create_offerer(
+            siren="349974931",
+            address="12 boulevard de Pesaro",
+            city="Nanterre",
+            postal_code="92000",
+            name="Crédit Coopératif",
+            validation_token=offerer_token,
+        )
+        user = create_user()
+        user_offerer = create_user_offerer(user, offerer, validation_token=user_offerer_token)
+        repository.save(offerer, user_offerer)
+        user_offerer_id = offerer.id
 
-            response = TestClient(app.test_client()).get(
-                "/validate/user-offerer/" + user_offerer_token, headers={"origin": "http://localhost:3000"}
-            )
+        # When
+        TestClient(app.test_client()).get(
+            "/validate/user-offerer/" + user_offerer_token, headers={"origin": "http://localhost:3000"}
+        )
 
-            # Then
-            assert response.status_code == 404
-            user_offerer = UserOfferer.query.filter_by(offererId=user_offerer_id).first()
+        response = TestClient(app.test_client()).get(
+            "/validate/user-offerer/" + user_offerer_token, headers={"origin": "http://localhost:3000"}
+        )
 
-            assert (
-                response.json["validation"][0]
-                == "Aucun(e) objet ne correspond à ce code de validation ou l'objet est déjà validé"
-            )
+        # Then
+        assert response.status_code == 404
+        user_offerer = UserOfferer.query.filter_by(offererId=user_offerer_id).first()
 
-            assert user_offerer.isValidated
+        assert (
+            response.json["validation"][0]
+            == "Aucun(e) objet ne correspond à ce code de validation ou l'objet est déjà validé"
+        )
+
+        assert user_offerer.isValidated

--- a/tests/routes/pro/validate_offerer_test.py
+++ b/tests/routes/pro/validate_offerer_test.py
@@ -15,106 +15,106 @@ from pcapi.repository import repository
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns202:
-        @pytest.mark.usefixtures("db_session")
-        def expect_offerer_to_be_validated(self, app):
-            # Given
-            offerer_token = secrets.token_urlsafe(20)
-            offerer = create_offerer(validation_token=offerer_token)
-            user = create_user()
-            admin = create_user_offerer(user, offerer)
-            repository.save(admin)
+class Returns202Test:
+    @pytest.mark.usefixtures("db_session")
+    def expect_offerer_to_be_validated(self, app):
+        # Given
+        offerer_token = secrets.token_urlsafe(20)
+        offerer = create_offerer(validation_token=offerer_token)
+        user = create_user()
+        admin = create_user_offerer(user, offerer)
+        repository.save(admin)
 
-            # When
-            response = TestClient(app.test_client()).get(
-                f"/validate/offerer/{offerer_token}", headers={"origin": "http://localhost:3000"}
-            )
+        # When
+        response = TestClient(app.test_client()).get(
+            f"/validate/offerer/{offerer_token}", headers={"origin": "http://localhost:3000"}
+        )
 
-            # Then
-            assert response.status_code == 202
-            offerer = Offerer.query.filter_by(id=offerer.id).first()
-            assert offerer.isValidated is True
+        # Then
+        assert response.status_code == 202
+        offerer = Offerer.query.filter_by(id=offerer.id).first()
+        assert offerer.isValidated is True
 
-        @patch("pcapi.routes.pro.validate.link_valid_venue_to_irises")
-        @pytest.mark.usefixtures("db_session")
-        def expect_link_venue_to_iris_if_valid_to_have_been_called_for_every_venue(
-            self, mocked_link_venue_to_iris_if_valid, app
-        ):
-            # Given
-            offerer_token = secrets.token_urlsafe(20)
-            offerer = create_offerer(validation_token=offerer_token)
-            create_venue(offerer)
-            create_venue(offerer, siret=f"{offerer.siren}65371")
-            create_venue(offerer, is_virtual=True, siret=None)
-            user = create_user()
-            admin = create_user_offerer(user, offerer)
-            repository.save(admin)
+    @patch("pcapi.routes.pro.validate.link_valid_venue_to_irises")
+    @pytest.mark.usefixtures("db_session")
+    def expect_link_venue_to_iris_if_valid_to_have_been_called_for_every_venue(
+        self, mocked_link_venue_to_iris_if_valid, app
+    ):
+        # Given
+        offerer_token = secrets.token_urlsafe(20)
+        offerer = create_offerer(validation_token=offerer_token)
+        create_venue(offerer)
+        create_venue(offerer, siret=f"{offerer.siren}65371")
+        create_venue(offerer, is_virtual=True, siret=None)
+        user = create_user()
+        admin = create_user_offerer(user, offerer)
+        repository.save(admin)
 
-            # When
-            response = TestClient(app.test_client()).get(
-                f"/validate/offerer/{offerer_token}", headers={"origin": "http://localhost:3000"}
-            )
+        # When
+        response = TestClient(app.test_client()).get(
+            f"/validate/offerer/{offerer_token}", headers={"origin": "http://localhost:3000"}
+        )
 
-            # Then
-            assert response.status_code == 202
-            assert mocked_link_venue_to_iris_if_valid.call_count == 3
+        # Then
+        assert response.status_code == 202
+        assert mocked_link_venue_to_iris_if_valid.call_count == 3
 
-        @patch("pcapi.routes.pro.validate.redis.add_venue_id")
-        @pytest.mark.usefixtures("db_session")
-        def expect_offerer_managed_venues_to_be_added_to_redis_when_feature_is_active(self, mocked_redis, app):
-            # Given
-            offerer_token = secrets.token_urlsafe(20)
-            offerer = create_offerer(validation_token=offerer_token)
-            create_venue(offerer, idx=1)
-            create_venue(offerer, idx=2, siret=f"{offerer.siren}65371")
-            create_venue(offerer, idx=3, is_virtual=True, siret=None)
-            user = create_user()
-            admin = create_user_offerer(user, offerer)
-            repository.save(admin)
+    @patch("pcapi.routes.pro.validate.redis.add_venue_id")
+    @pytest.mark.usefixtures("db_session")
+    def expect_offerer_managed_venues_to_be_added_to_redis_when_feature_is_active(self, mocked_redis, app):
+        # Given
+        offerer_token = secrets.token_urlsafe(20)
+        offerer = create_offerer(validation_token=offerer_token)
+        create_venue(offerer, idx=1)
+        create_venue(offerer, idx=2, siret=f"{offerer.siren}65371")
+        create_venue(offerer, idx=3, is_virtual=True, siret=None)
+        user = create_user()
+        admin = create_user_offerer(user, offerer)
+        repository.save(admin)
 
-            # When
-            response = TestClient(app.test_client()).get(
-                f"/validate/offerer/{offerer_token}", headers={"origin": "http://localhost:3000"}
-            )
+        # When
+        response = TestClient(app.test_client()).get(
+            f"/validate/offerer/{offerer_token}", headers={"origin": "http://localhost:3000"}
+        )
 
-            # Then
-            assert response.status_code == 202
-            assert mocked_redis.call_count == 3
-            assert mocked_redis.call_args_list == [
-                call(client=app.redis_client, venue_id=1),
-                call(client=app.redis_client, venue_id=2),
-                call(client=app.redis_client, venue_id=3),
-            ]
+        # Then
+        assert response.status_code == 202
+        assert mocked_redis.call_count == 3
+        assert mocked_redis.call_args_list == [
+            call(client=app.redis_client, venue_id=1),
+            call(client=app.redis_client, venue_id=2),
+            call(client=app.redis_client, venue_id=3),
+        ]
 
-        @pytest.mark.usefixtures("db_session")
-        @patch("pcapi.routes.pro.validate.redis.add_venue_id")
-        @override_features(SYNCHRONIZE_ALGOLIA=False)
-        def expect_offerer_managed_venues_not_to_be_added_to_redis_when_feature_is_not_active(self, mocked_redis, app):
-            # Given
-            offerer_token = secrets.token_urlsafe(20)
-            offerer = create_offerer(validation_token=offerer_token)
-            create_venue(offerer)
-            create_venue(offerer, siret=f"{offerer.siren}65371")
-            create_venue(offerer, is_virtual=True, siret=None)
-            user = create_user()
-            admin = create_user_offerer(user, offerer)
-            repository.save(admin)
+    @pytest.mark.usefixtures("db_session")
+    @patch("pcapi.routes.pro.validate.redis.add_venue_id")
+    @override_features(SYNCHRONIZE_ALGOLIA=False)
+    def expect_offerer_managed_venues_not_to_be_added_to_redis_when_feature_is_not_active(self, mocked_redis, app):
+        # Given
+        offerer_token = secrets.token_urlsafe(20)
+        offerer = create_offerer(validation_token=offerer_token)
+        create_venue(offerer)
+        create_venue(offerer, siret=f"{offerer.siren}65371")
+        create_venue(offerer, is_virtual=True, siret=None)
+        user = create_user()
+        admin = create_user_offerer(user, offerer)
+        repository.save(admin)
 
-            # When
-            response = TestClient(app.test_client()).get(
-                f"/validate/offerer/{offerer_token}", headers={"origin": "http://localhost:3000"}
-            )
+        # When
+        response = TestClient(app.test_client()).get(
+            f"/validate/offerer/{offerer_token}", headers={"origin": "http://localhost:3000"}
+        )
 
-            # Then
-            assert response.status_code == 202
-            assert mocked_redis.call_count == 0
+        # Then
+        assert response.status_code == 202
+        assert mocked_redis.call_count == 0
 
-    class Returns404:
-        @pytest.mark.usefixtures("db_session")
-        def expect_offerer_not_to_be_validated_with_unknown_token(self, app):
-            # When
-            response = TestClient(app.test_client()).with_auth(email="pro@example.com").get("/validate/offerer/123")
 
-            # Then
-            assert response.status_code == 404
+class Returns404Test:
+    @pytest.mark.usefixtures("db_session")
+    def expect_offerer_not_to_be_validated_with_unknown_token(self, app):
+        # When
+        response = TestClient(app.test_client()).with_auth(email="pro@example.com").get("/validate/offerer/123")
+
+        # Then
+        assert response.status_code == 404

--- a/tests/routes/shared/get_features_test.py
+++ b/tests/routes/shared/get_features_test.py
@@ -6,26 +6,25 @@ from pcapi.repository import repository
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_logged_in(self, app):
-            # given
-            user = create_user()
-            repository.save(user)
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_logged_in(self, app):
+        # given
+        user = create_user()
+        repository.save(user)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/features")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/features")
 
-            # then
-            assert response.status_code == 200
-            feature_name_keys = [feature_dict["nameKey"] for feature_dict in response.json]
-            assert "WEBAPP_SIGNUP" in feature_name_keys
+        # then
+        assert response.status_code == 200
+        feature_name_keys = [feature_dict["nameKey"] for feature_dict in response.json]
+        assert "WEBAPP_SIGNUP" in feature_name_keys
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_not_logged_in(self, app):
-            # when
-            response = TestClient(app.test_client()).get("/features")
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_not_logged_in(self, app):
+        # when
+        response = TestClient(app.test_client()).get("/features")
 
-            # then
-            assert response.status_code == 200
+        # then
+        assert response.status_code == 200

--- a/tests/routes/shared/get_user_profile_test.py
+++ b/tests/routes/shared/get_user_profile_test.py
@@ -15,88 +15,88 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_logged_in_and_has_no_deposit(self, app):
-            # Given
-            user = create_user(
-                civility="M.",
-                departement_code="93",
-                email="toto@example.com",
-                first_name="Jean",
-                last_name="Smisse",
-                date_of_birth=datetime.datetime(2000, 1, 1),
-                phone_number="0612345678",
-                postal_code="93020",
-                public_name="Toto",
-            )
-            user.isEmailValidated = True
-            repository.save(user)
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_logged_in_and_has_no_deposit(self, app):
+        # Given
+        user = create_user(
+            civility="M.",
+            departement_code="93",
+            email="toto@example.com",
+            first_name="Jean",
+            last_name="Smisse",
+            date_of_birth=datetime.datetime(2000, 1, 1),
+            phone_number="0612345678",
+            postal_code="93020",
+            public_name="Toto",
+        )
+        user.isEmailValidated = True
+        repository.save(user)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(email="toto@example.com").get("/users/current")
+        # When
+        response = TestClient(app.test_client()).with_auth(email="toto@example.com").get("/users/current")
 
-            # Then
-            assert response.status_code == 200
-            assert not any("password" in field.lower() for field in response.json)
-            assert response.json == {
-                "activity": None,
-                "address": None,
-                "city": None,
-                "civility": "M.",
-                "dateCreated": format_into_utc_date(user.dateCreated),
-                "dateOfBirth": format_into_utc_date(user.dateOfBirth),
-                "departementCode": "93",
-                "email": "toto@example.com",
-                "firstName": "Jean",
-                "hasCompletedIdCheck": None,
-                "hasPhysicalVenues": False,
-                "hasSeenProTutorials": True,
-                "id": humanize(user.id),
-                "idPieceNumber": None,
-                "isAdmin": False,
-                "isBeneficiary": True,
-                "isEmailValidated": True,
-                "lastConnectionDate": None,
-                "lastName": "Smisse",
-                "needsToFillCulturalSurvey": False,
-                "notificationSubscriptions": {"marketing_email": True, "marketing_push": True},
-                "phoneNumber": "0612345678",
-                "phoneValidationStatus": None,
-                "postalCode": "93020",
-                "publicName": "Toto",
-            }
+        # Then
+        assert response.status_code == 200
+        assert not any("password" in field.lower() for field in response.json)
+        assert response.json == {
+            "activity": None,
+            "address": None,
+            "city": None,
+            "civility": "M.",
+            "dateCreated": format_into_utc_date(user.dateCreated),
+            "dateOfBirth": format_into_utc_date(user.dateOfBirth),
+            "departementCode": "93",
+            "email": "toto@example.com",
+            "firstName": "Jean",
+            "hasCompletedIdCheck": None,
+            "hasPhysicalVenues": False,
+            "hasSeenProTutorials": True,
+            "id": humanize(user.id),
+            "idPieceNumber": None,
+            "isAdmin": False,
+            "isBeneficiary": True,
+            "isEmailValidated": True,
+            "lastConnectionDate": None,
+            "lastName": "Smisse",
+            "needsToFillCulturalSurvey": False,
+            "notificationSubscriptions": {"marketing_email": True, "marketing_push": True},
+            "phoneNumber": "0612345678",
+            "phoneValidationStatus": None,
+            "postalCode": "93020",
+            "publicName": "Toto",
+        }
 
-        @pytest.mark.usefixtures("db_session")
-        def test_returns_has_physical_venues_and_has_offers(self, app):
-            # Given
-            user = create_user(email="test@email.com")
-            offerer = create_offerer()
-            offerer2 = create_offerer(siren="123456788")
-            user_offerer = create_user_offerer(user, offerer)
-            user_offerer2 = create_user_offerer(user, offerer2)
-            offerer_virtual_venue = create_venue(offerer, is_virtual=True, siret=None)
-            offerer2_physical_venue = create_venue(offerer2, siret="12345678856734")
-            offerer2_virtual_venue = create_venue(offerer, is_virtual=True, siret=None)
-            offer = create_offer_with_thing_product(
-                offerer_virtual_venue, thing_type=ThingType.JEUX_VIDEO_ABO, url="http://fake.url"
-            )
-            offer2 = create_offer_with_thing_product(offerer2_physical_venue)
+    @pytest.mark.usefixtures("db_session")
+    def test_returns_has_physical_venues_and_has_offers(self, app):
+        # Given
+        user = create_user(email="test@email.com")
+        offerer = create_offerer()
+        offerer2 = create_offerer(siren="123456788")
+        user_offerer = create_user_offerer(user, offerer)
+        user_offerer2 = create_user_offerer(user, offerer2)
+        offerer_virtual_venue = create_venue(offerer, is_virtual=True, siret=None)
+        offerer2_physical_venue = create_venue(offerer2, siret="12345678856734")
+        offerer2_virtual_venue = create_venue(offerer, is_virtual=True, siret=None)
+        offer = create_offer_with_thing_product(
+            offerer_virtual_venue, thing_type=ThingType.JEUX_VIDEO_ABO, url="http://fake.url"
+        )
+        offer2 = create_offer_with_thing_product(offerer2_physical_venue)
 
-            repository.save(offer, offer2, offerer2_virtual_venue, user_offerer, user_offerer2)
+        repository.save(offer, offer2, offerer2_virtual_venue, user_offerer, user_offerer2)
 
-            # When
-            response = TestClient(app.test_client()).with_auth("test@email.com").get("/users/current")
+        # When
+        response = TestClient(app.test_client()).with_auth("test@email.com").get("/users/current")
 
-            # Then
-            assert response.json["hasPhysicalVenues"] is True
+        # Then
+        assert response.json["hasPhysicalVenues"] is True
 
-    class Returns401:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_not_logged_in(self, app):
-            # When
-            response = TestClient(app.test_client()).get("/users/current")
 
-            # Then
-            assert response.status_code == 401
+class Returns401Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_not_logged_in(self, app):
+        # When
+        response = TestClient(app.test_client()).get("/users/current")
+
+        # Then
+        assert response.status_code == 401

--- a/tests/routes/shared/get_user_token_test.py
+++ b/tests/routes/shared/get_user_token_test.py
@@ -6,27 +6,27 @@ from pcapi.repository import repository
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_activation_token_exists(self, app):
-            # given
-            token = "U2NCXTNB2"
-            user = create_user(reset_password_token=token)
-            repository.save(user)
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_activation_token_exists(self, app):
+        # given
+        token = "U2NCXTNB2"
+        user = create_user(reset_password_token=token)
+        repository.save(user)
 
-            # when
-            request = TestClient(app.test_client()).get("/users/token/" + token)
+        # when
+        request = TestClient(app.test_client()).get("/users/token/" + token)
 
-            # then
-            assert request.status_code == 200
-            assert request.json == {}
+        # then
+        assert request.status_code == 200
+        assert request.json == {}
 
-    class Returns404:
-        @pytest.mark.usefixtures("db_session")
-        def when_activation_token_does_not_exist(self, app):
-            # when
-            request = TestClient(app.test_client()).get("/users/token/3YU26FS")
 
-            # then
-            assert request.status_code == 404
+class Returns404Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_activation_token_does_not_exist(self, app):
+        # when
+        request = TestClient(app.test_client()).get("/users/token/3YU26FS")
+
+        # then
+        assert request.status_code == 404

--- a/tests/routes/shared/post_change_password_test.py
+++ b/tests/routes/shared/post_change_password_test.py
@@ -10,48 +10,44 @@ from pcapi.repository import repository
 from tests.conftest import TestClient
 
 
-class PostChangePassword:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_current_user_changes_password(self, app):
-            # given
-            user = create_user(email="user@test.com")
-            repository.save(user)
-            data = {
-                "oldPassword": user.clearTextPassword,
-                "newPassword": "N3W_p4ssw0rd",
-                "newConfirmationPassword": "N3W_p4ssw0rd",
-            }
-            user_id = user.id
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_current_user_changes_password(self, app):
+        # given
+        user = create_user(email="user@test.com")
+        repository.save(user)
+        data = {
+            "oldPassword": user.clearTextPassword,
+            "newPassword": "N3W_p4ssw0rd",
+            "newConfirmationPassword": "N3W_p4ssw0rd",
+        }
+        user_id = user.id
 
-            # when
-            response = (
-                TestClient(app.test_client()).with_auth(user.email).post("/users/current/change-password", json=data)
-            )
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).post("/users/current/change-password", json=data)
 
-            # then
-            user = User.query.get(user_id)
-            assert user.checkPassword("N3W_p4ssw0rd") is True
-            assert response.status_code == 204
+        # then
+        user = User.query.get(user_id)
+        assert user.checkPassword("N3W_p4ssw0rd") is True
+        assert response.status_code == 204
 
-    class Returns400:
-        @pytest.mark.usefixtures("db_session")
-        @patch("pcapi.routes.shared.passwords.validate_change_password_request")
-        def when_one_password_is_missing_in_the_request_body(self, validate_change_password_request, app):
-            # given
-            api_errors = ApiErrors()
-            api_errors.add_error("password", "missing password")
-            api_errors.status_code = 400
-            user = create_user(email="user@test.com")
-            repository.save(user)
-            validate_change_password_request.side_effect = api_errors
-            data = {}
 
-            # when
-            response = (
-                TestClient(app.test_client()).with_auth(user.email).post("/users/current/change-password", json=data)
-            )
+class Returns400Test:
+    @pytest.mark.usefixtures("db_session")
+    @patch("pcapi.routes.shared.passwords.validate_change_password_request")
+    def when_one_password_is_missing_in_the_request_body(self, validate_change_password_request, app):
+        # given
+        api_errors = ApiErrors()
+        api_errors.add_error("password", "missing password")
+        api_errors.status_code = 400
+        user = create_user(email="user@test.com")
+        repository.save(user)
+        validate_change_password_request.side_effect = api_errors
+        data = {}
 
-            # then
-            assert response.status_code == 400
-            assert response.json["password"] == ["missing password"]
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).post("/users/current/change-password", json=data)
+
+        # then
+        assert response.status_code == 400
+        assert response.json["password"] == ["missing password"]

--- a/tests/routes/shared/post_reset_password_test.py
+++ b/tests/routes/shared/post_reset_password_test.py
@@ -9,7 +9,7 @@ from pcapi.core.users.models import User
 from tests.conftest import TestClient
 
 
-class Returns400:
+class Returns400Test:
     @patch("pcapi.routes.shared.passwords.check_webapp_recaptcha_token", return_value=None)
     def when_email_is_empty(self, check_recaptcha_token_is_valid_mock, app, db_session):
         # given
@@ -70,7 +70,7 @@ class Returns400:
         assert response.json["token"] == ["Le token renseigné n'est pas valide"]
 
 
-class Returns204:
+class Returns204Test:
     @patch("pcapi.routes.shared.passwords.check_webapp_recaptcha_token", return_value=None)
     def when_user_email_is_unknown(self, check_recaptcha_token_is_valid_mock, app, db_session):
         # given

--- a/tests/routes/shared/signin_test.py
+++ b/tests/routes/shared/signin_test.py
@@ -11,169 +11,169 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Post:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_account_is_known(self, app):
-            # given
-            user = create_user(
-                civility="M.",
-                departement_code="93",
-                email="user@example.com",
-                first_name="Jean",
-                last_name="Smisse",
-                date_of_birth=datetime.datetime(2000, 1, 1),
-                phone_number="0612345678",
-                postal_code="93020",
-                public_name="Toto",
-                last_connection_date=datetime.datetime(2019, 1, 1),
-            )
-            user.isEmailValidated = True
-            repository.save(user)
-            data = {"identifier": user.email, "password": user.clearTextPassword}
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_account_is_known(self, app):
+        # given
+        user = create_user(
+            civility="M.",
+            departement_code="93",
+            email="user@example.com",
+            first_name="Jean",
+            last_name="Smisse",
+            date_of_birth=datetime.datetime(2000, 1, 1),
+            phone_number="0612345678",
+            postal_code="93020",
+            public_name="Toto",
+            last_connection_date=datetime.datetime(2019, 1, 1),
+        )
+        user.isEmailValidated = True
+        repository.save(user)
+        data = {"identifier": user.email, "password": user.clearTextPassword}
 
-            # when
-            response = TestClient(app.test_client()).post("/users/signin", json=data)
+        # when
+        response = TestClient(app.test_client()).post("/users/signin", json=data)
 
-            # then
-            assert response.status_code == 200
-            assert not any("password" in field.lower() for field in response.json)
-            assert response.json == {
-                "activity": None,
-                "address": None,
-                "city": None,
-                "civility": "M.",
-                "dateCreated": format_into_utc_date(user.dateCreated),
-                "dateOfBirth": format_into_utc_date(user.dateOfBirth),
-                "departementCode": "93",
-                "email": "user@example.com",
-                "firstName": "Jean",
-                "hasPhysicalVenues": False,
-                "hasSeenProTutorials": True,
-                "id": humanize(user.id),
-                "isAdmin": False,
-                "isBeneficiary": True,
-                "isEmailValidated": True,
-                "lastConnectionDate": format_into_utc_date(user.lastConnectionDate),
-                "lastName": "Smisse",
-                "needsToFillCulturalSurvey": False,
-                "phoneNumber": "0612345678",
-                "postalCode": "93020",
-                "publicName": "Toto",
-            }
+        # then
+        assert response.status_code == 200
+        assert not any("password" in field.lower() for field in response.json)
+        assert response.json == {
+            "activity": None,
+            "address": None,
+            "city": None,
+            "civility": "M.",
+            "dateCreated": format_into_utc_date(user.dateCreated),
+            "dateOfBirth": format_into_utc_date(user.dateOfBirth),
+            "departementCode": "93",
+            "email": "user@example.com",
+            "firstName": "Jean",
+            "hasPhysicalVenues": False,
+            "hasSeenProTutorials": True,
+            "id": humanize(user.id),
+            "isAdmin": False,
+            "isBeneficiary": True,
+            "isEmailValidated": True,
+            "lastConnectionDate": format_into_utc_date(user.lastConnectionDate),
+            "lastName": "Smisse",
+            "needsToFillCulturalSurvey": False,
+            "phoneNumber": "0612345678",
+            "postalCode": "93020",
+            "publicName": "Toto",
+        }
 
-        @pytest.mark.usefixtures("db_session")
-        def when_account_is_known_with_mixed_case_email(self, app):
-            # given
-            user = create_user(email="USER@example.COM")
-            repository.save(user)
-            data = {"identifier": "uSeR@EXAmplE.cOm", "password": user.clearTextPassword}
+    @pytest.mark.usefixtures("db_session")
+    def when_account_is_known_with_mixed_case_email(self, app):
+        # given
+        user = create_user(email="USER@example.COM")
+        repository.save(user)
+        data = {"identifier": "uSeR@EXAmplE.cOm", "password": user.clearTextPassword}
 
-            # when
-            response = TestClient(app.test_client()).post("/users/signin", json=data)
+        # when
+        response = TestClient(app.test_client()).post("/users/signin", json=data)
 
-            # then
-            assert response.status_code == 200
+        # then
+        assert response.status_code == 200
 
-        @pytest.mark.usefixtures("db_session")
-        def when_account_is_known_with_trailing_spaces_in_email(self, app):
-            # given
-            user = create_user(email="user@example.com")
-            repository.save(user)
-            data = {"identifier": "  user@example.com  ", "password": user.clearTextPassword}
+    @pytest.mark.usefixtures("db_session")
+    def when_account_is_known_with_trailing_spaces_in_email(self, app):
+        # given
+        user = create_user(email="user@example.com")
+        repository.save(user)
+        data = {"identifier": "  user@example.com  ", "password": user.clearTextPassword}
 
-            # when
-            response = TestClient(app.test_client()).post("/users/signin", json=data)
+        # when
+        response = TestClient(app.test_client()).post("/users/signin", json=data)
 
-            # then
-            assert response.status_code == 200
+        # then
+        assert response.status_code == 200
 
-        @pytest.mark.usefixtures("db_session")
-        def expect_a_new_user_session_to_be_recorded(self, app):
-            # given
-            user = create_user(email="user@example.com")
-            repository.save(user)
-            data = {"identifier": user.email, "password": user.clearTextPassword}
+    @pytest.mark.usefixtures("db_session")
+    def expect_a_new_user_session_to_be_recorded(self, app):
+        # given
+        user = create_user(email="user@example.com")
+        repository.save(user)
+        data = {"identifier": user.email, "password": user.clearTextPassword}
 
-            # when
-            response = TestClient(app.test_client()).post(
-                "/users/signin", json=data, headers={"origin": "http://localhost:3000"}
-            )
+        # when
+        response = TestClient(app.test_client()).post(
+            "/users/signin", json=data, headers={"origin": "http://localhost:3000"}
+        )
 
-            # then
-            assert response.status_code == 200
+        # then
+        assert response.status_code == 200
 
-            session = UserSession.query.filter_by(userId=user.id).first()
-            assert session is not None
+        session = UserSession.query.filter_by(userId=user.id).first()
+        assert session is not None
 
-    class Returns401:
-        @pytest.mark.usefixtures("db_session")
-        def when_identifier_is_missing(self, app):
-            # Given
-            user = create_user()
-            repository.save(user)
-            data = {"identifier": None, "password": user.clearTextPassword}
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signin", json=data)
+class Returns401Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_identifier_is_missing(self, app):
+        # Given
+        user = create_user()
+        repository.save(user)
+        data = {"identifier": None, "password": user.clearTextPassword}
 
-            # Then
-            assert response.status_code == 400
-            assert response.json["identifier"] == ["none is not an allowed value"]
+        # When
+        response = TestClient(app.test_client()).post("/users/signin", json=data)
 
-        @pytest.mark.usefixtures("db_session")
-        def when_identifier_is_incorrect(self, app):
-            # Given
-            user = create_user()
-            repository.save(user)
-            data = {"identifier": "random.email@test.com", "password": user.clearTextPassword}
+        # Then
+        assert response.status_code == 400
+        assert response.json["identifier"] == ["none is not an allowed value"]
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signin", json=data)
+    @pytest.mark.usefixtures("db_session")
+    def when_identifier_is_incorrect(self, app):
+        # Given
+        user = create_user()
+        repository.save(user)
+        data = {"identifier": "random.email@test.com", "password": user.clearTextPassword}
 
-            # Then
-            assert response.status_code == 401
-            assert response.json["identifier"] == ["Identifiant ou mot de passe incorrect"]
+        # When
+        response = TestClient(app.test_client()).post("/users/signin", json=data)
 
-        @pytest.mark.usefixtures("db_session")
-        def when_password_is_missing(self, app):
-            # Given
-            user = create_user()
-            repository.save(user)
-            data = {"identifier": user.email, "password": None}
+        # Then
+        assert response.status_code == 401
+        assert response.json["identifier"] == ["Identifiant ou mot de passe incorrect"]
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signin", json=data)
+    @pytest.mark.usefixtures("db_session")
+    def when_password_is_missing(self, app):
+        # Given
+        user = create_user()
+        repository.save(user)
+        data = {"identifier": user.email, "password": None}
 
-            # Then
-            assert response.status_code == 400
-            assert response.json["password"] == ["none is not an allowed value"]
+        # When
+        response = TestClient(app.test_client()).post("/users/signin", json=data)
 
-        @pytest.mark.usefixtures("db_session")
-        def when_password_is_incorrect(self, app):
-            # Given
-            user = create_user()
-            repository.save(user)
-            data = {"identifier": user.email, "password": "wr0ng_p455w0rd"}
+        # Then
+        assert response.status_code == 400
+        assert response.json["password"] == ["none is not an allowed value"]
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signin", json=data)
+    @pytest.mark.usefixtures("db_session")
+    def when_password_is_incorrect(self, app):
+        # Given
+        user = create_user()
+        repository.save(user)
+        data = {"identifier": user.email, "password": "wr0ng_p455w0rd"}
 
-            # Then
-            assert response.status_code == 401
-            assert response.json["identifier"] == ["Identifiant ou mot de passe incorrect"]
+        # When
+        response = TestClient(app.test_client()).post("/users/signin", json=data)
 
-        @pytest.mark.usefixtures("db_session")
-        def when_account_is_not_validated(self, app):
-            # Given
-            user = create_user()
-            user.generate_validation_token()
-            repository.save(user)
-            data = {"identifier": user.email, "password": user.clearTextPassword}
+        # Then
+        assert response.status_code == 401
+        assert response.json["identifier"] == ["Identifiant ou mot de passe incorrect"]
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signin", json=data)
+    @pytest.mark.usefixtures("db_session")
+    def when_account_is_not_validated(self, app):
+        # Given
+        user = create_user()
+        user.generate_validation_token()
+        repository.save(user)
+        data = {"identifier": user.email, "password": user.clearTextPassword}
 
-            # Then
-            assert response.status_code == 401
-            assert response.json["identifier"] == ["Ce compte n'est pas validé."]
+        # When
+        response = TestClient(app.test_client()).post("/users/signin", json=data)
+
+        # Then
+        assert response.status_code == 401
+        assert response.json["identifier"] == ["Ce compte n'est pas validé."]

--- a/tests/routes/shared/signout_test.py
+++ b/tests/routes/shared/signout_test.py
@@ -7,22 +7,21 @@ from pcapi.repository import repository
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def expect_the_existing_user_session_to_be_deleted_deleted(self, app):
-            # given
-            user = create_user(email="test@mail.com")
-            repository.save(user)
-            auth_request = TestClient(app.test_client()).with_auth(email=user.email)
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def expect_the_existing_user_session_to_be_deleted_deleted(self, app):
+        # given
+        user = create_user(email="test@mail.com")
+        repository.save(user)
+        auth_request = TestClient(app.test_client()).with_auth(email=user.email)
 
-            assert auth_request.get("/bookings").status_code == 200
+        assert auth_request.get("/bookings").status_code == 200
 
-            # when
-            response = auth_request.get("/users/signout")
+        # when
+        response = auth_request.get("/users/signout")
 
-            # then
-            assert response.status_code == 200
-            assert response.json == {"global": "Déconnecté"}
-            session = UserSession.query.filter_by(userId=user.id).first()
-            assert session is None
+        # then
+        assert response.status_code == 200
+        assert response.json == {"global": "Déconnecté"}
+        session = UserSession.query.filter_by(userId=user.id).first()
+        assert session is None

--- a/tests/routes/webapp/change_beneficiary_email_test.py
+++ b/tests/routes/webapp/change_beneficiary_email_test.py
@@ -15,7 +15,7 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns204:
+class Returns204Test:
     @freeze_time("2020-10-15 09:00:00")
     def when_account_is_known(self, app):
         # given
@@ -93,7 +93,7 @@ class Returns204:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns400:
+class Returns400Test:
     def when_password_is_missing(self, app):
         # Given
         user = users_factories.UserFactory()
@@ -122,7 +122,7 @@ class Returns400:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns401:
+class Returns401Test:
     def when_password_is_incorrect(self, app):
         # Given
         user = users_factories.UserFactory()

--- a/tests/routes/webapp/delete_favorites_test.py
+++ b/tests/routes/webapp/delete_favorites_test.py
@@ -13,61 +13,61 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Delete:
-    class Returns204:
-        @pytest.mark.usefixtures("db_session")
-        def when_favorite_exists_with_offerId(self, app):
-            # Given
-            user = create_user(email="test@email.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
-            offer = create_offer_with_thing_product(venue, thumb_count=0)
-            mediation = None
-            favorite = create_favorite(mediation=mediation, offer=offer, user=user)
-            repository.save(user, favorite)
+class Returns204Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_favorite_exists_with_offerId(self, app):
+        # Given
+        user = create_user(email="test@email.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
+        offer = create_offer_with_thing_product(venue, thumb_count=0)
+        mediation = None
+        favorite = create_favorite(mediation=mediation, offer=offer, user=user)
+        repository.save(user, favorite)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).delete(f"/favorites/{humanize(offer.id)}")
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).delete(f"/favorites/{humanize(offer.id)}")
 
-            # Then
-            assert response.status_code == 200
-            assert "id" in response.json
-            deleted_favorite = Favorite.query.first()
-            assert deleted_favorite is None
+        # Then
+        assert response.status_code == 200
+        assert "id" in response.json
+        deleted_favorite = Favorite.query.first()
+        assert deleted_favorite is None
 
-    class Returns404:
-        @pytest.mark.usefixtures("db_session")
-        def when_expected_parameters_are_not_given(self, app):
-            # Given
-            user = create_user(email="test@email.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
-            offer = create_offer_with_thing_product(venue, thumb_count=0)
-            mediation = create_mediation(offer, is_active=True)
-            favorite = create_favorite(mediation=mediation, offer=offer, user=user)
-            repository.save(user, favorite)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).delete("/favorites/1")
+class Returns404Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_expected_parameters_are_not_given(self, app):
+        # Given
+        user = create_user(email="test@email.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
+        offer = create_offer_with_thing_product(venue, thumb_count=0)
+        mediation = create_mediation(offer, is_active=True)
+        favorite = create_favorite(mediation=mediation, offer=offer, user=user)
+        repository.save(user, favorite)
 
-            # Then
-            assert response.status_code == 404
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).delete("/favorites/1")
 
-        @pytest.mark.usefixtures("db_session")
-        def when_favorite_does_not_exist(self, app):
-            # Given
-            user = create_user(email="test@email.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
-            offer = create_offer_with_thing_product(venue, thumb_count=0)
-            mediation = create_mediation(offer, is_active=True)
-            favorite = create_favorite(mediation=mediation, offer=offer, user=user)
-            repository.save(user, favorite)
+        # Then
+        assert response.status_code == 404
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).delete("/favorites/ABCD/ABCD")
+    @pytest.mark.usefixtures("db_session")
+    def when_favorite_does_not_exist(self, app):
+        # Given
+        user = create_user(email="test@email.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
+        offer = create_offer_with_thing_product(venue, thumb_count=0)
+        mediation = create_mediation(offer, is_active=True)
+        favorite = create_favorite(mediation=mediation, offer=offer, user=user)
+        repository.save(user, favorite)
 
-            # Then
-            assert response.status_code == 404
-            deleted_favorite = Favorite.query.first()
-            assert deleted_favorite == favorite
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).delete("/favorites/ABCD/ABCD")
+
+        # Then
+        assert response.status_code == 404
+        deleted_favorite = Favorite.query.first()
+        assert deleted_favorite == favorite

--- a/tests/routes/webapp/get_beneficiary_profile_test.py
+++ b/tests/routes/webapp/get_beneficiary_profile_test.py
@@ -14,146 +14,146 @@ from pcapi.repository import repository
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_logged_in_and_has_no_deposit(self, app):
-            # Given
-            user = UserFactory(
-                email="toto@example.com",
-                postalCode="93020",
-            )
-            repository.delete(*user.deposits)
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_logged_in_and_has_no_deposit(self, app):
+        # Given
+        user = UserFactory(
+            email="toto@example.com",
+            postalCode="93020",
+        )
+        repository.delete(*user.deposits)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(email="toto@example.com").get("/beneficiaries/current")
+        # When
+        response = TestClient(app.test_client()).with_auth(email="toto@example.com").get("/beneficiaries/current")
 
-            # Then
-            assert response.status_code == 200
-            json = response.json
-            assert json["email"] == "toto@example.com"
-            assert not json["domainsCredit"]
-            assert "password" not in json
-            assert "clearTextPassword" not in json
-            assert "resetPasswordToken" not in json
-            assert "resetPasswordTokenValidityLimit" not in json
-            assert json["wallet_is_activated"] == False
+        # Then
+        assert response.status_code == 200
+        json = response.json
+        assert json["email"] == "toto@example.com"
+        assert not json["domainsCredit"]
+        assert "password" not in json
+        assert "clearTextPassword" not in json
+        assert "resetPasswordToken" not in json
+        assert "resetPasswordTokenValidityLimit" not in json
+        assert json["wallet_is_activated"] == False
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_logged_in_and_has_a_deposit(self, app):
-            # Given
-            UserFactory(
-                email="wallet_test@email.com",
-                postalCode="93020",
-                deposit__dateCreated=datetime(2000, 1, 1, 2, 2),
-                deposit__expirationDate=datetime(2002, 1, 1, 2, 2),
-            )
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_logged_in_and_has_a_deposit(self, app):
+        # Given
+        UserFactory(
+            email="wallet_test@email.com",
+            postalCode="93020",
+            deposit__dateCreated=datetime(2000, 1, 1, 2, 2),
+            deposit__expirationDate=datetime(2002, 1, 1, 2, 2),
+        )
 
-            # When
-            response = TestClient(app.test_client()).with_auth("wallet_test@email.com").get("/beneficiaries/current")
+        # When
+        response = TestClient(app.test_client()).with_auth("wallet_test@email.com").get("/beneficiaries/current")
 
-            # Then
-            assert response.json["wallet_is_activated"] == True
-            assert response.json["deposit_expiration_date"] == "2002-01-01T02:02:00Z"
+        # Then
+        assert response.json["wallet_is_activated"] == True
+        assert response.json["deposit_expiration_date"] == "2002-01-01T02:02:00Z"
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_has_booked_some_offers(self, app):
-            # Given
-            user = UserFactory(
-                email="wallet_test@email.com",
-                postalCode="93020",
-            )
+    @pytest.mark.usefixtures("db_session")
+    def when_user_has_booked_some_offers(self, app):
+        # Given
+        user = UserFactory(
+            email="wallet_test@email.com",
+            postalCode="93020",
+        )
 
-            offerer = create_offerer(
-                siren="999199987", address="2 Test adress", city="Test city", postal_code="93000", name="Test offerer"
-            )
-            venue = create_venue(offerer)
-            thing_offer = create_offer_with_thing_product(venue=None)
-            stock = create_stock_with_thing_offer(offerer, venue, thing_offer, price=5)
-            booking = create_booking(user=user, stock=stock, venue=venue, quantity=1)
+        offerer = create_offerer(
+            siren="999199987", address="2 Test adress", city="Test city", postal_code="93000", name="Test offerer"
+        )
+        venue = create_venue(offerer)
+        thing_offer = create_offer_with_thing_product(venue=None)
+        stock = create_stock_with_thing_offer(offerer, venue, thing_offer, price=5)
+        booking = create_booking(user=user, stock=stock, venue=venue, quantity=1)
 
-            repository.save(venue, booking)
+        repository.save(venue, booking)
 
-            # When
-            response = TestClient(app.test_client()).with_auth("wallet_test@email.com").get("/beneficiaries/current")
+        # When
+        response = TestClient(app.test_client()).with_auth("wallet_test@email.com").get("/beneficiaries/current")
 
-            # Then
-            assert response.json["wallet_balance"] == 495.0
-            assert response.json["domainsCredit"] == {
-                "all": {"initial": 500.0, "remaining": 495.0},
-                "digital": {"initial": 200.0, "remaining": 200.0},
-                "physical": {"initial": 200.0, "remaining": 195.0},
-            }
+        # Then
+        assert response.json["wallet_balance"] == 495.0
+        assert response.json["domainsCredit"] == {
+            "all": {"initial": 500.0, "remaining": 495.0},
+            "digital": {"initial": 200.0, "remaining": 200.0},
+            "physical": {"initial": 200.0, "remaining": 195.0},
+        }
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_has_cancelled_some_offers(self, app):
-            # Given
-            BookingFactory(isCancelled=True, user__email="wallet_test@email.com", user__postalCode="75130")
+    @pytest.mark.usefixtures("db_session")
+    def when_user_has_cancelled_some_offers(self, app):
+        # Given
+        BookingFactory(isCancelled=True, user__email="wallet_test@email.com", user__postalCode="75130")
 
-            # When
-            response = TestClient(app.test_client()).with_auth("wallet_test@email.com").get("/beneficiaries/current")
+        # When
+        response = TestClient(app.test_client()).with_auth("wallet_test@email.com").get("/beneficiaries/current")
 
-            # Then
-            assert response.json["wallet_balance"] == 500.0
-            assert response.json["domainsCredit"] == {
-                "all": {"initial": 500.0, "remaining": 500.0},
-                "digital": {"initial": 200.0, "remaining": 200.0},
-                "physical": {"initial": 200.0, "remaining": 200.0},
-            }
+        # Then
+        assert response.json["wallet_balance"] == 500.0
+        assert response.json["domainsCredit"] == {
+            "all": {"initial": 500.0, "remaining": 500.0},
+            "digital": {"initial": 200.0, "remaining": 200.0},
+            "physical": {"initial": 200.0, "remaining": 200.0},
+        }
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_created_without_postal_code(self, app):
-            # Given
-            UserFactory(email="wallet_test@email.com", postalCode=None)
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_created_without_postal_code(self, app):
+        # Given
+        UserFactory(email="wallet_test@email.com", postalCode=None)
 
-            # When
-            response = TestClient(app.test_client()).with_auth("wallet_test@email.com").get("/beneficiaries/current")
+        # When
+        response = TestClient(app.test_client()).with_auth("wallet_test@email.com").get("/beneficiaries/current")
 
-            # Then
-            assert response.status_code == 200
+        # Then
+        assert response.status_code == 200
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_a_pro(self, app):
-            # Given
-            user = UserFactory(email="pro@example.com", postalCode=None, isBeneficiary=False, dateOfBirth=None)
-            user.suspensionReason = None
-            repository.save(user)
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_a_pro(self, app):
+        # Given
+        user = UserFactory(email="pro@example.com", postalCode=None, isBeneficiary=False, dateOfBirth=None)
+        user.suspensionReason = None
+        repository.save(user)
 
-            # When
-            response = TestClient(app.test_client()).with_auth("pro@example.com").get("/beneficiaries/current")
+        # When
+        response = TestClient(app.test_client()).with_auth("pro@example.com").get("/beneficiaries/current")
 
-            # Then
-            assert response.status_code == 200
-            assert response.json["suspensionReason"] == None
+        # Then
+        assert response.status_code == 200
+        assert response.json["suspensionReason"] == None
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_a_admin(self, app):
-            # Given
-            UserFactory(email="pro@example.com", postalCode=None, dateOfBirth=None, isAdmin=True)
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_a_admin(self, app):
+        # Given
+        UserFactory(email="pro@example.com", postalCode=None, dateOfBirth=None, isAdmin=True)
 
-            # When
-            response = TestClient(app.test_client()).with_auth("pro@example.com").get("/beneficiaries/current")
+        # When
+        response = TestClient(app.test_client()).with_auth("pro@example.com").get("/beneficiaries/current")
 
-            # Then
-            assert response.status_code == 200
+        # Then
+        assert response.status_code == 200
 
-        @pytest.mark.usefixtures("db_session")
-        def should_return_deposit_version(self, app):
-            # Given
-            UserFactory(email="wallet_test@email.com", postalCode="93020", deposit__version=1)
+    @pytest.mark.usefixtures("db_session")
+    def should_return_deposit_version(self, app):
+        # Given
+        UserFactory(email="wallet_test@email.com", postalCode="93020", deposit__version=1)
 
-            # When
-            response = TestClient(app.test_client()).with_auth("wallet_test@email.com").get("/beneficiaries/current")
+        # When
+        response = TestClient(app.test_client()).with_auth("wallet_test@email.com").get("/beneficiaries/current")
 
-            # Then
+        # Then
 
-            assert response.json["deposit_version"] == 1
+        assert response.json["deposit_version"] == 1
 
-    class Returns401:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_not_logged_in(self, app):
-            # When
-            response = TestClient(app.test_client()).get("/beneficiaries/current")
 
-            # Then
-            assert response.status_code == 401
+class Returns401Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_not_logged_in(self, app):
+        # When
+        response = TestClient(app.test_client()).get("/beneficiaries/current")
+
+        # Then
+        assert response.status_code == 401

--- a/tests/routes/webapp/get_booking_by_id_test.py
+++ b/tests/routes/webapp/get_booking_by_id_test.py
@@ -13,162 +13,159 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def expect_booking_to_have_completed_url(self, app):
-            # Given
-            user = create_user(email="user@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            offer = create_offer_with_thing_product(
-                venue, url="https://host/path/{token}?offerId={offerId}&email={email}"
-            )
-            stock = create_stock(offer=offer, price=0)
-            booking = create_booking(user=user, stock=stock, token="ABCDEF", venue=venue)
-            repository.save(booking)
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def expect_booking_to_have_completed_url(self, app):
+        # Given
+        user = create_user(email="user@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        offer = create_offer_with_thing_product(venue, url="https://host/path/{token}?offerId={offerId}&email={email}")
+        stock = create_stock(offer=offer, price=0)
+        booking = create_booking(user=user, stock=stock, token="ABCDEF", venue=venue)
+        repository.save(booking)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).get("/bookings/" + humanize(booking.id))
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).get("/bookings/" + humanize(booking.id))
 
-            # Then
-            assert response.status_code == 200
-            completed_url = "https://host/path/ABCDEF?offerId={}&email=user@example.com".format(humanize(offer.id))
+        # Then
+        assert response.status_code == 200
+        completed_url = "https://host/path/ABCDEF?offerId={}&email=user@example.com".format(humanize(offer.id))
 
-            assert "validationToken" not in response.json["stock"]["offer"]
-            assert response.json == {
-                "amount": 0.0,
-                "cancellationDate": None,
-                "cancellationReason": None,
-                "completedUrl": completed_url,
-                "confirmationDate": None,
-                "dateCreated": format_into_utc_date(booking.dateCreated),
-                "dateUsed": None,
-                "id": humanize(booking.id),
-                "isCancelled": False,
+        assert "validationToken" not in response.json["stock"]["offer"]
+        assert response.json == {
+            "amount": 0.0,
+            "cancellationDate": None,
+            "cancellationReason": None,
+            "completedUrl": completed_url,
+            "confirmationDate": None,
+            "dateCreated": format_into_utc_date(booking.dateCreated),
+            "dateUsed": None,
+            "id": humanize(booking.id),
+            "isCancelled": False,
+            "isEventExpired": False,
+            "isUsed": False,
+            "mediation": None,
+            "quantity": 1,
+            "stock": {
+                "beginningDatetime": None,
+                "bookingLimitDatetime": None,
+                "dateCreated": format_into_utc_date(stock.dateCreated),
+                "dateModified": format_into_utc_date(stock.dateModified),
+                "dateModifiedAtLastProvider": format_into_utc_date(stock.dateModifiedAtLastProvider),
+                "fieldsUpdated": [],
+                "id": humanize(stock.id),
+                "idAtProviders": None,
+                "isBookable": True,
                 "isEventExpired": False,
-                "isUsed": False,
-                "mediation": None,
-                "quantity": 1,
-                "stock": {
-                    "beginningDatetime": None,
-                    "bookingLimitDatetime": None,
-                    "dateCreated": format_into_utc_date(stock.dateCreated),
-                    "dateModified": format_into_utc_date(stock.dateModified),
-                    "dateModifiedAtLastProvider": format_into_utc_date(stock.dateModifiedAtLastProvider),
+                "isSoftDeleted": False,
+                "lastProviderId": None,
+                "offer": {
+                    "ageMax": None,
+                    "ageMin": None,
+                    "audioDisabilityCompliant": None,
+                    "bookingEmail": "booking@example.net",
+                    "conditions": None,
+                    "dateCreated": format_into_utc_date(offer.dateCreated),
+                    "dateModifiedAtLastProvider": format_into_utc_date(offer.dateModifiedAtLastProvider),
+                    "subcategoryId": None,
+                    "description": None,
+                    "durationMinutes": None,
+                    "externalTicketOfficeUrl": None,
+                    "extraData": {"author": "Test Author"},
                     "fieldsUpdated": [],
-                    "id": humanize(stock.id),
-                    "idAtProviders": None,
+                    "hasBookingLimitDatetimesPassed": False,
+                    "id": humanize(offer.id),
+                    "idAtProviders": offer.idAtProviders,
+                    "isActive": True,
                     "isBookable": True,
-                    "isEventExpired": False,
-                    "isSoftDeleted": False,
+                    "isDigital": True,
+                    "isDuo": False,
+                    "isEvent": False,
+                    "isNational": False,
                     "lastProviderId": None,
-                    "offer": {
-                        "ageMax": None,
-                        "ageMin": None,
-                        "audioDisabilityCompliant": None,
-                        "bookingEmail": "booking@example.net",
-                        "conditions": None,
-                        "dateCreated": format_into_utc_date(offer.dateCreated),
-                        "dateModifiedAtLastProvider": format_into_utc_date(offer.dateModifiedAtLastProvider),
-                        "subcategoryId": None,
-                        "description": None,
-                        "durationMinutes": None,
-                        "externalTicketOfficeUrl": None,
-                        "extraData": {"author": "Test Author"},
-                        "fieldsUpdated": [],
-                        "hasBookingLimitDatetimesPassed": False,
-                        "id": humanize(offer.id),
-                        "idAtProviders": offer.idAtProviders,
+                    "mediaUrls": ["test/urls"],
+                    "mentalDisabilityCompliant": None,
+                    "motorDisabilityCompliant": None,
+                    "name": "Test Book",
+                    "offerType": {
+                        "appLabel": "Film",
+                        "canExpire": True,
+                        "conditionalFields": [],
+                        "description": (
+                            "Action, science-fiction, documentaire ou comédie "
+                            "sentimentale ? En salle, en plein air ou bien au chaud "
+                            "chez soi ? Et si c’était plutôt cette exposition qui "
+                            "allait faire son cinéma ?"
+                        ),
                         "isActive": True,
-                        "isBookable": True,
-                        "isDigital": True,
-                        "isDuo": False,
-                        "isEvent": False,
-                        "isNational": False,
-                        "lastProviderId": None,
-                        "mediaUrls": ["test/urls"],
-                        "mentalDisabilityCompliant": None,
-                        "motorDisabilityCompliant": None,
-                        "name": "Test Book",
-                        "offerType": {
-                            "appLabel": "Film",
-                            "canExpire": True,
-                            "conditionalFields": [],
-                            "description": (
-                                "Action, science-fiction, documentaire ou comédie "
-                                "sentimentale ? En salle, en plein air ou bien au chaud "
-                                "chez soi ? Et si c’était plutôt cette exposition qui "
-                                "allait faire son cinéma ?"
-                            ),
-                            "isActive": True,
-                            "offlineOnly": False,
-                            "onlineOnly": False,
-                            "proLabel": "Audiovisuel - films sur supports physiques et VOD",
-                            "sublabel": "Regarder",
-                            "type": "Thing",
-                            "value": "ThingType.AUDIOVISUEL",
-                        },
-                        "productId": humanize(offer.product.id),
-                        "stocks": [
-                            {
-                                "beginningDatetime": None,
-                                "bookingLimitDatetime": None,
-                                "dateCreated": format_into_utc_date(stock.dateCreated),
-                                "dateModified": format_into_utc_date(stock.dateModified),
-                                "dateModifiedAtLastProvider": format_into_utc_date(stock.dateModifiedAtLastProvider),
-                                "fieldsUpdated": [],
-                                "id": humanize(stock.id),
-                                "idAtProviders": None,
-                                "isBookable": True,
-                                "isEventExpired": False,
-                                "isSoftDeleted": False,
-                                "lastProviderId": None,
-                                "offerId": humanize(offer.id),
-                                "price": 0.0,
-                                "quantity": None,
-                                "remainingQuantity": "unlimited",
-                            }
-                        ],
-                        "thumbUrl": None,
-                        "type": "ThingType.AUDIOVISUEL",
-                        "url": "https://host/path/{token}?offerId={offerId}&email={email}",
-                        "validation": "APPROVED",
-                        "venue": {
-                            "address": "123 rue de Paris",
-                            "bookingEmail": None,
-                            "city": "Montreuil",
-                            "comment": None,
-                            "dateCreated": format_into_utc_date(venue.dateCreated),
-                            "dateModifiedAtLastProvider": format_into_utc_date(venue.dateModifiedAtLastProvider),
-                            "departementCode": "93",
-                            "fieldsUpdated": [],
-                            "id": humanize(venue.id),
-                            "idAtProviders": None,
-                            "isPermanent": True,
-                            "isVirtual": False,
-                            "lastProviderId": None,
-                            "latitude": None,
-                            "longitude": None,
-                            "managingOffererId": humanize(offerer.id),
-                            "name": "La petite librairie",
-                            "postalCode": "93100",
-                            "publicName": None,
-                            "siret": "12345678912345",
-                            "thumbCount": 0,
-                            "venueLabelId": None,
-                            "venueTypeId": None,
-                        },
-                        "venueId": humanize(venue.id),
-                        "visualDisabilityCompliant": None,
-                        "withdrawalDetails": None,
+                        "offlineOnly": False,
+                        "onlineOnly": False,
+                        "proLabel": "Audiovisuel - films sur supports physiques et VOD",
+                        "sublabel": "Regarder",
+                        "type": "Thing",
+                        "value": "ThingType.AUDIOVISUEL",
                     },
-                    "offerId": humanize(offer.id),
-                    "price": 0.0,
-                    "quantity": None,
-                    "remainingQuantity": "unlimited",
+                    "productId": humanize(offer.product.id),
+                    "stocks": [
+                        {
+                            "beginningDatetime": None,
+                            "bookingLimitDatetime": None,
+                            "dateCreated": format_into_utc_date(stock.dateCreated),
+                            "dateModified": format_into_utc_date(stock.dateModified),
+                            "dateModifiedAtLastProvider": format_into_utc_date(stock.dateModifiedAtLastProvider),
+                            "fieldsUpdated": [],
+                            "id": humanize(stock.id),
+                            "idAtProviders": None,
+                            "isBookable": True,
+                            "isEventExpired": False,
+                            "isSoftDeleted": False,
+                            "lastProviderId": None,
+                            "offerId": humanize(offer.id),
+                            "price": 0.0,
+                            "quantity": None,
+                            "remainingQuantity": "unlimited",
+                        }
+                    ],
+                    "thumbUrl": None,
+                    "type": "ThingType.AUDIOVISUEL",
+                    "url": "https://host/path/{token}?offerId={offerId}&email={email}",
+                    "validation": "APPROVED",
+                    "venue": {
+                        "address": "123 rue de Paris",
+                        "bookingEmail": None,
+                        "city": "Montreuil",
+                        "comment": None,
+                        "dateCreated": format_into_utc_date(venue.dateCreated),
+                        "dateModifiedAtLastProvider": format_into_utc_date(venue.dateModifiedAtLastProvider),
+                        "departementCode": "93",
+                        "fieldsUpdated": [],
+                        "id": humanize(venue.id),
+                        "idAtProviders": None,
+                        "isPermanent": True,
+                        "isVirtual": False,
+                        "lastProviderId": None,
+                        "latitude": None,
+                        "longitude": None,
+                        "managingOffererId": humanize(offerer.id),
+                        "name": "La petite librairie",
+                        "postalCode": "93100",
+                        "publicName": None,
+                        "siret": "12345678912345",
+                        "thumbCount": 0,
+                        "venueLabelId": None,
+                        "venueTypeId": None,
+                    },
+                    "venueId": humanize(venue.id),
+                    "visualDisabilityCompliant": None,
+                    "withdrawalDetails": None,
                 },
-                "stockId": humanize(stock.id),
-                "token": booking.token,
-                "userId": humanize(user.id),
-            }
+                "offerId": humanize(offer.id),
+                "price": 0.0,
+                "quantity": None,
+                "remainingQuantity": "unlimited",
+            },
+            "stockId": humanize(stock.id),
+            "token": booking.token,
+            "userId": humanize(user.id),
+        }

--- a/tests/routes/webapp/get_bookings_test.py
+++ b/tests/routes/webapp/get_bookings_test.py
@@ -16,156 +16,155 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200Test:
-        @patch("pcapi.routes.webapp.bookings.feature_queries.is_active", return_value=False)
-        @pytest.mark.usefixtures("db_session")
-        def test_when_user_has_bookings_and_qr_code_feature_is_inactive_does_not_return_qr_code(
-            self, qr_code_is_active, app
-        ):
-            # Given
-            user1 = create_user(email="user1+plus@example.com")
-            user2 = create_user(email="user2+plus@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            offer = create_offer_with_thing_product(venue)
-            stock = create_stock(offer=offer, price=0)
-            offer2 = create_offer_with_thing_product(venue)
-            stock2 = create_stock(offer=offer2, price=0)
-            booking1 = create_booking(user=user1, stock=stock, token="ABCDEF", venue=venue)
-            booking2 = create_booking(user=user2, stock=stock, token="GHIJK", venue=venue)
-            booking3 = create_booking(user=user1, stock=stock2, token="BBBBB", venue=venue)
+class Returns200Test:
+    @patch("pcapi.routes.webapp.bookings.feature_queries.is_active", return_value=False)
+    @pytest.mark.usefixtures("db_session")
+    def test_when_user_has_bookings_and_qr_code_feature_is_inactive_does_not_return_qr_code(
+        self, qr_code_is_active, app
+    ):
+        # Given
+        user1 = create_user(email="user1+plus@example.com")
+        user2 = create_user(email="user2+plus@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer)
+        offer = create_offer_with_thing_product(venue)
+        stock = create_stock(offer=offer, price=0)
+        offer2 = create_offer_with_thing_product(venue)
+        stock2 = create_stock(offer=offer2, price=0)
+        booking1 = create_booking(user=user1, stock=stock, token="ABCDEF", venue=venue)
+        booking2 = create_booking(user=user2, stock=stock, token="GHIJK", venue=venue)
+        booking3 = create_booking(user=user1, stock=stock2, token="BBBBB", venue=venue)
 
-            repository.save(booking1, booking2, booking3)
+        repository.save(booking1, booking2, booking3)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user1.email).get("/bookings")
+        # When
+        response = TestClient(app.test_client()).with_auth(user1.email).get("/bookings")
 
-            # Then
-            assert response.status_code == 200
-            bookings = response.json
-            assert len(bookings) == 2
-            assert {b["id"] for b in bookings} == set(humanize(b.id) for b in {booking1, booking3})
-            assert "qrCode" not in bookings[0]
-            assert "validationToken" not in bookings[0]["stock"]["offer"]["venue"]
-            assert bookings[0]["id"] == humanize(booking1.id)
-            assert bookings[0] == {
-                "activationCode": None,
-                "amount": 0.0,
-                "cancellationDate": None,
-                "completedUrl": None,
-                "dateCreated": format_into_utc_date(booking1.dateCreated),
-                "dateUsed": None,
-                "displayAsEnded": None,
-                "id": humanize(booking1.id),
-                "isCancelled": False,
+        # Then
+        assert response.status_code == 200
+        bookings = response.json
+        assert len(bookings) == 2
+        assert {b["id"] for b in bookings} == set(humanize(b.id) for b in {booking1, booking3})
+        assert "qrCode" not in bookings[0]
+        assert "validationToken" not in bookings[0]["stock"]["offer"]["venue"]
+        assert bookings[0]["id"] == humanize(booking1.id)
+        assert bookings[0] == {
+            "activationCode": None,
+            "amount": 0.0,
+            "cancellationDate": None,
+            "completedUrl": None,
+            "dateCreated": format_into_utc_date(booking1.dateCreated),
+            "dateUsed": None,
+            "displayAsEnded": None,
+            "id": humanize(booking1.id),
+            "isCancelled": False,
+            "isEventExpired": False,
+            "isUsed": False,
+            "quantity": 1,
+            "stock": {
+                "beginningDatetime": None,
+                "id": humanize(stock.id),
                 "isEventExpired": False,
-                "isUsed": False,
-                "quantity": 1,
-                "stock": {
-                    "beginningDatetime": None,
-                    "id": humanize(stock.id),
-                    "isEventExpired": False,
-                    "offer": {
-                        "description": None,
-                        "durationMinutes": None,
-                        "extraData": {"author": "Test Author"},
-                        "id": humanize(offer.id),
-                        "isBookable": True,
-                        "isDigital": False,
-                        "isDuo": False,
-                        "isEvent": False,
-                        "isNational": False,
-                        "name": "Test Book",
-                        "offerType": {
-                            "appLabel": "Film",
-                            "canExpire": True,
-                            "conditionalFields": [],
-                            "description": (
-                                "Action, science-fiction, documentaire ou comédie "
-                                "sentimentale ? En salle, en plein air ou bien au chaud "
-                                "chez soi ? Et si c’était plutôt cette exposition qui "
-                                "allait faire son cinéma ?"
-                            ),
-                            "isActive": True,
-                            "offlineOnly": False,
-                            "onlineOnly": False,
-                            "proLabel": "Audiovisuel - films sur " "supports physiques et VOD",
-                            "sublabel": "Regarder",
-                            "type": "Thing",
-                            "value": "ThingType.AUDIOVISUEL",
-                        },
-                        "stocks": [
-                            {
-                                "beginningDatetime": None,
-                                "bookingLimitDatetime": None,
-                                "dateCreated": format_into_utc_date(stock.dateCreated),
-                                "dateModified": format_into_utc_date(stock.dateModified),
-                                "id": humanize(stock.id),
-                                "isBookable": True,
-                                "offerId": humanize(offer.id),
-                                "price": 0.0,
-                                "quantity": None,
-                                "remainingQuantity": "unlimited",
-                            }
-                        ],
-                        "thumbUrl": None,
-                        "venue": {
-                            "address": "123 rue de Paris",
-                            "city": "Montreuil",
-                            "departementCode": "93",
-                            "id": humanize(venue.id),
-                            "latitude": None,
-                            "longitude": None,
-                            "name": "La petite librairie",
-                            "postalCode": "93100",
-                        },
-                        "venueId": humanize(venue.id),
-                        "withdrawalDetails": None,
+                "offer": {
+                    "description": None,
+                    "durationMinutes": None,
+                    "extraData": {"author": "Test Author"},
+                    "id": humanize(offer.id),
+                    "isBookable": True,
+                    "isDigital": False,
+                    "isDuo": False,
+                    "isEvent": False,
+                    "isNational": False,
+                    "name": "Test Book",
+                    "offerType": {
+                        "appLabel": "Film",
+                        "canExpire": True,
+                        "conditionalFields": [],
+                        "description": (
+                            "Action, science-fiction, documentaire ou comédie "
+                            "sentimentale ? En salle, en plein air ou bien au chaud "
+                            "chez soi ? Et si c’était plutôt cette exposition qui "
+                            "allait faire son cinéma ?"
+                        ),
+                        "isActive": True,
+                        "offlineOnly": False,
+                        "onlineOnly": False,
+                        "proLabel": "Audiovisuel - films sur " "supports physiques et VOD",
+                        "sublabel": "Regarder",
+                        "type": "Thing",
+                        "value": "ThingType.AUDIOVISUEL",
                     },
-                    "offerId": humanize(offer.id),
-                    "price": 0.0,
+                    "stocks": [
+                        {
+                            "beginningDatetime": None,
+                            "bookingLimitDatetime": None,
+                            "dateCreated": format_into_utc_date(stock.dateCreated),
+                            "dateModified": format_into_utc_date(stock.dateModified),
+                            "id": humanize(stock.id),
+                            "isBookable": True,
+                            "offerId": humanize(offer.id),
+                            "price": 0.0,
+                            "quantity": None,
+                            "remainingQuantity": "unlimited",
+                        }
+                    ],
+                    "thumbUrl": None,
+                    "venue": {
+                        "address": "123 rue de Paris",
+                        "city": "Montreuil",
+                        "departementCode": "93",
+                        "id": humanize(venue.id),
+                        "latitude": None,
+                        "longitude": None,
+                        "name": "La petite librairie",
+                        "postalCode": "93100",
+                    },
+                    "venueId": humanize(venue.id),
+                    "withdrawalDetails": None,
                 },
-                "stockId": humanize(stock.id),
-                "token": "ABCDEF",
-                "userId": humanize(booking1.userId),
-            }
+                "offerId": humanize(offer.id),
+                "price": 0.0,
+            },
+            "stockId": humanize(stock.id),
+            "token": "ABCDEF",
+            "userId": humanize(booking1.userId),
+        }
 
-        @patch("pcapi.routes.webapp.bookings.feature_queries.is_active", return_value=True)
-        @pytest.mark.usefixtures("db_session")
-        def when_user_has_bookings_and_qr_code_feature_is_active(self, qr_code_is_active, app):
-            # Given
-            user1 = create_user(email="user1+plus@example.com")
-            user2 = create_user(email="user2+plus@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer=offerer)
-            offer = create_offer_with_thing_product(venue)
-            stock = create_stock_with_thing_offer(offerer=offerer, venue=venue, offer=offer, price=0)
-            offer2 = create_offer_with_thing_product(venue)
-            stock2 = create_stock_with_thing_offer(offerer=offerer, venue=venue, offer=offer2, price=0)
-            booking1 = create_booking(user=user1, stock=stock, venue=venue, token="ABCDEF")
-            booking2 = create_booking(user=user2, stock=stock, venue=venue, token="GHIJK")
-            booking3 = create_booking(user=user1, stock=stock2, venue=venue, token="BBBBB")
+    @patch("pcapi.routes.webapp.bookings.feature_queries.is_active", return_value=True)
+    @pytest.mark.usefixtures("db_session")
+    def when_user_has_bookings_and_qr_code_feature_is_active(self, qr_code_is_active, app):
+        # Given
+        user1 = create_user(email="user1+plus@example.com")
+        user2 = create_user(email="user2+plus@example.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer=offerer)
+        offer = create_offer_with_thing_product(venue)
+        stock = create_stock_with_thing_offer(offerer=offerer, venue=venue, offer=offer, price=0)
+        offer2 = create_offer_with_thing_product(venue)
+        stock2 = create_stock_with_thing_offer(offerer=offerer, venue=venue, offer=offer2, price=0)
+        booking1 = create_booking(user=user1, stock=stock, venue=venue, token="ABCDEF")
+        booking2 = create_booking(user=user2, stock=stock, venue=venue, token="GHIJK")
+        booking3 = create_booking(user=user1, stock=stock2, venue=venue, token="BBBBB")
 
-            repository.save(booking1, booking2, booking3)
+        repository.save(booking1, booking2, booking3)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user1.email).get("/bookings")
+        # When
+        response = TestClient(app.test_client()).with_auth(user1.email).get("/bookings")
 
-            # Then
-            all_bookings = response.json
-            assert len(all_bookings) == 2
-            first_booking = all_bookings[0]
-            assert response.status_code == 200
-            assert "qrCode" in first_booking
-            assert "completedUrl" in first_booking
-            assert "isEventExpired" in first_booking
-            assert "offer" in first_booking["stock"]
-            assert "isEventExpired" in first_booking["stock"]
-            assert "isDigital" in first_booking["stock"]["offer"]
-            assert "isEvent" in first_booking["stock"]["offer"]
-            assert "offerType" in first_booking["stock"]["offer"]
-            assert "thumbUrl" in first_booking["stock"]["offer"]
-            assert "stocks" in first_booking["stock"]["offer"]
-            assert "venue" in first_booking["stock"]["offer"]
-            assert "validationToken" not in first_booking["stock"]["offer"]["venue"]
+        # Then
+        all_bookings = response.json
+        assert len(all_bookings) == 2
+        first_booking = all_bookings[0]
+        assert response.status_code == 200
+        assert "qrCode" in first_booking
+        assert "completedUrl" in first_booking
+        assert "isEventExpired" in first_booking
+        assert "offer" in first_booking["stock"]
+        assert "isEventExpired" in first_booking["stock"]
+        assert "isDigital" in first_booking["stock"]["offer"]
+        assert "isEvent" in first_booking["stock"]["offer"]
+        assert "offerType" in first_booking["stock"]["offer"]
+        assert "thumbUrl" in first_booking["stock"]["offer"]
+        assert "stocks" in first_booking["stock"]["offer"]
+        assert "venue" in first_booking["stock"]["offer"]
+        assert "validationToken" not in first_booking["stock"]["offer"]["venue"]

--- a/tests/routes/webapp/get_favorites_test.py
+++ b/tests/routes/webapp/get_favorites_test.py
@@ -14,79 +14,79 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_logged_in_but_has_no_favorites(self, app):
-            # Given
-            user = create_user()
-            repository.save(user)
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_logged_in_but_has_no_favorites(self, app):
+        # Given
+        user = create_user()
+        repository.save(user)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).get("/favorites")
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).get("/favorites")
 
-            # Then
-            assert response.status_code == 200
-            assert response.json == []
+        # Then
+        assert response.status_code == 200
+        assert response.json == []
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_logged_in_and_has_two_favorite_offers(self, app):
-            # Given
-            user = create_user()
-            offerer = create_offerer()
-            venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
-            offer1 = create_offer_with_thing_product(venue=venue, thumb_count=0)
-            mediation1 = create_mediation(offer=offer1, is_active=True, idx=123)
-            favorite1 = create_favorite(mediation=mediation1, offer=offer1, user=user)
-            offer2 = create_offer_with_thing_product(venue=venue, thumb_count=0)
-            favorite2 = create_favorite(offer=offer2, user=user)
-            repository.save(user, favorite1, favorite2)
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_logged_in_and_has_two_favorite_offers(self, app):
+        # Given
+        user = create_user()
+        offerer = create_offerer()
+        venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
+        offer1 = create_offer_with_thing_product(venue=venue, thumb_count=0)
+        mediation1 = create_mediation(offer=offer1, is_active=True, idx=123)
+        favorite1 = create_favorite(mediation=mediation1, offer=offer1, user=user)
+        offer2 = create_offer_with_thing_product(venue=venue, thumb_count=0)
+        favorite2 = create_favorite(offer=offer2, user=user)
+        repository.save(user, favorite1, favorite2)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).get("/favorites")
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).get("/favorites")
 
-            # Then
-            assert response.status_code == 200
-            assert len(response.json) == 2
-            first_favorite = response.json[0]
-            assert "offer" in first_favorite
-            assert "venue" in first_favorite["offer"]
-            assert "mediationId" in first_favorite
-            assert "validationToken" not in first_favorite["offer"]["venue"]
+        # Then
+        assert response.status_code == 200
+        assert len(response.json) == 2
+        first_favorite = response.json[0]
+        assert "offer" in first_favorite
+        assert "venue" in first_favorite["offer"]
+        assert "mediationId" in first_favorite
+        assert "validationToken" not in first_favorite["offer"]["venue"]
 
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_logged_in_and_a_favorite_booked_offer_exist(self, app):
-            # Given
-            user = create_user()
-            offerer = create_offerer()
-            venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
-            offer = create_offer_with_thing_product(venue, thumb_count=0)
-            mediation = create_mediation(offer, is_active=True)
-            favorite = create_favorite(mediation=mediation, offer=offer, user=user)
-            stock = create_stock(offer=offer, price=0)
-            booking = create_booking(user=user, stock=stock)
-            repository.save(booking, favorite)
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_logged_in_and_a_favorite_booked_offer_exist(self, app):
+        # Given
+        user = create_user()
+        offerer = create_offerer()
+        venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
+        offer = create_offer_with_thing_product(venue, thumb_count=0)
+        mediation = create_mediation(offer, is_active=True)
+        favorite = create_favorite(mediation=mediation, offer=offer, user=user)
+        stock = create_stock(offer=offer, price=0)
+        booking = create_booking(user=user, stock=stock)
+        repository.save(booking, favorite)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).get("/favorites")
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).get("/favorites")
 
-            # Then
-            assert response.status_code == 200
-            assert len(response.json) == 1
-            favorite = response.json[0]
-            assert "offer" in favorite
-            assert "venue" in favorite["offer"]
-            assert "stocks" in favorite["offer"]
-            assert stock.price == favorite["offer"]["stocks"][0]["price"]
-            assert booking.quantity == favorite["booking"]["quantity"]
-            assert humanize(booking.id) in favorite["booking"]["id"]
-            assert "validationToken" not in favorite["offer"]["venue"]
+        # Then
+        assert response.status_code == 200
+        assert len(response.json) == 1
+        favorite = response.json[0]
+        assert "offer" in favorite
+        assert "venue" in favorite["offer"]
+        assert "stocks" in favorite["offer"]
+        assert stock.price == favorite["offer"]["stocks"][0]["price"]
+        assert booking.quantity == favorite["booking"]["quantity"]
+        assert humanize(booking.id) in favorite["booking"]["id"]
+        assert "validationToken" not in favorite["offer"]["venue"]
 
-    class Returns401:
-        @pytest.mark.usefixtures("db_session")
-        def when_user_is_not_logged_in(self, app):
-            # When
-            response = TestClient(app.test_client()).get("/favorites")
 
-            # Then
-            assert response.status_code == 401
+class Returns401Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_user_is_not_logged_in(self, app):
+        # When
+        response = TestClient(app.test_client()).get("/favorites")
+
+        # Then
+        assert response.status_code == 401

--- a/tests/routes/webapp/get_music_types_test.py
+++ b/tests/routes/webapp/get_music_types_test.py
@@ -7,18 +7,17 @@ from pcapi.repository import repository
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_list_music_types(self, app):
-            # given
-            user = create_user()
-            repository.save(user)
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_list_music_types(self, app):
+        # given
+        user = create_user()
+        repository.save(user)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/musicTypes")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/musicTypes")
 
-            # then
-            response_json = response.json
-            assert response.status_code == 200
-            assert response_json == music_types
+        # then
+        response_json = response.json
+        assert response.status_code == 200
+        assert response_json == music_types

--- a/tests/routes/webapp/get_show_types_test.py
+++ b/tests/routes/webapp/get_show_types_test.py
@@ -7,18 +7,17 @@ from pcapi.repository import repository
 from tests.conftest import TestClient
 
 
-class Get:
-    class Returns200:
-        @pytest.mark.usefixtures("db_session")
-        def when_list_show_types(self, app):
-            # given
-            user = create_user()
-            repository.save(user)
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_list_show_types(self, app):
+        # given
+        user = create_user()
+        repository.save(user)
 
-            # when
-            response = TestClient(app.test_client()).with_auth(user.email).get("/showTypes")
+        # when
+        response = TestClient(app.test_client()).with_auth(user.email).get("/showTypes")
 
-            # then
-            response_json = response.json
-            assert response.status_code == 200
-            assert response_json == show_types
+        # then
+        response_json = response.json
+        assert response.status_code == 200
+        assert response_json == show_types

--- a/tests/routes/webapp/post_booking_test.py
+++ b/tests/routes/webapp/post_booking_test.py
@@ -10,7 +10,7 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns201:
+class Returns201Test:
     def test_booking_creation(self, app):
         user = users_factories.UserFactory()
         stock = offers_factories.StockFactory()
@@ -65,7 +65,7 @@ class Returns201:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns400:
+class Returns400Test:
     def when_use_case_raise_stock_is_not_bookable_exception(self, app):
         user = users_factories.UserFactory()
         stock = offers_factories.StockFactory(quantity=0)

--- a/tests/routes/webapp/post_favorites_test.py
+++ b/tests/routes/webapp/post_favorites_test.py
@@ -12,110 +12,111 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Post:
-    class Returns400:
-        @pytest.mark.usefixtures("db_session")
-        def when_offer_id_is_not_received(self, app):
-            # Given
-            user = create_user(email="test@email.com")
-            repository.save(user)
+class Returns400Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_offer_id_is_not_received(self, app):
+        # Given
+        user = create_user(email="test@email.com")
+        repository.save(user)
 
-            json = {
-                "mediationId": "DA",
-            }
+        json = {
+            "mediationId": "DA",
+        }
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).post("/favorites", json=json)
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).post("/favorites", json=json)
 
-            # Then
-            assert response.status_code == 400
-            assert response.json["global"] == ["Le paramètre offerId est obligatoire"]
+        # Then
+        assert response.status_code == 400
+        assert response.json["global"] == ["Le paramètre offerId est obligatoire"]
 
-    class Returns404:
-        @pytest.mark.usefixtures("db_session")
-        def when_offer_is_not_found(self, app):
-            # Given
-            user = create_user(email="test@email.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
-            offer = create_offer_with_thing_product(venue, thumb_count=0)
-            mediation = create_mediation(offer, is_active=True)
-            repository.save(user)
 
-            json = {
-                "offerId": "ABCD",
-                "mediationId": humanize(mediation.id),
-            }
+class Returns404Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_offer_is_not_found(self, app):
+        # Given
+        user = create_user(email="test@email.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
+        offer = create_offer_with_thing_product(venue, thumb_count=0)
+        mediation = create_mediation(offer, is_active=True)
+        repository.save(user)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).post("/favorites", json=json)
+        json = {
+            "offerId": "ABCD",
+            "mediationId": humanize(mediation.id),
+        }
 
-            # Then
-            assert response.status_code == 404
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).post("/favorites", json=json)
 
-        @pytest.mark.usefixtures("db_session")
-        def when_mediation_is_not_found(self, app):
-            # Given
-            user = create_user(email="test@email.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
-            offer = create_offer_with_thing_product(venue, thumb_count=0)
-            mediation = create_mediation(offer, is_active=True)
-            repository.save(user, mediation)
+        # Then
+        assert response.status_code == 404
 
-            json = {
-                "offerId": humanize(offer.id),
-                "mediationId": "ABCD",
-            }
+    @pytest.mark.usefixtures("db_session")
+    def when_mediation_is_not_found(self, app):
+        # Given
+        user = create_user(email="test@email.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
+        offer = create_offer_with_thing_product(venue, thumb_count=0)
+        mediation = create_mediation(offer, is_active=True)
+        repository.save(user, mediation)
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).post("/favorites", json=json)
+        json = {
+            "offerId": humanize(offer.id),
+            "mediationId": "ABCD",
+        }
 
-            # Then
-            assert response.status_code == 404
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).post("/favorites", json=json)
 
-    class Returns201:
-        @pytest.mark.usefixtures("db_session")
-        def when_offer_is_added_as_favorite_for_current_user(self, app):
-            # Given
-            user = create_user(email="test@email.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
-            offer = create_offer_with_thing_product(venue, thumb_count=0)
-            mediation = create_mediation(offer, is_active=True)
-            repository.save(user, mediation)
+        # Then
+        assert response.status_code == 404
 
-            json = {
-                "offerId": humanize(offer.id),
-                "mediationId": humanize(mediation.id),
-            }
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).post("/favorites", json=json)
+class Returns201Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_offer_is_added_as_favorite_for_current_user(self, app):
+        # Given
+        user = create_user(email="test@email.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
+        offer = create_offer_with_thing_product(venue, thumb_count=0)
+        mediation = create_mediation(offer, is_active=True)
+        repository.save(user, mediation)
 
-            # Then
-            assert response.status_code == 201
+        json = {
+            "offerId": humanize(offer.id),
+            "mediationId": humanize(mediation.id),
+        }
 
-            favorite = Favorite.query.one()
-            assert favorite.offerId == offer.id
-            assert favorite.mediationId == mediation.id
-            assert favorite.userId == user.id
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).post("/favorites", json=json)
 
-        @pytest.mark.usefixtures("db_session")
-        def when_mediation_id_doest_not_exist(self, app):
-            # Given
-            user = create_user(email="test@email.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
-            offer = create_offer_with_thing_product(venue, thumb_count=0)
-            repository.save(user, offer)
+        # Then
+        assert response.status_code == 201
 
-            json = {
-                "offerId": humanize(offer.id),
-            }
+        favorite = Favorite.query.one()
+        assert favorite.offerId == offer.id
+        assert favorite.mediationId == mediation.id
+        assert favorite.userId == user.id
 
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).post("/favorites", json=json)
+    @pytest.mark.usefixtures("db_session")
+    def when_mediation_id_doest_not_exist(self, app):
+        # Given
+        user = create_user(email="test@email.com")
+        offerer = create_offerer()
+        venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
+        offer = create_offer_with_thing_product(venue, thumb_count=0)
+        repository.save(user, offer)
 
-            # Then
-            assert response.status_code == 201
+        json = {
+            "offerId": humanize(offer.id),
+        }
+
+        # When
+        response = TestClient(app.test_client()).with_auth(user.email).post("/favorites", json=json)
+
+        # Then
+        assert response.status_code == 201

--- a/tests/routes/webapp/post_id_check_application_update_test.py
+++ b/tests/routes/webapp/post_id_check_application_update_test.py
@@ -18,209 +18,209 @@ from pcapi.repository import repository
 from tests.conftest import TestClient
 
 
-class Post:
-    class Returns200:
-        @patch("pcapi.routes.webapp.beneficiaries.beneficiary_job.delay")
-        def when_has_exact_payload(self, mocked_beneficiary_job, app):
-            # Given
-            data = {"id": "5"}
+class Returns200Test:
+    @patch("pcapi.routes.webapp.beneficiaries.beneficiary_job.delay")
+    def when_has_exact_payload(self, mocked_beneficiary_job, app):
+        # Given
+        data = {"id": "5"}
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/application_update", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/application_update", json=data)
 
-            # Then
-            assert response.status_code == 200
-            mocked_beneficiary_job.assert_called_once_with(5)
+        # Then
+        assert response.status_code == 200
+        mocked_beneficiary_job.assert_called_once_with(5)
 
-        @override_features(APPLY_BOOKING_LIMITS_V2=False)
-        @patch("pcapi.use_cases.create_beneficiary_from_application.send_accepted_as_beneficiary_email")
-        @patch("pcapi.use_cases.create_beneficiary_from_application.send_activation_email")
-        @patch("pcapi.domain.password.random_token")
-        @override_settings(
-            JOUVE_APPLICATION_BACKEND="tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend"
-        )
-        @freeze_time("2013-05-15 09:00:00")
-        @pytest.mark.usefixtures("db_session")
-        def test_user_becomes_beneficiary(
-            self, stubed_random_token, mocked_send_activation_email, mocked_send_accepted_as_beneficiary_email, app
-        ):
-            """
-            Test that a user which has validated its email and phone number, becomes a
-            beneficiary. And that this user's information is updated with the
-            application's.
-            """
-            # Given
-            application_id = 35
-            stubed_random_token.return_value = "token"
+    @override_features(APPLY_BOOKING_LIMITS_V2=False)
+    @patch("pcapi.use_cases.create_beneficiary_from_application.send_accepted_as_beneficiary_email")
+    @patch("pcapi.use_cases.create_beneficiary_from_application.send_activation_email")
+    @patch("pcapi.domain.password.random_token")
+    @override_settings(
+        JOUVE_APPLICATION_BACKEND="tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend"
+    )
+    @freeze_time("2013-05-15 09:00:00")
+    @pytest.mark.usefixtures("db_session")
+    def test_user_becomes_beneficiary(
+        self, stubed_random_token, mocked_send_activation_email, mocked_send_accepted_as_beneficiary_email, app
+    ):
+        """
+        Test that a user which has validated its email and phone number, becomes a
+        beneficiary. And that this user's information is updated with the
+        application's.
+        """
+        # Given
+        application_id = 35
+        stubed_random_token.return_value = "token"
 
-            user = create_user(idx=4, email="rennes@example.org", is_beneficiary=False, is_email_validated=True)
+        user = create_user(idx=4, email="rennes@example.org", is_beneficiary=False, is_email_validated=True)
 
-            user.phoneValidationStatus = PhoneValidationStatusType.VALIDATED
-            repository.save(user)
+        user.phoneValidationStatus = PhoneValidationStatusType.VALIDATED
+        repository.save(user)
 
-            # When
-            data = {"id": "35"}
-            response = TestClient(app.test_client()).post("/beneficiaries/application_update", json=data)
+        # When
+        data = {"id": "35"}
+        response = TestClient(app.test_client()).post("/beneficiaries/application_update", json=data)
 
-            # Then
-            assert response.status_code == 200
+        # Then
+        assert response.status_code == 200
 
-            beneficiary = User.query.one()
-            assert beneficiary.activity == "Apprenti"
-            assert beneficiary.address == "3 rue de Valois"
-            assert beneficiary.isBeneficiary is True
-            assert beneficiary.city == "Paris"
-            assert beneficiary.civility == "Mme"
-            assert beneficiary.dateOfBirth == datetime(1995, 2, 5)
-            assert beneficiary.departementCode == "35"
-            assert beneficiary.email == "rennes@example.org"
-            assert beneficiary.firstName == "Thomas"
-            assert beneficiary.hasSeenTutorials is False
-            assert beneficiary.isAdmin is False
-            assert beneficiary.lastName == "DURAND"
-            assert beneficiary.password is not None
-            assert beneficiary.phoneNumber == "0123456789"
-            assert beneficiary.postalCode == "35123"
-            assert beneficiary.publicName == "Thomas DURAND"
-            assert beneficiary.notificationSubscriptions == {"marketing_push": True, "marketing_email": True}
+        beneficiary = User.query.one()
+        assert beneficiary.activity == "Apprenti"
+        assert beneficiary.address == "3 rue de Valois"
+        assert beneficiary.isBeneficiary is True
+        assert beneficiary.city == "Paris"
+        assert beneficiary.civility == "Mme"
+        assert beneficiary.dateOfBirth == datetime(1995, 2, 5)
+        assert beneficiary.departementCode == "35"
+        assert beneficiary.email == "rennes@example.org"
+        assert beneficiary.firstName == "Thomas"
+        assert beneficiary.hasSeenTutorials is False
+        assert beneficiary.isAdmin is False
+        assert beneficiary.lastName == "DURAND"
+        assert beneficiary.password is not None
+        assert beneficiary.phoneNumber == "0123456789"
+        assert beneficiary.postalCode == "35123"
+        assert beneficiary.publicName == "Thomas DURAND"
+        assert beneficiary.notificationSubscriptions == {"marketing_push": True, "marketing_email": True}
 
-            deposit = Deposit.query.one()
-            assert deposit.amount == 500
-            assert deposit.source == "dossier jouve [35]"
-            assert deposit.userId == beneficiary.id
+        deposit = Deposit.query.one()
+        assert deposit.amount == 500
+        assert deposit.source == "dossier jouve [35]"
+        assert deposit.userId == beneficiary.id
 
-            beneficiary_import = BeneficiaryImport.query.one()
-            assert beneficiary_import.currentStatus == ImportStatus.CREATED
-            assert beneficiary_import.applicationId == application_id
-            assert beneficiary_import.beneficiary == beneficiary
+        beneficiary_import = BeneficiaryImport.query.one()
+        assert beneficiary_import.currentStatus == ImportStatus.CREATED
+        assert beneficiary_import.applicationId == application_id
+        assert beneficiary_import.beneficiary == beneficiary
 
-            # New beneficiary already received the account activation email with
-            # the reset password token
-            assert not beneficiary.tokens
-            mocked_send_activation_email.assert_not_called()
-            mocked_send_accepted_as_beneficiary_email.assert_called_once()
+        # New beneficiary already received the account activation email with
+        # the reset password token
+        assert not beneficiary.tokens
+        mocked_send_activation_email.assert_not_called()
+        mocked_send_accepted_as_beneficiary_email.assert_called_once()
 
-            assert push_testing.requests == [
-                {
-                    "user_id": beneficiary.id,
-                    "attribute_values": {
-                        "u.credit": 50000,
-                        "u.departement_code": "35",
-                        "date(u.date_of_birth)": "1995-02-05T00:00:00",
-                        "u.postal_code": "35123",
-                        "date(u.date_created)": beneficiary.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                        "u.marketing_push_subscription": True,
-                        "u.is_beneficiary": True,
-                        "date(u.deposit_expiration_date)": "2015-05-15T09:00:00",
-                    },
-                }
-            ]
+        assert push_testing.requests == [
+            {
+                "user_id": beneficiary.id,
+                "attribute_values": {
+                    "u.credit": 50000,
+                    "u.departement_code": "35",
+                    "date(u.date_of_birth)": "1995-02-05T00:00:00",
+                    "u.postal_code": "35123",
+                    "date(u.date_created)": beneficiary.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
+                    "u.marketing_push_subscription": True,
+                    "u.is_beneficiary": True,
+                    "date(u.deposit_expiration_date)": "2015-05-15T09:00:00",
+                },
+            }
+        ]
 
-        @override_features(FORCE_PHONE_VALIDATION=True)
-        @patch("pcapi.use_cases.create_beneficiary_from_application.send_accepted_as_beneficiary_email")
-        @patch("pcapi.use_cases.create_beneficiary_from_application.send_activation_email")
-        @patch("pcapi.domain.password.random_token")
-        @patch(
-            "pcapi.settings.JOUVE_APPLICATION_BACKEND",
-            "tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
-        )
-        @freeze_time("2013-05-15 09:00:00")
-        @pytest.mark.usefixtures("db_session")
-        def test_user_does_not_become_beneficiary(
-            self, stubed_random_token, mocked_send_activation_email, mocked_send_accepted_as_beneficiary_email, app
-        ):
-            """
-            Test that an application is correctly processed and that a non-beneficiary
-            user is created. It cannot become a beneficiary since validation steps are
-            missing.
-            """
-            # Given
-            application_id = 35
-            stubed_random_token.return_value = "token"
+    @override_features(FORCE_PHONE_VALIDATION=True)
+    @patch("pcapi.use_cases.create_beneficiary_from_application.send_accepted_as_beneficiary_email")
+    @patch("pcapi.use_cases.create_beneficiary_from_application.send_activation_email")
+    @patch("pcapi.domain.password.random_token")
+    @patch(
+        "pcapi.settings.JOUVE_APPLICATION_BACKEND",
+        "tests.use_cases.create_beneficiary_from_application_test.FakeBeneficiaryJouveBackend",
+    )
+    @freeze_time("2013-05-15 09:00:00")
+    @pytest.mark.usefixtures("db_session")
+    def test_user_does_not_become_beneficiary(
+        self, stubed_random_token, mocked_send_activation_email, mocked_send_accepted_as_beneficiary_email, app
+    ):
+        """
+        Test that an application is correctly processed and that a non-beneficiary
+        user is created. It cannot become a beneficiary since validation steps are
+        missing.
+        """
+        # Given
+        application_id = 35
+        stubed_random_token.return_value = "token"
 
-            # When
-            data = {"id": "35"}
-            response = TestClient(app.test_client()).post("/beneficiaries/application_update", json=data)
+        # When
+        data = {"id": "35"}
+        response = TestClient(app.test_client()).post("/beneficiaries/application_update", json=data)
 
-            # Then
-            assert response.status_code == 200
+        # Then
+        assert response.status_code == 200
 
-            user = User.query.one()
-            assert user.activity == "Apprenti"
-            assert user.address == "3 rue de Valois"
-            assert not user.isBeneficiary
-            assert user.city == "Paris"
-            assert user.civility == "Mme"
-            assert user.dateOfBirth == datetime(1995, 2, 5)
-            assert user.departementCode == "35"
-            assert user.email == "rennes@example.org"
-            assert user.firstName == "Thomas"
-            assert not user.hasSeenTutorials
-            assert not user.isAdmin
-            assert user.lastName == "DURAND"
-            assert user.password is not None
-            assert user.phoneNumber == "0123456789"
-            assert user.postalCode == "35123"
-            assert user.publicName == "Thomas DURAND"
-            assert user.notificationSubscriptions == {"marketing_push": True, "marketing_email": True}
+        user = User.query.one()
+        assert user.activity == "Apprenti"
+        assert user.address == "3 rue de Valois"
+        assert not user.isBeneficiary
+        assert user.city == "Paris"
+        assert user.civility == "Mme"
+        assert user.dateOfBirth == datetime(1995, 2, 5)
+        assert user.departementCode == "35"
+        assert user.email == "rennes@example.org"
+        assert user.firstName == "Thomas"
+        assert not user.hasSeenTutorials
+        assert not user.isAdmin
+        assert user.lastName == "DURAND"
+        assert user.password is not None
+        assert user.phoneNumber == "0123456789"
+        assert user.postalCode == "35123"
+        assert user.publicName == "Thomas DURAND"
+        assert user.notificationSubscriptions == {"marketing_push": True, "marketing_email": True}
 
-            assert not Deposit.query.one_or_none()
+        assert not Deposit.query.one_or_none()
 
-            beneficiary_import = BeneficiaryImport.query.one()
-            assert beneficiary_import.currentStatus == ImportStatus.CREATED
-            assert beneficiary_import.applicationId == application_id
-            assert beneficiary_import.beneficiary == user
+        beneficiary_import = BeneficiaryImport.query.one()
+        assert beneficiary_import.currentStatus == ImportStatus.CREATED
+        assert beneficiary_import.applicationId == application_id
+        assert beneficiary_import.beneficiary == user
 
-            assert len(user.tokens) == 1
-            mocked_send_activation_email.assert_called_once()
-            mocked_send_accepted_as_beneficiary_email.assert_not_called()
+        assert len(user.tokens) == 1
+        mocked_send_activation_email.assert_called_once()
+        mocked_send_accepted_as_beneficiary_email.assert_not_called()
 
-            assert push_testing.requests == [
-                {
-                    "user_id": user.id,
-                    "attribute_values": {
-                        "u.credit": 0,
-                        "u.departement_code": "35",
-                        "date(u.date_of_birth)": "1995-02-05T00:00:00",
-                        "u.postal_code": "35123",
-                        "date(u.date_created)": user.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                        "u.marketing_push_subscription": True,
-                        "u.is_beneficiary": False,
-                        "date(u.deposit_expiration_date)": None,
-                    },
-                }
-            ]
+        assert push_testing.requests == [
+            {
+                "user_id": user.id,
+                "attribute_values": {
+                    "u.credit": 0,
+                    "u.departement_code": "35",
+                    "date(u.date_of_birth)": "1995-02-05T00:00:00",
+                    "u.postal_code": "35123",
+                    "date(u.date_created)": user.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
+                    "u.marketing_push_subscription": True,
+                    "u.is_beneficiary": False,
+                    "date(u.deposit_expiration_date)": None,
+                },
+            }
+        ]
 
-    class Returns400:
-        @patch("pcapi.routes.webapp.beneficiaries.beneficiary_job.delay")
-        def when_no_payload(self, mocked_beneficiary_job, app):
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/application_update")
 
-            # Then
-            assert response.status_code == 400
-            mocked_beneficiary_job.assert_not_called()
+class Returns400Test:
+    @patch("pcapi.routes.webapp.beneficiaries.beneficiary_job.delay")
+    def when_no_payload(self, mocked_beneficiary_job, app):
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/application_update")
 
-        @patch("pcapi.routes.webapp.beneficiaries.beneficiary_job.delay")
-        def when_has_wrong_payload(self, mocked_beneficiary_job, app):
-            # Given
-            data = {"next-id": "5"}
+        # Then
+        assert response.status_code == 400
+        mocked_beneficiary_job.assert_not_called()
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/application_update", json=data)
+    @patch("pcapi.routes.webapp.beneficiaries.beneficiary_job.delay")
+    def when_has_wrong_payload(self, mocked_beneficiary_job, app):
+        # Given
+        data = {"next-id": "5"}
 
-            # Then
-            assert response.status_code == 400
-            mocked_beneficiary_job.assert_not_called()
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/application_update", json=data)
 
-        @patch("pcapi.routes.webapp.beneficiaries.beneficiary_job.delay")
-        def when_id_is_not_a_number(self, mocked_beneficiary_job, app):
-            # Given
-            data = {"id": "cinq"}
+        # Then
+        assert response.status_code == 400
+        mocked_beneficiary_job.assert_not_called()
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/application_update", json=data)
+    @patch("pcapi.routes.webapp.beneficiaries.beneficiary_job.delay")
+    def when_id_is_not_a_number(self, mocked_beneficiary_job, app):
+        # Given
+        data = {"id": "cinq"}
 
-            # Then
-            assert response.status_code == 400
-            mocked_beneficiary_job.assert_not_called()
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/application_update", json=data)
+
+        # Then
+        assert response.status_code == 400
+        mocked_beneficiary_job.assert_not_called()

--- a/tests/routes/webapp/post_mailing_contacts_test.py
+++ b/tests/routes/webapp/post_mailing_contacts_test.py
@@ -7,35 +7,33 @@ from pcapi.workers.mailing_contacts_job import mailing_contacts_job
 from tests.conftest import TestClient
 
 
-class Post:
-    class Returns201:
-        @patch("pcapi.routes.webapp.mailing_contacts.validate_save_mailing_contact_request")
-        def when_contact_has_successfully_been_saved(self, validate_request, app):
-            # Given
-            mailing_contacts_job.delay = MagicMock()
-            data = {"email": "jeune@example.com", "dateOfBirth": "2003-02-02", "departmentCode": "98"}
+class Returns201Test:
+    @patch("pcapi.routes.webapp.mailing_contacts.validate_save_mailing_contact_request")
+    def when_contact_has_successfully_been_saved(self, validate_request, app):
+        # Given
+        mailing_contacts_job.delay = MagicMock()
+        data = {"email": "jeune@example.com", "dateOfBirth": "2003-02-02", "departmentCode": "98"}
 
-            # When
-            response = TestClient(app.test_client()).post("/mailing-contacts", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/mailing-contacts", json=data)
 
-            # Then
-            mailing_contacts_job.delay.assert_called_once_with(
-                data["email"], data["dateOfBirth"], data["departmentCode"]
-            )
-            validate_request.assert_called_once_with(data)
-            assert response.status_code == 201
+        # Then
+        mailing_contacts_job.delay.assert_called_once_with(data["email"], data["dateOfBirth"], data["departmentCode"])
+        validate_request.assert_called_once_with(data)
+        assert response.status_code == 201
 
-    class Returns400:
-        @patch("pcapi.routes.webapp.mailing_contacts.validate_save_mailing_contact_request")
-        def when_payload_validation_fails(self, validate_request, app):
-            # Given
-            data = {"dateOfBirth": "2003-02-02", "department_code": "98"}
 
-            validate_request.side_effect = ApiErrors({"email": "L'email est manquant"})
+class Returns400Test:
+    @patch("pcapi.routes.webapp.mailing_contacts.validate_save_mailing_contact_request")
+    def when_payload_validation_fails(self, validate_request, app):
+        # Given
+        data = {"dateOfBirth": "2003-02-02", "department_code": "98"}
 
-            # When
-            response = TestClient(app.test_client()).post("/mailing-contacts", json=data)
+        validate_request.side_effect = ApiErrors({"email": "L'email est manquant"})
 
-            # Then
-            validate_request.assert_called_once_with(data)
-            assert response.status_code == 400
+        # When
+        response = TestClient(app.test_client()).post("/mailing-contacts", json=data)
+
+        # Then
+        validate_request.assert_called_once_with(data)
+        assert response.status_code == 400

--- a/tests/routes/webapp/post_signin_beneficiary_test.py
+++ b/tests/routes/webapp/post_signin_beneficiary_test.py
@@ -7,7 +7,7 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns200:
+class Returns200Test:
     def when_account_is_known(self, app):
         # given
         user = users_factories.UserFactory(password="secret")
@@ -56,7 +56,7 @@ class Returns200:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns401:
+class Returns401Test:
     def when_identifier_is_missing(self, app):
         # Given
         users_factories.UserFactory()

--- a/tests/routes/webapp/post_verify_id_check_licence_token_test.py
+++ b/tests/routes/webapp/post_verify_id_check_licence_token_test.py
@@ -17,98 +17,99 @@ token_is_totaly_weird_mock = MagicMock(side_effect=ReCaptchaException())
 
 
 @pytest.mark.usefixtures("db_session")
-class Post:
-    class Returns200:
-        @patch("pcapi.core.users.repository.get_id_check_token", lambda x: None)
-        @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_valid_mock)
-        def when_has_the_exact_payload(self, app):
-            # Given
-            data = {"token": "authorized-token"}
+class Returns200Test:
+    @patch("pcapi.core.users.repository.get_id_check_token", lambda x: None)
+    @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_valid_mock)
+    def when_has_the_exact_payload(self, app):
+        # Given
+        data = {"token": "authorized-token"}
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
 
-            # Then
-            assert response.status_code == 200
+        # Then
+        assert response.status_code == 200
 
-        def when_has_an_existing_JWT_token(self, app):
-            # Given
-            user = UserFactory()
-            IdCheckToken(user=user, isUsed=False, value="authorized-token")
+    def when_has_an_existing_JWT_token(self, app):
+        # Given
+        user = UserFactory()
+        IdCheckToken(user=user, isUsed=False, value="authorized-token")
 
-            data = {"token": "authorized-token"}
+        data = {"token": "authorized-token"}
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
 
-            # Then
-            assert response.status_code == 200
+        # Then
+        assert response.status_code == 200
 
-    class Returns400:
-        @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_wrong_mock)
-        def when_token_is_wrong(self, app):
-            # Given
-            data = {"token": "wrong-token"}
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
+@pytest.mark.usefixtures("db_session")
+class Returns400Test:
+    @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_wrong_mock)
+    def when_token_is_wrong(self, app):
+        # Given
+        data = {"token": "wrong-token"}
 
-            # Then
-            assert response.status_code == 400
-            assert response.json["token"] == ["Le token renseigné n'est pas valide"]
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
 
-        @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_totaly_weird_mock)
-        def when_has_an_expired_JWT_token(self, app):
-            # Given
-            user = UserFactory()
-            IdCheckToken(user=user, isUsed=True, value="authorized-token")
+        # Then
+        assert response.status_code == 400
+        assert response.json["token"] == ["Le token renseigné n'est pas valide"]
 
-            data = {"token": "authorized-token"}
+    @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_totaly_weird_mock)
+    def when_has_an_expired_JWT_token(self, app):
+        # Given
+        user = UserFactory()
+        IdCheckToken(user=user, isUsed=True, value="authorized-token")
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
+        data = {"token": "authorized-token"}
 
-            # Then
-            assert response.status_code == 400
-            assert response.json["token"] == "Le token renseigné n'est pas valide"
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
 
-        @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_valid_mock)
-        def when_has_no_payload(self, app):
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/licence_verify")
+        # Then
+        assert response.status_code == 400
+        assert response.json["token"] == "Le token renseigné n'est pas valide"
 
-            # Then
-            assert response.status_code == 400
+    @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_valid_mock)
+    def when_has_no_payload(self, app):
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/licence_verify")
 
-        @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_valid_mock)
-        def when_token_is_null(self, app):
-            # Given
-            data = {"token": None}
+        # Then
+        assert response.status_code == 400
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
+    @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_valid_mock)
+    def when_token_is_null(self, app):
+        # Given
+        data = {"token": None}
 
-            # Then
-            assert response.status_code == 400
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
 
-        @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_valid_mock)
-        def when_token_is_the_string_null(self, app):
-            # Given
-            data = {"token": "null"}
+        # Then
+        assert response.status_code == 400
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
+    @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_valid_mock)
+    def when_token_is_the_string_null(self, app):
+        # Given
+        data = {"token": "null"}
 
-            # Then
-            assert response.status_code == 400
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
 
-        @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_valid_mock)
-        def when_has_wrong_token_key(self, app):
-            # Given
-            data = {"custom-token": "authorized-token"}
+        # Then
+        assert response.status_code == 400
 
-            # When
-            response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
+    @patch("pcapi.routes.webapp.beneficiaries.check_webapp_recaptcha_token", token_is_valid_mock)
+    def when_has_wrong_token_key(self, app):
+        # Given
+        data = {"custom-token": "authorized-token"}
 
-            # Then
-            assert response.status_code == 400
+        # When
+        response = TestClient(app.test_client()).post("/beneficiaries/licence_verify", json=data)
+
+        # Then
+        assert response.status_code == 400

--- a/tests/routes/webapp/put_cancel_booking_by_id_test.py
+++ b/tests/routes/webapp/put_cancel_booking_by_id_test.py
@@ -12,7 +12,7 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
-class Returns200:
+class Returns200Test:
     @pytest.mark.usefixtures("db_session")
     def expect_the_booking_to_be_cancelled_by_current_user(self, app):
         # Given
@@ -41,7 +41,7 @@ class Returns200:
         }
 
 
-class Returns400:
+class Returns400Test:
     @pytest.mark.usefixtures("db_session")
     def when_the_booking_cannot_be_cancelled(self, app):
         # Given
@@ -57,7 +57,7 @@ class Returns400:
         assert not Booking.query.get(booking.id).isCancelled
 
 
-class Returns404:
+class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     def when_cancelling_a_booking_of_someone_else(self, app):
         # Given

--- a/tests/routes/webapp/signup_webapp_test.py
+++ b/tests/routes/webapp/signup_webapp_test.py
@@ -25,276 +25,277 @@ BASE_DATA = {
 }
 
 
-class Post:
-    class Returns201:
-        @freeze_time("2019-01-01 01:00:00")
-        @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
-        @pytest.mark.usefixtures("db_session")
-        def when_data_is_accurate(self, get_authorized_emails_and_dept_codes, app):
-            # Given
-            data = BASE_DATA.copy()
-            expected_response_json = {
-                "isBeneficiary": False,
-                "departementCode": "93",
-                "email": "toto@example.com",
-                "firstName": "Toto",
-                "isAdmin": False,
-                "lastName": "Martin",
-                "phoneNumber": "0612345678",
-                "postalCode": "93100",
-                "publicName": "Toto",
-                "dateOfBirth": "2001-01-01T00:00:00Z",
-            }
-            other_expected_keys = {"id", "dateCreated"}
-            get_authorized_emails_and_dept_codes.return_value = (["toto@example.com"], ["93"])
+class Returns201Test:
+    @freeze_time("2019-01-01 01:00:00")
+    @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
+    @pytest.mark.usefixtures("db_session")
+    def when_data_is_accurate(self, get_authorized_emails_and_dept_codes, app):
+        # Given
+        data = BASE_DATA.copy()
+        expected_response_json = {
+            "isBeneficiary": False,
+            "departementCode": "93",
+            "email": "toto@example.com",
+            "firstName": "Toto",
+            "isAdmin": False,
+            "lastName": "Martin",
+            "phoneNumber": "0612345678",
+            "postalCode": "93100",
+            "publicName": "Toto",
+            "dateOfBirth": "2001-01-01T00:00:00Z",
+        }
+        other_expected_keys = {"id", "dateCreated"}
+        get_authorized_emails_and_dept_codes.return_value = (["toto@example.com"], ["93"])
 
-            # When
-            response = TestClient(app.test_client()).post("/users/signup/webapp", json=data)
+        # When
+        response = TestClient(app.test_client()).post("/users/signup/webapp", json=data)
 
-            # Then
-            assert response.status_code == 201
-            assert "Set-Cookie" not in response.headers
-            json = response.json
-            for key, value in expected_response_json.items():
-                if key != "dateCreated":
-                    assert json[key] == value
-            for key in other_expected_keys:
-                assert key in json
+        # Then
+        assert response.status_code == 201
+        assert "Set-Cookie" not in response.headers
+        json = response.json
+        for key, value in expected_response_json.items():
+            if key != "dateCreated":
+                assert json[key] == value
+        for key in other_expected_keys:
+            assert key in json
 
-            user = User.query.filter_by(email="toto@example.com").first()
-            assert user.notificationSubscriptions == {"marketing_push": True, "marketing_email": True}
-            assert user.hasSeenTutorials is True
-            assert user.needsToFillCulturalSurvey is False
+        user = User.query.filter_by(email="toto@example.com").first()
+        assert user.notificationSubscriptions == {"marketing_push": True, "marketing_email": True}
+        assert user.hasSeenTutorials is True
+        assert user.needsToFillCulturalSurvey is False
 
-        @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
-        @pytest.mark.usefixtures("db_session")
-        def test_created_user_does_not_have_validation_token_and_cannot_book_free_offers(
-            self, get_authorized_emails_and_dept_codes, app
-        ):
-            data = BASE_DATA.copy()
-            get_authorized_emails_and_dept_codes.return_value = (["toto@example.com"], ["93"])
+    @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
+    @pytest.mark.usefixtures("db_session")
+    def test_created_user_does_not_have_validation_token_and_cannot_book_free_offers(
+        self, get_authorized_emails_and_dept_codes, app
+    ):
+        data = BASE_DATA.copy()
+        get_authorized_emails_and_dept_codes.return_value = (["toto@example.com"], ["93"])
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
-            )
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
+        )
 
-            # Then
-            assert response.status_code == 201
-            assert "validationToken" not in response.json
-            created_user = User.query.filter_by(email="toto@example.com").first()
-            assert created_user.validationToken is None
-            assert not created_user.isBeneficiary
-            assert len(push_testing.requests) == 1
-            assert not push_testing.requests[0]["attribute_values"]["u.is_beneficiary"]
+        # Then
+        assert response.status_code == 201
+        assert "validationToken" not in response.json
+        created_user = User.query.filter_by(email="toto@example.com").first()
+        assert created_user.validationToken is None
+        assert not created_user.isBeneficiary
+        assert len(push_testing.requests) == 1
+        assert not push_testing.requests[0]["attribute_values"]["u.is_beneficiary"]
 
-        @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
-        @pytest.mark.usefixtures("db_session")
-        def test_does_not_allow_the_creation_of_admins(self, get_authorized_emails_and_dept_codes, app):
-            # Given
-            user_json = {
-                "email": "pctest.isAdmin.canBook@example.com",
-                "publicName": "IsAdmin CanBook",
-                "firstName": "IsAdmin",
-                "lastName": "CanBook",
-                "postalCode": "93100",
-                "password": "__v4l1d_P455sw0rd__",
-                "contact_ok": "true",
-                "isAdmin": True,
-                "isBeneficiary": True,
-            }
-            get_authorized_emails_and_dept_codes.return_value = (["pctest.isAdmin.canBook@example.com"], ["93"])
+    @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
+    @pytest.mark.usefixtures("db_session")
+    def test_does_not_allow_the_creation_of_admins(self, get_authorized_emails_and_dept_codes, app):
+        # Given
+        user_json = {
+            "email": "pctest.isAdmin.canBook@example.com",
+            "publicName": "IsAdmin CanBook",
+            "firstName": "IsAdmin",
+            "lastName": "CanBook",
+            "postalCode": "93100",
+            "password": "__v4l1d_P455sw0rd__",
+            "contact_ok": "true",
+            "isAdmin": True,
+            "isBeneficiary": True,
+        }
+        get_authorized_emails_and_dept_codes.return_value = (["pctest.isAdmin.canBook@example.com"], ["93"])
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=user_json, headers={"origin": "http://localhost:3000"}
-            )
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=user_json, headers={"origin": "http://localhost:3000"}
+        )
 
-            # Then
-            assert response.status_code == 201
-            created_user = User.query.filter_by(email="pctest.isadmin.canbook@example.com").one()
-            assert not created_user.isAdmin
+        # Then
+        assert response.status_code == 201
+        created_user = User.query.filter_by(email="pctest.isadmin.canbook@example.com").one()
+        assert not created_user.isAdmin
 
-    class Returns400:
-        @pytest.mark.usefixtures("db_session")
-        def when_email_missing(self, app):
-            # Given
-            data = BASE_DATA.copy()
-            del data["email"]
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
-            )
+class Returns400Test:
+    @pytest.mark.usefixtures("db_session")
+    def when_email_missing(self, app):
+        # Given
+        data = BASE_DATA.copy()
+        del data["email"]
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "email" in error
-            assert len(push_testing.requests) == 0
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
+        )
 
-        @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
-        @pytest.mark.usefixtures("db_session")
-        def when_email_with_invalid_format(self, get_authorized_emails_and_dept_codes, app):
-            # Given
-            get_authorized_emails_and_dept_codes.return_value = (["toto@example.com"], ["93"])
-            data = BASE_DATA.copy()
-            data["email"] = "toto"
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "email" in error
+        assert len(push_testing.requests) == 0
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
-            )
+    @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
+    @pytest.mark.usefixtures("db_session")
+    def when_email_with_invalid_format(self, get_authorized_emails_and_dept_codes, app):
+        # Given
+        get_authorized_emails_and_dept_codes.return_value = (["toto@example.com"], ["93"])
+        data = BASE_DATA.copy()
+        data["email"] = "toto"
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "email" in error
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
+        )
 
-        @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
-        @pytest.mark.usefixtures("db_session")
-        def when_email_is_already_used(self, get_authorized_emails_and_dept_codes, app):
-            # Given
-            get_authorized_emails_and_dept_codes.return_value = (["toto@example.com"], ["93"])
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "email" in error
 
-            TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=BASE_DATA, headers={"origin": "http://localhost:3000"}
-            )
+    @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
+    @pytest.mark.usefixtures("db_session")
+    def when_email_is_already_used(self, get_authorized_emails_and_dept_codes, app):
+        # Given
+        get_authorized_emails_and_dept_codes.return_value = (["toto@example.com"], ["93"])
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=BASE_DATA, headers={"origin": "http://localhost:3000"}
-            )
+        TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=BASE_DATA, headers={"origin": "http://localhost:3000"}
+        )
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "email" in error
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=BASE_DATA, headers={"origin": "http://localhost:3000"}
+        )
 
-        @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
-        @pytest.mark.usefixtures("db_session")
-        def when_public_name_is_missing(self, get_authorized_emails_and_dept_codes, app):
-            # Given
-            get_authorized_emails_and_dept_codes.return_value = (["toto@example.com"], ["93"])
-            data = BASE_DATA.copy()
-            del data["publicName"]
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "email" in error
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
-            )
+    @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
+    @pytest.mark.usefixtures("db_session")
+    def when_public_name_is_missing(self, get_authorized_emails_and_dept_codes, app):
+        # Given
+        get_authorized_emails_and_dept_codes.return_value = (["toto@example.com"], ["93"])
+        data = BASE_DATA.copy()
+        del data["publicName"]
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "publicName" in error
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
+        )
 
-        @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
-        @pytest.mark.usefixtures("db_session")
-        def when_public_name_is_too_long(self, get_authorized_emails_and_dept_codes, app):
-            # Given
-            get_authorized_emails_and_dept_codes.return_value = (["toto@example.com"], ["93"])
-            data = BASE_DATA.copy()
-            data["publicName"] = "x" * 300
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "publicName" in error
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
-            )
+    @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
+    @pytest.mark.usefixtures("db_session")
+    def when_public_name_is_too_long(self, get_authorized_emails_and_dept_codes, app):
+        # Given
+        get_authorized_emails_and_dept_codes.return_value = (["toto@example.com"], ["93"])
+        data = BASE_DATA.copy()
+        data["publicName"] = "x" * 300
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "publicName" in error
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
+        )
 
-        @pytest.mark.usefixtures("db_session")
-        def when_password_is_missing(self, app):
-            # Given
-            data = BASE_DATA.copy()
-            del data["password"]
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "publicName" in error
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
-            )
+    @pytest.mark.usefixtures("db_session")
+    def when_password_is_missing(self, app):
+        # Given
+        data = BASE_DATA.copy()
+        del data["password"]
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "password" in error
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
+        )
 
-        @pytest.mark.usefixtures("db_session")
-        def when_password_is_invalid(self, app):
-            # Given
-            data = BASE_DATA.copy()
-            data["password"] = "weakpassword"
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "password" in error
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
-            )
+    @pytest.mark.usefixtures("db_session")
+    def when_password_is_invalid(self, app):
+        # Given
+        data = BASE_DATA.copy()
+        data["password"] = "weakpassword"
 
-            # Then
-            assert response.status_code == 400
-            response = response.json
-            assert "password" in response
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
+        )
 
-        @pytest.mark.usefixtures("db_session")
-        def when_missing_contact_ok(self, app):
-            data = BASE_DATA.copy()
-            del data["contact_ok"]
+        # Then
+        assert response.status_code == 400
+        response = response.json
+        assert "password" in response
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
-            )
+    @pytest.mark.usefixtures("db_session")
+    def when_missing_contact_ok(self, app):
+        data = BASE_DATA.copy()
+        del data["contact_ok"]
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "contact_ok" in error
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
+        )
 
-        @pytest.mark.usefixtures("db_session")
-        def when_wrong_format_on_contact_ok(self, app):
-            data = BASE_DATA.copy()
-            data["contact_ok"] = "t"
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "contact_ok" in error
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
-            )
+    @pytest.mark.usefixtures("db_session")
+    def when_wrong_format_on_contact_ok(self, app):
+        data = BASE_DATA.copy()
+        data["contact_ok"] = "t"
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "contact_ok" in error
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
+        )
 
-        @pytest.mark.usefixtures("db_session")
-        @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
-        def when_user_not_in_exp_spreadsheet(self, get_authorized_emails_and_dept_codes, app):
-            # Given
-            get_authorized_emails_and_dept_codes.return_value = (["toto@email.com", "other@email.com"], ["93", "93"])
-            data = BASE_DATA.copy()
-            data["email"] = "unknown@unknown.com"
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "contact_ok" in error
 
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
-            )
+    @pytest.mark.usefixtures("db_session")
+    @patch("pcapi.routes.webapp.signup.get_authorized_emails_and_dept_codes")
+    def when_user_not_in_exp_spreadsheet(self, get_authorized_emails_and_dept_codes, app):
+        # Given
+        get_authorized_emails_and_dept_codes.return_value = (["toto@email.com", "other@email.com"], ["93", "93"])
+        data = BASE_DATA.copy()
+        data["email"] = "unknown@unknown.com"
 
-            # Then
-            assert response.status_code == 400
-            error = response.json
-            assert "email" in error
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=data, headers={"origin": "http://localhost:3000"}
+        )
 
-    class Returns403:
-        @pytest.mark.usefixtures("db_session")
-        @override_features(WEBAPP_SIGNUP=False)
-        def when_feature_is_not_active(self, app):
-            # When
-            response = TestClient(app.test_client()).post(
-                "/users/signup/webapp", json=BASE_DATA, headers={"origin": "http://localhost:3000"}
-            )
+        # Then
+        assert response.status_code == 400
+        error = response.json
+        assert "email" in error
 
-            # Then
-            assert response.status_code == 403
+
+class Returns403Test:
+    @pytest.mark.usefixtures("db_session")
+    @override_features(WEBAPP_SIGNUP=False)
+    def when_feature_is_not_active(self, app):
+        # When
+        response = TestClient(app.test_client()).post(
+            "/users/signup/webapp", json=BASE_DATA, headers={"origin": "http://localhost:3000"}
+        )
+
+        # Then
+        assert response.status_code == 403

--- a/tests/scripts/delete_corrupted_allocine_stocks_test.py
+++ b/tests/scripts/delete_corrupted_allocine_stocks_test.py
@@ -10,87 +10,89 @@ from pcapi.repository import repository
 from pcapi.scripts.delete_corrupted_allocine_stocks import delete_corrupted_allocine_stocks
 
 
-class DeleteCorruptedAllocineStocksTest:
-    @pytest.mark.usefixtures("db_session")
-    def test_should_delete_stock_from_allocine_provider_with_specific_id_at_provider_format(self, app):
-        # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        offer = create_offer_with_thing_product(venue)
-        stock = create_stock(
-            id_at_providers="TW92aWU6MjczNjU5%38986972800011-1",
-            is_soft_deleted=True,
-            last_provider_id=allocine_provider.id,
-            offer=offer,
-        )
-        repository.save(stock)
+@pytest.mark.usefixtures("db_session")
+def test_should_delete_stock_from_allocine_provider_with_specific_id_at_provider_format(app):
+    # Given
+    offerer = create_offerer()
+    venue = create_venue(offerer)
+    allocine_provider = get_provider_by_local_class("AllocineStocks")
+    offer = create_offer_with_thing_product(venue)
+    stock = create_stock(
+        id_at_providers="TW92aWU6MjczNjU5%38986972800011-1",
+        is_soft_deleted=True,
+        last_provider_id=allocine_provider.id,
+        offer=offer,
+    )
+    repository.save(stock)
 
-        # When
-        delete_corrupted_allocine_stocks()
+    # When
+    delete_corrupted_allocine_stocks()
 
-        # Then
-        assert Stock.query.count() == 0
+    # Then
+    assert Stock.query.count() == 0
 
-    @pytest.mark.usefixtures("db_session")
-    def test_should_not_delete_stock_from_allocine_with_new_id_format(self, app):
-        # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        offer = create_offer_with_thing_product(venue)
-        stock = create_stock(
-            id_at_providers="TW92aWU6MjczNTc5%31940406700021#LOCAL/2020-01-18T14:00:00",
-            is_soft_deleted=True,
-            last_provider_id=allocine_provider.id,
-            offer=offer,
-        )
-        repository.save(stock)
 
-        # When
-        delete_corrupted_allocine_stocks()
+@pytest.mark.usefixtures("db_session")
+def test_should_not_delete_stock_from_allocine_with_new_id_format(app):
+    # Given
+    offerer = create_offerer()
+    venue = create_venue(offerer)
+    allocine_provider = get_provider_by_local_class("AllocineStocks")
+    offer = create_offer_with_thing_product(venue)
+    stock = create_stock(
+        id_at_providers="TW92aWU6MjczNTc5%31940406700021#LOCAL/2020-01-18T14:00:00",
+        is_soft_deleted=True,
+        last_provider_id=allocine_provider.id,
+        offer=offer,
+    )
+    repository.save(stock)
 
-        # Then
-        assert Stock.query.count() == 1
+    # When
+    delete_corrupted_allocine_stocks()
 
-    @pytest.mark.usefixtures("db_session")
-    def test_should_not_delete_stock_from_other_provider_than_allocine(self, app):
-        # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        titelive_provider = get_provider_by_local_class("TiteLiveStocks")
-        offer = create_offer_with_thing_product(venue)
-        stock = create_stock(
-            id_at_providers="TW92aWU6MjczNjU5%38986972800011-1",
-            is_soft_deleted=True,
-            last_provider_id=titelive_provider.id,
-            offer=offer,
-        )
-        repository.save(stock)
+    # Then
+    assert Stock.query.count() == 1
 
-        # When
-        delete_corrupted_allocine_stocks()
 
-        # Then
-        assert Stock.query.count() == 1
+@pytest.mark.usefixtures("db_session")
+def test_should_not_delete_stock_from_other_provider_than_allocine(app):
+    # Given
+    offerer = create_offerer()
+    venue = create_venue(offerer)
+    titelive_provider = get_provider_by_local_class("TiteLiveStocks")
+    offer = create_offer_with_thing_product(venue)
+    stock = create_stock(
+        id_at_providers="TW92aWU6MjczNjU5%38986972800011-1",
+        is_soft_deleted=True,
+        last_provider_id=titelive_provider.id,
+        offer=offer,
+    )
+    repository.save(stock)
 
-    @pytest.mark.usefixtures("db_session")
-    def test_should_not_delete_stock_from_allocine_when_not_sof_deleted(self, app):
-        # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        offer = create_offer_with_thing_product(venue)
-        stock = create_stock(
-            id_at_providers="TW92aWU6MjczNjU5%38986972800011-1",
-            is_soft_deleted=False,
-            last_provider_id=allocine_provider.id,
-            offer=offer,
-        )
-        repository.save(stock)
+    # When
+    delete_corrupted_allocine_stocks()
 
-        # When
-        delete_corrupted_allocine_stocks()
+    # Then
+    assert Stock.query.count() == 1
 
-        # Then
-        assert Stock.query.count() == 1
+
+@pytest.mark.usefixtures("db_session")
+def test_should_not_delete_stock_from_allocine_when_not_sof_deleted(app):
+    # Given
+    offerer = create_offerer()
+    venue = create_venue(offerer)
+    allocine_provider = get_provider_by_local_class("AllocineStocks")
+    offer = create_offer_with_thing_product(venue)
+    stock = create_stock(
+        id_at_providers="TW92aWU6MjczNjU5%38986972800011-1",
+        is_soft_deleted=False,
+        last_provider_id=allocine_provider.id,
+        offer=offer,
+    )
+    repository.save(stock)
+
+    # When
+    delete_corrupted_allocine_stocks()
+
+    # Then
+    assert Stock.query.count() == 1

--- a/tests/scripts/delete_venue_and_offers_for_venue_id_test.py
+++ b/tests/scripts/delete_venue_and_offers_for_venue_id_test.py
@@ -11,71 +11,71 @@ from pcapi.scripts.delete_venue_and_offers_for_venue_id import delete_venue_and_
 from pcapi.utils.human_ids import humanize
 
 
-class DeleteVenueAndOffersForVenueIdTest:
-    @pytest.mark.usefixtures("db_session")
-    def test_delete_venue_and_offers_should_delete_venue_and_offers_with_venue_id(self, app):
-        # Given
-        offerer1 = create_offerer(siren="123456789")
-        offerer2 = create_offerer(siren="111111111")
-        venue1 = create_venue(
-            offerer1,
-            idx=1,
-            siret="12345678900002",
-            address="1 rue Vieille Adresse",
-            name="Vieux nom",
-            city="Vieilleville",
-            latitude="48.863",
-            longitude="2.36",
-            postal_code="75001",
-        )
-        venue2 = create_venue(
-            offerer2,
-            idx=2,
-            siret="12345678900003",
-            address="1 rue de valois",
-            name="super nom",
-            city="Paris",
-            latitude="48.890",
-            longitude="2.40",
-            postal_code="92000",
-        )
-        offer1 = create_offer_with_event_product(venue1)
-        offer2 = create_offer_with_event_product(venue2)
-        offer3 = create_offer_with_event_product(venue1)
-        repository.save(offer1, offer2, offer3, venue1, venue2)
+@pytest.mark.usefixtures("db_session")
+def test_delete_venue_and_offers_should_delete_venue_and_offers_with_venue_id(app):
+    # Given
+    offerer1 = create_offerer(siren="123456789")
+    offerer2 = create_offerer(siren="111111111")
+    venue1 = create_venue(
+        offerer1,
+        idx=1,
+        siret="12345678900002",
+        address="1 rue Vieille Adresse",
+        name="Vieux nom",
+        city="Vieilleville",
+        latitude="48.863",
+        longitude="2.36",
+        postal_code="75001",
+    )
+    venue2 = create_venue(
+        offerer2,
+        idx=2,
+        siret="12345678900003",
+        address="1 rue de valois",
+        name="super nom",
+        city="Paris",
+        latitude="48.890",
+        longitude="2.40",
+        postal_code="92000",
+    )
+    offer1 = create_offer_with_event_product(venue1)
+    offer2 = create_offer_with_event_product(venue2)
+    offer3 = create_offer_with_event_product(venue1)
+    repository.save(offer1, offer2, offer3, venue1, venue2)
 
-        # When
-        delete_venue_and_offers_for_venue_id(humanize(venue1.id))
+    # When
+    delete_venue_and_offers_for_venue_id(humanize(venue1.id))
 
-        # Then
-        offers = Offer.query.all()
-        assert all(o.venue == venue2 for o in offers)
-        assert Venue.query.get(venue1.id) is None
+    # Then
+    offers = Offer.query.all()
+    assert all(o.venue == venue2 for o in offers)
+    assert Venue.query.get(venue1.id) is None
 
-    @pytest.mark.usefixtures("db_session")
-    def test_delete_venue_and_offers_should_raise_an_attribute_error_when_at_least_one_offer_has_stocks(self, app):
-        # Given
-        offerer = create_offerer(siren="123456789")
-        venue = create_venue(
-            offerer,
-            idx=1,
-            siret="12345678900002",
-            address="1 rue Vieille Adresse",
-            name="Vieux nom",
-            city="Vieilleville",
-            latitude="48.863",
-            longitude="2.36",
-            postal_code="75001",
-        )
-        offer1 = create_offer_with_event_product(venue)
-        offer2 = create_offer_with_event_product(venue)
-        stock = create_stock(offer=offer1)
 
-        repository.save(offer1, offer2, stock, venue)
+@pytest.mark.usefixtures("db_session")
+def test_delete_venue_and_offers_should_raise_an_attribute_error_when_at_least_one_offer_has_stocks(app):
+    # Given
+    offerer = create_offerer(siren="123456789")
+    venue = create_venue(
+        offerer,
+        idx=1,
+        siret="12345678900002",
+        address="1 rue Vieille Adresse",
+        name="Vieux nom",
+        city="Vieilleville",
+        latitude="48.863",
+        longitude="2.36",
+        postal_code="75001",
+    )
+    offer1 = create_offer_with_event_product(venue)
+    offer2 = create_offer_with_event_product(venue)
+    stock = create_stock(offer=offer1)
 
-        # When
-        with pytest.raises(AttributeError) as e:
-            delete_venue_and_offers_for_venue_id(humanize(venue.id))
+    repository.save(offer1, offer2, stock, venue)
 
-        # Then
-        assert str(e.value) == "Offres non supprimables car au moins une contient des stocks"
+    # When
+    with pytest.raises(AttributeError) as e:
+        delete_venue_and_offers_for_venue_id(humanize(venue.id))
+
+    # Then
+    assert str(e.value) == "Offres non supprimables car au moins une contient des stocks"

--- a/tests/scripts/user_offerer/delete_user_offerers_from_file_test.py
+++ b/tests/scripts/user_offerer/delete_user_offerers_from_file_test.py
@@ -5,29 +5,28 @@ from pcapi.models import UserOfferer
 from pcapi.scripts.user_offerer.delete_user_offerer_from_csv import _delete_user_offerers_from_rows
 
 
-class DeleteUserOfferersFromFileTest:
-    @pytest.mark.usefixtures("db_session")
-    def test_should_delete_user_offerers_in_csv(self):
-        # Given
-        user_offerer1 = offers_factories.UserOffererFactory()
-        user_offerer2 = offers_factories.UserOffererFactory()
-        user_offerer3 = offers_factories.UserOffererFactory()
+@pytest.mark.usefixtures("db_session")
+def test_should_delete_user_offerers_in_csv():
+    # Given
+    user_offerer1 = offers_factories.UserOffererFactory()
+    user_offerer2 = offers_factories.UserOffererFactory()
+    user_offerer3 = offers_factories.UserOffererFactory()
 
-        csv_rows = [
-            [
-                "Lien structure sur le portail PRO",
-                "ID Structure",
-                "Email utilisateur",
-                "ID Utilisateur",
-                "Commentaire",
-            ],
-            ["unused", user_offerer1.offererId, "unused", user_offerer1.userId, "unused", "unused", "unused", "unused"],
-            ["unused", user_offerer2.offererId, "unused", user_offerer2.userId, "unused", "unused", "unused", "unused"],
-        ]
+    csv_rows = [
+        [
+            "Lien structure sur le portail PRO",
+            "ID Structure",
+            "Email utilisateur",
+            "ID Utilisateur",
+            "Commentaire",
+        ],
+        ["unused", user_offerer1.offererId, "unused", user_offerer1.userId, "unused", "unused", "unused", "unused"],
+        ["unused", user_offerer2.offererId, "unused", user_offerer2.userId, "unused", "unused", "unused", "unused"],
+    ]
 
-        # When
-        _delete_user_offerers_from_rows(csv_rows)
+    # When
+    _delete_user_offerers_from_rows(csv_rows)
 
-        # Then
-        user_offerer = UserOfferer.query.one()
-        assert user_offerer == user_offerer3
+    # Then
+    user_offerer = UserOfferer.query.one()
+    assert user_offerer == user_offerer3

--- a/tests/utils/date_test.py
+++ b/tests/utils/date_test.py
@@ -10,7 +10,7 @@ from pcapi.utils.date import get_postal_code_timezone
 from pcapi.utils.date import get_time_formatted_for_email
 
 
-class GetDateFormattedForEmail:
+class GetDateFormattedForEmailTest:
     def test_should_return_day_followed_by_month_written_in_words(self):
         # Given
         december_23 = datetime.date(2019, 12, 23)
@@ -32,7 +32,7 @@ class GetDateFormattedForEmail:
         assert date_formatted_for_email == "9 décembre 2019"
 
 
-class GetTimeFormattedForEmail:
+class GetTimeFormattedForEmailTest:
     def test_should_return_hour_followed_by_two_digits_minutes(self):
         # Given
         twelve_o_clock = datetime.time(12, 0, 0, 0)
@@ -44,7 +44,7 @@ class GetTimeFormattedForEmail:
         assert time_formatted_for_email == "12h00"
 
 
-class GetDepartmentTimezone:
+class GetDepartmentTimezoneTest:
     def test_should_alert_when_department_code_is_not_a_string(self):
         # When
         with pytest.raises(AssertionError):
@@ -61,7 +61,7 @@ class GetDepartmentTimezone:
             assert dateutil.tz.gettz(timezone) is not None, f"{timezone} is not a valid timezone"
 
 
-class GetPostalCodeTimezone:
+class GetPostalCodeTimezoneTest:
     def test_should_return_paris_as_default_timezone(self):
         assert get_postal_code_timezone("75000") == "Europe/Paris"
 


### PR DESCRIPTION
La configuration actuelle de **pytest** lui fait collecter les classes préfixées avec: `Post`, `Patch`, `Put`, `Get`, `Delete`, `Returns`*, `When`*.

Malheureusement, cela lui fait ou fera essayer de collecter des classes ayant un constructeur, ce qui est impossible et lèvera un avertissement.

Pour éviter cela, on éditera la directive `python_classes` afin d'utiliser la découverte standard des classes de test par Pytest:

> test functions or methods inside Test prefixed test classes (without an _init_ method)

Par souci de compatibilité avec les pratiques actuelles, on continuera de collecter les classes **suffixées** par `Test`.

NB: Les commits seront écrasés avant de fusionner la PR, et le nombre de tests collectés a été vérifié à chaque étape.