### PR TITLE
(PC-9461)[FIX] make departmentCode optional for eligibility

### DIFF
--- a/src/pcapi/domain/beneficiary_pre_subscription/beneficiary_pre_subscription_validator.py
+++ b/src/pcapi/domain/beneficiary_pre_subscription/beneficiary_pre_subscription_validator.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from pcapi.core.users.models import User
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription import BeneficiaryPreSubscription
@@ -35,7 +36,11 @@ EXCLUDED_DEPARTMENTS = {
 }
 
 
-def _is_postal_code_eligible(code: str) -> bool:
+def _is_postal_code_eligible(code: Optional[str]) -> bool:
+    # departmentCode can now be null
+    if not code:
+        return True
+
     # FIXME (dbaty, 2020-01-14): remove this block once we have opened
     # to (almost) all departments.
     # Legacy behaviour: only a few departments are eligible.


### PR DESCRIPTION
La PR précédente a rendu le code de département optionnel ce qui créé une erreur dans `is_eligible` qui fait une vérification sur le département. L'erreur remontée arrivait au moment de l'inscription, lors de l'envoi de l'email, le template a besoin de savoir si l'utilisateur est éligible ou non.

**FIX**

Rendre optionnel le paramètre `code` de `_is_postal_code_eligible` : on ne casse rien et on règle le problème.
Il faudra ensuite revoir toutes les vérifications sur les départements, plus en détail.