### PR TITLE
(PC-9703) : Change "hard" security checks into "soft" during IDCheck

### DIFF
--- a/src/pcapi/connectors/beneficiaries/jouve_backend.py
+++ b/src/pcapi/connectors/beneficiaries/jouve_backend.py
@@ -139,12 +139,11 @@ def get_fraud_fields(content: dict) -> dict:
         }
 
     return {
-        "strict_controls": [
+        "strict_controls": [],
+        "non_blocking_controls": [
             get_boolean_fraud_detection_item(content.posteCodeCtrl, "posteCodeCtrl"),
             get_boolean_fraud_detection_item(content.serviceCodeCtrl, "serviceCodeCtrl"),
             get_boolean_fraud_detection_item(content.birthLocationCtrl, "birthLocationCtrl"),
-        ],
-        "non_blocking_controls": [
             get_threshold_fraud_detection_item(content.bodyBirthDateLevel, "bodyBirthDateLevel", 100),
             get_threshold_fraud_detection_item(content.bodyNameLevel, "bodyNameLevel", 50),
             get_boolean_fraud_detection_item(content.bodyBirthDateCtrl, "bodyBirthDateCtrl"),

--- a/tests/use_cases/create_beneficiary_from_application_test.py
+++ b/tests/use_cases/create_beneficiary_from_application_test.py
@@ -387,34 +387,35 @@ BASE_JOUVE_CONTENT = {
 }
 
 
-@pytest.mark.parametrize(
-    "fraud_strict_detection_parameter",
-    [{"serviceCodeCtrl": "KO"}, {"posteCodeCtrl": "KO"}, {"birthLocationCtrl": "KO"}],
-)
-@patch("pcapi.connectors.beneficiaries.jouve_backend._get_raw_content")
-@pytest.mark.usefixtures("db_session")
-def test_cannot_save_beneficiary_when_fraud_is_detected(
-    mocked_get_content,
-    fraud_strict_detection_parameter,
-    app,
-):
-    # Given
-    mocked_get_content.return_value = BASE_JOUVE_CONTENT | {
-        "bodyNameLevel": 30,
-    }
-    # updates mocked return value from parametrized test
-    mocked_get_content.return_value.update(fraud_strict_detection_parameter)
+# TODO(xordoquy): make fraud fields configurable and reactivate this test
+# @pytest.mark.parametrize(
+#     "fraud_strict_detection_parameter",
+#     [{"serviceCodeCtrl": "KO"}, {"posteCodeCtrl": "KO"}, {"birthLocationCtrl": "KO"}],
+# )
+# @patch("pcapi.connectors.beneficiaries.jouve_backend._get_raw_content")
+# @pytest.mark.usefixtures("db_session")
+# def test_cannot_save_beneficiary_when_fraud_is_detected(
+#     mocked_get_content,
+#     fraud_strict_detection_parameter,
+#     app,
+# ):
+#     # Given
+#     mocked_get_content.return_value = BASE_JOUVE_CONTENT | {
+#         "bodyNameLevel": 30,
+#     }
+#     # updates mocked return value from parametrized test
+#     mocked_get_content.return_value.update(fraud_strict_detection_parameter)
 
-    # When
-    create_beneficiary_from_application.execute(BASE_APPLICATION_ID)
+#     # When
+#     create_beneficiary_from_application.execute(BASE_APPLICATION_ID)
 
-    # Then
-    fraud_strict_detection_cause = list(fraud_strict_detection_parameter.keys())[0]
-    beneficiary_import = BeneficiaryImport.query.one()
-    assert beneficiary_import.currentStatus == ImportStatus.REJECTED
-    assert beneficiary_import.detail == f"Fraud controls triggered: {fraud_strict_detection_cause}, bodyNameLevel"
+#     # Then
+#     fraud_strict_detection_cause = list(fraud_strict_detection_parameter.keys())[0]
+#     beneficiary_import = BeneficiaryImport.query.one()
+#     assert beneficiary_import.currentStatus == ImportStatus.REJECTED
+#     assert beneficiary_import.detail == f"Fraud controls triggered: {fraud_strict_detection_cause}, bodyNameLevel"
 
-    assert len(mails_testing.outbox) == 0
+#     assert len(mails_testing.outbox) == 0
 
 
 @patch("pcapi.connectors.beneficiaries.jouve_backend._get_raw_content")


### PR DESCRIPTION
Since there's quite some false negative hard checks, we want to make
them soft to make those cases go through a manuel check.