### PR TITLE
(PC-9772) : Jouve id card check skipped if fraud controls is off

### DIFF
--- a/src/pcapi/domain/beneficiary_pre_subscription/beneficiary_pre_subscription_validator.py
+++ b/src/pcapi/domain/beneficiary_pre_subscription/beneficiary_pre_subscription_validator.py
@@ -82,6 +82,8 @@ def _check_not_a_duplicate(beneficiary_pre_subscription: BeneficiaryPreSubscript
 
 
 def _check_id_piece_number_is_unique(beneficiary_pre_subscription: BeneficiaryPreSubscription) -> None:
+    if not feature_queries.is_active(FeatureToggle.ENABLE_IDCHECK_FRAUD_CONTROLS):
+        return
     if User.query.filter(User.idPieceNumber == beneficiary_pre_subscription.id_piece_number).count() > 0:
         raise IdPieceNumberDuplicate(f"id piece number n°{beneficiary_pre_subscription.id_piece_number} already taken")
 

--- a/src/pcapi/infrastructure/repository/beneficiary/beneficiary_pre_subscription_sql_converter.py
+++ b/src/pcapi/infrastructure/repository/beneficiary/beneficiary_pre_subscription_sql_converter.py
@@ -6,6 +6,8 @@ from pcapi.core.users.utils import sanitize_email
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription import BeneficiaryPreSubscription
 from pcapi.models import BeneficiaryImport
 from pcapi.models import ImportStatus
+from pcapi.models.feature import FeatureToggle
+from pcapi.repository import feature_queries
 
 
 def to_model(beneficiary_pre_subscription: BeneficiaryPreSubscription, user: Optional[User] = None) -> User:
@@ -47,7 +49,8 @@ def to_model(beneficiary_pre_subscription: BeneficiaryPreSubscription, user: Opt
     beneficiary.lastName = beneficiary_pre_subscription.last_name
     beneficiary.postalCode = beneficiary_pre_subscription.postal_code
     beneficiary.publicName = beneficiary_pre_subscription.public_name
-    beneficiary.idPieceNumber = beneficiary_pre_subscription.id_piece_number
+    if feature_queries.is_active(FeatureToggle.ENABLE_IDCHECK_FRAUD_CONTROLS):
+        beneficiary.idPieceNumber = beneficiary_pre_subscription.id_piece_number
     beneficiary.hasCompletedIdCheck = True
 
     if not beneficiary.phoneNumber:


### PR DESCRIPTION
This is meant to help with validation on testing/staging.
Turns the id card check off and do not save the id card so one
can be used to create several beneficiaries.