### PR TITLE
Add pydantic serializer to control sqlalchemy json serialization

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=lxml,posix_ipc,spidev,netifaces,pydantic,math,binascii,unicodedata
+extension-pkg-whitelist=lxml,posix_ipc,spidev,netifaces,pydantic,math,binascii,unicodedata,pydantic
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.

--- a/src/pcapi/core/fraud/factories.py
+++ b/src/pcapi/core/fraud/factories.py
@@ -102,7 +102,7 @@ class BeneficiaryFraudCheckFactory(testing.BaseFactory):
         factory_class = FRAUD_CHECK_TYPE_MODEL_ASSOCIATION.get(kwargs["type"])
         content = {}
         if factory_class:
-            content = factory_class().dict()
+            content = factory_class()
 
         kwargs["resultContent"] = content
 

--- a/src/pcapi/models/db.py
+++ b/src/pcapi/models/db.py
@@ -1,10 +1,16 @@
-from flask import json
+import functools
+import json
+
 from flask_sqlalchemy import SQLAlchemy
+import pydantic.json
 
 from pcapi import settings
 
 
-engine_options = {"json_serializer": json.dumps, "pool_size": settings.DATABASE_POOL_SIZE}
+engine_options = {
+    "json_serializer": functools.partial(json.dumps, default=pydantic.json.pydantic_encoder),
+    "pool_size": settings.DATABASE_POOL_SIZE,
+}
 
 db_options = []
 if settings.DATABASE_LOCK_TIMEOUT:


### PR DESCRIPTION
Using flask serializer was not enough : the date time serialized didn't have a common format for instance.

using Pydantic help us using standard formats, and allows us to directly hydrate a pydantic object.