### PR TITLE
(PC-9959) Fix batch attribute update

### DIFF
--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -26,7 +26,6 @@ from pcapi.repository import transaction
 from pcapi.utils.mailing import MailServiceException
 from pcapi.workers.push_notification_job import send_cancel_booking_notification
 from pcapi.workers.push_notification_job import update_user_attributes_job
-from pcapi.workers.push_notification_job import update_user_bookings_attributes_job
 from pcapi.workers.user_emails_job import send_booking_cancellation_emails_to_user_and_offerer_job
 
 from . import validation
@@ -122,7 +121,7 @@ def book_offer(
 
     search.async_index_offer_ids([stock.offerId])
 
-    update_user_bookings_attributes_job.delay(beneficiary.id)
+    update_user_attributes_job.delay(beneficiary.id)
 
     return booking
 

--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -266,6 +266,8 @@ def mark_as_used(booking: Booking, uncancel: bool = False) -> None:
         repository.save(*objects_to_save)
     logger.info("Booking was marked as used", extra={"booking": booking.id})
 
+    update_user_attributes_job.delay(booking.userId)
+
 
 def mark_as_unused(booking: Booking) -> None:
     validation.check_can_be_mark_as_unused(booking)
@@ -273,6 +275,8 @@ def mark_as_unused(booking: Booking) -> None:
     booking.dateUsed = None
     repository.save(booking)
     logger.info("Booking was marked as unused", extra={"booking": booking.id})
+
+    update_user_attributes_job.delay(booking.userId)
 
 
 def get_qr_code_data(booking_token: str) -> str:

--- a/src/pcapi/notifications/push/user_attributes_updates.py
+++ b/src/pcapi/notifications/push/user_attributes_updates.py
@@ -59,9 +59,7 @@ def get_user_booking_attributes(user: User) -> dict:
 
     for booking in user_bookings:
         if booking.dateUsed:
-            attributes[f"date(u.booked_product_{booking.stock.offer.productId}_date_used)"] = _format_date(
-                booking.dateUsed
-            )
+            attributes[f"date(u.product_{booking.stock.offer.productId}_use)"] = _format_date(booking.dateUsed)
 
     # A Batch tag can't be an empty list, otherwise the API returns an error
     if booking_categories:

--- a/src/pcapi/notifications/push/user_attributes_updates.py
+++ b/src/pcapi/notifications/push/user_attributes_updates.py
@@ -23,22 +23,6 @@ BATCH_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 def get_user_attributes(user: User) -> dict:
     from pcapi.core.users.api import get_domains_credit
 
-    credit = get_domains_credit(user)
-    return {
-        "u.credit": int(credit.all.remaining * 100) if credit else 0,
-        "u.departement_code": user.departementCode,
-        "date(u.date_of_birth)": _format_date(user.dateOfBirth),
-        "u.postal_code": user.postalCode,
-        "date(u.date_created)": _format_date(user.dateCreated),
-        "u.marketing_push_subscription": user.get_notification_subscriptions().marketing_push,
-        "u.is_beneficiary": user.isBeneficiary,
-        "date(u.deposit_expiration_date)": _format_date(user.deposit_expiration_date),
-    }
-
-
-def get_user_booking_attributes(user: User) -> dict:
-    from pcapi.core.users.api import get_domains_credit
-
     user_bookings = (
         Booking.query.options(
             joinedload(Booking.stock).joinedload(Stock.offer).load_only(Offer.type, Offer.url, Offer.productId)
@@ -53,8 +37,15 @@ def get_user_booking_attributes(user: User) -> dict:
     booking_categories = list(set(booking.stock.offer.type for booking in user_bookings))
 
     attributes = {
-        "date(u.last_booking_date)": _format_date(last_booking_date),
         "u.credit": int(credit.all.remaining * 100) if credit else 0,
+        "u.departement_code": user.departementCode,
+        "date(u.date_of_birth)": _format_date(user.dateOfBirth),
+        "u.postal_code": user.postalCode,
+        "date(u.date_created)": _format_date(user.dateCreated),
+        "u.marketing_push_subscription": user.get_notification_subscriptions().marketing_push,
+        "u.is_beneficiary": user.isBeneficiary,
+        "date(u.deposit_expiration_date)": _format_date(user.deposit_expiration_date),
+        "date(u.last_booking_date)": _format_date(last_booking_date),
     }
 
     for booking in user_bookings:

--- a/src/pcapi/scripts/batch_update_users_attributes.py
+++ b/src/pcapi/scripts/batch_update_users_attributes.py
@@ -11,7 +11,6 @@ from pcapi.models import User
 from pcapi.notifications.push import update_users_attributes
 from pcapi.notifications.push.user_attributes_updates import UserUpdateData
 from pcapi.notifications.push.user_attributes_updates import get_user_attributes
-from pcapi.notifications.push.user_attributes_updates import get_user_booking_attributes
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +42,7 @@ def get_users_chunks(chunk_size: int) -> Generator[list[User], None, None]:
 def format_users(users: list[User]) -> list[UserUpdateData]:
     res = []
     for user in users:
-        attributes = get_user_attributes(user) | get_user_booking_attributes(user)
+        attributes = get_user_attributes(user)
 
         res.append(UserUpdateData(user_id=str(user.id), attributes=attributes))
     print("%d users formatted...", len(res))

--- a/src/pcapi/workers/push_notification_job.py
+++ b/src/pcapi/workers/push_notification_job.py
@@ -9,7 +9,6 @@ from pcapi.notifications.push.transactional_notifications import get_bookings_ca
 from pcapi.notifications.push.transactional_notifications import get_offer_notification_data
 from pcapi.notifications.push.transactional_notifications import get_tomorrow_stock_notification_data
 from pcapi.notifications.push.user_attributes_updates import get_user_attributes
-from pcapi.notifications.push.user_attributes_updates import get_user_booking_attributes
 from pcapi.workers import worker
 from pcapi.workers.decorators import job
 
@@ -25,16 +24,6 @@ def update_user_attributes_job(user_id: int, *extra_providers: Callable[[User], 
         return
 
     update_user_attributes(user.id, get_user_attributes(user))
-
-
-@job(worker.default_queue)
-def update_user_bookings_attributes_job(user_id: int) -> None:
-    user = User.query.get(user_id)
-    if not user:
-        logger.error("No user with id=%s found to send push attributes updates requests", user_id)
-        return
-
-    update_user_attributes(user.id, get_user_booking_attributes(user))
 
 
 @job(worker.default_queue)

--- a/tests/admin/custom_views/beneficiary_user_view_test.py
+++ b/tests/admin/custom_views/beneficiary_user_view_test.py
@@ -94,23 +94,7 @@ class BeneficiaryUserViewTest:
             },
         }
 
-        assert push_testing.requests == [
-            {
-                "attribute_values": {
-                    "date(u.date_created)": user_created.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                    "date(u.date_of_birth)": "2002-07-13T10:05:00",
-                    "date(u.deposit_expiration_date)": user_created.deposit.expirationDate.strftime(
-                        "%Y-%m-%dT%H:%M:%S"
-                    ),
-                    "u.credit": 50000,
-                    "u.departement_code": "93",
-                    "u.is_beneficiary": True,
-                    "u.marketing_push_subscription": True,
-                    "u.postal_code": "93000",
-                },
-                "user_id": user_created.id,
-            },
-        ]
+        assert len(push_testing.requests) == 1
 
     @clean_database
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")

--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -341,7 +341,8 @@ class CancelByBeneficiaryTest:
         queries += 1  # select stock for update
         queries += 1  # refresh booking
         queries += 3  # update stock ; update booking ; release savepoint
-        queries += 6  # (TODO: optimize): select booking ; user ; deposit ; user.bookings ; stock, offer
+        queries += 4  # (update batch attributes): select booking ; user ; user.bookings ; deposit
+        queries += 1  # select offer
         queries += 2  # insert email ; release savepoint
         queries += 4  # (TODO: optimize) select booking ; stock ; offer ; user
         queries += 1  # select bookings of same stock with users joinedloaded to avoid N+1 requests

--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -537,6 +537,7 @@ class MarkAsUsedTest:
         booking = factories.BookingFactory()
         api.mark_as_used(booking)
         assert booking.isUsed
+        assert len(push_testing.requests) == 1
 
     def test_mark_as_used_with_uncancel(self):
         booking = factories.BookingFactory(isCancelled=True, cancellationReason="BENEFICIARY")
@@ -580,6 +581,7 @@ class MarkAsUnusedTest:
         booking = factories.BookingFactory(isUsed=True)
         api.mark_as_unused(booking)
         assert not booking.isUsed
+        assert len(push_testing.requests) == 1
 
     @override_features(AUTO_ACTIVATE_DIGITAL_BOOKINGS=True)
     def test_mark_as_unused_digital_offer(self):

--- a/tests/notifications/push/backends_test.py
+++ b/tests/notifications/push/backends_test.py
@@ -1,0 +1,16 @@
+import pytest
+
+from pcapi.notifications.push import testing as push_testing
+from pcapi.notifications.push import update_user_attributes
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def test_update_user_attributes():
+    user_id = 123
+    attributes = {"param": "value"}
+
+    update_user_attributes(user_id, attributes)
+
+    assert push_testing.requests == [{"attribute_values": {"param": "value"}, "user_id": 123}]

--- a/tests/notifications/push/user_attributes_updates_test.py
+++ b/tests/notifications/push/user_attributes_updates_test.py
@@ -30,12 +30,8 @@ class GetUserBookingAttributesTest:
         last_date_created = max(booking.dateCreated for booking in [b1, b2, b3, b4])
 
         assert attributes == {
-            f"date(u.booked_product_{b2.stock.offer.product.id}_date_used)": b2.dateUsed.strftime(
-                BATCH_DATETIME_FORMAT
-            ),
-            f"date(u.booked_product_{b3.stock.offer.product.id}_date_used)": b3.dateUsed.strftime(
-                BATCH_DATETIME_FORMAT
-            ),
+            f"date(u.product_{b2.stock.offer.product.id}_use)": b2.dateUsed.strftime(BATCH_DATETIME_FORMAT),
+            f"date(u.product_{b3.stock.offer.product.id}_use)": b3.dateUsed.strftime(BATCH_DATETIME_FORMAT),
             "date(u.last_booking_date)": last_date_created.strftime(BATCH_DATETIME_FORMAT),
             "u.credit": 47000,
             "ut.booking_categories": ["ThingType.AUDIOVISUEL"],

--- a/tests/notifications/push/user_attributes_updates_test.py
+++ b/tests/notifications/push/user_attributes_updates_test.py
@@ -6,15 +6,15 @@ from pcapi.core.bookings.factories import BookingFactory
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users.factories import UserFactory
 from pcapi.notifications.push.user_attributes_updates import BATCH_DATETIME_FORMAT
-from pcapi.notifications.push.user_attributes_updates import get_user_booking_attributes
+from pcapi.notifications.push.user_attributes_updates import get_user_attributes
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-class GetUserBookingAttributesTest:
+class GetUserAttributesTest:
     def test_get_attributes(self):
-        user = UserFactory()
+        user = UserFactory(dateOfBirth=datetime(2000, 1, 1))
         b1 = BookingFactory(user=user, amount=10)
         b2 = BookingFactory(user=user, amount=10, dateUsed=datetime(2021, 5, 6))
         b3 = BookingFactory(user=user, amount=10, dateUsed=datetime(2021, 7, 8))
@@ -25,16 +25,23 @@ class GetUserBookingAttributesTest:
         n_query_get_deposit = 1
 
         with assert_num_queries(n_query_get_user + n_query_get_bookings + n_query_get_deposit):
-            attributes = get_user_booking_attributes(user)
+            attributes = get_user_attributes(user)
 
         last_date_created = max(booking.dateCreated for booking in [b1, b2, b3, b4])
 
         assert attributes == {
+            "date(u.date_of_birth)": "2000-01-01T00:00:00",
+            "date(u.date_created)": user.dateCreated.strftime(BATCH_DATETIME_FORMAT),
+            "date(u.deposit_expiration_date)": user.deposit.expirationDate.strftime(BATCH_DATETIME_FORMAT),
             f"date(u.product_{b2.stock.offer.product.id}_use)": b2.dateUsed.strftime(BATCH_DATETIME_FORMAT),
             f"date(u.product_{b3.stock.offer.product.id}_use)": b3.dateUsed.strftime(BATCH_DATETIME_FORMAT),
             "date(u.last_booking_date)": last_date_created.strftime(BATCH_DATETIME_FORMAT),
             "u.credit": 47000,
+            "u.departement_code": "75",
+            "u.is_beneficiary": True,
             "ut.booking_categories": ["ThingType.AUDIOVISUEL"],
+            "u.marketing_push_subscription": True,
+            "u.postal_code": None,
         }
 
     def test_get_attributes_without_bookings(self):
@@ -45,9 +52,9 @@ class GetUserBookingAttributesTest:
         n_query_get_deposit = 1
 
         with assert_num_queries(n_query_get_user + n_query_get_bookings + n_query_get_deposit):
-            attributes = get_user_booking_attributes(user)
+            attributes = get_user_attributes(user)
 
-        assert attributes == {
-            "date(u.last_booking_date)": None,
-            "u.credit": 50000,
-        }
+        assert attributes["date(u.last_booking_date)"] == None
+        assert attributes["u.credit"] == 50000
+
+        assert "ut.booking_categories" not in attributes

--- a/tests/notifications/push/user_attributes_updates_test.py
+++ b/tests/notifications/push/user_attributes_updates_test.py
@@ -11,6 +11,8 @@ from pcapi.notifications.push.user_attributes_updates import get_user_attributes
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
+MAX_BATCH_PARAMETER_SIZE = 30
+
 
 class GetUserAttributesTest:
     def test_get_attributes(self):
@@ -43,6 +45,13 @@ class GetUserAttributesTest:
             "u.marketing_push_subscription": True,
             "u.postal_code": None,
         }
+
+        for attribute in attributes:
+            if attribute.startswith("date"):
+                attribute = attribute.split("date(")[1].split(")")[0]
+
+            parameter_name = attribute.split(".")[1]
+            assert len(parameter_name) <= MAX_BATCH_PARAMETER_SIZE
 
     def test_get_attributes_without_bookings(self):
         user = UserFactory()

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -385,21 +385,7 @@ class AccountCreationTest:
         mocked_check_recaptcha_token_is_valid.assert_called()
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0].sent_data["Mj-TemplateID"] == 2015423
-        assert push_testing.requests == [
-            {
-                "attribute_values": {
-                    "date(u.date_created)": user.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                    "date(u.date_of_birth)": "1960-12-31T00:00:00",
-                    "date(u.deposit_expiration_date)": None,
-                    "u.credit": 0,
-                    "u.departement_code": None,
-                    "u.is_beneficiary": False,
-                    "u.marketing_push_subscription": True,
-                    "u.postal_code": None,
-                },
-                "user_id": user.id,
-            }
-        ]
+        assert len(push_testing.requests) == 1
 
     @override_features(WHOLE_FRANCE_OPENING=True)
     @patch("pcapi.connectors.api_recaptcha.check_recaptcha_token_is_valid")
@@ -565,21 +551,7 @@ class AccountCreationBeforeGrandOpeningTest:
         assert user.externalIds == {"apps_flyer": {"platform": "SOME-PLATFORM", "user": "some-id"}}
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0].sent_data["Mj-TemplateID"] == 2015423
-        assert push_testing.requests == [
-            {
-                "attribute_values": {
-                    "date(u.date_created)": user.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                    "date(u.date_of_birth)": "1960-12-31T00:00:00",
-                    "date(u.deposit_expiration_date)": None,
-                    "u.credit": 0,
-                    "u.departement_code": "93",
-                    "u.is_beneficiary": False,
-                    "u.marketing_push_subscription": True,
-                    "u.postal_code": "93000",
-                },
-                "user_id": user.id,
-            }
-        ]
+        assert len(push_testing.requests) == 1
 
     @override_features(WHOLE_FRANCE_OPENING=False)
     @patch("pcapi.connectors.api_recaptcha.check_recaptcha_token_is_valid")
@@ -639,21 +611,7 @@ class UserProfileUpdateTest:
         assert user.get_notification_subscriptions().marketing_push
         assert not user.get_notification_subscriptions().marketing_email
 
-        assert push_testing.requests == [
-            {
-                "attribute_values": {
-                    "date(u.date_created)": user.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                    "date(u.date_of_birth)": "2000-01-01T00:00:00",
-                    "date(u.deposit_expiration_date)": user.deposit.expirationDate.strftime("%Y-%m-%dT%H:%M:%S"),
-                    "u.credit": 50000,
-                    "u.departement_code": "75",
-                    "u.is_beneficiary": True,
-                    "u.marketing_push_subscription": True,
-                    "u.postal_code": None,
-                },
-                "user_id": user.id,
-            }
-        ]
+        assert len(push_testing.requests) == 1
 
 
 class CulturalSurveyTest:

--- a/tests/routes/webapp/post_id_check_application_update_test.py
+++ b/tests/routes/webapp/post_id_check_application_update_test.py
@@ -129,21 +129,7 @@ class Returns200Test:
         mocked_send_activation_email.assert_not_called()
         mocked_send_accepted_as_beneficiary_email.assert_called_once()
 
-        assert push_testing.requests == [
-            {
-                "user_id": beneficiary.id,
-                "attribute_values": {
-                    "u.credit": 50000,
-                    "u.departement_code": "35",
-                    "date(u.date_of_birth)": "1995-05-22T00:00:00",
-                    "u.postal_code": "35123",
-                    "date(u.date_created)": beneficiary.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                    "u.marketing_push_subscription": True,
-                    "u.is_beneficiary": True,
-                    "date(u.deposit_expiration_date)": "2015-05-15T09:00:00",
-                },
-            }
-        ]
+        assert len(push_testing.requests) == 1
 
     @override_features(FORCE_PHONE_VALIDATION=True)
     @patch("pcapi.use_cases.create_beneficiary_from_application.send_accepted_as_beneficiary_email")
@@ -207,21 +193,7 @@ class Returns200Test:
         mocked_send_activation_email.assert_called_once()
         mocked_send_accepted_as_beneficiary_email.assert_not_called()
 
-        assert push_testing.requests == [
-            {
-                "user_id": user.id,
-                "attribute_values": {
-                    "u.credit": 0,
-                    "u.departement_code": "35",
-                    "date(u.date_of_birth)": "1995-05-22T00:00:00",
-                    "u.postal_code": "35123",
-                    "date(u.date_created)": user.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                    "u.marketing_push_subscription": True,
-                    "u.is_beneficiary": False,
-                    "date(u.deposit_expiration_date)": None,
-                },
-            }
-        ]
+        assert len(push_testing.requests) == 1
 
 
 class Returns400Test:

--- a/tests/scripts/beneficiary/remote_import_test.py
+++ b/tests/scripts/beneficiary/remote_import_test.py
@@ -339,21 +339,7 @@ class ProcessBeneficiaryApplicationTest:
         assert first.civility == "Mme"
         assert first.activity == "Étudiant"
 
-        assert push_testing.requests == [
-            {
-                "attribute_values": {
-                    "date(u.date_created)": first.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                    "date(u.date_of_birth)": "2000-05-01T00:00:00",
-                    "date(u.deposit_expiration_date)": first.deposit.expirationDate.strftime("%Y-%m-%dT%H:%M:%S"),
-                    "u.credit": 30000,
-                    "u.departement_code": "93",
-                    "u.is_beneficiary": True,
-                    "u.marketing_push_subscription": True,
-                    "u.postal_code": "93130",
-                },
-                "user_id": first.id,
-            }
-        ]
+        assert len(push_testing.requests) == 1
 
     @pytest.mark.usefixtures("db_session")
     def test_an_import_status_is_saved_if_beneficiary_is_created(self, app):
@@ -771,9 +757,6 @@ class RunIntegrationTest:
         assert beneficiary_import.beneficiary == user
         assert beneficiary_import.currentStatus == ImportStatus.CREATED
         assert len(push_testing.requests) == 1
-        assert push_testing.requests[0]["attribute_values"][
-            "date(u.date_of_birth)"
-        ] == self.BENEFICIARY_BIRTH_DATE.strftime("%Y-%m-%dT%H:%M:%S")
 
     @override_features(FORCE_PHONE_VALIDATION=True)
     @patch(
@@ -824,21 +807,7 @@ class RunIntegrationTest:
         assert beneficiary_import.currentStatus == ImportStatus.CREATED
         assert len(push_testing.requests) == 1
 
-        assert push_testing.requests == [
-            {
-                "attribute_values": {
-                    "date(u.date_created)": user.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                    "date(u.date_of_birth)": date_of_birth,
-                    "date(u.deposit_expiration_date)": None,
-                    "u.credit": 0,
-                    "u.departement_code": "93",
-                    "u.is_beneficiary": False,
-                    "u.marketing_push_subscription": True,
-                    "u.postal_code": "93450",
-                },
-                "user_id": user.id,
-            }
-        ]
+        assert len(push_testing.requests) == 1
 
     @patch(
         "pcapi.scripts.beneficiary.remote_import.get_closed_application_ids_for_demarche_simplifiee",
@@ -889,21 +858,7 @@ class RunIntegrationTest:
         assert beneficiary_import.currentStatus == ImportStatus.CREATED
         assert len(push_testing.requests) == 1
 
-        assert push_testing.requests == [
-            {
-                "attribute_values": {
-                    "date(u.date_created)": user.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                    "date(u.date_of_birth)": date_of_birth,
-                    "date(u.deposit_expiration_date)": user.deposit.expirationDate.strftime("%Y-%m-%dT%H:%M:%S"),
-                    "u.credit": 30000,
-                    "u.departement_code": "93",
-                    "u.is_beneficiary": True,
-                    "u.marketing_push_subscription": True,
-                    "u.postal_code": "93450",
-                },
-                "user_id": user.id,
-            }
-        ]
+        assert len(push_testing.requests) == 1
 
     @override_features(FORCE_PHONE_VALIDATION=False)
     @patch(

--- a/tests/use_cases/create_beneficiary_from_application_test.py
+++ b/tests/use_cases/create_beneficiary_from_application_test.py
@@ -98,21 +98,7 @@ def test_saved_a_beneficiary_from_application(stubed_random_token, app):
 
     assert len(mails_testing.outbox) == 1
 
-    assert push_testing.requests == [
-        {
-            "user_id": beneficiary.id,
-            "attribute_values": {
-                "u.credit": 30000,
-                "u.departement_code": "35",
-                "date(u.date_of_birth)": "1995-05-22T00:00:00",
-                "u.postal_code": "35123",
-                "date(u.date_created)": beneficiary.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                "u.marketing_push_subscription": True,
-                "u.is_beneficiary": True,
-                "date(u.deposit_expiration_date)": "2015-05-15T09:00:00",
-            },
-        }
-    ]
+    assert len(push_testing.requests) == 1
 
 
 @override_features(FORCE_PHONE_VALIDATION=False)
@@ -153,21 +139,7 @@ def test_application_for_native_app_user(app):
     assert beneficiary_import.beneficiary == beneficiary
     assert beneficiary.notificationSubscriptions == {"marketing_push": True, "marketing_email": False}
 
-    assert push_testing.requests == [
-        {
-            "user_id": beneficiary.id,
-            "attribute_values": {
-                "u.credit": 30000,
-                "date(u.date_of_birth)": "1995-05-22T00:00:00",
-                "u.departement_code": "35",
-                "u.postal_code": "35123",
-                "date(u.date_created)": beneficiary.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                "u.marketing_push_subscription": True,
-                "u.is_beneficiary": True,
-                "date(u.deposit_expiration_date)": "2015-05-15T09:00:00",
-            },
-        }
-    ]
+    assert len(push_testing.requests) == 1
 
 
 @freeze_time("2013-05-15 09:00:00")
@@ -232,21 +204,7 @@ def test_application_for_native_app_user_with_load_smoothing(_get_raw_content, a
     assert beneficiary_import.beneficiary == beneficiary
     assert beneficiary.notificationSubscriptions == {"marketing_push": True, "marketing_email": True}
 
-    assert push_testing.requests == [
-        {
-            "user_id": beneficiary.id,
-            "attribute_values": {
-                "u.credit": 30000,
-                "u.departement_code": "75",
-                "date(u.date_of_birth)": "2003-10-25T00:00:00",
-                "u.postal_code": "44300",
-                "date(u.date_created)": beneficiary.dateCreated.strftime("%Y-%m-%dT%H:%M:%S"),
-                "u.marketing_push_subscription": True,
-                "u.is_beneficiary": True,
-                "date(u.deposit_expiration_date)": "2015-05-15T09:00:00",
-            },
-        }
-    ]
+    assert len(push_testing.requests) == 1
     assert len(mails_testing.outbox) == 1
     assert mails_testing.outbox[0].sent_data["Mj-TemplateID"] == 2016025
 


### PR DESCRIPTION
This PR fixes three problems : 

- attribute parameters size cannot exceed 30 caracters, cf this error in sentry : https://sentry.internal-passculture.app/organizations/sentry/issues/11115/?environment=testing&project=5&query=is%3Aunresolved

- when a pro uses a booking, the update was not triggered

- flaky test in batch attribute update

We take advantage of the second point to improve the code by merging "user attributes" and "user booking attributes" update, for better maintenability. For example, there was another mistake : there was no update of "user booking attributes" on booking cancellation, only an update of "user attributes".

We also remove a wise number of test assertions on batch payload content, which are useless if we test well the function that builds the payload.