### PR TITLE
[PC-8993]: Performance improvements on homepage pro : venue stats

### DIFF
--- a/src/pcapi/alembic/versions/20210705_20349c929b56_adding_perf_venue_stats_feature_flag.py
+++ b/src/pcapi/alembic/versions/20210705_20349c929b56_adding_perf_venue_stats_feature_flag.py
@@ -1,0 +1,26 @@
+"""Adding PERF_VENUE_STATS feature flag
+
+Revision ID: 20349c929b56
+Revises: d9f2a9027e7d
+Create Date: 2021-07-05 14:06:52.076002
+
+"""
+from pcapi.models import feature
+
+
+# revision identifiers, used by Alembic.
+revision = "20349c929b56"
+down_revision = "d9f2a9027e7d"
+branch_labels = None
+depends_on = None
+
+
+FLAG = feature.FeatureToggle.PERF_VENUE_STATS
+
+
+def upgrade() -> None:
+    feature.add_feature_to_database(FLAG)
+
+
+def downgrade() -> None:
+    feature.remove_feature_from_database(FLAG)

--- a/src/pcapi/alembic/versions/20210705_d9f2a9027e7d_adding_offerid_and_venueid_to_bookings.py
+++ b/src/pcapi/alembic/versions/20210705_d9f2a9027e7d_adding_offerid_and_venueid_to_bookings.py
@@ -1,0 +1,50 @@
+"""Adding offerId and venueId to bookings
+
+Revision ID: d9f2a9027e7d
+Revises: bb84cb0e65c2
+Create Date: 2021-07-05 14:06:42.365681
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+from pcapi import settings
+
+
+# revision identifiers, used by Alembic.
+revision = "d9f2a9027e7d"
+down_revision = "bb84cb0e65c2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("booking", sa.Column("offererId", sa.BigInteger(), nullable=True))
+    op.create_index(op.f("ix_booking_offererId"), "booking", ["offererId"], unique=False)
+    op.create_foreign_key(None, "booking", "offerer", ["offererId"], ["id"])
+
+    op.add_column("booking", sa.Column("venueId", sa.BigInteger(), nullable=True))
+    op.create_index(op.f("ix_booking_venueId"), "booking", ["venueId"], unique=False)
+    op.create_foreign_key(None, "booking", "venue", ["venueId"], ["id"])
+
+    if not settings.IS_STAGING and not settings.IS_PROD:
+        op.execute(
+            text(
+                """
+             WITH "bookingByOfferer" AS
+            (SELECT b.id, venue."managingOffererId", venue.id "venueId"
+                FROM booking b JOIN stock ON stock.id = b."stockId"
+                JOIN offer ON offer.id = stock."offerId"
+                JOIN venue on offer."venueId" = venue.id
+                WHERE b."venueId" is null)
+            UPDATE booking SET "offererId"=bbo."managingOffererId", "venueId"=bbo."venueId" FROM "bookingByOfferer" bbo
+            WHERE booking.id=bbo.id
+            """
+            )
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("booking", "offererId")
+    op.drop_column("booking", "venueId")

--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -82,6 +82,8 @@ def book_offer(
             amount=stock.price,
             quantity=quantity,
             token=generate_booking_token(),
+            venueId=stock.offer.venueId,
+            offererId=stock.offer.venue.managingOffererId,
         )
 
         booking.dateCreated = datetime.datetime.utcnow()

--- a/src/pcapi/core/bookings/factories.py
+++ b/src/pcapi/core/bookings/factories.py
@@ -45,6 +45,8 @@ class BookingFactory(BaseFactory):
             stock = kwargs.get("stock")
             stock.dnBookedQuantity = stock.dnBookedQuantity + kwargs.get("quantity", 1)
             kwargs["stock"] = stock
+        kwargs["venue"] = kwargs["stock"].offer.venue
+        kwargs["offerer"] = kwargs["stock"].offer.venue.managingOfferer
         return super()._create(model_class, *args, **kwargs)
 
 

--- a/src/pcapi/core/bookings/models.py
+++ b/src/pcapi/core/bookings/models.py
@@ -52,6 +52,14 @@ class Booking(PcObject, Model):
 
     stock = relationship("Stock", foreign_keys=[stockId], backref="bookings")
 
+    venueId = Column(BigInteger, ForeignKey("venue.id"), index=True, nullable=True)
+
+    venue = relationship("Venue", foreign_keys=[venueId], backref="bookings")
+
+    offererId = Column(BigInteger, ForeignKey("offerer.id"), index=True, nullable=True)
+
+    offerer = relationship("Offerer", foreign_keys=[offererId], backref="bookings")
+
     quantity = Column(Integer, nullable=False, default=1)
 
     token = Column(String(6), unique=True, nullable=False)

--- a/src/pcapi/infrastructure/repository/beneficiary_bookings/beneficiary_bookings_sql_repository.py
+++ b/src/pcapi/infrastructure/repository/beneficiary_bookings/beneficiary_bookings_sql_repository.py
@@ -109,7 +109,7 @@ def _get_bookings_information(beneficiary_id: int) -> list[Booking]:
         .join(Stock, Stock.id == Booking.stockId)
         .join(Offer)
         .join(Product, Offer.productId == Product.id)
-        .join(Venue)
+        .join(Venue, Venue.id == Offer.venueId)
         .outerjoin(ActivationCode, ActivationCode.bookingId == Booking.id)
         .filter(Booking.userId == beneficiary_id)
         .filter(Offer.type.notin_(offer_activation_types))

--- a/src/pcapi/model_creators/generic_creators.py
+++ b/src/pcapi/model_creators/generic_creators.py
@@ -118,13 +118,15 @@ def create_booking(
     is_used: bool = False,
     quantity: int = 1,
     stock: Stock = None,
-    token: str = None,
     venue: Venue = None,
+    token: str = None,
+    offerer: Offerer = None,
 ) -> Booking:
     booking = Booking()
-    offerer = create_offerer(
-        siren="987654321", address="Test address", city="Test city", postal_code="93000", name="Test name"
-    )
+    if offerer is None:
+        offerer = create_offerer(
+            siren="987654321", address="Test address", city="Test city", postal_code="93000", name="Test name"
+        )
     if venue is None:
         venue = create_venue(
             offerer=offerer,
@@ -152,6 +154,8 @@ def create_booking(
     booking.isUsed = is_used
     booking.quantity = quantity
     booking.stock = stock
+    booking.offerer = offerer
+    booking.venue = venue
     booking.token = token if token is not None else random_token()
     booking.userId = user.id
     booking.confirmationDate = bookings_api.compute_confirmation_date(stock.beginningDatetime, date_created)

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -59,6 +59,7 @@ class FeatureToggle(enum.Enum):
     USER_PROFILING_FRAUD_CHECK = "Détection de la fraude basée sur le profil de l'utilisateur"
     BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS = "Active la validation d'un bénéficiaire via les contrôles de sécurité"
     ENABLE_VENUE_WITHDRAWAL_DETAILS = "Active les modalités de retrait sur la page lieu"
+    PERF_VENUE_STATS = "Permet de basculer vers une nouvelle implémentation performante de la page d'accueil pro contenant les indicateurs statistiques par venue"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -102,6 +103,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.USER_PROFILING_FRAUD_CHECK,
     FeatureToggle.BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS,
     FeatureToggle.ENABLE_VENUE_WITHDRAWAL_DETAILS,
+    FeatureToggle.PERF_VENUE_STATS,
 )
 
 

--- a/src/pcapi/routes/pro/offerers.py
+++ b/src/pcapi/routes/pro/offerers.py
@@ -5,12 +5,16 @@ from flask import request
 from flask_login import current_user
 from flask_login import login_required
 
+from pcapi.core.bookings.repository import get_active_bookings_quantity_for_offerer
+from pcapi.core.bookings.repository import get_validated_bookings_quantity_for_offerer
 from pcapi.core.offerers.api import create_digital_venue
 from pcapi.core.offerers.api import generate_and_save_api_key
 from pcapi.core.offerers.exceptions import ApiKeyCountMaxReached
 from pcapi.core.offerers.exceptions import ApiKeyPrefixGenerationError
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.repository import get_all_offerers_for_user
+from pcapi.core.offers.repository import get_active_offers_count_for_venue
+from pcapi.core.offers.repository import get_sold_out_offers_count_for_venue
 from pcapi.domain.admin_emails import maybe_send_offerer_validation_email
 from pcapi.flask_app import private_api
 from pcapi.infrastructure.container import list_offerers_for_pro_user
@@ -24,6 +28,7 @@ from pcapi.routes.serialization.offerers_serialize import GetOffererNameResponse
 from pcapi.routes.serialization.offerers_serialize import GetOffererResponseModel
 from pcapi.routes.serialization.offerers_serialize import GetOfferersNamesQueryModel
 from pcapi.routes.serialization.offerers_serialize import GetOfferersNamesResponseModel
+from pcapi.routes.serialization.venues_serialize import VenueStatsResponseModel
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.use_cases.list_offerers_for_pro_user import OfferersRequestParameters
 from pcapi.utils.human_ids import dehumanize
@@ -108,6 +113,31 @@ def get_offerer(offerer_id: str) -> GetOffererResponseModel:
     offerer = load_or_404(Offerer, offerer_id)
 
     return GetOffererResponseModel.from_orm(offerer)
+
+
+@private_api.route("/offerers/<humanized_offerer_id>/stats", methods=["GET"])
+@login_required
+@spectree_serialize(on_success_status=200, response_model=GetOffererResponseModel)
+def get_venues_by_offerer_with_stats(humanized_offerer_id: str) -> GetOffererResponseModel:
+    check_user_has_access_to_offerer(current_user, dehumanize(humanized_offerer_id))
+    offerer = load_or_404(Offerer, humanized_offerer_id)
+
+    venue_stats_by_ids = {}
+    active_bookings_quantity_by_venue = get_active_bookings_quantity_for_offerer(offerer.id)
+    validated_bookings_quantity_by_venue = get_validated_bookings_quantity_for_offerer(offerer.id)
+
+    for managedVenue in offerer.managedVenues:
+        active_offers_count = get_active_offers_count_for_venue(managedVenue.id)
+        sold_out_offers_count = get_sold_out_offers_count_for_venue(managedVenue.id)
+
+        venue_stats_by_ids[managedVenue.id] = VenueStatsResponseModel(
+            activeBookingsQuantity=active_bookings_quantity_by_venue.get(managedVenue.id, 0),
+            validatedBookingsQuantity=validated_bookings_quantity_by_venue.get(managedVenue.id, 0),
+            activeOffersCount=active_offers_count,
+            soldOutOffersCount=sold_out_offers_count,
+        )
+
+    return GetOffererResponseModel.from_orm(offerer, venue_stats_by_ids)
 
 
 @private_api.route("/offerers/<offerer_id>/api_keys", methods=["POST"])

--- a/src/pcapi/routes/pro/venues.py
+++ b/src/pcapi/routes/pro/venues.py
@@ -1,8 +1,8 @@
 from flask_login import current_user
 from flask_login import login_required
 
-from pcapi.core.bookings.repository import get_active_bookings_quantity_for_venue
-from pcapi.core.bookings.repository import get_validated_bookings_quantity_for_venue
+from pcapi.core.bookings.repository import get_legacy_active_bookings_quantity_for_venue
+from pcapi.core.bookings.repository import get_legacy_validated_bookings_quantity_for_venue
 from pcapi.core.offerers import api as offerers_api
 from pcapi.core.offerers import repository as offerers_repository
 from pcapi.core.offerers.models import Venue
@@ -92,8 +92,8 @@ def get_venue_stats(humanized_venue_id: str) -> VenueStatsResponseModel:
     venue = load_or_404(Venue, humanized_venue_id)
     check_user_has_access_to_offerer(current_user, venue.managingOffererId)
 
-    active_bookings_quantity = get_active_bookings_quantity_for_venue(venue.id)
-    validated_bookings_count = get_validated_bookings_quantity_for_venue(venue.id)
+    active_bookings_quantity = get_legacy_active_bookings_quantity_for_venue(venue.id)
+    validated_bookings_count = get_legacy_validated_bookings_quantity_for_venue(venue.id)
     active_offers_count = get_active_offers_count_for_venue(venue.id)
     sold_out_offers_count = get_sold_out_offers_count_for_venue(venue.id)
 

--- a/src/pcapi/sandboxes/scripts/creators/bookings_recap/bookings_recap.py
+++ b/src/pcapi/sandboxes/scripts/creators/bookings_recap/bookings_recap.py
@@ -1,270 +1,211 @@
 from datetime import datetime
 from datetime import timedelta
 
-from pcapi.core.payments.api import create_deposit
+from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.offers.factories import EventOfferFactory
+from pcapi.core.offers.factories import EventProductFactory
+from pcapi.core.offers.factories import EventStockFactory
+from pcapi.core.offers.factories import OffererFactory
+from pcapi.core.offers.factories import ThingOfferFactory
+from pcapi.core.offers.factories import ThingProductFactory
+from pcapi.core.offers.factories import ThingStockFactory
+from pcapi.core.offers.factories import UserOffererFactory
+from pcapi.core.offers.factories import VenueFactory
+from pcapi.core.payments.factories import DepositFactory
+from pcapi.core.payments.factories import PaymentFactory
+from pcapi.core.payments.factories import PaymentStatusFactory
+from pcapi.core.users.factories import UserFactory
 from pcapi.models import EventType
 from pcapi.models import ThingType
 from pcapi.models.payment_status import TransactionStatus
 from pcapi.repository import repository
-from pcapi.sandboxes.scripts.creators.helpers.sql_creators import create_booking
-from pcapi.sandboxes.scripts.creators.helpers.sql_creators import create_offer_with_event_product
-from pcapi.sandboxes.scripts.creators.helpers.sql_creators import create_offer_with_thing_product
-from pcapi.sandboxes.scripts.creators.helpers.sql_creators import create_offerer
-from pcapi.sandboxes.scripts.creators.helpers.sql_creators import create_payment
-from pcapi.sandboxes.scripts.creators.helpers.sql_creators import create_stock
-from pcapi.sandboxes.scripts.creators.helpers.sql_creators import create_user
-from pcapi.sandboxes.scripts.creators.helpers.sql_creators import create_user_offerer
-from pcapi.sandboxes.scripts.creators.helpers.sql_creators import create_venue
 
 
 def save_bookings_recap_sandbox():
     yesterday = datetime.utcnow() - timedelta(days=1)
     today = datetime.utcnow()
 
-    beneficiary1 = create_user(
-        public_name="Riri Duck",
-        first_name="Riri",
-        last_name="Duck",
-        email="riri.duck@example.com",
-    )
-    beneficiary2 = create_user(
-        public_name="Fifi Brindacier",
-        first_name="Fifi",
-        last_name="Brindacier",
+    beneficiary1 = UserFactory(publicName="Riri Duck", firstName="Riri", lastName="Duck", email="riri.duck@example.com")
+
+    beneficiary2 = UserFactory(
+        publicName="Fifi Brindacier",
+        firstName="Fifi",
+        lastName="Brindacier",
         email="fifi.brindacier@example.com",
     )
-    beneficiary3 = create_user(
-        public_name="LouLou Duck",
-        first_name="Loulou",
-        last_name="Duck",
+    beneficiary3 = UserFactory(
+        publicName="LouLou Duck",
+        firstName="Loulou",
+        lastName="Duck",
         email="loulou.duck@example.com",
     )
 
-    repository.save(beneficiary1, beneficiary2, beneficiary3)
-    deposit1 = create_deposit(beneficiary1, "public")
-    deposit2 = create_deposit(beneficiary2, "public")
-    deposit3 = create_deposit(beneficiary3, "public")
-    repository.save(deposit1, deposit2, deposit3)
+    DepositFactory(user=beneficiary1, version=1)
+    DepositFactory(user=beneficiary1, version=1)
+    DepositFactory(user=beneficiary1, version=1)
 
-    pro = create_user(
-        public_name="Balthazar Picsou",
-        first_name="Balthazar",
-        last_name="Picsou",
+    pro = UserFactory(
+        publicName="Balthazar Picsou",
+        firstName="Balthazar",
+        lastName="Picsou",
         email="balthazar.picsou@example.com",
-        is_beneficiary=False,
+        isBeneficiary=False,
     )
-    offerer = create_offerer(
-        siren="645389012",
-    )
-    user_offerer = create_user_offerer(user=pro, offerer=offerer)
-    venue1 = create_venue(offerer, name="Cinéma Le Monde Perdu", siret="64538901265877")
-    venue2 = create_venue(offerer, name="Librairie Atlantis", siret="64538901201379")
-    venue3 = create_venue(offerer, name="Théatre Mordor", siret="64538954601379")
-    venue4_virtual = create_venue(offerer, name="Un lieu virtuel", siret=None, is_virtual=True)
+    offerer = OffererFactory(siren="645389012")
+    UserOffererFactory(user=pro, offerer=offerer)
+    venue1 = VenueFactory(managingOfferer=offerer, name="Cinéma Le Monde Perdu", siret="64538901265877")
+    venue2 = VenueFactory(managingOfferer=offerer, name="Librairie Atlantis", siret="64538901201379")
+    venue3 = VenueFactory(managingOfferer=offerer, name="Théatre Mordor", siret="64538954601379")
+    venue4_virtual = VenueFactory(managingOfferer=offerer, name="Un lieu virtuel", siret=None, isVirtual=True)
 
-    offer1_venue1 = create_offer_with_event_product(
-        venue=venue1,
-        event_name="Jurassic Park",
-        event_type=EventType.CINEMA,
-        is_duo=True,
-    )
-    stock_1_offer1_venue1 = create_stock(
-        offer=offer1_venue1,
-        beginning_datetime=yesterday,
-        quantity=None,
-        price=12.99,
-    )
-    offer2_venue1 = create_offer_with_event_product(
-        venue=venue1,
-        event_name="Matrix",
-        event_type=EventType.CINEMA,
-        is_duo=False,
-    )
-    stock_2_offer2_venue1 = create_stock(
-        offer=offer2_venue1,
-        beginning_datetime=today,
-        quantity=None,
-        price=0,
+    product1_venue1 = EventProductFactory(name="Jurassic Park", type=str(EventType.CINEMA))
+    offer1_venue1 = EventOfferFactory(product=product1_venue1, venue=venue1, isDuo=True)
+    stock_1_offer1_venue1 = EventStockFactory(
+        offer=offer1_venue1, beginningDatetime=yesterday, quantity=None, price=12.99
     )
 
-    offer1_venue2 = create_offer_with_thing_product(
-        venue=venue2, thing_name="Fondation", thing_type=ThingType.LIVRE_EDITION, extra_data={"isbn": "9788804119135"}
-    )
-    stock_1_offer1_venue2 = create_stock(
-        offer=offer1_venue2,
-        quantity=42,
-        price=9.99,
-    )
-    offer2_venue2 = create_offer_with_thing_product(
-        venue=venue2,
-        thing_name="Martine à la playa",
-        thing_type=ThingType.LIVRE_EDITION,
-        extra_data={"isbn": "9787605639121"},
-    )
-    stock_1_offer2_venue2 = create_stock(
-        offer=offer2_venue2,
-        quantity=12,
-        price=49.99,
-    )
+    product2_venue1 = EventProductFactory(name="Matrix", type=str(EventType.CINEMA))
 
-    offer1_venue3 = create_offer_with_event_product(
-        venue=venue3,
-        event_name="Danse des haricots",
-        event_type=EventType.SPECTACLE_VIVANT,
-    )
-    stock_1_offer1_venue3 = create_stock(
-        offer=offer1_venue3,
-        quantity=44,
-        price=18.50,
-    )
+    offer2_venue1 = EventOfferFactory(product=product2_venue1, venue=venue1, isDuo=False)
+    stock_2_offer2_venue1 = EventStockFactory(offer=offer2_venue1, beginningDatetime=today, quantity=None, price=0)
 
-    offer1_venue4 = create_offer_with_thing_product(
-        venue=venue4_virtual,
-        thing_name="Le livre des haricots",
-        thing_type=ThingType.LIVRE_EDITION,
+    product1_venue2 = ThingProductFactory(
+        name="Fondation", type=str(ThingType.LIVRE_EDITION), extraData={"isbn": "9788804119135"}
     )
-    stock_1_offer1_venue4 = create_stock(
-        offer=offer1_venue4,
-        quantity=70,
-        price=10.99,
-    )
+    offer1_venue2 = ThingOfferFactory(product=product1_venue2, venue=venue2)
+    stock_1_offer1_venue2 = ThingStockFactory(offer=offer1_venue2, quantity=42, price=9.99)
 
-    booking1_beneficiary1 = create_booking(
+    product2_venue2 = ThingProductFactory(
+        name="Martine à la playa", type=str(ThingType.LIVRE_EDITION), extraData={"isbn": "9787605639121"}
+    )
+    offer2_venue2 = ThingOfferFactory(product=product2_venue2, venue=venue2)
+    stock_1_offer2_venue2 = ThingStockFactory(offer=offer2_venue2, quantity=12, price=49.99)
+
+    product1_venue3 = EventProductFactory(name="Danse des haricots", type=str(EventType.SPECTACLE_VIVANT))
+    offer1_venue3 = EventOfferFactory(product=product1_venue3, venue=venue3)
+    stock_1_offer1_venue3 = EventStockFactory(offer=offer1_venue3, quantity=44, price=18.50)
+
+    product1_venue4 = ThingProductFactory(name="Le livre des haricots", type=str(ThingType.LIVRE_EDITION))
+    offer1_venue4 = ThingOfferFactory(product=product1_venue4, venue=venue4_virtual)
+    stock_1_offer1_venue4 = ThingStockFactory(offer=offer1_venue4, quantity=70, price=10.99)
+
+    BookingFactory(
         user=beneficiary1,
         stock=stock_1_offer1_venue1,
-        date_created=datetime(2020, 3, 18, 14, 56, 12, 0),
-        is_used=True,
-        date_used=datetime(2020, 3, 22, 17, 00, 10, 0),
+        dateCreated=datetime(2020, 3, 18, 14, 56, 12, 0),
+        isUsed=True,
+        dateUsed=datetime(2020, 3, 22, 17, 00, 10, 0),
         quantity=2,
     )
-    booking2_beneficiary1 = create_booking(
-        user=beneficiary1,
-        stock=stock_2_offer2_venue1,
-        date_created=datetime(2020, 4, 22, 9, 17, 12, 0),
-    )
-    booking1_beneficiary2 = create_booking(
+
+    BookingFactory(user=beneficiary1, stock=stock_2_offer2_venue1, dateCreated=datetime(2020, 4, 22, 9, 17, 12, 0))
+
+    BookingFactory(
         user=beneficiary2,
         stock=stock_1_offer1_venue1,
-        date_created=datetime(2020, 3, 18, 12, 18, 12, 0),
-        is_used=True,
-        date_used=datetime(2020, 5, 2),
+        dateCreated=datetime(2020, 3, 18, 12, 18, 12, 0),
+        isUsed=True,
+        dateUsed=datetime(2020, 5, 2),
         quantity=2,
     )
-    booking2_beneficiary2 = create_booking(
+
+    booking2_beneficiary2 = BookingFactory(
         user=beneficiary2,
         stock=stock_1_offer1_venue2,
-        date_created=datetime(2020, 4, 12, 14, 31, 12, 0),
-        is_cancelled=False,
+        dateCreated=datetime(2020, 4, 12, 14, 31, 12, 0),
+        isCancelled=False,
     )
-    booking1_beneficiary3 = create_booking(
+
+    booking1_beneficiary3 = BookingFactory(
         user=beneficiary3,
         stock=stock_2_offer2_venue1,
-        date_created=datetime(2020, 1, 4, 19, 31, 12, 0),
-        is_cancelled=False,
-        is_used=True,
-        date_used=datetime(2020, 1, 4, 23, 00, 10, 0),
+        dateCreated=datetime(2020, 1, 4, 19, 31, 12, 0),
+        isCancelled=False,
+        isUsed=True,
+        dateUsed=datetime(2020, 1, 4, 23, 00, 10, 0),
         quantity=2,
     )
-    booking2_beneficiary3 = create_booking(
+
+    booking2_beneficiary3 = BookingFactory(
         user=beneficiary3,
         stock=stock_1_offer1_venue2,
-        date_created=datetime(2020, 3, 21, 22, 9, 12, 0),
-        is_cancelled=False,
+        dateCreated=datetime(2020, 3, 21, 22, 9, 12, 0),
+        isCancelled=False,
     )
-    booking3_beneficiary1 = create_booking(
-        user=beneficiary1,
-        stock=stock_1_offer1_venue3,
-        date_created=datetime(2020, 4, 12, 14, 31, 12, 0),
+
+    booking3_beneficiary1 = BookingFactory(
+        user=beneficiary1, stock=stock_1_offer1_venue3, dateCreated=datetime(2020, 4, 12, 14, 31, 12, 0)
     )
-    payment_booking3_beneficiary1 = create_payment(
-        booking=booking3_beneficiary1, offerer=offerer, status=TransactionStatus.PENDING
-    )
-    booking3_beneficiary2 = create_booking(
+
+    payment_booking3_beneficiary1 = PaymentFactory(booking=booking3_beneficiary1)
+    PaymentStatusFactory(payment=payment_booking3_beneficiary1, status=TransactionStatus.PENDING)
+
+    booking3_beneficiary2 = BookingFactory(
         user=beneficiary2,
         stock=stock_1_offer1_venue3,
-        date_created=datetime(2020, 4, 12, 19, 31, 12, 0),
-        is_used=True,
-        date_used=datetime(2020, 4, 22, 17, 00, 10, 0),
-        is_cancelled=False,
+        dateCreated=datetime(2020, 4, 12, 19, 31, 12, 0),
+        isUsed=True,
+        dateUsed=datetime(2020, 4, 22, 17, 00, 10, 0),
+        isCancelled=False,
     )
-    payment_booking3_beneficiary2 = create_payment(
-        booking=booking3_beneficiary2, offerer=offerer, status=TransactionStatus.SENT
+
+    PaymentFactory(booking=booking3_beneficiary2)
+    PaymentStatusFactory(payment=payment_booking3_beneficiary1, status=TransactionStatus.SENT)
+
+    booking3_beneficiary3 = BookingFactory(
+        user=beneficiary3, stock=stock_1_offer1_venue3, dateCreated=datetime(2020, 4, 12, 22, 9, 12, 0)
     )
-    booking3_beneficiary3 = create_booking(
-        user=beneficiary3,
-        stock=stock_1_offer1_venue3,
-        date_created=datetime(2020, 4, 12, 22, 9, 12, 0),
-    )
-    payment_booking3_beneficiary3 = create_payment(
-        booking=booking3_beneficiary3, offerer=offerer, status=TransactionStatus.ERROR
-    )
-    booking4_beneficiary3 = create_booking(
+
+    payment_booking3_beneficiary3 = PaymentFactory(booking=booking3_beneficiary3)
+    PaymentStatusFactory(payment=payment_booking3_beneficiary3, status=TransactionStatus.ERROR)
+
+    BookingFactory(
         user=beneficiary3,
         stock=stock_1_offer1_venue2,
-        date_created=datetime(2020, 3, 21, 22, 9, 12, 0),
-        is_cancelled=False,
-        is_used=False,
+        dateCreated=datetime(2020, 3, 21, 22, 9, 12, 0),
+        isUsed=True,
+        isCancelled=False,
     )
-    booking5_beneficiary3 = create_booking(
+
+    booking5_beneficiary3 = BookingFactory(
         user=beneficiary3,
         stock=stock_1_offer1_venue4,
-        date_created=datetime(2020, 3, 21, 22, 9, 12, 0),
-        is_cancelled=False,
+        dateCreated=datetime(2020, 3, 21, 22, 9, 12, 0),
+        isCancelled=False,
     )
 
-    booking6_beneficiary3 = create_booking(
+    booking6_beneficiary3 = BookingFactory(
         user=beneficiary3,
         stock=stock_1_offer2_venue2,
-        date_created=datetime(2020, 3, 21, 22, 9, 12, 0),
-        is_used=True,
-        date_used=datetime(2020, 4, 22, 21, 9, 12, 0),
-    )
-    payment_booking6_beneficiary3 = create_payment(
-        booking=booking6_beneficiary3, offerer=offerer, status=TransactionStatus.SENT
+        dateCreated=datetime(2020, 3, 21, 22, 9, 12, 0),
+        isUsed=True,
+        dateUsed=datetime(2020, 4, 22, 21, 9, 12, 0),
     )
 
-    booking7_beneficiary2 = create_booking(
+    payment_booking6_beneficiary3 = PaymentFactory(booking=booking6_beneficiary3)
+    PaymentStatusFactory(payment=payment_booking6_beneficiary3, status=TransactionStatus.SENT)
+
+    booking7_beneficiary2 = BookingFactory(
         user=beneficiary2,
         stock=stock_1_offer2_venue2,
-        date_created=datetime(2020, 4, 21, 22, 6, 12, 0),
-        is_used=True,
-        date_used=datetime(2020, 4, 22, 22, 9, 12, 0),
+        dateCreated=datetime(2020, 4, 21, 22, 6, 12, 0),
+        isUsed=True,
+        dateUsed=datetime(2020, 4, 22, 22, 9, 12, 0),
     )
 
-    payment_booking7_beneficiary2 = create_payment(
-        booking=booking7_beneficiary2, offerer=offerer, status=TransactionStatus.RETRY
-    )
+    payment_booking7_beneficiary2 = PaymentFactory(booking=booking7_beneficiary2)
+    PaymentStatusFactory(payment=payment_booking7_beneficiary2, status=TransactionStatus.RETRY)
 
-    booking8_beneficiary1 = create_booking(
+    BookingFactory(
         user=beneficiary1,
         stock=stock_1_offer2_venue2,
-        date_created=datetime(2020, 2, 21, 22, 6, 12, 0),
-        is_used=True,
-        date_used=datetime(2020, 4, 22, 23, 9, 12, 0),
+        dateCreated=datetime(2020, 2, 21, 22, 6, 12, 0),
+        isUsed=True,
+        dateUsed=datetime(2020, 4, 22, 23, 9, 12, 0),
     )
 
-    payment_booking8_beneficiary1 = create_payment(
-        booking=booking8_beneficiary1, offerer=offerer, status=TransactionStatus.PENDING
-    )
-
-    repository.save(
-        pro,
-        booking1_beneficiary1,
-        booking2_beneficiary1,
-        booking1_beneficiary2,
-        booking2_beneficiary2,
-        booking1_beneficiary3,
-        booking2_beneficiary3,
-        booking5_beneficiary3,
-        payment_booking3_beneficiary1,
-        payment_booking3_beneficiary2,
-        payment_booking3_beneficiary3,
-        user_offerer,
-        payment_booking6_beneficiary3,
-        payment_booking7_beneficiary2,
-        payment_booking8_beneficiary1,
-        booking4_beneficiary3,
-    )
+    payment_booking8_beneficiary1 = PaymentFactory(booking=booking7_beneficiary2)
+    PaymentStatusFactory(payment=payment_booking8_beneficiary1, status=TransactionStatus.PENDING)
 
     bookings_to_cancel = [
         booking2_beneficiary2,

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_activation_offers.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_activation_offers.py
@@ -22,7 +22,7 @@ def create_industrial_activation_offers():
     offer = create_offer_with_thing_product(venue, thing_type=ThingType.ACTIVATION)
     stock = create_stock_with_thing_offer(offerer, venue, offer=offer, price=0, quantity=10000)
 
-    booking = create_booking(user=activated_user, stock=stock, token="ACTIVA", venue=venue)
+    booking = create_booking(user=activated_user, stock=stock, offerer=offerer, venue=venue, token="ACTIVA")
 
     repository.save(booking)
     logger.info("created 1 activation offer")

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_bookings.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_bookings.py
@@ -104,6 +104,7 @@ def _create_bookings_for_other_beneficiaries(
                 date_used=datetime.now() if is_used else None,
                 stock=stock,
                 token=str(token),
+                offerer=offer.venue.managingOfferer,
                 venue=offer.venue,
             )
 

--- a/tests/core/bookings/test_models.py
+++ b/tests/core/bookings/test_models.py
@@ -62,6 +62,8 @@ def test_too_many_bookings_postgresql_exception():
         booking2 = models.Booking()
         booking2.user = users_factories.UserFactory()
         booking2.stock = booking1.stock
+        booking2.offerer = booking1.stock.offer.venue.managingOfferer
+        booking2.venue = booking1.stock.offer.venue
         booking2.quantity = 1
         booking2.amount = booking1.stock.price
         booking2.token = "123456"

--- a/tests/local_providers/titelive_things_test.py
+++ b/tests/local_providers/titelive_things_test.py
@@ -3,7 +3,14 @@ from unittest.mock import patch
 
 import pytest
 
+from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.offers.factories import OffererFactory
+from pcapi.core.offers.factories import ThingOfferFactory
+from pcapi.core.offers.factories import ThingProductFactory
+from pcapi.core.offers.factories import ThingStockFactory
+from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.providers.repository import get_provider_by_local_class
+from pcapi.core.users.factories import UserFactory
 from pcapi.local_providers import TiteLiveThings
 from pcapi.model_creators.generic_creators import create_booking
 from pcapi.model_creators.generic_creators import create_offerer
@@ -17,6 +24,7 @@ from pcapi.models import BookFormat
 from pcapi.models import LocalProviderEvent
 from pcapi.models import Offer
 from pcapi.models import Product
+from pcapi.models import ThingType
 from pcapi.models.local_provider_event import LocalProviderEventType
 from pcapi.repository import repository
 
@@ -952,20 +960,20 @@ class TiteliveThingsTest:
 
         titelive_provider = activate_provider("TiteLiveThings")
         repository.save(titelive_provider)
-        product = create_product_with_thing_type(
-            id_at_providers="9782895026310",
-            thing_name="Presse papier",
-            date_modified_at_last_provider=datetime(2001, 1, 1),
-            last_provider_id=titelive_provider.id,
-        )
-        user = create_user()
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        offer = create_offer_with_thing_product(venue, product=product, is_active=True)
-        stock = create_stock(offer=offer, price=0)
-        booking = create_booking(user=user, stock=stock)
 
-        repository.save(product, offer, booking)
+        user = UserFactory(email="user@example.net")
+        offerer = OffererFactory(siren="123456789")
+        venue = VenueFactory(managingOfferer=offerer)
+        product = ThingProductFactory(
+            idAtProviders="9782895026310",
+            name="Presse papier",
+            type=str(ThingType.LIVRE_EDITION),
+            dateModifiedAtLastProvider=datetime(2001, 1, 1),
+            lastProviderId=titelive_provider.id,
+        )
+        offer = ThingOfferFactory(product=product, venue=venue, isActive=True)
+        stock = ThingStockFactory(offer=offer, price=0)
+        BookingFactory(user=user, stock=stock)
 
         titelive_things = TiteLiveThings()
 

--- a/tests/routes/pro/get_booking_by_token_v2_test.py
+++ b/tests/routes/pro/get_booking_by_token_v2_test.py
@@ -32,7 +32,7 @@ from tests.conftest import TestClient
 class Returns200Test:
     @freeze_time("2019-11-26 18:29:20.891028")
     @pytest.mark.usefixtures("db_session")
-    def when_user_has_rights_and_regular_offer(self, app):
+    def test_when_user_has_rights_and_regular_offer(self, app):
         # Given
         user = users_factories.UserFactory(email="user@example.com", publicName="John Doe")
         admin_user = create_user(email="admin@example.com")
@@ -91,7 +91,7 @@ class Returns200Test:
         }
 
     @pytest.mark.usefixtures("db_session")
-    def when_api_key_is_provided_and_rights_and_regular_offer(self, app):
+    def test_when_api_key_is_provided_and_rights_and_regular_offer(self, app):
         # Given
         user = create_user(email="user@example.com", public_name="John Doe")
         user2 = create_user(email="user2@example.com", public_name="Jane Doe")
@@ -117,7 +117,7 @@ class Returns200Test:
         assert response.status_code == 200
 
     @pytest.mark.usefixtures("db_session")
-    def when_user_has_rights_and_regular_offer_and_token_in_lower_case(self, app):
+    def test_when_user_has_rights_and_regular_offer_and_token_in_lower_case(self, app):
         # Given
         user = create_user(email="user@example.com", public_name="John Doe")
         admin_user = create_user(email="admin@example.com")
@@ -139,7 +139,7 @@ class Returns200Test:
         assert response.status_code == 200
 
     @pytest.mark.usefixtures("db_session")
-    def when_non_standard_origin_header(self, app):
+    def test_when_non_standard_origin_header(self, app):
         # Given
         user = create_user()
         admin_user = create_user(email="admin@example.com")
@@ -169,7 +169,7 @@ class Returns200Test:
 
 
 class Returns401Test:
-    def when_user_not_logged_in_and_doesnt_give_api_key(self, app):
+    def test_when_user_not_logged_in_and_doesnt_give_api_key(self, app):
         # Given
         url = "/v2/bookings/token/MOCKED_TOKEN"
 
@@ -179,7 +179,7 @@ class Returns401Test:
         # Then
         assert response.status_code == 401
 
-    def when_user_not_logged_in_and_given_api_key_does_not_exist(self, app):
+    def test_when_user_not_logged_in_and_given_api_key_does_not_exist(self, app):
         # Given
         url = "/v2/bookings/token/FAKETOKEN"
 
@@ -192,7 +192,7 @@ class Returns401Test:
         assert response.status_code == 401
 
     @pytest.mark.usefixtures("db_session")
-    def when_user_not_logged_in_and_existing_api_key_given_with_no_bearer_prefix(self, app):
+    def test_when_user_not_logged_in_and_existing_api_key_given_with_no_bearer_prefix(self, app):
         # Given
         url = "/v2/bookings/token/FAKETOKEN"
 
@@ -207,7 +207,7 @@ class Returns401Test:
 
 class Returns403Test:
     @pytest.mark.usefixtures("db_session")
-    def when_user_doesnt_have_rights_and_token_exists(self, app):
+    def test_when_user_doesnt_have_rights_and_token_exists(self, app):
         # Given
         user = create_user(email="user@example.com")
         querying_user = create_user(email="querying@example.com")
@@ -228,19 +228,14 @@ class Returns403Test:
         assert response.json["user"] == ["Vous n'avez pas les droits suffisants pour valider cette contremarque."]
 
     @pytest.mark.usefixtures("db_session")
-    def when_given_api_key_not_related_to_booking_offerer(self, app):
+    def test_when_given_api_key_not_related_to_booking_offerer(self, app):
         # Given
-        user = create_user(email="user@example.com")
-        admin_user = create_user(email="admin@example.com")
-        offerer = create_offerer()
-        offerer2 = create_offerer(siren="987654321")
-        user_offerer = create_user_offerer(admin_user, offerer)
-        venue = create_venue(offerer)
-        offer = create_offer_with_event_product(venue, event_name="Event Name")
-        event_occurrence = create_event_occurrence(offer)
-        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-        booking = create_booking(user=user, stock=stock, venue=venue)
-        repository.save(admin_user, booking, user_offerer, offerer2)
+        user = users_factories.UserFactory(email="user@example.com")
+        offerer2 = offers_factories.OffererFactory(siren="987654321")
+        offer = offers_factories.EventOfferFactory(type="EventType.CINEMA")
+        stock = offers_factories.EventStockFactory(offer=offer, price=0)
+        booking = bookings_factories.BookingFactory(user=user, stock=stock)
+
         ApiKeyFactory(offerer=offerer2)
         user2ApiKey = "Bearer development_prefix_clearSecret"
         url = f"/v2/bookings/token/{booking.token}"
@@ -256,7 +251,7 @@ class Returns403Test:
 
     @mock.patch("pcapi.core.bookings.validation.check_is_usable")
     @pytest.mark.usefixtures("db_session")
-    def when_booking_not_confirmed(self, mocked_check_is_usable, app):
+    def test_when_booking_not_confirmed(self, mocked_check_is_usable, app):
         # Given
         next_week = datetime.utcnow() + timedelta(weeks=1)
         unconfirmed_booking = bookings_factories.BookingFactory(stock__beginningDatetime=next_week)
@@ -274,7 +269,7 @@ class Returns403Test:
         assert response.json["booking"] == ["Not confirmed"]
 
     @pytest.mark.usefixtures("db_session")
-    def when_booking_is_cancelled(self, app):
+    def test_when_booking_is_cancelled(self, app):
         # Given
         user = create_user(email="user@example.com")
         admin_user = create_user(email="admin@example.com")
@@ -298,7 +293,7 @@ class Returns403Test:
         assert response.json["booking"] == ["Cette réservation a été annulée"]
 
     @pytest.mark.usefixtures("db_session")
-    def when_booking_is_refunded(self, app):
+    def test_when_booking_is_refunded(self, app):
         # Given
         user = create_user(email="user@example.com")
         admin_user = create_user(email="admin@example.com")
@@ -325,7 +320,7 @@ class Returns403Test:
 
 class Returns404Test:
     @pytest.mark.usefixtures("db_session")
-    def when_booking_is_not_provided_at_all(self, app):
+    def test_when_booking_is_not_provided_at_all(self, app):
         # Given
         user = create_user(email="user@example.com")
         offerer = create_offerer()
@@ -344,7 +339,7 @@ class Returns404Test:
         assert response.status_code == 404
 
     @pytest.mark.usefixtures("db_session")
-    def when_token_user_has_rights_but_token_not_found(self, app):
+    def test_when_token_user_has_rights_but_token_not_found(self, app):
         # Given
         admin_user = create_user(email="admin@example.com")
         repository.save(admin_user)
@@ -358,7 +353,7 @@ class Returns404Test:
         assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
 
     @pytest.mark.usefixtures("db_session")
-    def when_user_has_api_key_but_token_not_found(self, app):
+    def test_when_user_has_api_key_but_token_not_found(self, app):
         # Given
         user = create_user(email="user@example.com")
         admin_user = create_user(email="admin@example.com")
@@ -386,7 +381,7 @@ class Returns404Test:
 
 class Returns410Test:
     @pytest.mark.usefixtures("db_session")
-    def when_booking_is_already_validated(self, app):
+    def test_when_booking_is_already_validated(self, app):
         # Given
         user = create_user(email="user@example.com")
         admin_user = create_user(email="admin@example.com")

--- a/tests/routes/pro/get_offerer_test.py
+++ b/tests/routes/pro/get_offerer_test.py
@@ -13,7 +13,7 @@ from tests.conftest import TestClient
 
 class Returns404Test:
     @pytest.mark.usefixtures("db_session")
-    def when_user_offerer_does_not_exist(self, app):
+    def test_when_user_offerer_does_not_exist(self, app):
         # Given
         pro = users_factories.UserFactory(isBeneficiary=False)
         invalid_id = 12
@@ -28,7 +28,7 @@ class Returns404Test:
 
 class Returns200Test:
     @pytest.mark.usefixtures("db_session")
-    def when_user_has_rights_on_offerer(self, app):
+    def test_when_user_has_rights_on_offerer(self, app):
         # given
 
         pro = users_factories.UserFactory(isBeneficiary=False)

--- a/tests/routes/pro/get_offerer_test.py
+++ b/tests/routes/pro/get_offerer_test.py
@@ -84,6 +84,7 @@ class Returns200Test:
                     "postalCode": offererVenue.postalCode,
                     "publicName": offererVenue.publicName,
                     "siret": offererVenue.siret,
+                    "stats": None,
                     "venueLabelId": humanize(offererVenue.venueLabelId),
                     "venueTypeId": humanize(offererVenue.venueTypeId),
                 }

--- a/tests/routes/webapp/get_booking_by_id_test.py
+++ b/tests/routes/webapp/get_booking_by_id_test.py
@@ -55,6 +55,7 @@ class Returns200Test:
             "isEventExpired": False,
             "isUsed": False,
             "mediation": None,
+            "offererId": humanize(offer.venue.managingOffererId),
             "quantity": 1,
             "stock": {
                 "beginningDatetime": None,
@@ -177,4 +178,5 @@ class Returns200Test:
             "stockId": humanize(stock.id),
             "token": booking.token,
             "userId": humanize(user.id),
+            "venueId": humanize(offer.venue.id),
         }


### PR DESCRIPTION
This Pull request contains 2 commits :
1. Migration from legacy fixtures to Factory Fixtures (Prérequesite for point 2)
2. Adding a new route for pro, Adding feature flip PERF_VENUE_STATS, adding 2 foreign keys to booking and the corresponding indexes to make the queries far more efficient

A manuel migration of data will be perfomed during MEP (according to the corresponding notion page)