### PR TITLE
(PC-9791) : remove poste/serviceCodeCtrl from security checks

### DIFF
--- a/src/pcapi/connectors/beneficiaries/jouve_backend.py
+++ b/src/pcapi/connectors/beneficiaries/jouve_backend.py
@@ -141,8 +141,6 @@ def get_fraud_fields(content: dict) -> dict:
     return {
         "strict_controls": [],
         "non_blocking_controls": [
-            get_boolean_fraud_detection_item(content.posteCodeCtrl, "posteCodeCtrl"),
-            get_boolean_fraud_detection_item(content.serviceCodeCtrl, "serviceCodeCtrl"),
             get_boolean_fraud_detection_item(content.birthLocationCtrl, "birthLocationCtrl"),
             get_threshold_fraud_detection_item(content.bodyBirthDateLevel, "bodyBirthDateLevel", 100),
             get_threshold_fraud_detection_item(content.bodyNameLevel, "bodyNameLevel", 50),

--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -104,8 +104,6 @@ def _id_check_fraud_items(content: models.JouveContent) -> List[models.FraudItem
 
     fraud_items = []
 
-    fraud_items.append(_get_boolean_id_fraud_item(content.posteCodeCtrl, "posteCodeCtrl", False))
-    fraud_items.append(_get_boolean_id_fraud_item(content.serviceCodeCtrl, "serviceCodeCtrl", False))
     fraud_items.append(_get_boolean_id_fraud_item(content.birthLocationCtrl, "birthLocationCtrl", False))
     fraud_items.append(_get_boolean_id_fraud_item(content.bodyBirthDateCtrl, "bodyBirthDateCtrl", False))
     fraud_items.append(_get_boolean_id_fraud_item(content.bodyFirstnameCtrl, "bodyFirstnameCtrl", False))


### PR DESCRIPTION
Since they only seem to be false negative, let's juste remove
them.