### PR TITLE
flask-admin: migrate to bootstrap v4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ coveralls==2.1.2
 debugpy
 factory-boy
 Flask==1.1.*
-Flask-Admin==1.5.6
+Flask-Admin==1.5.8
 Flask-Cors==3.0.9
 Flask-JWT-Extended==3.24.1
 Flask-Limiter==1.4

--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -119,7 +119,7 @@ api = SpecTree("flask", MODE="strict", before=before_handler)
 api.register(app)
 
 login_manager = LoginManager()
-admin = Admin(name="Back Office du Pass Culture", url="/pc/back-office/", template_mode="bootstrap3")
+admin = Admin(name="Back Office du Pass Culture", url="/pc/back-office/", template_mode="bootstrap4")
 
 if settings.PROFILE_REQUESTS:
     profiling_restrictions = [settings.PROFILE_REQUESTS_LINES_LIMIT]

--- a/tests/utils/db_test.py
+++ b/tests/utils/db_test.py
@@ -16,12 +16,12 @@ class GetBatchesTest:
         assert isinstance(batches, types.GeneratorType)
         batches = list(batches)
         assert len(batches) == 6
-        assert list(batches[0]) == [users[0], users[1]]
-        assert list(batches[1]) == [users[2], users[3]]
-        assert list(batches[2]) == [users[4], users[5]]
-        assert list(batches[3]) == [users[6], users[7]]
-        assert list(batches[4]) == [users[8], users[9]]
-        assert list(batches[5]) == [users[10]]
+        assert list(batches[0].order_by(users_models.User.id)) == [users[0], users[1]]
+        assert list(batches[1].order_by(users_models.User.id)) == [users[2], users[3]]
+        assert list(batches[2].order_by(users_models.User.id)) == [users[4], users[5]]
+        assert list(batches[3].order_by(users_models.User.id)) == [users[6], users[7]]
+        assert list(batches[4].order_by(users_models.User.id)) == [users[8], users[9]]
+        assert list(batches[5].order_by(users_models.User.id)) == [users[10]]
         assert list(itertools.chain.from_iterable(batches)) == users
 
     def test_empty(self):


### PR DESCRIPTION
Takes advantage of bootstrapv4 to use more css components
as described in the docs
https://getbootstrap.com/docs/4.0/getting-started/introduction/

for now, I only found a "subtile" change in the header color which is lighter.