### PR TITLE
(PC-9965) Update user phone number on beneficiary_information route

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -224,23 +224,21 @@ def validate_phone_number_and_activate_user(user: User, code: str) -> User:
 
 
 def update_beneficiary_mandatory_information(
-    user: User,
-    address: str,
-    city: str,
-    postal_code: str,
-    activity: str,
+    user: User, address: str, city: str, postal_code: str, activity: str, phone_number: Optional[str] = None
 ) -> None:
+    update_payload = {
+        "address": address,
+        "city": city,
+        "postalCode": postal_code,
+        "departementCode": PostalCode(postal_code).get_departement_code(),
+        "activity": activity,
+        "hasCompletedIdCheck": True,
+    }
+    if not user.phoneNumber and phone_number:
+        update_payload["phoneNumber"] = phone_number
+
     with transaction():
-        User.query.filter(User.id == user.id).update(
-            {
-                "address": address,
-                "city": city,
-                "postalCode": postal_code,
-                "departementCode": PostalCode(postal_code).get_departement_code(),
-                "activity": activity,
-                "hasCompletedIdCheck": True,
-            }
-        )
+        User.query.filter(User.id == user.id).update(update_payload)
     db.session.refresh(user)
 
     if not steps_to_become_beneficiary(user):

--- a/src/pcapi/routes/native/v1/account.py
+++ b/src/pcapi/routes/native/v1/account.py
@@ -76,6 +76,7 @@ def update_beneficiary_mandatory_information(user: User, body: serializers.Benef
         city=body.city,
         postal_code=body.postal_code,
         activity=body.activity,
+        phone_number=body.phone,
     )
     update_user_attributes_job.delay(user.id)
 

--- a/src/pcapi/routes/native/v1/serialization/account.py
+++ b/src/pcapi/routes/native/v1/serialization/account.py
@@ -182,10 +182,11 @@ class UserProfileUpdateRequest(BaseModel):
 
 
 class BeneficiaryInformationUpdateRequest(BaseModel):
+    activity: ActivityEnum
     address: Optional[str]
     city: str
+    phone: Optional[str]
     postal_code: str
-    activity: ActivityEnum
 
     class Config:
         use_enum_values = True

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -1399,6 +1399,7 @@ class UpdateBeneficiaryInformationTest:
             postalCode=None,
             activity=None,
             phoneValidationStatus=PhoneValidationStatusType.VALIDATED,
+            phoneNumber="+33609080706",
             roles=[],
         )
 
@@ -1425,6 +1426,7 @@ class UpdateBeneficiaryInformationTest:
         assert user.city == "Uneville"
         assert user.postalCode == "77000"
         assert user.activity == "Lycéen"
+        assert user.phoneNumber == "+33609080706"
 
         assert user.isBeneficiary
         assert user.has_beneficiary_role
@@ -1466,6 +1468,7 @@ class UpdateBeneficiaryInformationTest:
             "city": "Uneville",
             "postalCode": "77000",
             "activity": "Lycéen",
+            "phone": "0601020304",
         }
 
         response = test_client.patch("/native/v1/beneficiary_information", profile_data)
@@ -1477,6 +1480,7 @@ class UpdateBeneficiaryInformationTest:
         assert user.city == "Uneville"
         assert user.postalCode == "77000"
         assert user.activity == "Lycéen"
+        assert user.phoneNumber == "0601020304"
 
         assert user.isBeneficiary
         assert user.has_beneficiary_role


### PR DESCRIPTION
the update of this field had been forgotten. Do not update user phone number if it is already present on user, which will be the case when PhoneValidation will be activated