### PR TITLE
(PC-9334) add clean duplicated offers script

### DIFF
--- a/src/pcapi/scripts/clean_duplicated_offers.py
+++ b/src/pcapi/scripts/clean_duplicated_offers.py
@@ -1,0 +1,129 @@
+from time import time
+from typing import Optional
+
+from pcapi.models import db
+
+
+VENUE_IDS_WITH_DUPLICATES_SQL = """
+-- Two rows with the same venueId and the same id given by the provider
+-- (isbn in the query) are duplicates.
+SELECT distinct("venueId")
+FROM (
+
+    -- find venue ids that have duplicated offers
+    SELECT "venueId"
+    FROM (
+
+        -- extract isbn from idAtProviders in order to perform
+        -- a group by
+        SELECT "id", "venueId", split_part("idAtProviders", '@', 1) isbn
+        FROM offer
+        WHERE "idAtProviders" is not null
+
+    ) offer
+    GROUP BY "venueId", "isbn"
+    HAVING count("isbn") > 1
+
+) sub
+"""
+
+UPDATE_VENUE_DUPLICATES_SQL = """
+UPDATE offer
+SET
+    "lastProviderId" = null,
+    "idAtProviders" = null,
+    "idAtProvider" = null
+WHERE
+    id in (
+        -- Do not update the most recent row: it is the valid one.
+        -- Since offer ids are integers, we can sort them and move the most
+        -- recent out.
+        --
+        -- sort(ids, 'desc') -> sort items, descending order
+        -- (...)[2:] -> slice list, remove first item (1-based indexing)
+        -- unnest(...) -> for each item, build a new row
+        --
+        -- NOTE: sort() is provided by the intarray module, which must be
+        -- activated
+        SELECT unnest((sort(ids, 'desc'))[2:])
+        FROM (
+
+            -- search for the duplicates offers from a specific venue
+            -- convert id to integer, because sort() does not handle big integers
+            SELECT array_agg(id::integer) as ids
+            FROM (
+
+                -- extract isbn from idAtProviders in order to perform
+                -- a group by
+                SELECT "id", "venueId", split_part("idAtProviders", '@', 1) isbn
+                FROM offer
+                WHERE
+                    "idAtProviders" is not null
+                    AND "venueId" = :venue_id
+
+            ) extract_isbn
+            GROUP BY "isbn"
+            HAVING count("isbn") > 1
+
+        ) agg_venue_ids
+    )
+RETURNING id
+"""
+
+
+COUNT_DUPLICATES_SQL = """
+SELECT count(*)
+FROM (
+    SELECT "venueId", "isbn"
+    FROM (
+
+        -- extract isbn from idAtProviders in order to perform
+        -- a group by
+        SELECT "id", "venueId", split_part("idAtProviders", '@', 1) isbn
+        FROM offer
+        WHERE "idAtProviders" is not null
+
+    ) extract_isbn
+    GROUP BY "venueId", "isbn"
+    HAVING count("isbn") > 1
+) main
+"""
+
+
+def get_venue_ids_with_duplicates() -> set[int]:
+    res = db.session.execute(VENUE_IDS_WITH_DUPLICATES_SQL)
+    return {row.venueId for row in res}
+
+
+def count_duplicate_offers() -> int:
+    return db.session.execute(COUNT_DUPLICATES_SQL).scalar()
+
+
+def handle_venue_duplicates(venue_id: int) -> set[int]:
+    res = db.session.execute(UPDATE_VENUE_DUPLICATES_SQL, {"venue_id": venue_id})
+    return {row[0] for row in res}
+
+
+def handle_offer_duplicates(path: Optional[str]) -> set[int]:
+    """
+    Update offer rows that are duplicates.
+
+    Note that the duplicating computation occurs twice: first time inside
+    get_venue_ids_with_duplicates to get the venues with duplicates, second
+    one in handle_venue_duplicates (for a specific venue) that does the update.
+    """
+    # Needed by the UPDATE_VENUE_DUPLICATES_SQL query
+    db.session.execute("CREATE EXTENSION if not exists intarray")
+
+    updated_ids = set()
+    for venue_id in get_venue_ids_with_duplicates():
+        updated_ids |= handle_venue_duplicates(venue_id)
+
+    if not path:
+        path = f"duplicated_offer_ids_{int(time())}"
+
+    with open(path, mode="w") as f:
+        rows = "\n,".join([str(updated_id) for updated_id in updated_ids])
+        f.write(rows)
+
+    return updated_ids

--- a/tests/scripts/clean_duplicated_offers_test.py
+++ b/tests/scripts/clean_duplicated_offers_test.py
@@ -1,0 +1,83 @@
+import pytest
+
+from pcapi.core.offerers.factories import VenueFactory
+from pcapi.core.offers.factories import OfferFactory
+from pcapi.scripts.clean_duplicated_offers import count_duplicate_offers
+from pcapi.scripts.clean_duplicated_offers import get_venue_ids_with_duplicates
+from pcapi.scripts.clean_duplicated_offers import handle_offer_duplicates
+
+
+class VenueOffersWrapper:
+    def __init__(self, nb_duplicates, nb_regulars):
+        self.venue = VenueFactory()
+
+        self.duplicates = [
+            (
+                OfferFactory(idAtProviders=f"duplicate-id-{count}@siret-venue-{self.venue.id}", venue=self.venue),
+                OfferFactory(idAtProviders=f"duplicate-id-{count}@other-siret-venue-{self.venue.id}", venue=self.venue),
+            )
+            for count in range(nb_duplicates)
+        ]
+
+        self.others = [
+            OfferFactory(idAtProviders=f"regular-id-{count}@siret-venue-{self.venue.id}", venue=self.venue)
+            for count in range(nb_regulars)
+        ]
+
+
+@pytest.mark.usefixtures("db_session")
+def test_get_venue_ids_with_duplicates(app):
+    venues_with_duplicates = [
+        VenueOffersWrapper(nb_duplicates=1, nb_regulars=0),
+        VenueOffersWrapper(nb_duplicates=2, nb_regulars=1),
+    ]
+
+    VenueOffersWrapper(nb_duplicates=0, nb_regulars=1)
+
+    venue_ids = get_venue_ids_with_duplicates()
+    assert venue_ids == {wrapper.venue.id for wrapper in venues_with_duplicates}
+
+
+@pytest.mark.usefixtures("db_session")
+def test_count_duplicates(app):
+    VenueOffersWrapper(nb_duplicates=3, nb_regulars=1)
+    VenueOffersWrapper(nb_duplicates=0, nb_regulars=2)
+
+    assert count_duplicate_offers() == 3
+
+
+@pytest.mark.usefixtures("db_session")
+def test_handle_offer_duplicates(app, tmp_path):
+    """
+    Test that the expected duplicated rows have been updated (and no more)
+    The most recent ones remain unchanged, same for offers that have no
+    duplicates.
+    """
+    venues_with_duplicates = [
+        VenueOffersWrapper(nb_duplicates=1, nb_regulars=0),
+        VenueOffersWrapper(nb_duplicates=1, nb_regulars=6),
+        VenueOffersWrapper(nb_duplicates=2, nb_regulars=1),
+        VenueOffersWrapper(nb_duplicates=3, nb_regulars=5),
+    ]
+
+    VenueOffersWrapper(nb_duplicates=0, nb_regulars=2)
+    VenueOffersWrapper(nb_duplicates=0, nb_regulars=3)
+
+    updated_ids = handle_offer_duplicates(tmp_path / "updated_offer_ids")
+
+    assert count_duplicate_offers() == 0
+
+    expected_ids = set()
+    for venue_wrapper in venues_with_duplicates:
+        for duplicates in venue_wrapper.duplicates:
+            # first duplicate row: oldest one -> should have been updated
+            assert not duplicates[0].lastProviderId
+            assert not duplicates[0].idAtProviders
+            assert not duplicates[0].idAtProvider
+
+            expected_ids.add(duplicates[0].id)
+
+            # second duplicate row: most recent one -> should not have been updated
+            assert duplicates[1].idAtProviders
+
+    assert updated_ids == expected_ids


### PR DESCRIPTION
**Besoin**

Corriger les offres dupliquées, lieu par lieu puisqu'il semble que ces offres sont concentrées dans quelques lieux uniquement.

⚠️ cette PR active [le module `intarray `de Postgresql](https://www.postgresql.org/docs/12/intarray.html), qui nous permet de trier une liste d'entier ⚠️ 

Note : la conversion des id des offres en `integer `(`big integer` -> `integer`) ne devrait pas poser de soucis, ça devrait rester largement dans les limites du type `integer`.