### PR TITLE
(PC-9303) send email on document validation error

### DIFF
--- a/src/pcapi/domain/user_emails.py
+++ b/src/pcapi/domain/user_emails.py
@@ -244,6 +244,5 @@ def send_offer_validation_status_update_email(
 
 
 def send_document_verification_error_email(email: str, code: str) -> bool:
-    user = User.query.filter_by(email=email).one()
-    data = build_data_for_document_verification_error(user, code)
+    data = build_data_for_document_verification_error(code)
     return mails.send(recipients=[email], data=data)

--- a/src/pcapi/emails/user_document_validation.py
+++ b/src/pcapi/emails/user_document_validation.py
@@ -1,12 +1,11 @@
 from pcapi import settings
-from pcapi.core.users.models import User
 
 
 class DocumentValidationUnknownError(Exception):
     pass
 
 
-def build_data_for_document_verification_error(user: User, code: str) -> dict:
+def build_data_for_document_verification_error(code: str) -> dict:
     error_codes_switch = {
         "unread-document": _build_unread_document_data,
         "unread-mrz-document": _build_invalid_document_data,
@@ -20,46 +19,40 @@ def build_data_for_document_verification_error(user: User, code: str) -> dict:
         raise DocumentValidationUnknownError(str(code))
 
     handler = error_codes_switch[code]
-    return handler(user)
+    return handler()
 
 
-def _build_unread_document_data(user: User) -> dict:
+def _build_unread_document_data() -> dict:
     return {
         "MJ-TemplateID": 2958557,
         "MJ-TemplateLanguage": True,
         "Vars": {
-            "first_name": user.firstName,
             "url": settings.DMS_USER_URL,
         },
     }
 
 
-def _build_invalid_document_date_data(user: User) -> dict:
+def _build_invalid_document_date_data() -> dict:
     return {
         "MJ-TemplateID": 2958563,
         "MJ-TemplateLanguage": True,
         "Vars": {
-            "first_name": user.firstName,
             "url": settings.DMS_USER_URL,
         },
     }
 
 
-def _build_invalid_document_data(user: User) -> dict:
+def _build_invalid_document_data() -> dict:
     return {
         "MJ-TemplateID": 2958584,
         "MJ-TemplateLanguage": True,
-        "Vars": {
-            "first_name": user.firstName,
-        },
+        "Vars": {},
     }
 
 
-def _build_invalid_age_data(user: User) -> dict:
+def _build_invalid_age_data() -> dict:
     return {
         "MJ-TemplateID": 2958585,
         "MJ-TemplateLanguage": True,
-        "Vars": {
-            "first_name": user.firstName,
-        },
+        "Vars": {},
     }

--- a/tests/core/users/test_api.py
+++ b/tests/core/users/test_api.py
@@ -10,6 +10,7 @@ from freezegun import freeze_time
 import jwt
 import pytest
 
+from pcapi import settings
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.mails import testing as mails_testing
 from pcapi.core.offers import factories as offers_factories
@@ -873,16 +874,15 @@ class VerifyIdentityDocumentInformationsTest:
         self, mocked_get_identity_informations, mocked_ask_for_identity, mocked_delete_object, app
     ):
         # Given
-        user = users_factories.UserFactory(email="py@test.com")
         mocked_get_identity_informations.return_value = ("py@test.com", b"")
-        mocked_ask_for_identity.return_value = (False, "invalid-document")
+        mocked_ask_for_identity.return_value = (False, "unread-document")
 
         users_api.verify_identity_document_informations("some_path")
 
         assert len(mails_testing.outbox) == 1
         sent_data = mails_testing.outbox[0].sent_data
 
-        assert sent_data["Vars"]["first_name"] == user.firstName
+        assert sent_data["Vars"]["url"] == settings.DMS_USER_URL
 
     @patch("pcapi.core.users.api.delete_object")
     @patch("pcapi.core.users.api.ask_for_identity_document_verification")
@@ -891,7 +891,6 @@ class VerifyIdentityDocumentInformationsTest:
         self, mocked_get_identity_informations, mocked_ask_for_identity, mocked_delete_object, app
     ):
         # Given
-        users_factories.UserFactory(email="py@test.com")
         mocked_get_identity_informations.return_value = ("py@test.com", b"")
         mocked_ask_for_identity.return_value = (True, "registration:completed")
 


### PR DESCRIPTION
Ne plus utiliser l'utilisateur dans les données des templates : puisqu'en cas d'erreur, il y a peu de chances pour que l'utilisateur ait son prénom en base de données, le prénom a été retiré du template d'email.

En plus : il semble que l'API de Mailjet n'apprécie pas particulièrement une variable avec une valeur nulle.