### PR TITLE
(PC-9388) Fix log message on adage 503 error

### DIFF
--- a/src/pcapi/connectors/api_adage.py
+++ b/src/pcapi/connectors/api_adage.py
@@ -4,10 +4,10 @@ from pcapi.utils import requests
 
 
 class AdageException(Exception):
-    def __init__(self, message, status_code, api_response):
+    def __init__(self, message, status_code, response_text):
         self.message = message
         self.status_code = status_code
-        self.api_response = api_response
+        self.response_text = response_text
         super().__init__()
 
 
@@ -28,6 +28,6 @@ def get_institutional_project_redactor_by_email(email: str) -> InstitutionalProj
     if api_response.status_code == 404:
         raise InstitutionalProjectRedactorNotFoundException("Requested email is not a known Project Redactor for Adage")
     if api_response.status_code != 200:
-        raise AdageException("Error getting Adage API", api_response.status_code, api_response.json()["message"])
+        raise AdageException("Error getting Adage API", api_response.status_code, api_response.text)
 
     return InstitutionalProjectRedactorResponse.parse_obj(api_response.json())

--- a/src/pcapi/routes/native/v1/account.py
+++ b/src/pcapi/routes/native/v1/account.py
@@ -142,7 +142,7 @@ def create_institutional_project_redactor_account(body: serializers.Institutiona
     except InstitutionalProjectRedactorNotFoundException:
         logger.info("Cette adresse mail n'est pas une adresse mail académique reconnue")
     except AdageException as exception:
-        logger.error(exception.message, extra={"statusCode": exception.status_code, "error": exception.api_response})
+        logger.error(exception.message, extra={"statusCode": exception.status_code, "error": exception.response_text})
         abort(503)
 
 

--- a/tests/connectors/api_adage_test.py
+++ b/tests/connectors/api_adage_test.py
@@ -51,7 +51,7 @@ class GetInstitutionalProjectRedactorByEmailTest:
     def test_should_raise_exception_when_api_call_fails(self):
         # Given
         institutional_project_redactor_email = "project.redactor@example.com"
-        adage_error_message = "Something want wrong"
+        adage_error_message = "Something went wrong"
 
         # When
         with pytest.raises(AdageException) as exception:
@@ -61,7 +61,7 @@ class GetInstitutionalProjectRedactorByEmailTest:
                     request_headers={
                         "X-omogen-api-key": "adage-api-key",
                     },
-                    json={"message": adage_error_message},
+                    text=adage_error_message,
                     status_code=400,
                 )
                 get_institutional_project_redactor_by_email(institutional_project_redactor_email)
@@ -69,7 +69,7 @@ class GetInstitutionalProjectRedactorByEmailTest:
         # Then
         assert str(exception.value.message) == "Error getting Adage API"
         assert str(exception.value.status_code) == "400"
-        assert str(exception.value.api_response) == adage_error_message
+        assert exception.value.response_text == adage_error_message
 
     @override_settings(ADAGE_API_URL="https://adage-api-url")
     @override_settings(ADAGE_API_KEY="adage-api-key")


### PR DESCRIPTION
Avoid JSONDecodeError('Expecting value: line 1 column 1 (char 0)')

cf this error on sentry https://sentry.internal-passculture.app/organizations/sentry/issues/42981/?environment=testing&project=5&query=is%3Aunresolved