### PR TITLE
(PC-9478)[FIX] enrich email sent to support

### DIFF
--- a/src/pcapi/alembic/versions/20210712_f151ee109bd4_add_on_delete_cascade_to_offer_report_.py
+++ b/src/pcapi/alembic/versions/20210712_f151ee109bd4_add_on_delete_cascade_to_offer_report_.py
@@ -1,0 +1,29 @@
+"""add_on_delete_cascade_to_offer_report_offer_id_and_user_id
+
+Revision ID: f151ee109bd4
+Revises: 5c5141274495
+Create Date: 2021-07-12 12:29:19.528478
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "f151ee109bd4"
+down_revision = "5c5141274495"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint("offer_report_userId_fkey", "offer_report", type_="foreignkey")
+    op.drop_constraint("offer_report_offerId_fkey", "offer_report", type_="foreignkey")
+    op.create_foreign_key(None, "offer_report", "user", ["userId"], ["id"], ondelete="CASCADE")
+    op.create_foreign_key(None, "offer_report", "offer", ["offerId"], ["id"], ondelete="CASCADE")
+
+
+def downgrade():
+    op.drop_constraint(None, "offer_report", type_="foreignkey")
+    op.drop_constraint(None, "offer_report", type_="foreignkey")
+    op.create_foreign_key("offer_report_offerId_fkey", "offer_report", "offer", ["offerId"], ["id"])
+    op.create_foreign_key("offer_report_userId_fkey", "offer_report", "user", ["userId"], ["id"])

--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -808,4 +808,4 @@ def report_offer(user: User, offer: Offer, reason: str, custom_reason: Optional[
             raise ReportMalformed() from error
         raise
 
-    offer_report_emails.send_report_notification(user, offer, reason)
+    offer_report_emails.send_report_notification(user, offer, reason, custom_reason)

--- a/src/pcapi/core/offers/models.py
+++ b/src/pcapi/core/offers/models.py
@@ -686,11 +686,11 @@ class OfferReport(PcObject, Model):
 
     id = Column(BigInteger, primary_key=True, autoincrement=True)
 
-    userId = Column(BigInteger, ForeignKey("user.id"), index=True, nullable=False)
+    userId = Column(BigInteger, ForeignKey("user.id", ondelete="CASCADE"), index=True, nullable=False)
 
     user = relationship("User", foreign_keys=[userId], backref="reported_offers")
 
-    offerId = Column(BigInteger, ForeignKey("offer.id"), index=True, nullable=False)
+    offerId = Column(BigInteger, ForeignKey("offer.id", ondelete="CASCADE"), index=True, nullable=False)
 
     offer = relationship("Offer", foreign_keys=[offerId], backref="reports")
 

--- a/src/pcapi/domain/offer_report_emails.py
+++ b/src/pcapi/domain/offer_report_emails.py
@@ -5,6 +5,6 @@ from pcapi.core.users.models import User
 from pcapi.emails.offer_report import build_offer_report_data
 
 
-def send_report_notification(user: User, offer: Offer, reason: str) -> bool:
-    data = build_offer_report_data(user, offer, reason)
+def send_report_notification(user: User, offer: Offer, reason: str, custom_reason: str) -> bool:
+    data = build_offer_report_data(user, offer, reason, custom_reason)
     return mails.send(recipients=[settings.SUPPORT_EMAIL_ADDRESS], data=data)

--- a/src/pcapi/emails/offer_report.py
+++ b/src/pcapi/emails/offer_report.py
@@ -1,9 +1,14 @@
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Reason
 from pcapi.core.users.models import User
+from pcapi.utils.mailing import build_pc_pro_offer_link
 
 
-def build_offer_report_data(user: User, offer: Offer, reason: str) -> dict:
+def build_offer_report_data(user: User, offer: Offer, reason: str, custom_reason: str) -> dict:
+    reason = Reason.get_meta(reason).title
+    if custom_reason:
+        reason = f"[{reason}] {custom_reason}"
+
     return {
         "MJ-TemplateID": 3020502,
         "MJ-TemplateLanguage": True,
@@ -11,6 +16,7 @@ def build_offer_report_data(user: User, offer: Offer, reason: str) -> dict:
             "user_id": user.id,
             "offer_id": offer.id,
             "offer_name": offer.name,
-            "reason": Reason.get_meta(reason).title,
+            "reason": reason,
+            "offer_url": build_pc_pro_offer_link(offer),
         },
     }

--- a/src/pcapi/routes/native/v1/offers.py
+++ b/src/pcapi/routes/native/v1/offers.py
@@ -59,7 +59,7 @@ def report_offer_reasons(user: User) -> serializers.OfferReportReasons:
 
 
 @blueprint.native_v1.route("/offers/reports", methods=["GET"])
-@spectree_serialize(on_success_status=200, api=blueprint.api)
+@spectree_serialize(on_success_status=200, api=blueprint.api, response_model=serializers.UserReportedOffersResponse)
 @authenticated_user_required
 def user_reported_offers(user: User) -> serializers.UserReportedOffersResponse:
     return serializers.UserReportedOffersResponse(reportedOffers=user.reported_offers)


### PR DESCRIPTION
**But**

1. ajouter la raison du signalement précisée par l'utilisateur si la raison est _OTHER_. (note : le code qui génère le contenu de l'email ne vérifie pas que `reason == "OTHER"` puisque cette vérification est censée être faite en amont).
2. ajouter un lien vers la page PRO de l'offre.

**Au passage**

1. Corriger un oubli de contraintes sur la table `offer_report`.

➡️ ajouter un `on delete cascade` sur `offerId`
➡️ ajouter un `on delete cascade` sur `userId`

2. Corriger les informations de l'API pour la route `GET /offers/reports`