### PR TITLE
(PC-9977) Add a beneficiary_import mode to bypass idPieceNumber duplicate check

### DIFF
--- a/src/pcapi/connectors/beneficiaries/jouve_backend.py
+++ b/src/pcapi/connectors/beneficiaries/jouve_backend.py
@@ -76,12 +76,18 @@ def _get_raw_content(application_id: str) -> dict:
     return response.json()
 
 
-def get_application_content(application_id: str) -> JouveContent:
+def get_application_content(application_id: str, ignore_id_piece_number_field: bool = False) -> JouveContent:
     application_content = _get_raw_content(application_id)
+
     try:
-        return JouveContent(**application_content)
+        jouve_content = JouveContent(**application_content)
     except ValidationError as exc:
         raise JouveContentValidationError(str(exc), exc.errors)
+
+    if ignore_id_piece_number_field:
+        jouve_content.bodyPieceNumber = None
+
+    return jouve_content
 
 
 def get_subscription_from_content(content: JouveContent) -> BeneficiaryPreSubscription:

--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -108,11 +108,13 @@ def on_identity_fraud_check_result(
 
 
 def _validate_id_piece_number_format_fraud_item(id_piece_number):
-    if not id_piece_number.strip():
-        return models.FraudItem(status=models.FraudStatus.SUSPICIOUS, detail="La Piece d'identité est vide")
+    if not id_piece_number or not id_piece_number.strip():
+        return models.FraudItem(
+            status=models.FraudStatus.SUSPICIOUS, detail="Le numéro de la pièce d'identité est vide"
+        )
     if not re.match(r"^\w{9,10}|\w{12}$", id_piece_number):
         return models.FraudItem(
-            status=models.FraudStatus.SUSPICIOUS, detail="Le format de la pièce d'identité n'est pas valide"
+            status=models.FraudStatus.SUSPICIOUS, detail="Le format du numéro de la pièce d'identité n'est pas valide"
         )
     return models.FraudItem(status=models.FraudStatus.OK, detail=None)
 

--- a/src/pcapi/domain/beneficiary_pre_subscription/beneficiary_pre_subscription.py
+++ b/src/pcapi/domain/beneficiary_pre_subscription/beneficiary_pre_subscription.py
@@ -15,7 +15,7 @@ class BeneficiaryPreSubscription:
     date_of_birth: datetime
     email: str
     first_name: str
-    id_piece_number: str
+    id_piece_number: Optional[str]
     last_name: str
     phone_number: str
     postal_code: str

--- a/src/pcapi/domain/beneficiary_pre_subscription/beneficiary_pre_subscription_validator.py
+++ b/src/pcapi/domain/beneficiary_pre_subscription/beneficiary_pre_subscription_validator.py
@@ -105,13 +105,18 @@ def _check_id_piece_number_is_unique(beneficiary_pre_subscription: BeneficiaryPr
         raise IdPieceNumberDuplicate(f"id piece number n°{beneficiary_pre_subscription.id_piece_number} already taken")
 
 
-def validate(beneficiary_pre_subscription: BeneficiaryPreSubscription, preexisting_account: User = None) -> None:
+def validate(
+    beneficiary_pre_subscription: BeneficiaryPreSubscription,
+    preexisting_account: User = None,
+    ignore_id_piece_number_field: bool = False,
+) -> None:
     _check_department_is_eligible(beneficiary_pre_subscription)
     if not preexisting_account:
         _check_email_is_not_taken(beneficiary_pre_subscription)
     else:
         if preexisting_account.isBeneficiary or not preexisting_account.isEmailValidated:
             raise BeneficiaryIsADuplicate(f"Email {beneficiary_pre_subscription.email} is already taken.")
-    _check_id_piece_number_format(beneficiary_pre_subscription)
     _check_not_a_duplicate(beneficiary_pre_subscription)
-    _check_id_piece_number_is_unique(beneficiary_pre_subscription)
+    if not ignore_id_piece_number_field:
+        _check_id_piece_number_format(beneficiary_pre_subscription)
+        _check_id_piece_number_is_unique(beneficiary_pre_subscription)

--- a/src/pcapi/workers/beneficiary_job.py
+++ b/src/pcapi/workers/beneficiary_job.py
@@ -4,5 +4,15 @@ from pcapi.workers.decorators import job
 
 
 @job(worker.id_check_queue)
-def beneficiary_job(application_id: int, run_fraud_detection: bool = True, fraud_detection_ko: bool = False) -> None:
-    create_beneficiary_from_application.execute(application_id, run_fraud_detection, fraud_detection_ko)
+def beneficiary_job(
+    application_id: int,
+    run_fraud_detection: bool = True,
+    ignore_id_piece_number_field: bool = False,
+    fraud_detection_ko: bool = False,
+) -> None:
+    create_beneficiary_from_application.execute(
+        application_id,
+        run_fraud_detection=run_fraud_detection,
+        ignore_id_piece_number_field=ignore_id_piece_number_field,
+        fraud_detection_ko=fraud_detection_ko,
+    )

--- a/tests/use_cases/create_beneficiary_from_application_test.py
+++ b/tests/use_cases/create_beneficiary_from_application_test.py
@@ -569,3 +569,33 @@ def test_id_piece_number_wrong_format(mocked_get_content, id_piece_number):
     assert len(mails_testing.outbox) == 1
     assert mails_testing.outbox[0].sent_data["Mj-TemplateID"] == 2905960
     assert mails_testing.outbox[0].sent_data["Mj-campaign"] == "dossier-en-analyse"
+
+
+@patch("pcapi.connectors.beneficiaries.jouve_backend._get_raw_content")
+@pytest.mark.usefixtures("db_session")
+def test_id_piece_number_by_pass(
+    mocked_get_content,
+    app,
+):
+    # Given
+    ID_PIECE_NUMBER = "NOT_APPLICABLE"
+    subscribing_user = UserFactory(
+        isBeneficiary=False,
+        dateOfBirth=datetime.now() - relativedelta(years=18, day=5),
+        email=BASE_JOUVE_CONTENT["email"],
+    )
+    UserFactory(idPieceNumber=ID_PIECE_NUMBER)
+    UserFactory(idPieceNumber=None)
+    mocked_get_content.return_value = BASE_JOUVE_CONTENT | {"bodyPieceNumber": ID_PIECE_NUMBER}
+
+    # When
+    create_beneficiary_from_application.execute(BASE_APPLICATION_ID, ignore_id_piece_number_field=True)
+
+    # Then
+    beneficiary_import = BeneficiaryImport.query.filter(BeneficiaryImport.beneficiary == subscribing_user).first()
+
+    assert beneficiary_import.currentStatus == ImportStatus.CREATED
+    assert subscribing_user.isBeneficiary
+    assert not subscribing_user.idPieceNumber
+
+    assert len(mails_testing.outbox) == 1

--- a/tests/workers/beneficiary_job_test.py
+++ b/tests/workers/beneficiary_job_test.py
@@ -12,4 +12,6 @@ def test_calls_use_case(mocked_create_beneficiary_use_case):
     beneficiary_job(application_id)
 
     # Then
-    mocked_create_beneficiary_use_case.assert_called_once_with(application_id, True, False)
+    mocked_create_beneficiary_use_case.assert_called_once_with(
+        application_id, run_fraud_detection=True, ignore_id_piece_number_field=False, fraud_detection_ko=False
+    )


### PR DESCRIPTION
For a good amount of uploaded identity cards, Jouve sends a wrong value for idPieceNumber field, for example ''. Some files have been manually checked by admins and must be reimported by bypassing the check