### PR TITLE
qa: Fix GitGuardian configuration

### DIFF
--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -21,5 +21,3 @@ jobs:
           GITHUB_PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
-        matches-ignore:
-            - code-5uzk15fbha4


### PR DESCRIPTION
Those two lines have been introduced in be5ad43730dd98a1032dffdb0ab5b078db1035ba.

They are bogus, GitGuardian fails with:

    The workflow is not valid.
    .github/workflows/gitguardian.yml (Line: 24, Col: 9): Unexpected value 'matches-ignore'

In fact, I don't think this exemption is necessary, since that
password-looking code has been removed in the aforementioned commit.