### PR TITLE
(PC-9517) Do not index offer.id into app search offers

### DIFF
--- a/src/pcapi/core/search/backends/appsearch.py
+++ b/src/pcapi/core/search/backends/appsearch.py
@@ -230,7 +230,6 @@ class AppSearchBackend(base.SearchBackend):
             "isbn": isbn,
             "label": offer.offerType["appLabel"],
             "name": offer.name,
-            "id": offer.id,
             "prices": [int(stock.price * 100) for stock in offer.bookableStocks],
             "ranking_weight": offer.rankingWeight or 0,
             "stocks_date_created": [stock.dateCreated.timestamp() for stock in offer.bookableStocks],


### PR DESCRIPTION
Following https://github.com/pass-culture/pass-culture-browser/pull/2021/commits/538830089301216be7d3803e77a1d40178e2e35c, offer.id is not used by the webapp  nor the mobile app and can be safely removed.