### PR TITLE
flask_app: Cope with badly encoded query string

### DIFF
--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -80,7 +80,7 @@ def log_request_details(response: flask.wrappers.Response) -> flask.wrappers.Res
         "method": request.method,
         "route": str(request.url_rule),  # e.g "/offers/<offer_id>"
         "path": request.path,
-        "queryParams": request.query_string.decode("UTF-8"),
+        "queryParams": request.query_string.decode(request.url_charset, errors="backslashreplace"),
         "size": response.headers.get("Content-Length", type=int),
         "deviceId": request.headers.get("device-id"),
         "sourceIp": request.headers.get("X-Forwarded-For"),


### PR DESCRIPTION
The request may be encoded in something other than "utf-8" (although
it's unlikely). Also, if the client sends badly encoded content, cope
with it and don't fail when logging the request.

---

Exemple d'erreur dans Sentry : https://logs.passculture.app/organizations/sentry/issues/21825