### PR TITLE
(PC-9457) fix dms crashes recovery

### DIFF
--- a/src/pcapi/scripts/beneficiary/remote_import.py
+++ b/src/pcapi/scripts/beneficiary/remote_import.py
@@ -31,6 +31,7 @@ from pcapi.workers.push_notification_job import update_user_attributes_job
 logger = logging.getLogger(__name__)
 
 
+# TODO(xordoquy): remove process_applications_updated_after since it is not used
 def run(
     process_applications_updated_after: datetime,
     procedure_id: int,
@@ -48,7 +49,7 @@ def run(
     )
     error_messages: list[str] = []
     new_beneficiaries: list[User] = []
-    applications_ids = get_all_applications_ids(procedure_id, settings.DMS_TOKEN, process_applications_updated_after)
+    applications_ids = get_all_applications_ids(procedure_id, settings.DMS_TOKEN)
     retry_ids = get_applications_ids_to_retry()
 
     logger.info(

--- a/tests/domain/demarches_simplifiees_test.py
+++ b/tests/domain/demarches_simplifiees_test.py
@@ -154,12 +154,15 @@ class GetAllApplicationIdsForBeneficiaryImportTest:
 
 
 @patch("pcapi.domain.demarches_simplifiees.get_all_applications_for_procedure")
+@patch("pcapi.domain.demarches_simplifiees.get_existing_applications_id")
 class GetClosedApplicationIdsForBeneficiaryImportTest:
     def setup_method(self):
         self.PROCEDURE_ID = "123456789"
         self.TOKEN = "AZERTY123/@.,!é"
 
-    def test_returns_applications_with_state_closed_only(self, get_all_applications_for_procedure):
+    def test_returns_applications_with_state_closed_only(
+        self, get_existing_applications_id, get_all_applications_for_procedure
+    ):
         # Given
         get_all_applications_for_procedure.return_value = {
             "dossiers": [
@@ -168,11 +171,10 @@ class GetClosedApplicationIdsForBeneficiaryImportTest:
             ],
             "pagination": {"page": 1, "resultats_par_page": 100, "nombre_de_page": 1},
         }
+        get_existing_applications_id.return_value = set()
 
         # When
-        application_ids = get_closed_application_ids_for_demarche_simplifiee(
-            self.PROCEDURE_ID, self.TOKEN, datetime(2019, 1, 1)
-        )
+        application_ids = get_closed_application_ids_for_demarche_simplifiee(self.PROCEDURE_ID, self.TOKEN)
 
         # Then
         assert application_ids == [2]

--- a/tests/scripts/beneficiary/remote_import_test.py
+++ b/tests/scripts/beneficiary/remote_import_test.py
@@ -61,7 +61,7 @@ class RunTest:
 
         # then
         assert get_all_application_ids.call_count == 1
-        get_all_application_ids.assert_called_with(6712558, ANY, ANY)
+        get_all_application_ids.assert_called_with(6712558, ANY)
 
     @patch("pcapi.scripts.beneficiary.remote_import.process_beneficiary_application")
     def test_all_applications_are_processed_once(self, process_beneficiary_application):
@@ -689,7 +689,7 @@ class RunIntegrationTest:
             }
         }
 
-    def _get_all_applications_ids(self, procedure_id: str, token: str, last_update: datetime):
+    def _get_all_applications_ids(self, procedure_id: str, token: str):
         return [123]
 
     @override_features(FORCE_PHONE_VALIDATION=False)

--- a/tests/use_cases/create_beneficiary_from_application_test.py
+++ b/tests/use_cases/create_beneficiary_from_application_test.py
@@ -177,7 +177,7 @@ def test_application_for_native_app_user_with_load_smoothing(_get_raw_content, a
     # Given
     application_id = 35
     user = UserFactory(
-        dateOfBirth="10/25/2003",
+        dateOfBirth=datetime(2003, 10, 25),
         phoneNumber="0607080900",
         isBeneficiary=False,
         address="an address",


### PR DESCRIPTION
DMS somtimes missed files when it crashes while processing
applications.
Former behaviour was taking only the files that were processed
after the last imported beneficiairy was created on the backend.
If it crashed for some reasons (most likely couldn't reach the
DMS server) the files that were not processed were not recovered
after because there process time was before the latest created
beneficiary.
New behaviour is to ignore process time and only look in the
beneficiary import table whether the file has been processed or
not