### PR TITLE
(PC-9770) add view for categories

### DIFF
--- a/src/pcapi/admin/custom_views/category_view.py
+++ b/src/pcapi/admin/custom_views/category_view.py
@@ -1,0 +1,41 @@
+from dataclasses import fields
+
+from flask import Response
+from flask_admin import expose
+
+from pcapi.admin.base_configuration import BaseCustomAdminView
+from pcapi.core.categories.categories import ALL_CATEGORIES
+from pcapi.core.categories.categories import Category
+from pcapi.core.categories.subcategories import ALL_SUBCATEGORIES
+from pcapi.core.categories.subcategories import Subcategory
+
+
+class CategoryView(BaseCustomAdminView):
+    @expose("/", methods=["GET"])
+    def categories(self) -> Response:
+        column_names = [field.name for field in fields(Category)]
+        column_labels = {
+            "id": "Nom tech de la catégorie",
+        }
+        return self.render(
+            "admin/categories_list.html",
+            categories=ALL_CATEGORIES,
+            column_names=column_names,
+            column_labels=column_labels,
+        )
+
+
+class SubcategoryView(BaseCustomAdminView):
+    @expose("/", methods=["GET"])
+    def subcategories(self) -> Response:
+        column_names = [field.name for field in fields(Subcategory)]
+        column_labels = {
+            "id": "Nom tech de la sous-catégorie",
+            "category_id": "Nom tech de la catégorie",
+        }
+        return self.render(
+            "admin/subcategories_list.html",
+            subcategories=ALL_SUBCATEGORIES,
+            column_names=column_names,
+            column_labels=column_labels,
+        )

--- a/src/pcapi/admin/install.py
+++ b/src/pcapi/admin/install.py
@@ -13,6 +13,8 @@ from pcapi.admin.custom_views.api_key_view import ApiKeyView
 from pcapi.admin.custom_views.beneficiary_import_view import BeneficiaryImportView
 from pcapi.admin.custom_views.beneficiary_user_view import BeneficiaryUserView
 from pcapi.admin.custom_views.booking_view import BookingView
+from pcapi.admin.custom_views.category_view import CategoryView
+from pcapi.admin.custom_views.category_view import SubcategoryView
 from pcapi.admin.custom_views.criteria_view import CriteriaView
 from pcapi.admin.custom_views.feature_view import FeatureView
 from pcapi.admin.custom_views.many_offers_operations_view import ManyOffersOperationsView
@@ -154,6 +156,22 @@ def install_admin_views(admin: Admin, session: Session) -> None:
         SuspendFraudulentUsersView(
             name="Suspension d'utilisateurs via noms de domaine",
             endpoint="/suspend_fraud_users",
+            category=Category.CUSTOM_OPERATIONS,
+        )
+    )
+
+    admin.add_view(
+        CategoryView(
+            name="Catégories",
+            endpoint="/categories",
+            category=Category.CUSTOM_OPERATIONS,
+        )
+    )
+
+    admin.add_view(
+        SubcategoryView(
+            name="Sous-catégories",
+            endpoint="/subcategories",
             category=Category.CUSTOM_OPERATIONS,
         )
     )

--- a/src/pcapi/core/categories/subcategories.py
+++ b/src/pcapi/core/categories/subcategories.py
@@ -36,19 +36,19 @@ class Subcategory:
     id: str
     category_id: str
     matching_type: str
+    pro_label: str
     app_label: str
     search_group: str
     is_event: bool
-    pro_label: str
     conditional_fields: list[str]
     can_expire: bool
     # the booking amount will be substracted from physical cap
     is_physical_deposit: bool
-    reimbursement_rule: str
-    can_be_duo: bool
-    online_offline_platform: str
     # the booking amount will be substracted from digital cap
     is_digital_deposit: bool
+    online_offline_platform: str
+    reimbursement_rule: str
+    can_be_duo: bool
     # used by pc pro to build dropdown of subcategories during offer creation
     is_selectable: bool = True
 

--- a/src/pcapi/templates/admin/categories_list.html
+++ b/src/pcapi/templates/admin/categories_list.html
@@ -1,0 +1,27 @@
+{% extends 'admin/base.html' %}
+
+{% block body %}
+<br>
+<h2>Liste des catégories existantes</h2>
+<br>
+<table class="table table-striped table-bordered table-hover model-list">
+    <tr>
+        {% for column_name in column_names %}
+            {% if column_labels[column_name] %}
+                <th> {{ column_labels[column_name] }}</th>
+            {% else %}
+                <th> {{ column_name }}</th>
+            {% endif %}
+        {% endfor %}
+    </tr>
+    {% for category in categories %}
+    <tr>
+        {% for column_name in column_names %}
+        <td>
+            {{ category[column_name] }}
+        </td>
+        {% endfor %}
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/src/pcapi/templates/admin/offer_categories_list.html
+++ b/src/pcapi/templates/admin/offer_categories_list.html
@@ -1,6 +1,0 @@
-{% extends 'admin/model/list.html' %}
-
-{% block body %}
-    <h2>Catégories d'offres</h2>
-    {{ super() }}
-{% endblock %}

--- a/src/pcapi/templates/admin/offer_subcategories_list.html
+++ b/src/pcapi/templates/admin/offer_subcategories_list.html
@@ -1,6 +1,0 @@
-{% extends 'admin/model/list.html' %}
-
-{% block body %}
-    <h2>Sous-catégories d'offres</h2>
-    {{ super() }}
-{% endblock %}

--- a/src/pcapi/templates/admin/subcategories_list.html
+++ b/src/pcapi/templates/admin/subcategories_list.html
@@ -1,0 +1,33 @@
+{% extends 'admin/base.html' %}
+
+{% block body %}
+<br>
+<h2>Liste des sous-catégories existantes</h2>
+<br>
+<table class="table table-striped table-bordered table-hover">
+    <tr>
+        {% for column_name in column_names %}
+            {% if column_labels[column_name] %}
+                <th> {{ column_labels[column_name] }}</th>
+            {% else %}
+                <th> {{ column_name }}</th>
+            {% endif %}
+        {% endfor %}
+    </tr>
+    {% for subcategory in subcategories %}
+    <tr>
+        {% for column_name in column_names %}
+        <td>
+            {% if subcategory[column_name] == True %}
+            <span class="fa fa-check-circle glyphicon glyphicon-ok-circle icon-ok-circle" style="color:green;"></span>
+            {% elif subcategory[column_name] == False %}
+            <span class="fa fa-minus-circle glyphicon glyphicon-minus-sign icon-minus-sign" style="color:red;"></span>
+            {% else %}
+            {{ subcategory[column_name] }}
+            {% endif %}
+        </td>
+        {% endfor %}
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/tests/admin/custom_views/category_view_test.py
+++ b/tests/admin/custom_views/category_view_test.py
@@ -1,0 +1,25 @@
+import pcapi.core.categories.categories as categories
+import pcapi.core.categories.subcategories as subcategories
+import pcapi.core.users.factories as users_factories
+
+
+class CategoryViewTest:
+    def test_authorized_user(self, app, db_session, client):
+        admin = users_factories.UserFactory(email="admin@example.com", isAdmin=True)
+        client.with_auth(admin.email)
+
+        response = client.get("/pc/back-office/categories")
+
+        assert response.status_code == 200
+        assert any(c.id in response.data.decode("utf-8") for c in categories.ALL_CATEGORIES)
+
+
+class SubcategoryViewTest:
+    def test_authorized_user(self, app, db_session, client):
+        admin = users_factories.UserFactory(email="admin@example.com", isAdmin=True)
+        client.with_auth(admin.email)
+
+        response = client.get("/pc/back-office/subcategories")
+
+        assert response.status_code == 200
+        assert any(s.id in response.data.decode("utf-8") for s in subcategories.ALL_SUBCATEGORIES)


### PR DESCRIPTION
##  Objectif

Ajout des vues FA permettant d'afficher les attributs des `Categories` et `Subcategories`.

##  Implémentation

- Ajout de 2 vues
- Ajout de 2 templates

<img width="1845" alt="FA-categories" src="https://user-images.githubusercontent.com/33030007/123829025-6144e880-d902-11eb-8462-f72ea7d2b789.png">
