### PR TITLE
[PC-9858] fix pro testcafe

### DIFF
--- a/src/pcapi/utils/requests.py
+++ b/src/pcapi/utils/requests.py
@@ -82,5 +82,6 @@ class Session(_SessionMixin, requests.Session):
         safe_adapter = HTTPAdapter(max_retries=safe_retry_strategy)
         unsafe_adapter = HTTPAdapter(max_retries=unsafe_retry_strategy)
         self.mount("https://www.demarches-simplifiees.fr", safe_adapter)
-        self.mount(settings.JOUVE_API_DOMAIN, safe_adapter)
+        if settings.JOUVE_API_DOMAIN:
+            self.mount(settings.JOUVE_API_DOMAIN, safe_adapter)
         self.mount("https://api.mailjet.com", unsafe_adapter)


### PR DESCRIPTION
  pro testcafe fail since 21ef8b7f19dcd1338765a2395c2c986aef17bc2d
  
  =====
  
  Fix rapide afin que la CI de pro repasse au vert.
  Source de l'erreur: 
  https://github.com/pass-culture/pass-culture-api/commit/21ef8b7f19dcd1338765a2395c2c986aef17bc2d