### PR TITLE
PC-9905 : Allows to update the user's ID numbers

### DIFF
--- a/src/pcapi/admin/base_configuration.py
+++ b/src/pcapi/admin/base_configuration.py
@@ -14,15 +14,6 @@ import pcapi.core.users.models as users_models
 logger = logging.getLogger(__name__)
 
 
-def is_accessible() -> bool:
-    authorized = current_user.is_authenticated and current_user.isAdmin
-
-    if not authorized:
-        logger.warning("[ADMIN] Tentative d'accès non autorisé à l'interface d'administation par %s", current_user)
-
-    return authorized
-
-
 class BaseAdminMixin:
     # We need to override `create_form()` and `edit_form()`, otherwise
     # Flask-Admin loads the form classes from its cache, which is
@@ -44,7 +35,11 @@ class BaseAdminMixin:
         # to add permissions based on groups and sync'ed from our google IDP, and not developp a way to do it here.
         if current_user.is_authenticated and users_models.UserRole.JOUVE in current_user.roles:
             return False
-        return is_accessible()
+        authorized = current_user.is_authenticated and current_user.isAdmin
+        if not authorized:
+            logger.warning("[ADMIN] Tentative d'accès non autorisé à l'interface d'administation par %s", current_user)
+
+        return authorized
 
 
 class BaseAdminView(BaseAdminMixin, ModelView):

--- a/src/pcapi/admin/base_configuration.py
+++ b/src/pcapi/admin/base_configuration.py
@@ -8,8 +8,6 @@ from flask_admin.helpers import get_form_data
 from flask_login import current_user
 from werkzeug.utils import redirect
 
-import pcapi.core.users.models as users_models
-
 
 logger = logging.getLogger(__name__)
 
@@ -30,11 +28,6 @@ class BaseAdminMixin:
         return form_class(get_form_data(), obj=obj)
 
     def is_accessible(self) -> bool:
-        # TODO: remove when we have a clean way to get groups from google.
-        # This is a hackish way to filter from a user role which is weak : we do want a way
-        # to add permissions based on groups and sync'ed from our google IDP, and not developp a way to do it here.
-        if current_user.is_authenticated and users_models.UserRole.JOUVE in current_user.roles:
-            return False
         authorized = current_user.is_authenticated and current_user.isAdmin
         if not authorized:
             logger.warning("[ADMIN] Tentative d'accès non autorisé à l'interface d'administation par %s", current_user)

--- a/src/pcapi/admin/custom_views/fraud_view.py
+++ b/src/pcapi/admin/custom_views/fraud_view.py
@@ -116,7 +116,13 @@ class FraudView(base_configuration.BaseAdminView):
         return formatters
 
     def is_accessible(self) -> bool:
-        return flask_login.current_user.is_authenticated and flask_login.current_user.isAdmin
+        # TODO: remove when we have a clean way to get groups from google.
+        # This is a hackish way to filter from a user role which is weak : we do want a way
+        # to add permissions based on groups and sync'ed from our google IDP, and not developp a way to do it here.
+        if flask_login.current_user.is_authenticated and users_models.UserRole.JOUVE in flask_login.current_user.roles:
+            return True
+
+        return super().is_accessible()
 
     def get_query(self):
         filters = users_models.User.beneficiaryFraudChecks.any() | users_models.User.beneficiaryFraudResult.has()

--- a/src/pcapi/admin/custom_views/fraud_view.py
+++ b/src/pcapi/admin/custom_views/fraud_view.py
@@ -104,6 +104,9 @@ class FraudView(base_configuration.BaseAdminView):
         )
         return formatters
 
+    def is_accessible(self) -> bool:
+        return flask_login.current_user.is_authenticated and flask_login.current_user.isAdmin
+
     def get_query(self):
         return users_models.User.query.filter(
             (users_models.User.beneficiaryFraudChecks.any()) | (users_models.User.beneficiaryFraudResult.has())

--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -79,6 +79,7 @@ def on_identity_fraud_check_result(
     fraud_items = []
 
     fraud_items.append(_duplicate_user_fraud_item(jouve_content))
+    fraud_items.append(_validate_id_piece_number_format_fraud_item(jouve_content.bodyPieceNumber))
     fraud_items.append(_duplicate_id_piece_number_fraud_item(jouve_content))
     fraud_items.extend(_id_check_fraud_items(jouve_content))
 
@@ -103,6 +104,16 @@ def on_identity_fraud_check_result(
     )
 
     repository.save(fraud_result)
+
+
+def _validate_id_piece_number_format_fraud_item(id_piece_number):
+    if not id_piece_number.strip():
+        return models.FraudItem(status=models.FraudStatus.SUSPICIOUS, detail="La Piece d'identité est vide")
+    if not re.match(r"^\w{9,10}|\w{12}$", id_piece_number):
+        return models.FraudItem(
+            status=models.FraudStatus.SUSPICIOUS, detail="Le format de la pièce d'identité n'est pas valide"
+        )
+    return models.FraudItem(status=models.FraudStatus.OK, detail=None)
 
 
 def _duplicate_user_fraud_item(jouve_content: models.JouveContent) -> models.FraudItem:

--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -66,7 +66,7 @@ def admin_update_identity_fraud_check_result(
 def on_identity_fraud_check_result(
     user: User,
     beneficiary_fraud_check: models.BeneficiaryFraudCheck,
-):
+) -> models.BeneficiaryFraudResult:
     if user.isBeneficiary:
         raise exceptions.UserAlreadyBeneficiary()
     if not user.isEmailValidated:
@@ -104,6 +104,7 @@ def on_identity_fraud_check_result(
     )
 
     repository.save(fraud_result)
+    return fraud_result
 
 
 def _validate_id_piece_number_format_fraud_item(id_piece_number):

--- a/src/pcapi/core/fraud/factories.py
+++ b/src/pcapi/core/fraud/factories.py
@@ -94,17 +94,17 @@ class BeneficiaryFraudCheckFactory(testing.BaseFactory):
     user = factory.SubFactory(users_factories.UserFactory)
     type = factory.LazyAttribute(lambda o: random.choice(list(models.FraudCheckType)))
     thirdPartyId = factory.Sequence("ThirdPartyIdentifier-{0}".format)
+    resultContent = factory.SubFactory(JouveContentFactory)
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
         """Override the default ``_create`` with our custom call."""
-
         factory_class = FRAUD_CHECK_TYPE_MODEL_ASSOCIATION.get(kwargs["type"])
         content = {}
         if factory_class:
             content = factory_class()
-
-        kwargs["resultContent"] = content
+        if not isinstance(kwargs["resultContent"], factory_class._meta.get_model_class()):
+            kwargs["resultContent"] = content
 
         return super()._create(model_class, *args, **kwargs)
 

--- a/src/pcapi/core/fraud/factories.py
+++ b/src/pcapi/core/fraud/factories.py
@@ -103,7 +103,7 @@ class BeneficiaryFraudCheckFactory(testing.BaseFactory):
         content = {}
         if factory_class:
             content = factory_class()
-        if not isinstance(kwargs["resultContent"], factory_class._meta.get_model_class()):
+        if factory_class and not isinstance(kwargs["resultContent"], factory_class._meta.get_model_class()):
             kwargs["resultContent"] = content
 
         return super()._create(model_class, *args, **kwargs)

--- a/src/pcapi/core/users/models.py
+++ b/src/pcapi/core/users/models.py
@@ -124,6 +124,8 @@ class UserRole(enum.Enum):
     BENEFICIARY = "BENEFICIARY"
     INSTITUTIONAL_PROJECT_REDACTOR = "INSTITUTIONAL_PROJECT_REDACTOR"
     PRO = "PRO"
+    # TODO(bcalvez) : remove this role as soon as we get a proper identification mecanism in F.A.
+    JOUVE = "JOUVE"
 
 
 @dataclass

--- a/src/pcapi/templates/admin/fraud_details.html
+++ b/src/pcapi/templates/admin/fraud_details.html
@@ -42,13 +42,56 @@
   </div>
 </div>
 
+<div class="modal fade" id="userIdPieceNumberUpdate" tabindex="-1" role="dialog" aria-labelledby="userIdPieceNumberUpdateTitle" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="userIdPieceNumberUpdateTitle">Validation de l'utilisateur {{ model.firstName}} {{model.lastName}}</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <form method="POST" action="{{ url_for('beneficiary_fraud.update_beneficiary_id_piece_number', user_id=model.id)}}">
+      <div class="modal-body">
+          <div class="form-group row">
+            <label for="id_piece_number" class="col-4 col-form-label">N° de carte d'identité</label>
+            <div class="col-8">
+              <div class="input-group">
+                <div class="input-group-prepend">
+                  <div class="input-group-text">
+                    <i class="fa fa-address-card"></i>
+                  </div>
+                </div>
+                <input id="id_piece_number" name="id_piece_number" type="text" class="form-control">
+              </div>
+            </div>
+          </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Fermer</button>
+        <button name="submit" type="submit" class="btn btn-primary">Valider</button>
+      </div>
+    </form>
+    </div>
+  </div>
+</div>
 <div class="row">
   <div class="col">
-    <h3>Utilisateur</h3>{% if not model.beneficiaryFraudReview and current_user.is_super_user() %}
-    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#userValidationModal">
-      Soumettre une revue manuelle
-    </button>
-    {% endif %}
+  {% if not model.beneficiaryFraudReview and current_user.is_super_user() %}
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#userValidationModal">
+    Soumettre une revue manuelle
+  </button>
+  {% endif %}
+  {% if "JOUVE" in current_user.roles or current_user.is_super_user() %}
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#userIdPieceNumberUpdate">
+    Mettre à jour la pièce d'identité
+  </button>
+  {% endif %}
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    <h3>Utilisateur</h3>
     <table class="table">
     <tr>
       <th scope="row">Id</th>

--- a/tests/admin/base_configuration_test.py
+++ b/tests/admin/base_configuration_test.py
@@ -2,7 +2,6 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 import flask_login
-import pytest
 
 from pcapi.admin.base_configuration import BaseAdminView
 from pcapi.core.testing import override_settings
@@ -141,35 +140,3 @@ class BaseAdminFormTest:
                 form = view.get_edit_form()
                 assert hasattr(form, "firstName") is False
                 assert hasattr(form, "lastName") is False
-
-
-@pytest.mark.usefixtures("db_session")
-class JouveAccessTest:
-    """Specific tests to ensure JOUVE does not access anything else"""
-
-    def test_access_index(self, client):
-        user = users_factories.UserFactory(isAdmin=True, roles=[users_models.UserRole.JOUVE])
-        client.with_auth(user.email)
-        response = client.get("/pc/back-office/")
-        assert response.status_code == 200
-
-    def test_access_fraud_views(self, client):
-        user = users_factories.UserFactory(isAdmin=True, roles=[users_models.UserRole.JOUVE])
-        client.with_auth(user.email)
-        response = client.get("/pc/back-office/beneficiary_fraud")
-        assert response.status_code == 200
-
-    @pytest.mark.parametrize(
-        "url",
-        [
-            "/pc/back-office/pro_users",
-            "/pc/back-office/admin_users",
-            "/pc/back-office/beneficiary_users",
-        ],
-    )
-    def test_access_forbidden_views(self, client, url):
-        user = users_factories.UserFactory(isAdmin=True, roles=[users_models.UserRole.JOUVE])
-        client.with_auth(user.email)
-        response = client.get(url)
-        assert response.status_code == 302
-        assert response.headers["Location"] == "http://localhost/pc/back-office/"

--- a/tests/admin/base_configuration_test.py
+++ b/tests/admin/base_configuration_test.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 import flask_login
+import pytest
 
 from pcapi.admin.base_configuration import BaseAdminView
 from pcapi.core.testing import override_settings
@@ -140,3 +141,35 @@ class BaseAdminFormTest:
                 form = view.get_edit_form()
                 assert hasattr(form, "firstName") is False
                 assert hasattr(form, "lastName") is False
+
+
+@pytest.mark.usefixtures("db_session")
+class JouveAccessTest:
+    """Specific tests to ensure JOUVE does not access anything else"""
+
+    def test_access_index(self, client):
+        user = users_factories.UserFactory(isAdmin=True, roles=[users_models.UserRole.JOUVE])
+        client.with_auth(user.email)
+        response = client.get("/pc/back-office/")
+        assert response.status_code == 200
+
+    def test_access_fraud_views(self, client):
+        user = users_factories.UserFactory(isAdmin=True, roles=[users_models.UserRole.JOUVE])
+        client.with_auth(user.email)
+        response = client.get("/pc/back-office/beneficiary_fraud")
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "/pc/back-office/pro_users",
+            "/pc/back-office/admin_users",
+            "/pc/back-office/beneficiary_users",
+        ],
+    )
+    def test_access_forbidden_views(self, client, url):
+        user = users_factories.UserFactory(isAdmin=True, roles=[users_models.UserRole.JOUVE])
+        client.with_auth(user.email)
+        response = client.get(url)
+        assert response.status_code == 302
+        assert response.headers["Location"] == "http://localhost/pc/back-office/"

--- a/tests/admin/custom_views/fraud_view_test.py
+++ b/tests/admin/custom_views/fraud_view_test.py
@@ -180,3 +180,14 @@ class JouveUpdateIDPieceNumberTest:
         assert user.isBeneficiary
         assert len(user.beneficiaryImports) == 1
         assert user.beneficiaryImports[0].currentStatus == pcapi.models.ImportStatus.CREATED
+
+    def test_jouve_specific_query_filter(self, client):
+        jouve_admin = users_factories.UserFactory(
+            isAdmin=True, isBeneficiary=False, roles=[users_models.UserRole.JOUVE]
+        )
+        client.with_auth(jouve_admin.email)
+
+        fraud_factories.BeneficiaryFraudCheckFactory(type=fraud_models.FraudCheckType.JOUVE)
+        fraud_factories.BeneficiaryFraudCheckFactory(type=fraud_models.FraudCheckType.DMS)
+        response = client.get("/pc/back-office/beneficiary_fraud")
+        assert "<ul><li>dms</li></ul>" not in response.data.decode()

--- a/tests/core/fraud/test_api.py
+++ b/tests/core/fraud/test_api.py
@@ -132,6 +132,29 @@ class JouveFraudCheckTest:
 
         assert item_found
 
+    @pytest.mark.parametrize(
+        "id_piece_number",
+        [
+            "I III1",
+            "I I 1JII 11IB I E",
+            "",
+        ],
+    )
+    def test_jouve_id_piece_number_wrong_format(self, id_piece_number):
+        item = fraud_api._validate_id_piece_number_format_fraud_item(id_piece_number)
+        assert item.status == fraud_models.FraudStatus.SUSPICIOUS
+
+    @pytest.mark.parametrize(
+        "id_piece_number",
+        [
+            "321070751234",
+            "090435303687",
+        ],
+    )
+    def test_jouve_id_piece_number_valid_format(self, id_piece_number):
+        item = fraud_api._validate_id_piece_number_format_fraud_item(id_piece_number)
+        assert item.status == fraud_models.FraudStatus.OK
+
     def test_on_identity_fraud_check_result_retry(self):
         user = UserFactory(isBeneficiary=False)
         content = fraud_factories.JouveContentFactory(

--- a/tests/core/fraud/test_factories.py
+++ b/tests/core/fraud/test_factories.py
@@ -8,10 +8,20 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 
 class FactoriesTest:
-    def test_content_(self):
-        instance = fraud_factories.BeneficiaryFraudCheckFactory(type=fraud_models.FraudCheckType.USER_PROFILING)
-        assert isinstance(instance.resultContent, dict)
+    @pytest.mark.parametrize(
+        "check_type,instance_type",
+        [
+            (fraud_models.FraudCheckType.USER_PROFILING, fraud_models.UserProfilingFraudData),
+            (fraud_models.FraudCheckType.JOUVE, fraud_models.JouveContent),
+        ],
+    )
+    def test_database_serialization(self, check_type, instance_type):
+        instance = fraud_factories.BeneficiaryFraudCheckFactory(type=check_type)
+        instance_type(**instance.resultContent)
 
-    def test_database_serialization(self):
-        instance = fraud_factories.BeneficiaryFraudCheckFactory(type=fraud_models.FraudCheckType.USER_PROFILING)
-        fraud_models.UserProfilingFraudData(**instance.resultContent)
+    def test_database_overwrite(self):
+        content = fraud_factories.JouveContentFactory()
+        instance = fraud_factories.BeneficiaryFraudCheckFactory(
+            type=fraud_models.FraudCheckType.JOUVE, resultContent=content
+        )
+        assert instance.resultContent == content.dict()


### PR DESCRIPTION
Renommage de la branche https://github.com/pass-culture/pass-culture-api/pull/2806 qui ne respectait pas le bon nom de ticket, mon mauvais.

But : permettre de modifier le n° de carte d'identité d'un utilisateur dont le profil est flaggué comme potentiellement frauduleux,
et relancer la machine (de verification de fraude).

Ces interfaces doivent être accessibles par les operationnels ayant pour role "JOUVE" qui ne doivent accéder qu'a ces interfaces spécifiques.