### PR TITLE
search: Fix call to async_index_offer_ids

### DIFF
--- a/src/pcapi/core/search/__init__.py
+++ b/src/pcapi/core/search/__init__.py
@@ -34,6 +34,8 @@ def async_index_offer_ids(offer_ids: Iterable[int]) -> None:
         try:
             backend.enqueue_offer_ids(offer_ids)
         except Exception:  # pylint: disable=broad-except
+            if settings.IS_RUNNING_TESTS:
+                raise
             logger.exception(
                 "Could not enqueue offer ids to index", extra={"offers": offer_ids, "backend": str(backend)}
             )
@@ -51,6 +53,8 @@ def async_index_venue_ids(venue_ids: Iterable[int]) -> None:
         try:
             backend.enqueue_venue_ids(venue_ids)
         except Exception:  # pylint: disable=broad-except
+            if settings.IS_RUNNING_TESTS:
+                raise
             logger.exception(
                 "Could not enqueue venue ids to index", extra={"venues": venue_ids, "backend": str(backend)}
             )
@@ -81,6 +85,8 @@ def index_offers_in_queue(stop_only_when_empty: bool = False, from_error_queue: 
                 backend, stop_only_when_empty=stop_only_when_empty, from_error_queue=from_error_queue
             )
         except Exception:  # pylint: disable=broad-except
+            if settings.IS_RUNNING_TESTS:
+                raise
             logger.exception("Could not index offers from queue", extra={"backend": str(backend)})
 
 
@@ -105,6 +111,8 @@ def _index_offers_in_queue(backend, stop_only_when_empty: bool = False, from_err
         try:
             _reindex_offer_ids(backend, offer_ids)
         except Exception as exc:  # pylint: disable=broad-except
+            if settings.IS_RUNNING_TESTS:
+                raise
             logger.exception(
                 "Exception while reindexing offers, must fix manually",
                 extra={
@@ -131,6 +139,8 @@ def index_venues_in_queue():
         try:
             _index_venues_in_queue(backend)
         except Exception:  # pylint: disable=broad-except
+            if settings.IS_RUNNING_TESTS:
+                raise
             logger.exception("Could not index venues from queue", extra={"backend": str(backend)})
 
 
@@ -166,6 +176,8 @@ def reindex_offer_ids(offer_ids: Iterable[int]):
         try:
             _reindex_offer_ids(backend, offer_ids)
         except Exception:  # pylint: disable=broad-except
+            if settings.IS_RUNNING_TESTS:
+                raise
             logger.exception("Could not reindex offers", extra={"offers": offer_ids, "backend": str(backend)})
 
 
@@ -193,6 +205,8 @@ def _reindex_offer_ids(backend, offer_ids: Iterable[int]):
     try:
         backend.index_offers(to_add)
     except Exception as exc:  # pylint: disable=broad-except
+        if settings.IS_RUNNING_TESTS:
+            raise
         logger.warning(
             "Could not reindex offers, will automatically retry",
             extra={"exc": str(exc), "offers": [offer.id for offer in to_add], "backend": str(backend)},
@@ -204,6 +218,8 @@ def _reindex_offer_ids(backend, offer_ids: Iterable[int]):
     try:
         backend.unindex_offer_ids([offer.id for offer in to_delete])
     except Exception as exc:  # pylint: disable=broad-except
+        if settings.IS_RUNNING_TESTS:
+            raise
         logger.warning(
             "Could not unindex offers, will automatically retry",
             extra={"exc": str(exc), "offers": [offer.id for offer in to_delete], "backend": str(backend)},
@@ -218,6 +234,8 @@ def unindex_offer_ids(offer_ids: Iterable[int]):
         try:
             backend.unindex_offer_ids(offer_ids)
         except Exception:  # pylint: disable=broad-except
+            if settings.IS_RUNNING_TESTS:
+                raise
             logger.exception("Could not unindex offers", extra={"offers": offer_ids, "backend": str(backend)})
 
 
@@ -229,4 +247,6 @@ def unindex_all_offers():
         try:
             backend.unindex_all_offers()
         except Exception:  # pylint: disable=broad-except
+            if settings.IS_RUNNING_TESTS:
+                raise
             logger.exception("Could not unindex all offers", extra={"backend": str(backend)})

--- a/src/pcapi/core/search/backends/algolia.py
+++ b/src/pcapi/core/search/backends/algolia.py
@@ -102,7 +102,7 @@ class AlgoliaBackend(base.SearchBackend):
             if settings.IS_RUNNING_TESTS:
                 raise
             logger.exception("Could not get venue ids to index from queue")
-            return []
+            return set()
 
     def delete_venue_ids_from_queue(self, venue_ids: Iterable[int]) -> None:
         if not venue_ids:

--- a/src/pcapi/local_providers/local_provider.py
+++ b/src/pcapi/local_providers/local_provider.py
@@ -265,4 +265,4 @@ def _reindex_offers(created_or_updated_objects):
             offer_ids.add(obj.offerId)
         elif isinstance(obj, Offer):
             offer_ids.add(obj.id)
-    search.async_index_offer_ids([offer_ids])
+    search.async_index_offer_ids(offer_ids)

--- a/tests/core/search/test_api.py
+++ b/tests/core/search/test_api.py
@@ -76,7 +76,8 @@ class ReindexOfferIdsTest:
     def test_handle_indexation_error(self):
         offer = make_bookable_offer()
         assert search_testing.search_store == {}
-        search.reindex_offer_ids([offer.id])
+        with override_settings(IS_RUNNING_TESTS=False):  # as on prod: don't catch errors
+            search.reindex_offer_ids([offer.id])
         assert offer.id not in search_testing.search_store
         backend = search._get_backends()[0]
         assert backend.pop_offer_ids_from_queue(5, from_error_queue=True) == {offer.id}
@@ -86,7 +87,8 @@ class ReindexOfferIdsTest:
         offer = make_unbookable_offer()
         app.redis_client.hset("indexed_offers", offer.id, "")
         search_testing.search_store[offer.id] = "dummy"
-        search.reindex_offer_ids([offer.id])
+        with override_settings(IS_RUNNING_TESTS=False):  # as on prod: don't catch errors
+            search.reindex_offer_ids([offer.id])
         assert offer.id in search_testing.search_store
         backend = search._get_backends()[0]
         assert backend.pop_offer_ids_from_queue(5, from_error_queue=True) == {offer.id}


### PR DESCRIPTION
Spotted by @fseguin.


search: Don't catch errors during tests

This could mask errors, such as calling a function of the Redis client
with wrong arguments.


____ WIP: DO NOT MERGE : Revert "search: Fix call to async_index_offer_ids"

This reverts commit 2fca021513c2238e45887c58f13cc1610b98122d.