### PR TITLE
(PC-9834) address is now mandatory

### DIFF
--- a/src/pcapi/routes/native/v1/serialization/account.py
+++ b/src/pcapi/routes/native/v1/serialization/account.py
@@ -174,7 +174,7 @@ class UserProfileUpdateRequest(BaseModel):
 
 
 class BeneficiaryInformationUpdateRequest(BaseModel):
-    address: Optional[str]
+    address: str
     city: str
     postal_code: str
     activity: ActivityEnum


### PR DESCRIPTION
**Besoin**

Rendre l'adresse obligatoire lors de l'inscription

**Implémentation**

Cette contrainte est limitée à l'API. Aucune modification n'est faite en BDD : comment gérer les utilisateurs existant n'en ayant aucune ? valeur par défaut ? Sans parler du coût de la migration (temps / ressources).