### PR TITLE
(PC-9987): UserProfiling might response with known session

### DIFF
--- a/src/pcapi/core/fraud/models.py
+++ b/src/pcapi/core/fraud/models.py
@@ -113,7 +113,7 @@ class UserProfilingFraudData(pydantic.BaseModel):
     tmx_risk_rating: str
     tmx_summary_reason_code: typing.Optional[typing.List[str]]
     summary_risk_score: int
-    unknown_session: str
+    unknown_session: typing.Optional[str]
 
 
 class BeneficiaryFraudCheck(PcObject, Model):

--- a/tests/connectors/user_profiling_fixtures.py
+++ b/tests/connectors/user_profiling_fixtures.py
@@ -835,7 +835,6 @@ CORRECT_RESPONSE = {
         "week": "10080",
     },
     "transaction_id": "transaction-id",
-    "unknown_session": "yes",
 }
 
 INVALID_PROFILING_RESPONSE = {


### PR DESCRIPTION
Objectif: corriger un probleme sur le retour de la réponse de l'user_profiling : lorsque la requete est valide, la reponse ne contient pas le champs known_session