### PR TITLE
(PC-9738) : Add FF to disable beneficiary activation from admin

### DIFF
--- a/src/pcapi/admin/custom_views/fraud_view.py
+++ b/src/pcapi/admin/custom_views/fraud_view.py
@@ -12,6 +12,8 @@ import pcapi.core.fraud.models as fraud_models
 import pcapi.core.users.api as users_api
 import pcapi.core.users.models as users_models
 from pcapi.models import db
+from pcapi.models.feature import FeatureToggle
+from pcapi.repository import feature_queries
 
 
 def beneficiary_fraud_result_formatter(view, context, model, name) -> Markup:
@@ -112,7 +114,9 @@ class FraudView(base_configuration.BaseAdminView):
 
     @flask_admin.expose("/validate/beneficiary/<user_id>", methods=["POST"])
     def validate_beneficiary(self, user_id):
-        if not self.check_super_admins():
+        if not self.check_super_admins() or not feature_queries.is_active(
+            FeatureToggle.BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS
+        ):
             flask.flash("Vous n'avez pas les droits suffisant pour activer ce bénéficiaire", "error")
             return flask.redirect(flask.url_for(".details_view", id=user_id))
         form = FraudReviewForm(flask.request.form)

--- a/src/pcapi/alembic/versions/20210630_29c8b67b67a5_add_beneficiary_validation_after_fraud_.py
+++ b/src/pcapi/alembic/versions/20210630_29c8b67b67a5_add_beneficiary_validation_after_fraud_.py
@@ -1,0 +1,26 @@
+"""Add BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS feature flag
+
+Revision ID: 29c8b67b67a5
+Revises: d8b409a3cf0c
+Create Date: 2021-06-30 11:38:09.161751
+
+"""
+from pcapi.models import feature
+
+
+# revision identifiers, used by Alembic.
+revision = "29c8b67b67a5"
+down_revision = "d8b409a3cf0c"
+branch_labels = None
+depends_on = None
+
+
+FLAG = feature.FeatureToggle.BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS
+
+
+def upgrade() -> None:
+    feature.add_feature_to_database(FLAG)
+
+
+def downgrade() -> None:
+    feature.remove_feature_from_database(FLAG)

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -56,6 +56,7 @@ class FeatureToggle(enum.Enum):
     USE_APP_SEARCH_ON_WEBAPP = "Utiliser App Search au lieu d'Algolia sur la webapp"
     ID_CHECK_ADDRESS_AUTOCOMPLETION = "Autocomplétion de l'adresse lors du parcours IDCheck"
     USER_PROFILING_FRAUD_CHECK = "Détection de la fraude basée sur le profil de l'utilisateur"
+    BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS = "Active la validation d'un bénéficiaire via les contrôles de sécurité"
 
 
 class Feature(PcObject, Model, DeactivableMixin):
@@ -81,6 +82,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.USE_APP_SEARCH_ON_WEBAPP,
     FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
     FeatureToggle.USER_PROFILING_FRAUD_CHECK,
+    FeatureToggle.BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS,
 )
 
 

--- a/tests/admin/custom_views/fraud_view_test.py
+++ b/tests/admin/custom_views/fraud_view_test.py
@@ -2,6 +2,7 @@ import pytest
 
 import pcapi.core.fraud.factories as fraud_factories
 import pcapi.core.fraud.models as fraud_models
+from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 import pcapi.core.users.factories as users_factories
 import pcapi.core.users.models as users_models
@@ -34,12 +35,14 @@ class BeneficiaryFraudDetailViewTest:
 
 @pytest.mark.usefixtures("db_session")
 class BeneficiaryFraudValidationViewTest:
+    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_view_auth_required(self, client):
         user = users_factories.UserFactory()
         response = client.post(f"/pc/back-office/beneficiary_fraud/validate/beneficiary/{user.id}")
         assert response.status_code == 302
         assert response.headers["Location"] == "http://localhost/pc/back-office/"
 
+    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_view_validate_user(self, client):
         user = users_factories.UserFactory(isBeneficiary=False)
         admin = users_factories.UserFactory(isAdmin=True)
@@ -58,6 +61,7 @@ class BeneficiaryFraudValidationViewTest:
         assert user.isBeneficiary is True
         assert len(user.deposits) == 1
 
+    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_view_validate_user_wrong_args(self, client):
         user = users_factories.UserFactory(isBeneficiary=False)
         admin = users_factories.UserFactory(isAdmin=True)
@@ -76,6 +80,7 @@ class BeneficiaryFraudValidationViewTest:
         assert user.isBeneficiary is False
         assert user.deposits == []
 
+    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_view_validate_user_already_reviewed(self, client):
         user = users_factories.UserFactory(isBeneficiary=False)
         admin = users_factories.UserFactory(isAdmin=True)
@@ -90,6 +95,7 @@ class BeneficiaryFraudValidationViewTest:
         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one()
         assert review.reason == expected_review.reason
 
+    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_view_validate_not_super_user_fails(self, client):
         user = users_factories.UserFactory(isBeneficiary=False)
         admin = users_factories.UserFactory(isAdmin=True)
@@ -105,6 +111,7 @@ class BeneficiaryFraudValidationViewTest:
         assert review is None
         assert user.isBeneficiary is False
 
+    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_prod_requires_super_admin(self, client):
         user = users_factories.UserFactory(isBeneficiary=False)
         admin = users_factories.UserFactory(isAdmin=True)


### PR DESCRIPTION
Since we have not yet group permissions let's add a feature flag
to allow the validation of beneficiaries by super admins for
validation purposes.