### PR TITLE
PC-9862 : Checks Jouve ID number before rejecting the subscription

### DIFF
--- a/src/pcapi/connectors/beneficiaries/jouve_backend.py
+++ b/src/pcapi/connectors/beneficiaries/jouve_backend.py
@@ -116,8 +116,18 @@ class FraudDetectionItem:
         return f"{self.key}: {self.value} - {self.valid}"
 
 
-def get_boolean_fraud_detection_item(value: Optional[str], key: str) -> FraudDetectionItem:
-    valid = value.upper() != "KO" if value else True
+def get_boolean_fraud_detection_item(
+    value: Optional[str], key: str, allow_empty=True, allow_not_applicable=False
+) -> FraudDetectionItem:
+    if allow_empty and not value:
+        valid = True
+    elif allow_not_applicable and value == "NOT_APPLICABLE":
+        valid = True
+    elif value is None or value.upper() in ("NOT_APPLICABLE", "KO", ""):
+        valid = False
+    else:
+        valid = True
+
     return FraudDetectionItem(key=key, value=value, valid=valid)
 
 
@@ -149,7 +159,7 @@ def get_fraud_fields(content: dict) -> dict:
             get_boolean_fraud_detection_item(content.bodyNameCtrl, "bodyNameCtrl"),
             get_boolean_fraud_detection_item(content.bodyPieceNumberCtrl, "bodyPieceNumberCtrl"),
             get_threshold_fraud_detection_item(content.bodyPieceNumberLevel, "bodyPieceNumberLevel", 50),
-            get_boolean_fraud_detection_item(content.creatorCtrl, "creatorCtrl"),
+            get_boolean_fraud_detection_item(content.creatorCtrl, "creatorCtrl", allow_not_applicable=True),
             get_boolean_fraud_detection_item(content.initialNumberCtrl, "initialNumberCtrl"),
             get_boolean_fraud_detection_item(content.initialSizeCtrl, "initialSizeCtrl"),
         ],

--- a/src/pcapi/connectors/beneficiaries/jouve_backend.py
+++ b/src/pcapi/connectors/beneficiaries/jouve_backend.py
@@ -119,6 +119,7 @@ class FraudDetectionItem:
 def get_boolean_fraud_detection_item(
     value: Optional[str], key: str, allow_empty=True, allow_not_applicable=False
 ) -> FraudDetectionItem:
+    # TODO: cleanup required when migrating to fraud validation journey v2
     if allow_empty and not value:
         valid = True
     elif allow_not_applicable and value == "NOT_APPLICABLE":

--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -121,6 +121,7 @@ def _id_check_fraud_items(content: models.JouveContent) -> List[models.FraudItem
 
 
 def _get_boolean_id_fraud_item(value: Optional[str], key: str, is_strict_ko: bool) -> models.FraudItem:
+    # TODO: refactor with jouve_backend items.
     is_valid = None
     if key == "creatorCtrl" and value == "NOT_APPLICABLE":
         is_valid = True

--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -121,7 +121,13 @@ def _id_check_fraud_items(content: models.JouveContent) -> List[models.FraudItem
 
 
 def _get_boolean_id_fraud_item(value: Optional[str], key: str, is_strict_ko: bool) -> models.FraudItem:
-    is_valid = value.upper() != "KO" if value else True
+    is_valid = None
+    if key == "creatorCtrl" and value == "NOT_APPLICABLE":
+        is_valid = True
+    elif value in ("NOT_APPLICABLE", "KO", ""):
+        is_valid = False
+    else:
+        is_valid = value.upper() != "KO" if value else True
     if is_valid:
         status = models.FraudStatus.OK
     elif is_strict_ko:

--- a/tests/connectors/beneficiaries/beneficiary_jouve_repository_test.py
+++ b/tests/connectors/beneficiaries/beneficiary_jouve_repository_test.py
@@ -45,103 +45,102 @@ def get_token_detail_response(token: str) -> dict:
     return {"Value": token}
 
 
-@freeze_time("2020-10-15 09:00:00")
-@patch("pcapi.settings.JOUVE_API_DOMAIN", "https://jouve.com")
-@patch("pcapi.settings.JOUVE_API_PASSWORD", "secret-password")
-@patch("pcapi.settings.JOUVE_API_USERNAME", "username")
-@patch("pcapi.settings.JOUVE_API_VAULT_GUID", "12")
-@patch("pcapi.settings.IS_PROD", True)
-@patch("pcapi.connectors.beneficiaries.jouve_backend.requests.post")
-def test_calls_jouve_api_with_previously_fetched_token(mocked_requests_post):
-    # Given
-    token = "token-for-tests"
-    application_id = 5
+class JouveBackendTest:
+    @freeze_time("2020-10-15 09:00:00")
+    @patch("pcapi.settings.JOUVE_API_DOMAIN", "https://jouve.com")
+    @patch("pcapi.settings.JOUVE_API_PASSWORD", "secret-password")
+    @patch("pcapi.settings.JOUVE_API_USERNAME", "username")
+    @patch("pcapi.settings.JOUVE_API_VAULT_GUID", "12")
+    @patch("pcapi.settings.IS_PROD", True)
+    @patch("pcapi.connectors.beneficiaries.jouve_backend.requests.post")
+    def test_calls_jouve_api_with_previously_fetched_token(self, mocked_requests_post):
+        # Given
+        token = "token-for-tests"
+        application_id = 5
 
-    get_token_response = MagicMock(status_code=200)
-    get_token_response.json = MagicMock(return_value=get_token_detail_response(token))
+        get_token_response = MagicMock(status_code=200)
+        get_token_response.json = MagicMock(return_value=get_token_detail_response(token))
 
-    get_application_by_json = get_application_by_detail_response(
-        application_id=application_id,
-        birth_date="24/08/1995",
-    )
-    get_application_by_response = MagicMock(status_code=200)
-    get_application_by_response.json = MagicMock(return_value=get_application_by_json)
+        get_application_by_json = get_application_by_detail_response(
+            application_id=application_id,
+            birth_date="24/08/1995",
+        )
+        get_application_by_response = MagicMock(status_code=200)
+        get_application_by_response.json = MagicMock(return_value=get_application_by_json)
 
-    mocked_requests_post.side_effect = [get_token_response, get_application_by_response]
+        mocked_requests_post.side_effect = [get_token_response, get_application_by_response]
 
-    # When
-    jouve_content = get_application_content(application_id)
-    beneficiary_pre_subscription = get_subscription_from_content(jouve_content)
+        # When
+        jouve_content = get_application_content(application_id)
+        beneficiary_pre_subscription = get_subscription_from_content(jouve_content)
 
-    # Then
-    assert mocked_requests_post.call_args_list[0] == call(
-        "https://jouve.com/REST/server/authenticationtokens",
-        headers={"Content-Type": "application/json"},
-        json={
-            "Username": "username",
-            "Password": "secret-password",
-            "VaultGuid": "12",
-            "Expiration": "2020-10-15T10:00:00",
-        },
-    )
-    assert mocked_requests_post.call_args_list[1] == call(
-        "https://jouve.com/REST/vault/extensionmethod/VEM_GetJeuneByID",
-        data=str(application_id),
-        headers={"X-Authentication": token},
-    )
-    assert isinstance(beneficiary_pre_subscription, BeneficiaryPreSubscription)
-    assert beneficiary_pre_subscription.activity == "Apprenti"
-    assert beneficiary_pre_subscription.address == "18 avenue des fleurs"
-    assert beneficiary_pre_subscription.application_id == 5
-    assert beneficiary_pre_subscription.city == "RENNES"
-    assert beneficiary_pre_subscription.civility == "Mme"
-    assert beneficiary_pre_subscription.date_of_birth == datetime(1995, 8, 24).date()
-    assert beneficiary_pre_subscription.department_code == "35"
-    assert beneficiary_pre_subscription.email == "rennes@example.org"
-    assert beneficiary_pre_subscription.first_name == "Céline"
-    assert beneficiary_pre_subscription.last_name == "DURAND"
-    assert beneficiary_pre_subscription.phone_number == "0123456789"
-    assert beneficiary_pre_subscription.postal_code == "35123"
-    assert beneficiary_pre_subscription.public_name == "Céline DURAND"
-    assert beneficiary_pre_subscription.id_piece_number == "id-piece-number"
+        # Then
+        assert mocked_requests_post.call_args_list[0] == call(
+            "https://jouve.com/REST/server/authenticationtokens",
+            headers={"Content-Type": "application/json"},
+            json={
+                "Username": "username",
+                "Password": "secret-password",
+                "VaultGuid": "12",
+                "Expiration": "2020-10-15T10:00:00",
+            },
+        )
+        assert mocked_requests_post.call_args_list[1] == call(
+            "https://jouve.com/REST/vault/extensionmethod/VEM_GetJeuneByID",
+            data=str(application_id),
+            headers={"X-Authentication": token},
+        )
+        assert isinstance(beneficiary_pre_subscription, BeneficiaryPreSubscription)
+        assert beneficiary_pre_subscription.activity == "Apprenti"
+        assert beneficiary_pre_subscription.address == "18 avenue des fleurs"
+        assert beneficiary_pre_subscription.application_id == 5
+        assert beneficiary_pre_subscription.city == "RENNES"
+        assert beneficiary_pre_subscription.civility == "Mme"
+        assert beneficiary_pre_subscription.date_of_birth == datetime(1995, 8, 24).date()
+        assert beneficiary_pre_subscription.department_code == "35"
+        assert beneficiary_pre_subscription.email == "rennes@example.org"
+        assert beneficiary_pre_subscription.first_name == "Céline"
+        assert beneficiary_pre_subscription.last_name == "DURAND"
+        assert beneficiary_pre_subscription.phone_number == "0123456789"
+        assert beneficiary_pre_subscription.postal_code == "35123"
+        assert beneficiary_pre_subscription.public_name == "Céline DURAND"
+        assert beneficiary_pre_subscription.id_piece_number == "id-piece-number"
 
+    @patch("pcapi.connectors.beneficiaries.jouve_backend.requests.post")
+    def test_raise_exception_when_password_is_invalid(self, stubed_requests_post):
+        # Given
+        application_id = "5"
+        stubed_requests_post.return_value = MagicMock(status_code=400)
 
-@patch("pcapi.connectors.beneficiaries.jouve_backend.requests.post")
-def test_raise_exception_when_password_is_invalid(stubed_requests_post):
-    # Given
-    application_id = "5"
-    stubed_requests_post.return_value = MagicMock(status_code=400)
+        # When
+        with pytest.raises(ApiJouveException) as api_jouve_exception:
+            get_application_content(application_id)
 
-    # When
-    with pytest.raises(ApiJouveException) as api_jouve_exception:
-        get_application_content(application_id)
+        # Then
+        assert str(api_jouve_exception.value.message) == "Error getting API Jouve authentication token"
+        assert api_jouve_exception.value.route == "/REST/server/authenticationtokens"
+        assert api_jouve_exception.value.status_code == 400
 
-    # Then
-    assert str(api_jouve_exception.value.message) == "Error getting API Jouve authentication token"
-    assert api_jouve_exception.value.route == "/REST/server/authenticationtokens"
-    assert api_jouve_exception.value.status_code == 400
+    @patch("pcapi.connectors.beneficiaries.jouve_backend.requests.post")
+    def test_raise_exception_when_token_is_invalid(self, stubed_requests_post):
+        # Given
+        token = "token-for-tests"
+        application_id = "5"
 
+        get_token_response = MagicMock(status_code=200)
+        get_token_response.json = MagicMock(return_value=get_token_detail_response(token))
 
-@patch("pcapi.connectors.beneficiaries.jouve_backend.requests.post")
-def test_raise_exception_when_token_is_invalid(stubed_requests_post):
-    # Given
-    token = "token-for-tests"
-    application_id = "5"
+        get_application_by_json = get_application_by_detail_response()
+        get_application_by_response = MagicMock(status_code=500)
+        get_application_by_response.json = MagicMock(return_value=get_application_by_json)
 
-    get_token_response = MagicMock(status_code=200)
-    get_token_response.json = MagicMock(return_value=get_token_detail_response(token))
+        stubed_requests_post.side_effect = [get_token_response, get_application_by_response]
 
-    get_application_by_json = get_application_by_detail_response()
-    get_application_by_response = MagicMock(status_code=500)
-    get_application_by_response.json = MagicMock(return_value=get_application_by_json)
+        # When
+        with pytest.raises(ApiJouveException) as api_jouve_exception:
+            get_application_content(application_id)
 
-    stubed_requests_post.side_effect = [get_token_response, get_application_by_response]
-
-    # When
-    with pytest.raises(ApiJouveException) as api_jouve_exception:
-        get_application_content(application_id)
-
-    # Then
-    assert str(api_jouve_exception.value.message) == "Error getting API jouve GetJeuneByID"
-    assert api_jouve_exception.value.route == "/REST/vault/extensionmethod/VEM_GetJeuneByID"
-    assert api_jouve_exception.value.status_code == 500
+        # Then
+        assert str(api_jouve_exception.value.message) == "Error getting API jouve GetJeuneByID"
+        assert api_jouve_exception.value.route == "/REST/vault/extensionmethod/VEM_GetJeuneByID"
+        assert api_jouve_exception.value.status_code == 500

--- a/tests/domain/beneficiary/beneficiary_pre_subscription_validator_test.py
+++ b/tests/domain/beneficiary/beneficiary_pre_subscription_validator_test.py
@@ -3,12 +3,11 @@ from datetime import datetime
 import pytest
 
 from pcapi.core.testing import override_features
+import pcapi.core.users.factories as users_factories
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_exceptions import BeneficiaryIsADuplicate
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_exceptions import BeneficiaryIsNotEligible
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_exceptions import CantRegisterBeneficiary
 from pcapi.domain.beneficiary_pre_subscription.beneficiary_pre_subscription_validator import validate
-from pcapi.model_creators.generic_creators import create_user
-from pcapi.repository import repository
 
 from tests.domain_creators.generic_creators import create_domain_beneficiary_pre_subcription
 
@@ -30,8 +29,7 @@ def test_should_not_raise_exception_for_valid_beneficiary(app):
 def test_raises_if_email_already_taken_by_beneficiary(app):
     # Given
     email = "email@example.org"
-    existing_user = create_user(email=email)
-    repository.save(existing_user)
+    existing_user = users_factories.UserFactory(email=email)
 
     beneficiary_pre_subcription = create_domain_beneficiary_pre_subcription(email=email)
 
@@ -46,8 +44,7 @@ def test_raises_if_email_already_taken_by_beneficiary(app):
 @pytest.mark.usefixtures("db_session")
 def test_validates_for_non_beneficiary_with_same_mail(app):
     email = "email@example.org"
-    existing_user = create_user(email=email, is_beneficiary=False, is_email_validated=True)
-    repository.save(existing_user)
+    existing_user = users_factories.UserFactory(email=email, isBeneficiary=False, isEmailValidated=True)
 
     beneficiary_pre_subcription = create_domain_beneficiary_pre_subcription(email=email)
 
@@ -58,8 +55,7 @@ def test_validates_for_non_beneficiary_with_same_mail(app):
 @pytest.mark.usefixtures("db_session")
 def test_doesnt_raise_if_email_not_taken(app):
     # Given
-    existing_user = create_user(email="email@example.org")
-    repository.save(existing_user)
+    users_factories.UserFactory(email="email@example.org")
 
     beneficiary_pre_subcription = create_domain_beneficiary_pre_subcription(email="different.email@example.org")
 
@@ -77,8 +73,7 @@ def test_raises_if_duplicate(app):
     first_name = "John"
     last_name = "Doe"
     date_of_birth = datetime(1993, 2, 2)
-    existing_user = create_user(first_name=first_name, last_name=last_name, date_of_birth=date_of_birth)
-    repository.save(existing_user)
+    existing_user = users_factories.UserFactory(firstName=first_name, lastName=last_name, dateOfBirth=date_of_birth)
 
     beneficiary_pre_subcription = create_domain_beneficiary_pre_subcription(
         first_name=first_name, last_name=last_name, date_of_birth=date_of_birth
@@ -98,14 +93,11 @@ def test_doesnt_raise_if_no_exact_duplicate(app):
     first_name = "John"
     last_name = "Doe"
     date_of_birth = datetime(1993, 2, 2)
-    existing_user1 = create_user(first_name="Joe", last_name=last_name, date_of_birth=date_of_birth, email="e1@ex.org")
-    existing_user2 = create_user(
-        first_name=first_name, last_name="Trump", date_of_birth=date_of_birth, email="e2@ex.org"
+    users_factories.UserFactory(firstName="Joe", lastName=last_name, dateOfBirth=date_of_birth, email="e1@ex.org")
+    users_factories.UserFactory(firstName=first_name, lastName="Trump", dateOfBirth=date_of_birth, email="e2@ex.org")
+    users_factories.UserFactory(
+        firstName=first_name, lastName=last_name, dateOfBirth=datetime(1992, 2, 2), email="e3@ex.org"
     )
-    existing_user3 = create_user(
-        first_name=first_name, last_name=last_name, date_of_birth=datetime(1992, 2, 2), email="e3@ex.org"
-    )
-    repository.save(existing_user1, existing_user2, existing_user3)
 
     beneficiary_pre_subcription = create_domain_beneficiary_pre_subcription(
         first_name=first_name, last_name=last_name, date_of_birth=date_of_birth

--- a/tests/domain_creators/generic_creators.py
+++ b/tests/domain_creators/generic_creators.py
@@ -25,7 +25,7 @@ def create_domain_beneficiary_pre_subcription(
     phone_number: str = "0123456789",
     source: str = "jouve",
     source_id: str = None,
-    id_piece_number: str = "id-piece-number",
+    id_piece_number: str = "140767100016",
 ) -> BeneficiaryPreSubscription:
     return BeneficiaryPreSubscription(
         address=address,

--- a/tests/routes/webapp/post_id_check_application_update_test.py
+++ b/tests/routes/webapp/post_id_check_application_update_test.py
@@ -27,7 +27,7 @@ JOUVE_CONTENT = {
     "bodyFirstnameLevel": 100,
     "bodyNameLevel": 80,
     "bodyNameCtrl": "OK",
-    "bodyPieceNumber": "id-piece-number",
+    "bodyPieceNumber": "140767100016",
     "bodyPieceNumberCtrl": "OK",
     "bodyPieceNumberLevel": 100,
     "city": "Paris",


### PR DESCRIPTION
Deux tickets:

- PC-9937 : Le dossier est suspicieux en fonction de retours  de jouve en erreur de lecture de la pièce d'identité
- PC-9862 : ne pas rejeter les dossiers ID check si le champs N° de CNI est une chaine vide