### PR TITLE
payments: Remove SQLAlchemy sugar from get_venues_to_reimburse()

### DIFF
--- a/src/pcapi/core/bookings/repository.py
+++ b/src/pcapi/core/bookings/repository.py
@@ -460,7 +460,7 @@ def _find_bookings_eligible_for_payment(cutoff_date: datetime) -> Query:
     # fmt: off
     return (
         _query_keep_only_used_and_non_cancelled_bookings_on_non_activation_offers()
-        .filter(Booking.dateUsed < cutoff_date)
+        .filter(Booking.dateUsed < cutoff_date, Booking.amount > 0)
         .filter(
             ~(cast(Stock.beginningDatetime, Date) >= date.today())
             | (Stock.beginningDatetime.is_(None))

--- a/src/pcapi/scripts/payment/batch_steps.py
+++ b/src/pcapi/scripts/payment/batch_steps.py
@@ -60,7 +60,7 @@ def get_venues_to_reimburse(cutoff_date: datetime) -> Iterable[tuple[id, str]]:
         .join(Offer)
         .join(Stock)
         .join(Booking)
-        .filter(Booking.dateUsed < cutoff_date, ~Booking.isCancelled)
+        .filter(Booking.dateUsed < cutoff_date, ~Booking.isCancelled, Booking.amount > 0)
         .outerjoin(Payment, Booking.id == Payment.bookingId)
         .filter(Payment.id.is_(None))
         .with_entities(Venue.id, Venue.publicName, Venue.name)


### PR DESCRIPTION
We don't need the alias on Booking (since the table is only joined
once) and `sql.and_()` is also useless.


payments: Ignore free offers when looking for bookings to reimburse

It used to be implicit that free bookings were not reimbursed, because
"standard" rules yielded a 0 € reimbursement that was ignored (i.e. it
did not generate a Payment object).

However, an offer may now have a custom reimbursement rule. If one of
its stock used to be 0 € for a while (because of a manual entry
error), then the corresponding bookings would be free and yet we would
calculate a custom reimbursement amount (based on the real price of
the offer) for them.  Of course we don't want to reimburse an offerer
for free bookings.

(Yes, it happened on stock 5160973 which had 4 free bookings: 601757,
615731, 624400 and 1226123. We blocked them manually, but that was
more work than we would like.)