### PR TITLE
(PC-9689)[FIX] set externalIds if None

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -183,6 +183,8 @@ def create_account(
     )
 
     if apps_flyer_user_id and apps_flyer_platform:
+        if user.externalIds is None:
+            user.externalIds = {}
         user.externalIds["apps_flyer"] = {"user": apps_flyer_user_id, "platform": apps_flyer_platform.upper()}
 
     if not user.age or user.age < constants.ACCOUNT_CREATION_MINIMUM_AGE:

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -453,6 +453,8 @@ class AccountCreationBeforeGrandOpeningTest:
             "token": "gnagna",
             "marketingEmailSubscription": True,
             "postalCode": "93000",
+            "appsFlyerUserId": "some-id",
+            "appsFlyerPlatform": "some-platform",
         }
 
         response = test_client.post("/native/v1/account", json=data)
@@ -466,6 +468,7 @@ class AccountCreationBeforeGrandOpeningTest:
         mocked_check_recaptcha_token_is_valid.assert_called()
         assert user.departementCode == "93"
         assert user.postalCode == "93000"
+        assert user.externalIds == {"apps_flyer": {"platform": "SOME-PLATFORM", "user": "some-id"}}
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0].sent_data["Mj-TemplateID"] == 2015423
         assert push_testing.requests == [


### PR DESCRIPTION
SQLA's default parameter is not applied until the object is saved
into DB, which can cause some trouble if some code expects that
externalIds is never None.