### PR TITLE
(FIX) Return roles for beneficiaries and fix spectree serialization

### DIFF
--- a/src/pcapi/routes/serialization/beneficiaries.py
+++ b/src/pcapi/routes/serialization/beneficiaries.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from pydantic.class_validators import validator
 
 from pcapi.core.users.api import get_domains_credit
-from pcapi.core.users.models import ExpenseDomain
+from pcapi.core.users.models import ExpenseDomain, UserRole
 from pcapi.core.users.models import User
 from pcapi.models.api_errors import ApiErrors
 from pcapi.serialization.utils import humanize_field
@@ -100,6 +100,7 @@ class BeneficiaryAccountResponse(BaseModel):
     wallet_balance: float
     deposit_expiration_date: Optional[datetime]
     wallet_is_activated: bool
+    roles: list[UserRole]
 
     _humanize_id = humanize_field("id")
 
@@ -112,6 +113,7 @@ class BeneficiaryAccountResponse(BaseModel):
     class Config:
         orm_mode = True
         json_encoders = {datetime: format_into_utc_date}
+        use_enum_values = True
 
 
 class PatchBeneficiaryBodyModel(BaseModel):

--- a/src/pcapi/routes/serialization/beneficiaries.py
+++ b/src/pcapi/routes/serialization/beneficiaries.py
@@ -5,8 +5,9 @@ from pydantic import BaseModel
 from pydantic.class_validators import validator
 
 from pcapi.core.users.api import get_domains_credit
-from pcapi.core.users.models import ExpenseDomain, UserRole
+from pcapi.core.users.models import ExpenseDomain
 from pcapi.core.users.models import User
+from pcapi.core.users.models import UserRole
 from pcapi.models.api_errors import ApiErrors
 from pcapi.serialization.utils import humanize_field
 from pcapi.serialization.utils import to_camel
@@ -79,7 +80,7 @@ class BeneficiaryAccountResponse(BaseModel):
     civility: Optional[str]
     dateCreated: datetime
     dateOfBirth: Optional[datetime]
-    departementCode: str
+    departementCode: Optional[str]
     deposit_version: Optional[int]
     domainsCredit: Optional[DomainsCredit]
     email: str

--- a/src/pcapi/routes/serialization/users.py
+++ b/src/pcapi/routes/serialization/users.py
@@ -88,7 +88,7 @@ class SharedLoginUserResponseModel(BaseModel):
     civility: Optional[str]
     dateCreated: datetime
     dateOfBirth: Optional[datetime]
-    departementCode: str
+    departementCode: Optional[str]
     email: str
     firstName: Optional[str]
     hasPhysicalVenues: Optional[bool]

--- a/tests/routes/shared/signin_test.py
+++ b/tests/routes/shared/signin_test.py
@@ -64,6 +64,19 @@ class Returns200Test:
         }
 
     @pytest.mark.usefixtures("db_session")
+    def when_user_has_no_departement_code(self, app):
+        # given
+        user = create_user(email="USER@example.COM", departement_code=None)
+        repository.save(user)
+        data = {"identifier": user.email, "password": user.clearTextPassword}
+
+        # when
+        response = TestClient(app.test_client()).post("/users/signin", json=data)
+
+        # then
+        assert response.status_code == 200
+
+    @pytest.mark.usefixtures("db_session")
     def when_account_is_known_with_mixed_case_email(self, app):
         # given
         user = create_user(email="USER@example.COM")

--- a/tests/routes/webapp/get_beneficiary_profile_test.py
+++ b/tests/routes/webapp/get_beneficiary_profile_test.py
@@ -39,9 +39,9 @@ class Returns200Test:
             "dateCreated": format_into_utc_date(user.dateCreated),
             "dateOfBirth": format_into_utc_date(user.dateOfBirth),
             "departementCode": user.departementCode,
-            'deposit_expiration_date': None,
-            'deposit_version': None,
-            'domainsCredit': None,
+            "deposit_expiration_date": None,
+            "deposit_version": None,
+            "domainsCredit": None,
             "email": "toto@example.com",
             "firstName": user.firstName,
             "hasPhysicalVenues": user.hasPhysicalVenues,
@@ -53,14 +53,14 @@ class Returns200Test:
             "lastName": user.lastName,
             "needsToFillCulturalSurvey": True,
             "needsToSeeTutorials": True,
-            "pk":user.id,
+            "pk": user.id,
             "phoneNumber": user.phoneNumber,
             "postalCode": user.postalCode,
             "publicName": user.publicName,
             "roles": ["BENEFICIARY"],
-            'suspensionReason': '',
-            'wallet_balance': 0.0,
-            'wallet_is_activated': False,
+            "suspensionReason": "",
+            "wallet_balance": 0.0,
+            "wallet_is_activated": False,
         }
 
     @pytest.mark.usefixtures("db_session")
@@ -128,7 +128,7 @@ class Returns200Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_is_created_without_postal_code(self, app):
         # Given
-        UserFactory(email="wallet_test@email.com", postalCode=None)
+        UserFactory(email="wallet_test@email.com", postalCode=None, departementCode=None)
 
         # When
         response = TestClient(app.test_client()).with_auth("wallet_test@email.com").get("/beneficiaries/current")

--- a/tests/routes/webapp/get_beneficiary_profile_test.py
+++ b/tests/routes/webapp/get_beneficiary_profile_test.py
@@ -10,6 +10,8 @@ from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
 from pcapi.model_creators.specific_creators import create_stock_with_thing_offer
 from pcapi.repository import repository
+from pcapi.utils.date import format_into_utc_date
+from pcapi.utils.human_ids import humanize
 
 from tests.conftest import TestClient
 
@@ -29,14 +31,37 @@ class Returns200Test:
 
         # Then
         assert response.status_code == 200
-        json = response.json
-        assert json["email"] == "toto@example.com"
-        assert not json["domainsCredit"]
-        assert "password" not in json
-        assert "clearTextPassword" not in json
-        assert "resetPasswordToken" not in json
-        assert "resetPasswordTokenValidityLimit" not in json
-        assert json["wallet_is_activated"] == False
+        assert response.json == {
+            "activity": user.activity,
+            "address": user.address,
+            "city": user.city,
+            "civility": user.civility,
+            "dateCreated": format_into_utc_date(user.dateCreated),
+            "dateOfBirth": format_into_utc_date(user.dateOfBirth),
+            "departementCode": user.departementCode,
+            'deposit_expiration_date': None,
+            'deposit_version': None,
+            'domainsCredit': None,
+            "email": "toto@example.com",
+            "firstName": user.firstName,
+            "hasPhysicalVenues": user.hasPhysicalVenues,
+            "id": humanize(user.id),
+            "isActive": True,
+            "isAdmin": False,
+            "isBeneficiary": True,
+            "isEmailValidated": True,
+            "lastName": user.lastName,
+            "needsToFillCulturalSurvey": True,
+            "needsToSeeTutorials": True,
+            "pk":user.id,
+            "phoneNumber": user.phoneNumber,
+            "postalCode": user.postalCode,
+            "publicName": user.publicName,
+            "roles": ["BENEFICIARY"],
+            'suspensionReason': '',
+            'wallet_balance': 0.0,
+            'wallet_is_activated': False,
+        }
 
     @pytest.mark.usefixtures("db_session")
     def when_user_is_logged_in_and_has_a_deposit(self, app):

--- a/tests/routes/webapp/patch_beneficiary_test.py
+++ b/tests/routes/webapp/patch_beneficiary_test.py
@@ -52,6 +52,7 @@ def test_patch_beneficiary(app):
         "phoneNumber": user.phoneNumber,
         "postalCode": user.postalCode,
         "publicName": "Anne",
+        "roles": ["BENEFICIARY"],
         "suspensionReason": "",
         "wallet_balance": 500.0,
         "deposit_expiration_date": format_into_utc_date(user.deposit_expiration_date),


### PR DESCRIPTION
Commits à relire séparement
:one: Le premier commit ajoute le retour des rôles sur la route `GET /beneficiaries/current`

:two: Le deuxième commit corrige spectree pour prendre en compte le fait que les codes de départements sont maintenant optionels