### PR TITLE
[PC-9514] remove field offer.canExpire (app native)

### DIFF
--- a/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/src/pcapi/routes/native/v1/serialization/offers.py
@@ -202,7 +202,6 @@ class OfferResponse(BaseModel):
     expense_domains: list[ExpenseDomain]
     externalTicketOfficeUrl: Optional[str]
     extraData: Optional[OfferExtraData]
-    canExpire: bool
     isExpired: bool
     isReleased: bool
     isSoldOut: bool

--- a/tests/routes/native/v1/offers_test.py
+++ b/tests/routes/native/v1/offers_test.py
@@ -79,7 +79,6 @@ class OffersTest:
                 "motorDisability": False,
                 "visualDisability": True,
             },
-            "canExpire": False,
             "stocks": [
                 {
                     "id": bookableStock.id,
@@ -174,33 +173,6 @@ class OffersTest:
             "name": "VISITE",
         }
         assert not response.json["isExpired"]
-        assert response.json["canExpire"] is True
-
-    def test_get_digital_offer_book_cannot_exire(self, app):
-        product = ProductFactory(thumbCount=1)
-        offer_type = ThingType.LIVRE_AUDIO
-        offer = OfferFactory(type=str(offer_type), product=product)
-        ThingStockFactory(offer=offer, price=12.34)
-
-        offer_id = offer.id
-        with assert_num_queries(1):
-            response = TestClient(app.test_client()).get(f"/native/v1/offer/{offer_id}")
-
-        assert response.status_code == 200
-        assert response.json["canExpire"] is False
-
-    def test_get_digital_offer_press_cannot_exire(self, app):
-        product = ProductFactory(thumbCount=1)
-        offer_type = ThingType.PRESSE_ABO
-        offer = OfferFactory(type=str(offer_type), product=product)
-        ThingStockFactory(offer=offer, price=12.34)
-
-        offer_id = offer.id
-        with assert_num_queries(1):
-            response = TestClient(app.test_client()).get(f"/native/v1/offer/{offer_id}")
-
-        assert response.status_code == 200
-        assert response.json["canExpire"] is False
 
     def test_get_digital_offer_with_available_activation_and_no_expiration_date(self, app):
         # given


### PR DESCRIPTION
This reverts commit 145c8df237fe0eb3c423a0988a67d53aa5ba6383.

This field is not used by the mobile application.