### PR TITLE
(PC-9690) bookings: Raise error in `mark_as_used()` if already used

### DIFF
--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -255,9 +255,6 @@ def mark_as_used(booking: Booking, uncancel: bool = False) -> None:
     library and then cancelled their booking before the library marked
     it as used).
     """
-    if booking.isUsed:
-        logger.info("Booking was already marked as used", extra={"booking": booking.id})
-        return
     # I'm not 100% sure the transaction is required here
     # It is not clear to me wether or not Flask-SQLAlchemy will make
     # a rollback if we raise a validation exception.

--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -565,10 +565,10 @@ class MarkAsUsedTest:
         api.mark_as_used(booking)
         assert booking.isUsed
 
-    def test_no_op_if_already_used(self):
+    def test_raise_if_already_used(self):
         booking = factories.BookingFactory(isUsed=True)
-        api.mark_as_used(booking)
-        assert booking.isUsed  # unchanged
+        with pytest.raises(api_errors.ResourceGoneError):
+            api.mark_as_used(booking)
 
     def test_raise_if_cancelled(self):
         booking = factories.BookingFactory(isCancelled=True)
@@ -576,11 +576,11 @@ class MarkAsUsedTest:
             api.mark_as_used(booking)
         assert not booking.isUsed
 
-    def test_no_op_if_refunded(self):
+    def test_raise_if_already_reimbursed(self):
         booking = factories.BookingFactory(isUsed=True)
         payments_factories.PaymentFactory(booking=booking)
-        api.mark_as_used(booking)
-        assert booking.isUsed  # unchanged
+        with pytest.raises(api_errors.ForbiddenError):
+            api.mark_as_used(booking)
 
     def test_raise_if_too_soon_to_mark_as_used(self):
         booking = factories.BookingFactory(stock__beginningDatetime=datetime.now() + timedelta(days=4))


### PR DESCRIPTION
This is a revert of c67da9cce8df76599cf0b6b97dc4676ca4874790. In that
former commit, we made `mark_as_used()` a no-op if the booking was
already used. This was done to prevent errors when the offerer tried
to validate a booking that had been automatically marked as used.

This was both:

- useless: offerers never use our API to mark bookings as used for
  automatically-validated bookings. These bookings always have an
  activation code, which the beneficiary uses on the offerer's web
  site. The booking token is never used in that case.

- wrong: for bookings that are not automatically validated upon
  creation, we (obviously) do NOT want to allow a token to be used
  twice. Therefore, the mark-as-used API must fail if it's given
  a booking that has already been used.