### PR TITLE
(Api native) Remove unused field offer.isActive

### DIFF
--- a/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/src/pcapi/routes/native/v1/serialization/offers.py
@@ -202,7 +202,6 @@ class OfferResponse(BaseModel):
     expense_domains: list[ExpenseDomain]
     externalTicketOfficeUrl: Optional[str]
     extraData: Optional[OfferExtraData]
-    isActive: bool  # TODO (viconnex): remove field when frontend uses isReleased
     canExpire: bool
     isExpired: bool
     isReleased: bool

--- a/tests/routes/native/v1/offers_test.py
+++ b/tests/routes/native/v1/offers_test.py
@@ -134,7 +134,6 @@ class OffersTest:
                 "visa": "vasi",
             },
             "image": {"url": "http://localhost/storage/thumbs/mediations/N4", "credit": "street credit"},
-            "isActive": True,
             "isExpired": False,
             "isSoldOut": False,
             "isDuo": True,


### PR DESCRIPTION
This field is not used on the mobile app. Last commit:
https://github.com/pass-culture/pass-culture-app-native/commit/e7948b4bb7d8ee2c9c619d053820df486ea92191
and was not in production so it is safe to remove.