### PR TITLE
db: configure jsonencoder to ease jsonb usage

### DIFF
--- a/src/pcapi/models/db.py
+++ b/src/pcapi/models/db.py
@@ -1,9 +1,10 @@
+from flask import json
 from flask_sqlalchemy import SQLAlchemy
 
 from pcapi import settings
 
 
-engine_options = {"pool_size": settings.DATABASE_POOL_SIZE}
+engine_options = {"json_serializer": json.dumps, "pool_size": settings.DATABASE_POOL_SIZE}
 
 db_options = []
 if settings.DATABASE_LOCK_TIMEOUT:


### PR DESCRIPTION
when using PG's JSONB field, we might want to serialize complex types, such as datetime etc..
This commit configure flask's json encoder to simplify this, avoiding us to store json as string