### PR TITLE
(PC-9979): Remove unused jouve fraud fields

### DIFF
--- a/src/pcapi/connectors/beneficiaries/jouve_backend.py
+++ b/src/pcapi/connectors/beneficiaries/jouve_backend.py
@@ -116,13 +116,9 @@ class FraudDetectionItem:
         return f"{self.key}: {self.value} - {self.valid}"
 
 
-def get_boolean_fraud_detection_item(
-    value: Optional[str], key: str, allow_empty=True, allow_not_applicable=False
-) -> FraudDetectionItem:
+def get_boolean_fraud_detection_item(value: Optional[str], key: str, allow_empty=True) -> FraudDetectionItem:
     # TODO: cleanup required when migrating to fraud validation journey v2
     if allow_empty and not value:
-        valid = True
-    elif allow_not_applicable and value == "NOT_APPLICABLE":
         valid = True
     elif value is None or value.upper() in ("NOT_APPLICABLE", "KO", ""):
         valid = False
@@ -155,13 +151,8 @@ def get_fraud_fields(content: dict) -> dict:
             get_threshold_fraud_detection_item(content.bodyBirthDateLevel, "bodyBirthDateLevel", 100),
             get_threshold_fraud_detection_item(content.bodyNameLevel, "bodyNameLevel", 50),
             get_boolean_fraud_detection_item(content.bodyBirthDateCtrl, "bodyBirthDateCtrl"),
-            get_boolean_fraud_detection_item(content.bodyFirstnameCtrl, "bodyFirstnameCtrl"),
-            get_threshold_fraud_detection_item(content.bodyFirstnameLevel, "bodyFirstnameLevel", 50),
             get_boolean_fraud_detection_item(content.bodyNameCtrl, "bodyNameCtrl"),
             get_boolean_fraud_detection_item(content.bodyPieceNumberCtrl, "bodyPieceNumberCtrl"),
             get_threshold_fraud_detection_item(content.bodyPieceNumberLevel, "bodyPieceNumberLevel", 50),
-            get_boolean_fraud_detection_item(content.creatorCtrl, "creatorCtrl", allow_not_applicable=True),
-            get_boolean_fraud_detection_item(content.initialNumberCtrl, "initialNumberCtrl"),
-            get_boolean_fraud_detection_item(content.initialSizeCtrl, "initialSizeCtrl"),
         ],
     }

--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -164,7 +164,7 @@ def _get_boolean_id_fraud_item(value: Optional[str], key: str, is_strict_ko: boo
     is_valid = None
     if key == "creatorCtrl" and value == "NOT_APPLICABLE":
         is_valid = True
-    elif value in ("NOT_APPLICABLE", "KO", ""):
+    elif value in ("NOT_APPLICABLE", "KO"):
         is_valid = False
     else:
         is_valid = value.upper() != "KO" if value else True

--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -146,19 +146,14 @@ def _id_check_fraud_items(content: models.JouveContent) -> list[models.FraudItem
         return []
 
     fraud_items = []
-
     fraud_items.append(_get_boolean_id_fraud_item(content.birthLocationCtrl, "birthLocationCtrl", False))
     fraud_items.append(_get_boolean_id_fraud_item(content.bodyBirthDateCtrl, "bodyBirthDateCtrl", False))
-    fraud_items.append(_get_boolean_id_fraud_item(content.bodyFirstnameCtrl, "bodyFirstnameCtrl", False))
     fraud_items.append(_get_boolean_id_fraud_item(content.bodyNameCtrl, "bodyNameCtrl", False))
     fraud_items.append(_get_boolean_id_fraud_item(content.bodyPieceNumberCtrl, "bodyPieceNumberCtrl", False))
-    fraud_items.append(_get_boolean_id_fraud_item(content.creatorCtrl, "creatorCtrl", False))
     fraud_items.append(_get_boolean_id_fraud_item(content.initialNumberCtrl, "initialNumberCtrl", False))
-    fraud_items.append(_get_boolean_id_fraud_item(content.initialSizeCtrl, "initialSizeCtrl", False))
 
     fraud_items.append(_get_threshold_id_fraud_item(content.bodyBirthDateLevel, "bodyBirthDateLevel", 100, False))
     fraud_items.append(_get_threshold_id_fraud_item(content.bodyNameLevel, "bodyNameLevel", 50, False))
-    fraud_items.append(_get_threshold_id_fraud_item(content.bodyFirstnameLevel, "bodyFirstnameLevel", 50, False))
     fraud_items.append(_get_threshold_id_fraud_item(content.bodyPieceNumberLevel, "bodyPieceNumberLevel", 50, False))
 
     return fraud_items

--- a/tests/connectors/beneficiaries/beneficiary_jouve_repository_test.py
+++ b/tests/connectors/beneficiaries/beneficiary_jouve_repository_test.py
@@ -145,9 +145,7 @@ class JouveBackendTest:
         assert api_jouve_exception.value.route == "/REST/vault/extensionmethod/VEM_GetJeuneByID"
         assert api_jouve_exception.value.status_code == 500
 
-    @pytest.mark.parametrize(
-        "jouve_field", ["birthLocationCtrl", "bodyBirthDateCtrl", "bodyFirstnameCtrl", "bodyNameCtrl"]
-    )
+    @pytest.mark.parametrize("jouve_field", ["birthLocationCtrl", "bodyBirthDateCtrl", "bodyNameCtrl"])
     @pytest.mark.parametrize("wrong_possible_value", ["NOT_APPLICABLE", "KO"])
     @patch("pcapi.connectors.beneficiaries.jouve_backend._get_raw_content")
     def test_jouve_response_with_wrong_values_are_supiscious(self, _get_raw_content, jouve_field, wrong_possible_value):

--- a/tests/core/fraud/test_api.py
+++ b/tests/core/fraud/test_api.py
@@ -119,7 +119,7 @@ class JouveFraudCheckTest:
         assert not user.isBeneficiary
 
     @pytest.mark.parametrize("jouve_field", ["birthLocationCtrl", "bodyBirthDateCtrl", "bodyNameCtrl"])
-    @pytest.mark.parametrize("wrong_possible_value", ["NOT_APPLICABLE", "KO", ""])
+    @pytest.mark.parametrize("wrong_possible_value", ["NOT_APPLICABLE", "KO"])
     def test_id_check_fraud_items_wrong_values_are_supiscious(self, jouve_field, wrong_possible_value):
         jouve_content = fraud_factories.JouveContentFactory(**{jouve_field: wrong_possible_value})
         item_found = False

--- a/tests/core/fraud/test_api.py
+++ b/tests/core/fraud/test_api.py
@@ -118,9 +118,7 @@ class JouveFraudCheckTest:
         db.session.refresh(user)
         assert not user.isBeneficiary
 
-    @pytest.mark.parametrize(
-        "jouve_field", ["birthLocationCtrl", "bodyBirthDateCtrl", "bodyFirstnameCtrl", "bodyNameCtrl"]
-    )
+    @pytest.mark.parametrize("jouve_field", ["birthLocationCtrl", "bodyBirthDateCtrl", "bodyNameCtrl"])
     @pytest.mark.parametrize("wrong_possible_value", ["NOT_APPLICABLE", "KO", ""])
     def test_id_check_fraud_items_wrong_values_are_supiscious(self, jouve_field, wrong_possible_value):
         jouve_content = fraud_factories.JouveContentFactory(**{jouve_field: wrong_possible_value})


### PR DESCRIPTION
The fields BodyFirstNameCtrl, BodyFirstNamelvl, InitialSizeCtrl, InitialNumberlvl, CreatorCtrl are not used in fraud check validation