### PR TITLE
(PC-9729) : Recompute dnBookedQuantity for each booking batch cancelled

### DIFF
--- a/src/pcapi/scripts/booking/handle_expired_bookings.py
+++ b/src/pcapi/scripts/booking/handle_expired_bookings.py
@@ -54,10 +54,6 @@ def cancel_expired_bookings(batch_size: int = 500) -> None:
     updated_total = 0
     expiring_booking_ids = bookings_repository.find_expiring_bookings_ids().limit(batch_size).all()
     max_id = expiring_booking_ids[-1][0]
-    stocks_to_recompute = [
-        row[0]
-        for row in db.session.query(Booking.stockId).filter(Booking.id.in_(expiring_booking_ids)).distinct().all()
-    ]
 
     # we commit here to make sure there is no unexpected objects in SQLA cache before the update,
     # as we use synchronize_session=False
@@ -72,6 +68,12 @@ def cancel_expired_bookings(batch_size: int = 500) -> None:
                 synchronize_session=False,
             )
         )
+        # Recompute denormalized stock quantity
+        stocks_to_recompute = [
+            row[0]
+            for row in db.session.query(Booking.stockId).filter(Booking.id.in_(expiring_booking_ids)).distinct().all()
+        ]
+        recompute_dnBookedQuantity(stocks_to_recompute)
         db.session.commit()
 
         updated_total += updated
@@ -82,11 +84,6 @@ def cancel_expired_bookings(batch_size: int = 500) -> None:
             "[cancel_expired_bookings] %d Bookings have been cancelled in this batch",
             updated,
         )
-
-    # Recompute denormalized stock quantity
-    if stocks_to_recompute:
-        recompute_dnBookedQuantity(stocks_to_recompute)
-        db.session.commit()
 
     logger.info(
         "[cancel_expired_bookings] %d Bookings have been cancelled",

--- a/tests/scripts/booking/handle_expired_bookings_test.py
+++ b/tests/scripts/booking/handle_expired_bookings_test.py
@@ -118,11 +118,15 @@ class CancelExpiredBookingsTest:
         n_queries = (
             1  # select count
             + 1  # select initial booking ids
-            + 1  # select associated stocks
             + 1  # release savepoint/COMMIT
-            + 4 * 3  # update, release savepoint/COMMIT, select next ids
-            + 1  # recompute denormalized booking quantity in stock
-            + 1  # commit previous computation
+            + 4
+            * (
+                1  # update
+                + 1  # release savepoint/COMMIT
+                + 1  # select stock
+                + 1  # recompute dnBookedQuantity
+                + 1  # select next ids
+            )
         )
 
         with assert_num_queries(n_queries):


### PR DESCRIPTION
This fixes the fact that only the latest batch of cancelled bookings
was used to recompute dnBookedQuantity on the associated stock.
We also want to commit the recomputed dnBookedQuantity along with
the cancelled bookings so that if something goes south for whatever
reason during the process, the already cancelled bookings will be
aligned with the stock's dnBookedQuantity.