### PR TITLE
FlaskAdmin : custom view disable edit and creation form cache

### DIFF
--- a/src/pcapi/admin/base_configuration.py
+++ b/src/pcapi/admin/base_configuration.py
@@ -4,6 +4,7 @@ from flask import url_for
 from flask_admin.base import BaseView
 from flask_admin.contrib.sqla import ModelView
 from flask_admin.form import SecureForm
+from flask_admin.helpers import get_form_data
 from flask_login import current_user
 from werkzeug.utils import redirect
 
@@ -22,7 +23,23 @@ def is_accessible() -> bool:
     return authorized
 
 
-class BaseAdminView(ModelView):
+class BaseAdminMixin:
+    # We need to override `create_form()` and `edit_form()`, otherwise
+    # Flask-Admin loads the form classes from its cache, which is
+    # populated when the admin view is registered. It does not work
+    # for us because we want the form to be different depending on the
+    # logged-in user's privileges (see `form_columns()`). Thus, we
+    # don't use the cache.
+    def create_form(self, obj=None):
+        form_class = self.get_create_form()
+        return form_class(get_form_data(), obj=obj)
+
+    def edit_form(self, obj=None):
+        form_class = self.get_edit_form()
+        return form_class(get_form_data(), obj=obj)
+
+
+class BaseAdminView(BaseAdminMixin, ModelView):
     page_size = 25
     can_set_page_size = True
     can_create = False
@@ -51,7 +68,7 @@ class BaseAdminView(ModelView):
         return True
 
 
-class BaseCustomAdminView(BaseView):
+class BaseCustomAdminView(BaseAdminMixin, BaseView):
     def is_accessible(self) -> bool:
         return is_accessible()
 

--- a/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from flask.helpers import flash
-from flask_admin.helpers import get_form_data
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import query
 from sqlalchemy.sql.functions import func
@@ -87,20 +86,6 @@ class BeneficiaryUserView(SuspensionMixin, BaseAdminView):
         postalCode=dict(validators=[DataRequired()]),
         email=dict(validators=[DataRequired()], filters=[filter_email]),
     )
-
-    # We need to override `create_form()` and `edit_form()`, otherwise
-    # Flask-Admin loads the form classes from its cache, which is
-    # populated when the admin view is registered. It does not work
-    # for us because we want the form to be different depending on the
-    # logged-in user's privileges (see `form_columns()`). Thus, we
-    # don't use the cache.
-    def create_form(self, obj=None):
-        form_class = self.get_create_form()
-        return form_class(get_form_data(), obj=obj)
-
-    def edit_form(self, obj=None):
-        form_class = self.get_edit_form()
-        return form_class(get_form_data(), obj=obj)
 
     def get_create_form(self):
         form_class = super().scaffold_form()

--- a/tests/admin/base_configuration_test.py
+++ b/tests/admin/base_configuration_test.py
@@ -13,103 +13,99 @@ class DummyAdminView(BaseAdminView):
     pass
 
 
-class BaseAdminViewTest:
-    class DefaultConfigurationTest:
-        def test_model_in_admin_view_is_not_deletable(self):
-            # when
-            view = DummyAdminView(Booking, fake_db_session)
+class DefaultConfigurationTest:
+    def test_model_in_admin_view_is_not_deletable(self):
+        # when
+        view = DummyAdminView(Booking, fake_db_session)
 
-            # then
-            assert (
-                view.can_delete is False
-            ), "Deletion from admin views is strictly forbidden to guarantee data consistency"
+        # then
+        assert view.can_delete is False, "Deletion from admin views is strictly forbidden to guarantee data consistency"
 
-        def test_model_in_admin_view_is_not_creatable(self):
-            # when
-            view = DummyAdminView(Booking, fake_db_session)
+    def test_model_in_admin_view_is_not_creatable(self):
+        # when
+        view = DummyAdminView(Booking, fake_db_session)
 
-            # then
-            assert (
-                view.can_create is False
-            ), "Creation from admin views is strictly forbidden to guarantee data consistency"
+        # then
+        assert view.can_create is False, "Creation from admin views is strictly forbidden to guarantee data consistency"
 
-        def test_model_in_admin_view_is_not_editable_by_default(self):
-            # when
-            view = DummyAdminView(Booking, fake_db_session)
+    def test_model_in_admin_view_is_not_editable_by_default(self):
+        # when
+        view = DummyAdminView(Booking, fake_db_session)
 
-            # then
-            assert (
-                view.can_edit is False
-            ), "Edition from admin views is disabled by default. It can be enabled on a custom view"
+        # then
+        assert (
+            view.can_edit is False
+        ), "Edition from admin views is disabled by default. It can be enabled on a custom view"
 
-    class IsAccessibleTest:
-        @patch("pcapi.admin.base_configuration.current_user")
-        def test_access_is_forbidden_for_anonymous_users(self, current_user):
-            # given
-            current_user.is_authenticated = False
 
-            # when
-            view = DummyAdminView(Booking, fake_db_session)
+class IsAccessibleTest:
+    @patch("pcapi.admin.base_configuration.current_user")
+    def test_access_is_forbidden_for_anonymous_users(self, current_user):
+        # given
+        current_user.is_authenticated = False
 
-            # then
-            assert not view.is_accessible()
+        # when
+        view = DummyAdminView(Booking, fake_db_session)
 
-        @patch("pcapi.admin.base_configuration.current_user")
-        def test_access_is_forbidden_for_non_admin_users(self, current_user):
-            # given
-            current_user.is_authenticated = True
-            current_user.isAdmin = False
+        # then
+        assert not view.is_accessible()
 
-            # when
-            view = DummyAdminView(Booking, fake_db_session)
+    @patch("pcapi.admin.base_configuration.current_user")
+    def test_access_is_forbidden_for_non_admin_users(self, current_user):
+        # given
+        current_user.is_authenticated = True
+        current_user.isAdmin = False
 
-            # then
-            assert not view.is_accessible()
+        # when
+        view = DummyAdminView(Booking, fake_db_session)
 
-        @patch("pcapi.admin.base_configuration.current_user")
-        def test_access_is_authorized_for_admin_users(self, current_user):
-            # given
-            current_user.is_authenticated = True
-            current_user.isAdmin = True
+        # then
+        assert not view.is_accessible()
 
-            # when
-            view = DummyAdminView(Booking, fake_db_session)
+    @patch("pcapi.admin.base_configuration.current_user")
+    def test_access_is_authorized_for_admin_users(self, current_user):
+        # given
+        current_user.is_authenticated = True
+        current_user.isAdmin = True
 
-            # then
-            assert view.is_accessible() is True
+        # when
+        view = DummyAdminView(Booking, fake_db_session)
 
-        @patch("pcapi.admin.base_configuration.current_user")
-        @override_settings(SUPER_ADMIN_EMAIL_ADDRESSES="", IS_PROD=True)
-        def test_check_super_admins_is_false_for_non_super_admin_users(self, current_user):
-            # given
-            current_user.email = "dummy@email.com"
+        # then
+        assert view.is_accessible() is True
 
-            # when
-            view = DummyAdminView(Booking, fake_db_session)
+    @patch("pcapi.admin.base_configuration.current_user")
+    @override_settings(SUPER_ADMIN_EMAIL_ADDRESSES="", IS_PROD=True)
+    def test_check_super_admins_is_false_for_non_super_admin_users(self, current_user):
+        # given
+        current_user.email = "dummy@email.com"
 
-            # then
-            assert view.check_super_admins() is False
+        # when
+        view = DummyAdminView(Booking, fake_db_session)
 
-        @patch("pcapi.admin.base_configuration.current_user")
-        @override_settings(SUPER_ADMIN_EMAIL_ADDRESSES="super@admin.user", IS_PROD=True)
-        def test_check_super_admins_is_true_for_super_admin_users(self, current_user):
-            # given
-            current_user.email = "super@admin.user"
+        # then
+        assert view.check_super_admins() is False
 
-            # when
-            view = DummyAdminView(Booking, fake_db_session)
+    @patch("pcapi.admin.base_configuration.current_user")
+    @override_settings(SUPER_ADMIN_EMAIL_ADDRESSES="super@admin.user", IS_PROD=True)
+    def test_check_super_admins_is_true_for_super_admin_users(self, current_user):
+        # given
+        current_user.email = "super@admin.user"
 
-            # then
-            assert view.check_super_admins() is True
+        # when
+        view = DummyAdminView(Booking, fake_db_session)
 
-        @patch("pcapi.admin.base_configuration.current_user")
-        @override_settings(SUPER_ADMIN_EMAIL_ADDRESSES="")
-        def test_check_super_admins_is_deactived_in_non_prod_environments(self, current_user):
-            # given
-            current_user.email = "dummy@email.com"
+        # then
+        assert view.check_super_admins() is True
 
-            # when
-            view = DummyAdminView(Booking, fake_db_session)
+    @patch("pcapi.admin.base_configuration.current_user")
+    @override_settings(SUPER_ADMIN_EMAIL_ADDRESSES="")
+    def test_check_super_admins_is_deactived_in_non_prod_environments(self, current_user):
+        # given
+        current_user.email = "dummy@email.com"
 
-            # then
-            assert view.check_super_admins() is True
+        # when
+        view = DummyAdminView(Booking, fake_db_session)
+
+        # then
+        assert view.check_super_admins() is True


### PR DESCRIPTION
Flask admin cache all forms at loading time, which breaks when we want to customize some forms field depending on the user role for instance.

This has been done in `beneficiary_user_view` admin views already, but I think we would like to have this behavior to all our admin views.
The form cache is probably not necessary for our needs