### PR TITLE
(PC-6977) [FIX] booking confirmation email: missing departement code

### DIFF
--- a/src/pcapi/utils/date.py
+++ b/src/pcapi/utils/date.py
@@ -77,8 +77,6 @@ def get_postal_code_timezone(postal_code: str) -> str:
 
 
 def get_department_timezone(departement_code: str) -> str:
-    assert isinstance(departement_code, str)
-
     return CUSTOM_TIMEZONES.get(departement_code, METROPOLE_TIMEZONE)
 
 

--- a/tests/emails/beneficiary_booking_confirmation_test.py
+++ b/tests/emails/beneficiary_booking_confirmation_test.py
@@ -310,3 +310,20 @@ def test_should_return_total_price_for_duo_offers():
     booking = bookings_factories.BookingFactory(quantity=2, stock__price=10)
     email_data = retrieve_data_for_beneficiary_booking_confirmation_email(booking)
     assert email_data["Vars"]["offer_price"] == "20.00 €"
+
+
+@pytest.mark.usefixtures("db_session")
+def test_digital_offer_without_departement_code_information():
+    """
+    Test that a user without any postal code information can book a digital
+    offer. The booking date information should use the default timezone:
+    metropolitan France.
+    """
+    offer = offers_factories.DigitalOfferFactory()
+    stock = offers_factories.StockFactory(offer=offer)
+    date_created = datetime(2021, 7, 1, 10, 0, 0, tzinfo=timezone.utc)
+    booking = bookings_factories.BookingFactory(stock=stock, dateCreated=date_created, user__departementCode=None)
+
+    email_data = retrieve_data_for_beneficiary_booking_confirmation_email(booking)
+    assert email_data["Vars"]["booking_date"] == "1 juillet 2021"
+    assert email_data["Vars"]["booking_hour"] == "12h00"

--- a/tests/utils/date_test.py
+++ b/tests/utils/date_test.py
@@ -1,7 +1,6 @@
 import datetime
 
 import dateutil
-import pytest
 
 from pcapi.utils.date import CUSTOM_TIMEZONES
 from pcapi.utils.date import get_date_formatted_for_email
@@ -45,11 +44,6 @@ class GetTimeFormattedForEmailTest:
 
 
 class GetDepartmentTimezoneTest:
-    def test_should_alert_when_department_code_is_not_a_string(self):
-        # When
-        with pytest.raises(AssertionError):
-            get_department_timezone(86)
-
     def test_should_return_paris_as_default_timezone(self):
         assert get_department_timezone("1") == "Europe/Paris"
 


### PR DESCRIPTION
Lorsqu'un utilisateur sans département essaie de réserver une offre numérique, on a une erreur lors de la construction de l'email de confirmation de réservation.

Le code cherche à s'assurer que le département est bien de type `str`, ce qui est inutile puisqu'une clé de dict peut être d'un autre type. La clé peut même être `None `puisque `None` est _hashable_.