### PR TITLE
(PC-9509): Ajout d'un log au retour de réponse jouve

### DIFF
--- a/src/pcapi/connectors/beneficiaries/id_check_middleware.py
+++ b/src/pcapi/connectors/beneficiaries/id_check_middleware.py
@@ -28,9 +28,20 @@ def ask_for_identity_document_verification(email: str, identity_document: bytes)
             "Error asking API jouve identity document verification for email %s with reponse content: %s",
             email,
             response.json(),
+            extra={"jouve_reference": response.headers.get("dossier-reference")},
         )
         raise IdCheckMiddlewareException(
             f"Error asking API jouve identity document verification for email {email}",
         )
+    logger.info(
+        "Jouve identity document verification",
+        extra={
+            "jouve_reference": response.headers.get("dossier-reference"),
+            "mfiles_id": response.headers.get("ged-user-id"),
+            "success": response.status_code == 200,
+            "error": response.json()["code"],
+            "email": email,
+        },
+    )
 
     return response.status_code == 200, response.json()["code"]


### PR DESCRIPTION
Pas de test #yolo

J'ai aussi mis l'email, comme dans les autres logs du circuit, pour pouvoir retrouver un utilisateur si besoin

Mais c'est pas top il faudrait enlever l'email de tout ces logs et remplacer par une donnée non personnelle je pense : leur id