### PR TITLE
(PC-9793) add fraud checks and results on user actions

### DIFF
--- a/src/pcapi/core/fraud/models.py
+++ b/src/pcapi/core/fraud/models.py
@@ -17,6 +17,7 @@ class FraudCheckType(enum.Enum):
     JOUVE = "jouve"
     USER_PROFILING = "user_profiling"
     DMS = "dms"
+    INTERNAL_REVIEW = "internal_review"
 
 
 class FraudStatus(enum.Enum):
@@ -114,6 +115,19 @@ class UserProfilingFraudData(pydantic.BaseModel):
     tmx_summary_reason_code: typing.Optional[typing.List[str]]
     summary_risk_score: int
     unknown_session: typing.Optional[str]
+
+
+class InternalReviewSource(enum.Enum):
+    SMS_SENDING_LIMIT_REACHED = "sms_sending_limit_reached"
+    PHONE_VALIDATION_ATTEMPTS_LIMIT_REACHED = "phone_validation_attempts_limit_reached"
+    PHONE_ALREADY_EXISTS = "phone_already_exists"
+    BLACKLISTED_PHONE_NUMBER = "blacklisted_phone_number"
+
+
+class InternalReviewFraudData(pydantic.BaseModel):
+    source: InternalReviewSource
+    message: str
+    phone_number: str
 
 
 class BeneficiaryFraudCheck(PcObject, Model):

--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from dataclasses import asdict
 from datetime import date
 from datetime import datetime
@@ -7,6 +8,7 @@ from enum import Enum
 import logging
 import random
 import secrets
+import typing
 from typing import Optional
 from typing import Tuple
 
@@ -26,6 +28,7 @@ from pcapi.connectors.beneficiaries.id_check_middleware import ask_for_identity_
 from pcapi.core import mails
 from pcapi.core.bookings.conf import LIMIT_CONFIGURATIONS
 import pcapi.core.bookings.repository as bookings_repository
+import pcapi.core.fraud.api as fraud_api
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.payments.api as payment_api
 from pcapi.core.users.models import Credit
@@ -670,17 +673,15 @@ def set_pro_tuto_as_seen(user: User) -> None:
     repository.save(user)
 
 
-def change_user_phone_number(user: User, phone_number: str):
+def change_user_phone_number(user: User, phone_number: str) -> None:
     _check_phone_number_validation_is_authorized(user)
 
-    formatted_phone_number = get_legit_phone_number(phone_number)
-    if not formatted_phone_number:
-        raise exceptions.InvalidPhoneNumber(phone_number)
+    phone_data = ParsedPhoneNumber(phone_number)
+    with fraud_manager(user=user, phone_number=phone_data.phone_number):
+        check_phone_number_is_legit(phone_data.phone_number, phone_data.country_code)
+        check_phone_number_not_used(phone_data.phone_number)
 
-    if does_validated_phone_exist(formatted_phone_number):
-        raise exceptions.PhoneAlreadyExists()
-
-    user.phoneNumber = formatted_phone_number
+    user.phoneNumber = phone_data.phone_number
     Token.query.filter(Token.user == user, Token.type == TokenType.PHONE_VALIDATION).delete()
     repository.save(user)
 
@@ -688,17 +689,16 @@ def change_user_phone_number(user: User, phone_number: str):
 def send_phone_validation_code(user: User) -> None:
     _check_phone_number_validation_is_authorized(user)
 
-    formatted_phone_number = get_legit_phone_number(user.phoneNumber)
-    if not formatted_phone_number:
-        raise exceptions.InvalidPhoneNumber(user.phoneNumber)
-
-    if not is_SMS_sending_allowed(app.redis_client, user):
-        raise exceptions.SMSSendingLimitReached()
+    phone_data = ParsedPhoneNumber(user.phoneNumber)
+    with fraud_manager(user=user, phone_number=phone_data.phone_number):
+        check_phone_number_is_legit(phone_data.phone_number, phone_data.country_code)
+        check_phone_number_not_used(phone_data.phone_number)
+        check_sms_sending_is_allowed(user)
 
     phone_validation_token = create_phone_validation_token(user)
     content = f"{phone_validation_token.value} est ton code de confirmation pass Culture"
 
-    if not send_transactional_sms(formatted_phone_number, content):
+    if not send_transactional_sms(phone_data.phone_number, content):
         raise exceptions.PhoneVerificationCodeSendingException()
 
     update_sent_SMS_counter(app.redis_client, user)
@@ -706,11 +706,11 @@ def send_phone_validation_code(user: User) -> None:
 
 def validate_phone_number(user: User, code: str) -> None:
     _check_phone_number_validation_is_authorized(user)
-    _check_and_update_phone_validation_attempts(app.redis_client, user)
 
-    phone_number = get_legit_phone_number(user.phoneNumber)
-    if not phone_number:
-        raise exceptions.InvalidPhoneNumber(user.phoneNumber)
+    phone_data = ParsedPhoneNumber(user.phoneNumber)
+    with fraud_manager(user=user, phone_number=phone_data.phone_number):
+        check_phone_number_is_legit(phone_data.phone_number, phone_data.country_code)
+        check_and_update_phone_validation_attempts(app.redis_client, user)
 
     token = Token.query.filter(
         Token.user == user, Token.value == code, Token.type == TokenType.PHONE_VALIDATION
@@ -724,30 +724,20 @@ def validate_phone_number(user: User, code: str) -> None:
 
     db.session.delete(token)
 
-    if does_validated_phone_exist(phone_number):
-        raise exceptions.InvalidPhoneNumber(user.phoneNumber)
+    # not wrapped inside a fraud_manager because we don't need to add any fraud
+    # log in case this check raises an exception at this point
+    check_phone_number_not_used(phone_data.phone_number)
 
     user.phoneValidationStatus = PhoneValidationStatusType.VALIDATED
     repository.save(user)
 
 
-def get_legit_phone_number(phone_number: Optional[str]) -> Optional[str]:
-    try:
-        parsed_phone_number = parse_phone_number(phone_number)
-        formatted_phone_number = get_formatted_phone_number(parsed_phone_number)
-    except exceptions.InvalidPhoneNumber:
-        return None
+def check_phone_number_is_legit(phone_number: str, country_code: str) -> None:
+    if phone_number in settings.BLACKLISTED_SMS_RECIPIENTS:
+        raise exceptions.BlacklistedPhoneNumber(phone_number)
 
-    if is_phone_number_legit(formatted_phone_number, parsed_phone_number.country_code):
-        return formatted_phone_number
-    return None
-
-
-def is_phone_number_legit(phone_number: str, country_code) -> bool:
-    return (
-        phone_number not in settings.BLACKLISTED_SMS_RECIPIENTS
-        and country_code in constants.WHITELISTED_COUNTRY_PHONE_CODES
-    )
+    if country_code not in constants.WHITELISTED_COUNTRY_PHONE_CODES:
+        raise exceptions.InvalidCountryCode(country_code)
 
 
 def _check_phone_number_validation_is_authorized(user: User) -> None:
@@ -761,7 +751,7 @@ def _check_phone_number_validation_is_authorized(user: User) -> None:
         raise exceptions.UserAlreadyBeneficiary()
 
 
-def _check_and_update_phone_validation_attempts(redis: Redis, user: User) -> None:
+def check_and_update_phone_validation_attempts(redis: Redis, user: User) -> None:
     phone_validation_attempts_key = f"phone_validation_attempts_user_{user.id}"
     phone_validation_attempts = redis.get(phone_validation_attempts_key)
 
@@ -771,11 +761,21 @@ def _check_and_update_phone_validation_attempts(redis: Redis, user: User) -> Non
             user.id,
             extra={"attempts_count": int(phone_validation_attempts)},
         )
-        raise exceptions.PhoneValidationAttemptsLimitReached()
+        raise exceptions.PhoneValidationAttemptsLimitReached(int(phone_validation_attempts))
 
     count = redis.incr(phone_validation_attempts_key)
     if count == 1:
         redis.expire(phone_validation_attempts_key, settings.PHONE_VALIDATION_ATTEMPTS_TTL)
+
+
+def check_phone_number_not_used(phone_number: str) -> None:
+    if does_validated_phone_exist(phone_number):
+        raise exceptions.PhoneAlreadyExists(phone_number)
+
+
+def check_sms_sending_is_allowed(user: User) -> None:
+    if not is_SMS_sending_allowed(app.redis_client, user):
+        raise exceptions.SMSSendingLimitReached()
 
 
 def get_next_beneficiary_validation_step(user: User) -> Optional[BeneficiaryValidationStep]:
@@ -847,3 +847,28 @@ def verify_identity_document_informations(image_storage_path: str) -> None:
     if not valid:
         user_emails.send_document_verification_error_email(email, code)
     delete_object(image_storage_path)
+
+
+class ParsedPhoneNumber:
+    def __init__(self, base_phone_number: str):
+        self.parsed_phone_number = parse_phone_number(base_phone_number)
+        self.phone_number = get_formatted_phone_number(self.parsed_phone_number)
+        self.country_code = self.parsed_phone_number.country_code
+
+
+@contextmanager
+def fraud_manager(user: User, phone_number: str) -> typing.Generator:
+    try:
+        yield
+    except exceptions.BlacklistedPhoneNumber:
+        fraud_api.handle_blacklisted_sms_recipient(user, phone_number)
+        raise
+    except exceptions.PhoneAlreadyExists:
+        fraud_api.handle_phone_already_exists(user, phone_number)
+        raise
+    except exceptions.SMSSendingLimitReached:
+        fraud_api.handle_sms_sending_limit_reached(user)
+        raise
+    except exceptions.PhoneValidationAttemptsLimitReached as error:
+        fraud_api.handle_phone_validation_attempts_limit_reached(user, error.attempts)
+        raise

--- a/src/pcapi/core/users/exceptions.py
+++ b/src/pcapi/core/users/exceptions.py
@@ -39,7 +39,9 @@ class SMSSendingLimitReached(PhoneVerificationException):
 
 
 class PhoneValidationAttemptsLimitReached(PhoneVerificationException):
-    pass
+    def __init__(self, attempts: int):
+        self.attempts = attempts
+        super().__init__()
 
 
 class PhoneAlreadyExists(PhoneVerificationException):
@@ -83,6 +85,14 @@ class BeneficiaryImportMissingException(Exception):
 
 
 class InvalidPhoneNumber(PhoneVerificationException):
+    pass
+
+
+class BlacklistedPhoneNumber(InvalidPhoneNumber):
+    pass
+
+
+class InvalidCountryCode(InvalidPhoneNumber):
     pass
 
 

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -17,6 +17,7 @@ from pcapi.connectors.api_adage import AdageException
 from pcapi.connectors.api_adage import InstitutionalProjectRedactorNotFoundException
 from pcapi.connectors.serialization.api_adage_serializers import InstitutionalProjectRedactorResponse
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.fraud import models as fraud_models
 from pcapi.core.fraud.models import BeneficiaryFraudCheck
 from pcapi.core.fraud.models import FraudCheckType
 import pcapi.core.mails.testing as mails_testing
@@ -996,6 +997,24 @@ class SendPhoneValidationCodeTest:
         assert response.status_code == 400
         assert response.json["code"] == "TOO_MANY_SMS_SENT"
 
+        # check that a fraud check has been created
+        fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(
+            userId=user.id, type=fraud_models.FraudCheckType.INTERNAL_REVIEW, thirdPartyId=f"PC-{user.id}"
+        ).one_or_none()
+
+        assert fraud_check is not None
+
+        content = fraud_check.resultContent
+        expected_reason = "Le nombre maximum de sms envoyés est atteint"
+        assert content["source"] == fraud_models.InternalReviewSource.SMS_SENDING_LIMIT_REACHED.value
+        assert content["message"] == expected_reason
+        assert content["phone_number"] == "+33601020304"
+
+        # check that a fraud result has also been created
+        assert user.beneficiaryFraudResult
+        assert user.beneficiaryFraudResult.status == fraud_models.FraudStatus.SUSPICIOUS
+        assert user.beneficiaryFraudResult.reason == expected_reason
+
     def test_send_phone_validation_code_already_beneficiary(self, app):
         user = users_factories.UserFactory(
             isEmailValidated=True, isBeneficiary=True, phoneNumber="+33601020304", roles=[UserRole.BENEFICIARY]
@@ -1063,7 +1082,7 @@ class SendPhoneValidationCodeTest:
         assert user.phoneNumber == "+33102030405"
 
     def test_send_phone_validation_code_for_new_validated_duplicated_phone_number(self, app):
-        users_factories.UserFactory(
+        orig_user = users_factories.UserFactory(
             isEmailValidated=True,
             phoneValidationStatus=PhoneValidationStatusType.VALIDATED,
             isBeneficiary=False,
@@ -1086,6 +1105,18 @@ class SendPhoneValidationCodeTest:
         db.session.refresh(user)
         assert user.phoneNumber == "+33601020304"
         assert response.json == {"message": "Le numéro de téléphone est invalide", "code": "INVALID_PHONE_NUMBER"}
+
+        # check that a fraud check has been created
+        fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(
+            userId=user.id, type=fraud_models.FraudCheckType.INTERNAL_REVIEW, thirdPartyId=f"PC-{user.id}"
+        ).one_or_none()
+
+        assert fraud_check is not None
+
+        content = fraud_check.resultContent
+        assert content["source"] == fraud_models.InternalReviewSource.PHONE_ALREADY_EXISTS.value
+        assert content["message"] == f"Le numéro est déjà utilisé par l'utilisateur {orig_user.id}"
+        assert content["phone_number"] == "+33102030405"
 
     @override_settings(BLACKLISTED_SMS_RECIPIENTS={"+33607080900"})
     def test_update_phone_number_with_blocked_phone_number(self, app):
@@ -1174,6 +1205,18 @@ class SendPhoneValidationCodeTest:
         db.session.refresh(user)
         assert user.phoneNumber == "+33601020304"
 
+        # check that a fraud check has been created
+        fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(
+            userId=user.id, type=fraud_models.FraudCheckType.INTERNAL_REVIEW, thirdPartyId=f"PC-{user.id}"
+        ).one_or_none()
+
+        assert fraud_check is not None
+
+        content = fraud_check.resultContent
+        assert content["source"] == fraud_models.InternalReviewSource.BLACKLISTED_PHONE_NUMBER.value
+        assert content["message"] == "Le numéro saisi est interdit"
+        assert content["phone_number"] == "+33601020304"
+
 
 class ValidatePhoneNumberTest:
     def test_validate_phone_number(self, app):
@@ -1234,11 +1277,31 @@ class ValidatePhoneNumberTest:
 
         assert response.status_code == 400
         assert response.json["message"] == "Le nombre de tentatives maximal est dépassé"
+        assert response.json["code"] == "TOO_MANY_VALIDATION_ATTEMPTS"
 
         db.session.refresh(user)
         assert not user.is_phone_validated
 
-        assert int(app.redis_client.get(f"phone_validation_attempts_user_{user.id}")) == 1
+        attempts_count = int(app.redis_client.get(f"phone_validation_attempts_user_{user.id}"))
+        assert attempts_count == 1
+
+        # check that a fraud check has been created
+        fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(
+            userId=user.id, type=fraud_models.FraudCheckType.INTERNAL_REVIEW, thirdPartyId=f"PC-{user.id}"
+        ).one_or_none()
+
+        assert fraud_check is not None
+
+        expected_reason = f"Le nombre maximum de tentatives de validation est atteint: {attempts_count}"
+        content = fraud_check.resultContent
+        assert content["source"] == fraud_models.InternalReviewSource.PHONE_VALIDATION_ATTEMPTS_LIMIT_REACHED.value
+        assert content["message"] == expected_reason
+        assert content["phone_number"] == "+33607080900"
+
+        # check that a fraud result has also been created
+        assert user.beneficiaryFraudResult
+        assert user.beneficiaryFraudResult.status == fraud_models.FraudStatus.SUSPICIOUS
+        assert user.beneficiaryFraudResult.reason == expected_reason
 
     def test_wrong_code(self, app):
         user = users_factories.UserFactory(isBeneficiary=False, phoneNumber="+33607080900", roles=[])


### PR DESCRIPTION
create fraud checks on phone number validation/update errors:
+ phone already exists
+ blacklisted phone number
+ sms sending limit reached
+ phone validation attempts reached

also create a fraud result on two of them:
+ sms sending limit reached
+ phone validation attempts reached

These check and results will be visible from the admin panel and help
track the user errors regarding phone validation.