### PR TITLE
(PC-9144) Skip books marked with 'xxx' in titelive synchronization

### DIFF
--- a/src/pcapi/local_providers/titelive_things/titelive_things.py
+++ b/src/pcapi/local_providers/titelive_things/titelive_things.py
@@ -28,6 +28,7 @@ THINGS_FOLDER_NAME_TITELIVE = "livre3_11"
 NUMBER_OF_ELEMENTS_PER_LINE = 46  # (45 elements from line + \n)
 PAPER_PRESS_TVA = "2,10"
 PAPER_PRESS_SUPPORT_CODE = "R"
+UNRELEASED_BOOK_MARKER = "xxx"
 SCHOOL_RELATED_CSR_CODE = [
     "2700",
     "2701",
@@ -124,6 +125,13 @@ class TiteLiveThings(LocalProvider):
                 self.log_provider_event(
                     LocalProviderEventType.SyncError, f"Error deleting product with ISBN: {self.product_infos['ean13']}"
                 )
+            return []
+
+        if is_unreleased_book(self.product_infos):
+            logger.info(
+                "Ignoring isbn=%s because it has 'xxx' in 'titre' and 'auteurs' fields, which means it is not yet released",
+                book_unique_identifier,
+            )
             return []
 
         book_information_last_update = read_things_date(self.product_infos["date_updated"])
@@ -316,3 +324,9 @@ def get_extra_data_from_infos(infos: dict) -> dict:
     if infos["commentaire"] != "":
         extra_data["comment"] = trim_with_elipsis(infos["commentaire"], 92)
     return extra_data
+
+
+def is_unreleased_book(product_info: dict) -> None:
+    title = product_info.get("titre", "").lower()
+    authors = product_info.get("auteurs", "").lower()
+    return title == authors == UNRELEASED_BOOK_MARKER

--- a/tests/local_providers/titelive_things_test.py
+++ b/tests/local_providers/titelive_things_test.py
@@ -21,6 +21,56 @@ from pcapi.models.local_provider_event import LocalProviderEventType
 from pcapi.repository import repository
 
 
+BASE_DATA_LINE_PARTS = [
+    "9782895026310",
+    "2895026319",
+    "nouvelles du Chili",
+    "",
+    "0203",
+    "1",
+    "",
+    "",
+    "",
+    "18,99",
+    "LES EDITIONS DE L'INSTANT MEME",
+    "EPAGINE",
+    "11/05/2011",
+    "BL",
+    "2",
+    "0",
+    "0,0",
+    "0,0",
+    "0,0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "Collectif",
+    "15/01/2013",
+    "02/03/2018",
+    "5,50",
+    "Littérature Hispano-Portugaise",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "1",
+    "3012420280013",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "0",
+    "",
+    "369",
+    "860",
+    "3694440",
+    "",
+]
+
+
 class TiteliveThingsTest:
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp")
@@ -33,54 +83,7 @@ class TiteliveThingsTest:
 
         get_files_to_process_from_titelive_ftp.return_value = files_list
 
-        data_line = (
-            "9782895026310"
-            "~2895026319"
-            "~nouvelles du Chili"
-            "~"
-            "~0203"
-            "~1"
-            "~"
-            "~"
-            "~"
-            "~18,99"
-            "~LES EDITIONS DE L'INSTANT MEME"
-            "~EPAGINE"
-            "~11/05/2011"
-            "~BL"
-            "~2"
-            "~0"
-            "~0,0"
-            "~0,0"
-            "~0,0"
-            "~0"
-            "~0"
-            "~0"
-            "~0"
-            "~Collectif"
-            "~15/01/2013"
-            "~02/03/2018"
-            "~5,50"
-            "~Littérature Hispano-Portugaise"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~3012420280013"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~0"
-            "~"
-            "~369"
-            "~860"
-            "~3694440"
-            "~"
-        )
+        data_line = "~".join(BASE_DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
         activate_provider("TiteLiveThings")
@@ -106,54 +109,14 @@ class TiteliveThingsTest:
 
         get_files_to_process_from_titelive_ftp.return_value = files_list
 
-        data_line = (
-            "9782895026310"
-            "~2895026319"
-            "~livre scolaire"
-            "~"
-            "~0203"
-            "~1"
-            "~"
-            "~"
-            "~"
-            "~18,99"
-            "~LES EDITIONS DE L'INSTANT MEME"
-            "~EPAGINE"
-            "~11/05/2011"
-            "~BL"
-            "~2"
-            "~0"
-            "~0,0"
-            "~0,0"
-            "~0,0"
-            "~0"
-            "~0"
-            "~0"
-            "~0"
-            "~Collectif"
-            "~15/01/2013"
-            "~02/03/2018"
-            "~5,50"
-            "~Littérature scolaire"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~3012420280013"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~"
-            "~"
-            "~369"
-            "~860"
-            "~3694440"
-            "~"
-        )
+        DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
+        DATA_LINE_PARTS[2] = "livre scolaire"
+        DATA_LINE_PARTS[27] = "Littérature scolaire"
+        DATA_LINE_PARTS[39] = "1"
+        DATA_LINE_PARTS[40] = "0"
+
+        data_line = "~".join(DATA_LINE_PARTS)
+
         get_lines_from_thing_file.return_value = iter([data_line])
 
         activate_provider("TiteLiveThings")
@@ -177,54 +140,8 @@ class TiteliveThingsTest:
 
         get_files_to_process_from_titelive_ftp.return_value = files_list
 
-        data_line = (
-            "9782895026310"
-            "~2895026319"
-            "~nouvelles du Chili"
-            "~"
-            "~0203"
-            "~1"
-            "~"
-            "~"
-            "~"
-            "~18,99"
-            "~LES EDITIONS DE L'INSTANT MEME"
-            "~EPAGINE"
-            "~11/05/2011"
-            "~BL"
-            "~2"
-            "~0"
-            "~0,0"
-            "~0,0"
-            "~0,0"
-            "~0"
-            "~0"
-            "~0"
-            "~0"
-            "~Collectif"
-            "~15/01/2013"
-            "~02/03/2018"
-            "~5,50"
-            "~Littérature Hispano-Portugaise"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~3012420280013"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~0"
-            "~"
-            "~369"
-            "~860"
-            "~3694440"
-            "~"
-        )
+        data_line = "~".join(BASE_DATA_LINE_PARTS)
+
         get_lines_from_thing_file.return_value = iter([data_line])
 
         titelive_things_provider = get_provider_by_local_class("TiteLiveThings")
@@ -300,58 +217,14 @@ class TiteliveThingsTest:
 
         get_files_to_process_from_titelive_ftp.return_value = files_list
 
-        data_line = (
-            "9782895026310"
-            "~2895026319"
-            "~nouvelles du Chili"
-            "~"
-            "~0203"
-            "~1"
-            "~"
-            "~"
-            "~"
-            "~18,99"
-            "~LES EDITIONS DE L'INSTANT MEME"
-            "~EPAGINE"
-            "~11/05/2011"
-            "~LE"
-            "~2"
-            "~0"
-            "~0,0"
-            "~0,0"
-            "~0,0"
-            "~0"
-            "~0"
-            "~0"
-            "~0"
-            "~Collectif"
-            "~15/01/2013"
-            "~02/03/2018"
-            "~5,50"
-            "~Littérature Hispano-Portugaise"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~3012420280013"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~0"
-            "~"
-            "~369"
-            "~860"
-            "~3694440"
-            "~"
-            "~Few Data"
-            "~Some Test Data"
-            "~Test Data"
-            "~Other Test Data"
-        )
+        DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
+        DATA_LINE_PARTS[13] = "LE"
+        DATA_LINE_PARTS[27] = "Littérature scolaire"
+        DATA_LINE_PARTS[39] = "1"
+        DATA_LINE_PARTS[40] = "0"
+
+        data_line = "~".join(DATA_LINE_PARTS)
+
         get_lines_from_thing_file.return_value = iter([data_line])
 
         activate_provider("TiteLiveThings")
@@ -375,54 +248,14 @@ class TiteliveThingsTest:
 
         get_files_to_process_from_titelive_ftp.return_value = files_list
 
-        data_line = (
-            "9782895026310"
-            "~2895026319"
-            "~livre scolaire"
-            "~"
-            "~2704"
-            "~1"
-            "~"
-            "~"
-            "~"
-            "~18,99"
-            "~LES EDITIONS DE L'INSTANT MEME"
-            "~EPAGINE"
-            "~11/05/2011"
-            "~BL"
-            "~2"
-            "~0"
-            "~0,0"
-            "~0,0"
-            "~0,0"
-            "~0"
-            "~0"
-            "~0"
-            "~0"
-            "~Collectif"
-            "~15/01/2013"
-            "~02/03/2018"
-            "~5,50"
-            "~Littérature scolaire"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~3012420280013"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~369"
-            "~860"
-            "~3694440"
-            "~"
-        )
+        DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
+        DATA_LINE_PARTS[2] = "livre scolaire"
+        DATA_LINE_PARTS[4] = "2704"
+        DATA_LINE_PARTS[27] = "Littérature scolaire"
+        DATA_LINE_PARTS[40] = ""
+
+        data_line = "~".join(DATA_LINE_PARTS)
+
         get_lines_from_thing_file.return_value = iter([data_line])
 
         activate_provider("TiteLiveThings")
@@ -446,54 +279,13 @@ class TiteliveThingsTest:
 
         get_files_to_process_from_titelive_ftp.return_value = files_list
 
-        data_line = (
-            "9782895026310"
-            "~2895026319"
-            "~livre scolaire"
-            "~"
-            "~2704"
-            "~1"
-            "~"
-            "~"
-            "~"
-            "~18,99"
-            "~LES EDITIONS DE L'INSTANT MEME"
-            "~EPAGINE"
-            "~11/05/2011"
-            "~BL"
-            "~2"
-            "~0"
-            "~0,0"
-            "~0,0"
-            "~0,0"
-            "~0"
-            "~0"
-            "~0"
-            "~0"
-            "~Collectif"
-            "~15/01/2013"
-            "~02/03/2018"
-            "~5,50"
-            "~Littérature scolaire"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~3012420280013"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~369"
-            "~860"
-            "~3694440"
-            "~"
-        )
+        DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
+        DATA_LINE_PARTS[2] = "livre scolaire"
+        DATA_LINE_PARTS[4] = "2704"
+        DATA_LINE_PARTS[27] = "Littérature scolaire"
+        DATA_LINE_PARTS[40] = ""
+
+        data_line = "~".join(DATA_LINE_PARTS)
 
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -527,55 +319,16 @@ class TiteliveThingsTest:
 
         get_files_to_process_from_titelive_ftp.return_value = files_list
 
-        data_line = (
-            "9782895026310"
-            "~2895026319"
-            "~jeux de société"
-            "~"
-            "~1234"
-            "~1"
-            "~"
-            "~"
-            "~"
-            "~18,99"
-            "~LES EDITIONS DE L'INSTANT MEME"
-            "~EPAGINE"
-            "~11/05/2011"
-            "~O"
-            "~2"
-            "~0"
-            "~0,0"
-            "~0,0"
-            "~0,0"
-            "~0"
-            "~0"
-            "~0"
-            "~0"
-            "~Collectif"
-            "~15/01/2013"
-            "~02/03/2018"
-            "~5,50"
-            "~Littérature scolaire"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~3012420280013"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~369"
-            "~860"
-            "~3694440"
-            "~"
-        )
+        DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
+        DATA_LINE_PARTS[2] = "jeux de société"
+        DATA_LINE_PARTS[4] = "1234"
+        DATA_LINE_PARTS[13] = "O"
+        DATA_LINE_PARTS[27] = "Littérature scolaire"
+        DATA_LINE_PARTS[40] = ""
 
+        data_line = "~".join(DATA_LINE_PARTS)
+
+        get_lines_from_thing_file.return_value = iter([data_line])
         get_lines_from_thing_file.return_value = iter([data_line])
 
         titelive_provider = activate_provider("TiteLiveThings")
@@ -606,54 +359,14 @@ class TiteliveThingsTest:
 
         get_files_to_process_from_titelive_ftp.return_value = files_list
 
-        data_line = (
-            "9782895026310"
-            "~2895026319"
-            "~jeux de société"
-            "~"
-            "~1234"
-            "~1"
-            "~"
-            "~"
-            "~"
-            "~18,99"
-            "~LES EDITIONS DE L'INSTANT MEME"
-            "~EPAGINE"
-            "~11/05/2011"
-            "~O"
-            "~2"
-            "~0"
-            "~0,0"
-            "~0,0"
-            "~0,0"
-            "~0"
-            "~0"
-            "~0"
-            "~0"
-            "~Collectif"
-            "~15/01/2013"
-            "~02/03/2018"
-            "~5,50"
-            "~Littérature scolaire"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~3012420280013"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~369"
-            "~860"
-            "~3694440"
-            "~"
-        )
+        DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
+        DATA_LINE_PARTS[2] = "jeux de société"
+        DATA_LINE_PARTS[4] = "1234"
+        DATA_LINE_PARTS[13] = "O"
+        DATA_LINE_PARTS[27] = "Littérature scolaire"
+        DATA_LINE_PARTS[40] = ""
+
+        data_line = "~".join(DATA_LINE_PARTS)
 
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -695,102 +408,17 @@ class TiteliveThingsTest:
 
         get_files_to_process_from_titelive_ftp.return_value = files_list
 
-        data_line_1 = (
-            "9782895026310"
-            "~9136205982"
-            "~nouvelles du Chili"
-            "~"
-            "~0203"
-            "~1"
-            "~"
-            "~"
-            "~"
-            "~18,99"
-            "~LES EDITIONS DE L'INSTANT MEME"
-            "~EPAGINE"
-            "~11/05/2011"
-            "~R"
-            "~2"
-            "~0"
-            "~0,0"
-            "~0,0"
-            "~0,0"
-            "~0"
-            "~0"
-            "~0"
-            "~0"
-            "~Collectif"
-            "~15/01/2013"
-            "~02/03/2018"
-            "~2,10"
-            "~Littérature Hispano-Portugaise"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~3012420280013"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~0"
-            "~"
-            "~369"
-            "~860"
-            "~3694440"
-            "~"
-        )
-        data_line_2 = (
-            "9782895026310"
-            "~2895026319"
-            "~nouvelles du Chili"
-            "~"
-            "~0203"
-            "~1"
-            "~"
-            "~"
-            "~"
-            "~18,99"
-            "~LES EDITIONS DE L'INSTANT MEME"
-            "~EPAGINE"
-            "~11/05/2011"
-            "~BL"
-            "~2"
-            "~0"
-            "~0,0"
-            "~0,0"
-            "~0,0"
-            "~0"
-            "~0"
-            "~0"
-            "~0"
-            "~Collectif"
-            "~15/01/2013"
-            "~02/03/2018"
-            "~2,10"
-            "~Littérature Hispano-Portugaise"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~3012420280013"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~0"
-            "~"
-            "~369"
-            "~860"
-            "~3694440"
-            "~"
-        )
+        DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
+        DATA_LINE_PARTS[1] = "9136205982"
+        DATA_LINE_PARTS[13] = "R"
+        DATA_LINE_PARTS[26] = "2,10"
+
+        data_line_1 = "~".join(DATA_LINE_PARTS)
+
+        DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
+        DATA_LINE_PARTS[26] = "2,10"
+
+        data_line_2 = "~".join(DATA_LINE_PARTS)
 
         get_lines_from_thing_file.return_value = iter([data_line_1, data_line_2])
 
@@ -816,54 +444,10 @@ class TiteliveThingsTest:
         files_list = list()
         files_list.append("Quotidien30.tit")
 
-        data_line = (
-            "9782895026310"
-            "~2895026319"
-            "~nouvelles du Chili"
-            "~"
-            "~0203"
-            "~1"
-            "~"
-            "~"
-            "~"
-            "~18,99"
-            "~LES EDITIONS DE L'INSTANT MEME"
-            "~EPAGINE"
-            "~11/05/2011"
-            "~R"
-            "~2"
-            "~0"
-            "~0,0"
-            "~0,0"
-            "~0,0"
-            "~0"
-            "~0"
-            "~0"
-            "~0"
-            "~Collectif"
-            "~15/01/2013"
-            "~02/03/2018"
-            "~2,10"
-            "~Littérature Hispano-Portugaise"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~3012420280013"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~0"
-            "~"
-            "~369"
-            "~860"
-            "~3694440"
-            "~"
-        )
+        DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
+        DATA_LINE_PARTS[13] = "R"
+        DATA_LINE_PARTS[26] = "2,10"
+        data_line = "~".join(DATA_LINE_PARTS)
 
         get_files_to_process_from_titelive_ftp.return_value = files_list
 
@@ -897,54 +481,11 @@ class TiteliveThingsTest:
         files_list = list()
         files_list.append("Quotidien30.tit")
 
-        data_line = (
-            "9782895026310"
-            "~2895026319"
-            "~nouvelles du Chili"
-            "~"
-            "~0203"
-            "~1"
-            "~"
-            "~"
-            "~"
-            "~18,99"
-            "~LES EDITIONS DE L'INSTANT MEME"
-            "~EPAGINE"
-            "~11/05/2011"
-            "~R"
-            "~2"
-            "~0"
-            "~0,0"
-            "~0,0"
-            "~0,0"
-            "~0"
-            "~0"
-            "~0"
-            "~0"
-            "~Collectif"
-            "~15/01/2013"
-            "~02/03/2018"
-            "~2,10"
-            "~Littérature Hispano-Portugaise"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~1"
-            "~3012420280013"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~"
-            "~0"
-            "~"
-            "~369"
-            "~860"
-            "~3694440"
-            "~"
-        )
+        DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
+        DATA_LINE_PARTS[13] = "R"
+        DATA_LINE_PARTS[26] = "2,10"
+
+        data_line = "~".join(DATA_LINE_PARTS)
 
         get_files_to_process_from_titelive_ftp.return_value = files_list
 
@@ -976,3 +517,31 @@ class TiteliveThingsTest:
         offer = Offer.query.one()
         assert offer.isActive is False
         assert Product.query.count() == 1
+
+    @pytest.mark.usefixtures("db_session")
+    @patch("pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp")
+    @patch("pcapi.local_providers.titelive_things.titelive_things.get_lines_from_thing_file")
+    def test_does_not_create_product_with_xxx_mark(
+        self, get_lines_from_thing_file, get_files_to_process_from_titelive_ftp, app
+    ):
+        files_list = list()
+        files_list.append("Quotidien30.tit")
+
+        get_files_to_process_from_titelive_ftp.return_value = files_list
+
+        DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
+        DATA_LINE_PARTS[2] = "xxx"
+        DATA_LINE_PARTS[23] = "Xxx"
+
+        data_line = "~".join(DATA_LINE_PARTS)
+
+        get_lines_from_thing_file.return_value = iter([data_line])
+
+        activate_provider("TiteLiveThings")
+        titelive_things = TiteLiveThings()
+
+        # When
+        titelive_things.updateObjects()
+
+        # Then
+        assert Product.query.count() == 0


### PR DESCRIPTION
Some books are marked with 'xxx' in their title and author fields. It's a convention for titelive and means the book is not released yet so dont import it