### PR TITLE
Fraud fix after manual tests

### DIFF
--- a/src/pcapi/admin/custom_views/fraud_view.py
+++ b/src/pcapi/admin/custom_views/fraud_view.py
@@ -80,7 +80,13 @@ class FraudView(base_configuration.BaseAdminView):
     }
 
     column_searchable_list = ["id", "email", "firstName", "lastName"]
-    column_filters = ["postalCode", "email", "beneficiaryFraudResult.status", "beneficiaryFraudChecks.type"]
+    column_filters = [
+        "postalCode",
+        "email",
+        "beneficiaryFraudResult.status",
+        "beneficiaryFraudChecks.type",
+        "beneficiaryFraudReview",
+    ]
 
     can_view_details = True
     details_template = "admin/fraud_details.html"

--- a/src/pcapi/admin/custom_views/fraud_view.py
+++ b/src/pcapi/admin/custom_views/fraud_view.py
@@ -8,6 +8,7 @@ import wtforms
 import wtforms.validators
 
 from pcapi.admin import base_configuration
+import pcapi.core.fraud.api as fraud_api
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.users.api as users_api
 import pcapi.core.users.models as users_models
@@ -143,6 +144,7 @@ class FraudView(base_configuration.BaseAdminView):
         )
         db.session.add(review)
         db.session.commit()
+        users_api.update_user_information_from_external_source(user, fraud_api.get_source_data(user))
         users_api.activate_beneficiary(user, "fraud_validation")
         flask.flash(f"Une revue manuelle ajoutée pour le bénéficiaire {user.firstName} {user.lastName}")
         return flask.redirect(flask.url_for(".details_view", id=user_id))

--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -160,3 +160,16 @@ def create_user_profiling_check(
     )
     repository.save(fraud_check)
     return fraud_check
+
+
+def get_source_data(user: User) -> models.JouveContent:
+    mapped_class = {models.FraudCheckType.JOUVE: models.JouveContent}
+    fraud_check_type = (
+        models.BeneficiaryFraudCheck.query.filter(
+            models.BeneficiaryFraudCheck.userId == user.id,
+            models.BeneficiaryFraudCheck.type.in_([models.FraudCheckType.JOUVE]),
+        )
+        .order_by(models.BeneficiaryFraudCheck.dateCreated.desc())
+        .first()
+    )
+    return mapped_class[fraud_check_type.type](**fraud_check_type.resultContent)

--- a/src/pcapi/templates/admin/fraud_details.html
+++ b/src/pcapi/templates/admin/fraud_details.html
@@ -159,7 +159,7 @@
       </tr>
       <tr>
         <th scope="row">Explication</th>
-        <td>{{ model.beneficiaryFraudResult.reason }}</dd></td>
+        <td>{{ model.beneficiaryFraudReview.reason }}</dd></td>
       </tr>
     </table>
   </div>

--- a/tests/admin/custom_views/fraud_view_test.py
+++ b/tests/admin/custom_views/fraud_view_test.py
@@ -45,6 +45,7 @@ class BeneficiaryFraudValidationViewTest:
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_view_validate_user(self, client):
         user = users_factories.UserFactory(isBeneficiary=False)
+        check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.JOUVE)
         admin = users_factories.UserFactory(isAdmin=True)
         client.with_auth(admin.email)
 
@@ -60,6 +61,10 @@ class BeneficiaryFraudValidationViewTest:
         user = users_models.User.query.get(user.id)
         assert user.isBeneficiary is True
         assert len(user.deposits) == 1
+
+        jouve_content = fraud_models.JouveContent(**check.resultContent)
+        assert user.firstName == jouve_content.firstName
+        assert user.lastName == jouve_content.lastName
 
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_view_validate_user_wrong_args(self, client):
@@ -114,6 +119,7 @@ class BeneficiaryFraudValidationViewTest:
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_prod_requires_super_admin(self, client):
         user = users_factories.UserFactory(isBeneficiary=False)
+        check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.JOUVE)
         admin = users_factories.UserFactory(isAdmin=True)
         client.with_auth(admin.email)
 
@@ -127,3 +133,7 @@ class BeneficiaryFraudValidationViewTest:
         assert review is not None
         assert review.author == admin
         assert user.isBeneficiary is True
+
+        jouve_content = fraud_models.JouveContent(**check.resultContent)
+        assert user.firstName == jouve_content.firstName
+        assert user.lastName == jouve_content.lastName

--- a/tests/core/fraud/test_api.py
+++ b/tests/core/fraud/test_api.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 
 import pytest
 
+import pcapi.core.fraud.api as fraud_api
+import pcapi.core.fraud.factories as fraud_factories
 from pcapi.core.fraud.models import BeneficiaryFraudCheck
 from pcapi.core.fraud.models import BeneficiaryFraudResult
 from pcapi.core.fraud.models import FraudCheckType
@@ -141,3 +143,15 @@ class JouveFraudCheckTest:
 
     #     db.session.refresh(user)
     #     assert not user.isBeneficiary
+
+
+class CommonTest:
+    def test_validator_data(self):
+        user = UserFactory()
+        fraud_data = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=FraudCheckType.JOUVE)
+        fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=FraudCheckType.DMS)
+
+        expected = fraud_api.get_source_data(user)
+
+        assert isinstance(expected, JouveContent)
+        assert expected == JouveContent(**fraud_data.resultContent)

--- a/tests/core/users/test_api.py
+++ b/tests/core/users/test_api.py
@@ -14,6 +14,7 @@ import requests_mock
 from pcapi import settings
 from pcapi.connectors.serialization.api_adage_serializers import InstitutionalProjectRedactorResponse
 from pcapi.core.bookings import factories as bookings_factories
+import pcapi.core.fraud.factories as fraud_factories
 from pcapi.core.mails import testing as mails_testing
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.payments.api import DEPOSIT_VALIDITY_IN_YEARS
@@ -40,6 +41,7 @@ from pcapi.core.users.api import update_beneficiary_mandatory_information
 from pcapi.core.users.exceptions import CloudTaskCreationException
 from pcapi.core.users.exceptions import IdentityDocumentUploadException
 from pcapi.core.users.factories import BeneficiaryImportFactory
+from pcapi.core.users.factories import UserFactory
 from pcapi.core.users.models import Credit
 from pcapi.core.users.models import DomainsCredit
 from pcapi.core.users.models import PhoneValidationStatusType
@@ -972,3 +974,25 @@ class VerifyIdentityDocumentInformationsTest:
         users_api.verify_identity_document_informations("some_path")
 
         assert not mails_testing.outbox
+
+
+class BeneficairyInformationUpdateTest:
+    def test_update_user_information_from_external_source(self):
+        user = UserFactory(
+            activity=None,
+            address=None,
+            city=None,
+            departementCode=None,
+            firstName=None,
+            lastName=None,
+            postalCode=None,
+            publicName="UNSET",
+        )
+        jouve_data = fraud_factories.JouveContentFactory()
+        new_user = users_api.update_user_information_from_external_source(user, jouve_data)
+
+        assert new_user.activity == jouve_data.activity
+        assert new_user.address == jouve_data.address
+        assert new_user.city == jouve_data.city
+        assert new_user.firstName == jouve_data.firstName
+        assert new_user.lastName == jouve_data.lastName


### PR DESCRIPTION
* Allows to filter frauds if no manual review as been done
* Fix the display of the manual review in F.A.
* Stores the beneficiary data from the External ID checks