### PR TITLE
search: Fix import loop when `core.search` is imported early

### DIFF
--- a/src/pcapi/core/search/__init__.py
+++ b/src/pcapi/core/search/__init__.py
@@ -2,7 +2,7 @@ import logging
 from typing import Iterable
 
 from pcapi import settings
-import pcapi.core.offers.models as offers_models
+from pcapi.models import Offer
 from pcapi.repository import offer_queries
 from pcapi.utils.module_loading import import_string
 
@@ -174,7 +174,7 @@ def _reindex_offer_ids(backend, offer_ids: Iterable[int]):
     to_delete = []
     # FIXME (dbaty, 2021-06-16): join-load Stock, Venue and Offerer to
     # avoid N+1 queries on each offer.
-    offers = offers_models.Offer.query.filter(offers_models.Offer.id.in_(offer_ids))
+    offers = Offer.query.filter(Offer.id.in_(offer_ids))
     for offer in offers:
         if offer and offer.isBookable:
             to_add.append(offer)


### PR DESCRIPTION
Avoid this:

    Traceback (most recent call last):
      File "/src/pcapi/scheduled_tasks/algolia_clock.py", line 4, in <module>
        from pcapi.core import search
      File "/src/pcapi/core/search/__init__.py", line 5, in <module>
        import pcapi.core.offers.models as offers_models
      File "/src/pcapi/core/offers/models.py", line 36, in <module>
        from pcapi.models.db import Model
      File "/src/pcapi/models/__init__.py", line 8, in <module>
        from pcapi.core.offerers.models import ApiKey
      File "/src/pcapi/core/offerers/models.py", line 33, in <module>
        from pcapi.core.offers.models import Offer
    ImportError: cannot import name 'Offer' from partially initialized module 'pcapi.core.offers.models' (most likely due to a circular import) (/src/pcapi/core/offers/models.py)

Enough is enough. I'll fix that import mess next Friday...