### PR TITLE
(PC-9687) Set subcategories when creating Products

### DIFF
--- a/alembic_version_conflict_detection.txt
+++ b/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-ffce4944b6b7 (head)
+e910e1cc2112 (head)

--- a/alembic_version_conflict_detection.txt
+++ b/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-1c5bec8d2aec
+ffce4944b6b7 (head)

--- a/src/pcapi/alembic/versions/20210719_d1c3b30ef70d_add_subcategory_to_product.py
+++ b/src/pcapi/alembic/versions/20210719_d1c3b30ef70d_add_subcategory_to_product.py
@@ -1,0 +1,24 @@
+"""add_subcategory_to_product
+
+Revision ID: d1c3b30ef70d
+Revises: 19b36a0b880a
+Create Date: 2021-07-19 14:28:35.887679
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "d1c3b30ef70d"
+down_revision = "19b36a0b880a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("product", sa.Column("subcategoryId", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("product", "subcategoryId")

--- a/src/pcapi/alembic/versions/20210719_d1c3b30ef70d_add_subcategory_to_product.py
+++ b/src/pcapi/alembic/versions/20210719_d1c3b30ef70d_add_subcategory_to_product.py
@@ -1,7 +1,7 @@
 """add_subcategory_to_product
 
 Revision ID: d1c3b30ef70d
-Revises: ffce4944b6b7
+Revises: 1c5bec8d2aec
 Create Date: 2021-07-19 14:28:35.887679
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "d1c3b30ef70d"
-down_revision = "ffce4944b6b7"
+down_revision = "1c5bec8d2aec"
 branch_labels = None
 depends_on = None
 

--- a/src/pcapi/alembic/versions/20210719_d1c3b30ef70d_add_subcategory_to_product.py
+++ b/src/pcapi/alembic/versions/20210719_d1c3b30ef70d_add_subcategory_to_product.py
@@ -1,7 +1,7 @@
 """add_subcategory_to_product
 
 Revision ID: d1c3b30ef70d
-Revises: 19b36a0b880a
+Revises: ffce4944b6b7
 Create Date: 2021-07-19 14:28:35.887679
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "d1c3b30ef70d"
-down_revision = "19b36a0b880a"
+down_revision = "ffce4944b6b7"
 branch_labels = None
 depends_on = None
 

--- a/src/pcapi/alembic/versions/20210719_e910e1cc2112_add_index_on_product_subcategoryid.py
+++ b/src/pcapi/alembic/versions/20210719_e910e1cc2112_add_index_on_product_subcategoryid.py
@@ -1,0 +1,45 @@
+"""add_index_on_product_subcategoryId
+
+Revision ID: e910e1cc2112
+Revises: d1c3b30ef70d
+Create Date: 2021-07-19 14:29:22.866117
+
+"""
+from alembic import op
+
+from pcapi import settings
+
+
+# revision identifiers, used by Alembic.
+revision = "e910e1cc2112"
+down_revision = "d1c3b30ef70d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.execute(
+        """
+        SET SESSION statement_timeout = '300s'
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_product_subcategoryId" ON product ("subcategoryId")
+        """
+    )
+    op.execute(
+        f"""
+        SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}
+        """
+    )
+
+
+def downgrade():
+    op.execute("COMMIT")
+    op.execute(
+        """
+        DROP INDEX CONCURRENTLY IF EXISTS "ix_product_subcategoryId"
+        """
+    )

--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -190,8 +190,6 @@ def update_offer(  # pylint: disable=redefined-builtin
     isNational: bool = UNCHANGED,
     name: str = UNCHANGED,
     extraData: dict = UNCHANGED,
-    # FIXME: type (and subcategoryId) should not be updatable
-    type: str = UNCHANGED,
     externalTicketOfficeUrl: str = UNCHANGED,
     url: str = UNCHANGED,
     withdrawalDetails: str = UNCHANGED,

--- a/src/pcapi/core/offers/factories.py
+++ b/src/pcapi/core/offers/factories.py
@@ -7,7 +7,7 @@ from pcapi import models
 from pcapi.core.categories import subcategories
 from pcapi.core.categories.subcategories import ALL_SUBCATEGORIES
 from pcapi.core.categories.subcategories import ALL_SUBCATEGORIES_DICT
-import pcapi.core.offerers.models
+import pcapi.core.offerers.models as offerers_models
 from pcapi.core.offers.models import OfferReport
 from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.core.testing import BaseFactory

--- a/src/pcapi/local_providers/allocine/allocine_stocks.py
+++ b/src/pcapi/local_providers/allocine/allocine_stocks.py
@@ -8,13 +8,13 @@ from dateutil.parser import parse
 from sqlalchemy import Sequence
 
 from pcapi import settings
+from pcapi.core.categories import subcategories
 from pcapi.core.providers.models import AllocineVenueProvider
 from pcapi.domain.allocine import get_movie_poster
 from pcapi.domain.allocine import get_movies_showtimes
 from pcapi.domain.price_rule import AllocineStocksPriceRule
 from pcapi.local_providers.local_provider import LocalProvider
 from pcapi.local_providers.providable_info import ProvidableInfo
-from pcapi.models import EventType
 from pcapi.models import Offer
 from pcapi.models import Product
 from pcapi.models import Stock
@@ -132,7 +132,8 @@ class AllocineStocks(LocalProvider):
 
     def fill_product_attributes(self, allocine_product: Product):
         allocine_product.name = self.movie_information["title"]
-        allocine_product.type = str(EventType.CINEMA)
+        allocine_product.subcategoryId = subcategories.SEANCE_CINE.id
+        allocine_product.type = subcategories.SEANCE_CINE.matching_type
         allocine_product.thumbCount = 0
 
         self.update_from_movie_information(allocine_product, self.movie_information)
@@ -167,7 +168,8 @@ class AllocineStocks(LocalProvider):
         )
 
         allocine_offer.name = f"{self.movie_information['title']} - {movie_version}"
-        allocine_offer.type = str(EventType.CINEMA)
+        allocine_offer.subcategoryId = subcategories.SEANCE_CINE.id
+        allocine_offer.type = subcategories.SEANCE_CINE.matching_type
         allocine_offer.productId = self.last_product_id
 
         is_new_offer_to_insert = allocine_offer.id is None

--- a/src/pcapi/models/product.py
+++ b/src/pcapi/models/product.py
@@ -59,6 +59,8 @@ class Product(PcObject, Model, ExtraDataMixin, HasThumbMixin, ProvidableMixin):
 
     owningOfferer = relationship("Offerer", foreign_keys=[owningOffererId], backref="events")
 
+    subcategoryId = Column(Text, nullable=True, index=True)
+
     @property
     def offerType(self):
         all_types = list(ThingType) + list(EventType)

--- a/src/pcapi/routes/serialization/offers_serialize.py
+++ b/src/pcapi/routes/serialization/offers_serialize.py
@@ -25,7 +25,6 @@ from pcapi.validation.routes.offers import check_offer_isbn_is_valid
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
 from pcapi.validation.routes.offers import check_offer_not_duo_and_educational
 from pcapi.validation.routes.offers import check_offer_subcategory_is_valid
-from pcapi.validation.routes.offers import check_offer_type_is_valid
 
 
 class SubcategoryResponseModel(BaseModel):
@@ -98,12 +97,6 @@ class PostOfferBodyModel(BaseModel):
         if not values["product_id"]:
             check_offer_name_length_is_valid(name)
         return name
-
-    @validator("type", pre=True)
-    def validate_type(cls, type_field, values):  # pylint: disable=no-self-argument
-        if not values["product_id"]:
-            check_offer_type_is_valid(type_field)
-        return type_field
 
     @validator("is_educational", pre=True)
     def validate_educational(cls, type_field, values):  # pylint: disable=no-self-argument

--- a/src/pcapi/routes/serialization/offers_serialize.py
+++ b/src/pcapi/routes/serialization/offers_serialize.py
@@ -137,7 +137,6 @@ class PatchOfferBodyModel(BaseModel):
     isNational: Optional[bool]
     name: Optional[str]
     extraData: Any
-    type: Optional[str]
     externalTicketOfficeUrl: Optional[HttpUrl]
     url: Optional[HttpUrl]
     withdrawalDetails: Optional[str]

--- a/src/pcapi/sandboxes/scripts/creators/allocine/__init__.py
+++ b/src/pcapi/sandboxes/scripts/creators/allocine/__init__.py
@@ -1,14 +1,13 @@
 from random import randint
 
+from pcapi.core.categories import subcategories
 from pcapi.core.providers.repository import get_provider_by_local_class
-from pcapi.core.users import factories as users_factories
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_user_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.generic_creators import create_venue_provider
 from pcapi.model_creators.provider_creators import activate_provider
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
-from pcapi.models import EventType
 from pcapi.repository import repository
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_admin_users import *
 
@@ -65,7 +64,7 @@ def save_allocine_sandbox() -> None:
 
     offer = create_offer_with_event_product(
         venue,
-        event_type=EventType.CINEMA,
+        event_subcategory_id=subcategories.SEANCE_CINE.id,
         last_provider_id=provider.id,
         id_at_providers="TW92aWU6MjQ4MTAy%34007977100028-VF",
         last_provider=provider,

--- a/src/pcapi/sandboxes/scripts/creators/bookings_recap/bookings_recap.py
+++ b/src/pcapi/sandboxes/scripts/creators/bookings_recap/bookings_recap.py
@@ -5,6 +5,7 @@ import logging
 from pcapi.core.bookings.exceptions import BookingIsAlreadyCancelled
 from pcapi.core.bookings.exceptions import BookingIsAlreadyUsed
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import EventOfferFactory
 from pcapi.core.offers.factories import EventProductFactory
 from pcapi.core.offers.factories import EventStockFactory
@@ -19,8 +20,6 @@ from pcapi.core.payments.factories import PaymentFactory
 from pcapi.core.payments.factories import PaymentStatusFactory
 from pcapi.core.users.factories import BeneficiaryFactory
 from pcapi.core.users.factories import ProFactory
-from pcapi.models import EventType
-from pcapi.models import ThingType
 from pcapi.models.payment_status import TransactionStatus
 from pcapi.repository import repository
 
@@ -66,34 +65,38 @@ def save_bookings_recap_sandbox():
     venue3 = VenueFactory(managingOfferer=offerer, name="Théatre Mordor", siret="64538954601379")
     venue4_virtual = VenueFactory(managingOfferer=offerer, name="Un lieu virtuel", siret=None, isVirtual=True)
 
-    product1_venue1 = EventProductFactory(name="Jurassic Park", type=str(EventType.CINEMA))
+    product1_venue1 = EventProductFactory(name="Jurassic Park", subcategoryId=subcategories.SEANCE_CINE.id)
     offer1_venue1 = EventOfferFactory(product=product1_venue1, venue=venue1, isDuo=True)
     stock_1_offer1_venue1 = EventStockFactory(
         offer=offer1_venue1, beginningDatetime=yesterday, quantity=None, price=12.99
     )
 
-    product2_venue1 = EventProductFactory(name="Matrix", type=str(EventType.CINEMA))
+    product2_venue1 = EventProductFactory(name="Matrix", subcategoryId=subcategories.SEANCE_CINE.id)
 
     offer2_venue1 = EventOfferFactory(product=product2_venue1, venue=venue1, isDuo=False)
     stock_2_offer2_venue1 = EventStockFactory(offer=offer2_venue1, beginningDatetime=today, quantity=None, price=0)
 
     product1_venue2 = ThingProductFactory(
-        name="Fondation", type=str(ThingType.LIVRE_EDITION), extraData={"isbn": "9788804119135"}
+        name="Fondation", subcategoryId=subcategories.LIVRE_PAPIER.id, extraData={"isbn": "9788804119135"}
     )
     offer1_venue2 = ThingOfferFactory(product=product1_venue2, venue=venue2)
     stock_1_offer1_venue2 = ThingStockFactory(offer=offer1_venue2, quantity=42, price=9.99)
 
     product2_venue2 = ThingProductFactory(
-        name="Martine à la playa", type=str(ThingType.LIVRE_EDITION), extraData={"isbn": "9787605639121"}
+        name="Martine à la playa",
+        subcategoryId=subcategories.LIVRE_PAPIER.id,
+        extraData={"isbn": "9787605639121"},
     )
     offer2_venue2 = ThingOfferFactory(product=product2_venue2, venue=venue2)
     stock_1_offer2_venue2 = ThingStockFactory(offer=offer2_venue2, quantity=12, price=49.99)
 
-    product1_venue3 = EventProductFactory(name="Danse des haricots", type=str(EventType.SPECTACLE_VIVANT))
+    product1_venue3 = EventProductFactory(
+        name="Danse des haricots", subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id
+    )
     offer1_venue3 = EventOfferFactory(product=product1_venue3, venue=venue3)
     stock_1_offer1_venue3 = EventStockFactory(offer=offer1_venue3, quantity=44, price=18.50)
 
-    product1_venue4 = ThingProductFactory(name="Le livre des haricots", type=str(ThingType.LIVRE_EDITION))
+    product1_venue4 = ThingProductFactory(name="Le livre des haricots", subcategoryId=subcategories.LIVRE_PAPIER.id)
     offer1_venue4 = ThingOfferFactory(product=product1_venue4, venue=venue4_virtual)
     stock_1_offer1_venue4 = ThingStockFactory(offer=offer1_venue4, quantity=70, price=10.99)
 

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_activation_offers.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_activation_offers.py
@@ -1,12 +1,12 @@
 import logging
 
+from pcapi.core.categories import subcategories
 from pcapi.core.users.models import User
 from pcapi.model_creators.generic_creators import create_booking
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
 from pcapi.model_creators.specific_creators import create_stock_with_thing_offer
-from pcapi.models import ThingType
 from pcapi.repository import repository
 
 
@@ -19,7 +19,7 @@ def create_industrial_activation_offers():
     activated_user = User.query.filter_by(isBeneficiary=True).first()
     offerer = create_offerer()
     venue = create_venue(offerer, is_virtual=True, siret=None)
-    offer = create_offer_with_thing_product(venue, thing_type=ThingType.ACTIVATION)
+    offer = create_offer_with_thing_product(venue, thing_subcategory_id=subcategories.ACTIVATION_THING.id)
     stock = create_stock_with_thing_offer(offerer, venue, offer=offer, price=0, quantity=10000)
 
     booking = create_booking(user=activated_user, stock=stock, offerer=offerer, venue=venue, token="ACTIVA")

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_offers.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_offers.py
@@ -46,7 +46,7 @@ def create_industrial_event_offers(events_by_name, offerers_by_name):
             else:
                 is_duo = True
             event_offers_by_name[name] = create_offer_with_event_product(
-                event_venue, product=event, event_type=event.type, is_active=is_active, is_duo=is_duo
+                event_venue, product=event, event_subcategory_id=event.subcategoryId, is_active=is_active, is_duo=is_duo
             )
             offer_index += 1
 

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_products.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_products.py
@@ -1,9 +1,10 @@
 import logging
 
+from pcapi.core.categories.conf import get_subcategory_from_type
 from pcapi.domain.music_types import music_types
 from pcapi.domain.show_types import show_types
 from pcapi.domain.types import get_formatted_active_product_types
-from pcapi.model_creators.specific_creators import create_product_with_event_type
+from pcapi.model_creators.specific_creators import create_product_with_event_subcategory
 from pcapi.models.offer_type import EventType
 from pcapi.repository import repository
 from pcapi.sandboxes.scripts.mocks.event_mocks import MOCK_ACTIVATION_DESCRIPTION
@@ -45,11 +46,11 @@ def create_industrial_event_products():
             event_type = event_type_dict["value"]
 
             name = "{} / {}".format(event_type_dict["value"], event_name)
-            event_product = create_product_with_event_type(
+            event_product = create_product_with_event_subcategory(
                 description=description,
                 duration_minutes=60,
                 event_name=event_name,
-                event_type=event_type,
+                event_subcategory_id=get_subcategory_from_type(offer_type=event_type, is_virtual_venue=False),
                 thumb_count=0,
             )
 
@@ -82,7 +83,6 @@ def create_industrial_event_products():
                     pass
                 extra_data_index += 1
             event_product.extraData = extraData
-
             event_products_by_name[name] = event_product
 
         type_index += len(event_type_dicts)

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_thing_offers.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_thing_offers.py
@@ -53,7 +53,7 @@ def create_industrial_thing_offers(things_by_name, offerers_by_name, venues_by_n
             thing_offers_by_name[name] = create_offer_with_thing_product(
                 thing_venue,
                 product=thing,
-                thing_type=thing.type,
+                thing_subcategory_id=thing.subcategoryId,
                 is_active=is_active,
                 id_at_providers=str(id_at_providers),
             )

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_thing_products.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_thing_products.py
@@ -1,8 +1,9 @@
 import logging
 
+from pcapi.core.categories.conf import get_subcategory_from_type
 from pcapi.domain.music_types import music_types
 from pcapi.domain.types import get_formatted_active_product_types
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.repository import repository
 from pcapi.sandboxes.scripts.mocks.thing_mocks import MOCK_AUTHOR_NAMES
 from pcapi.sandboxes.scripts.mocks.thing_mocks import MOCK_DESCRIPTIONS
@@ -36,13 +37,27 @@ def create_industrial_thing_products():
             name = "{} / {}".format(thing_type_dict["value"], MOCK_NAMES[mock_index])
             is_national = thing_type_dict["onlineOnly"]
             url = "https://ilestencoretemps.fr/" if thing_type_dict["onlineOnly"] else None
-            thing_product = create_product_with_thing_type(
+            thing_product = create_product_with_thing_subcategory(
                 author_name=MOCK_AUTHOR_NAMES[mock_index],
                 description=MOCK_DESCRIPTIONS[mock_index],
                 id_at_providers=str(id_at_providers),
                 is_national=is_national,
                 thing_name=MOCK_NAMES[mock_index],
-                thing_type=thing_type_dict["value"],
+                thing_subcategory_id=get_subcategory_from_type(
+                    offer_type=thing_type_dict["value"], is_virtual_venue=False
+                ),
+                thumb_count=0,
+                url=url,
+            )
+            virtual_venue_thing_product = create_product_with_thing_subcategory(
+                author_name=MOCK_AUTHOR_NAMES[mock_index],
+                description=MOCK_DESCRIPTIONS[mock_index],
+                id_at_providers=str(id_at_providers + 1),
+                is_national=is_national,
+                thing_name=MOCK_NAMES[mock_index],
+                thing_subcategory_id=get_subcategory_from_type(
+                    offer_type=thing_type_dict["value"], is_virtual_venue=True
+                ),
                 thumb_count=0,
                 url=url,
             )
@@ -73,10 +88,12 @@ def create_industrial_thing_products():
                     extraData[conditionalField] = random_token(13)
                 extra_data_index += 1
             thing_product.extraData = extraData
+            virtual_venue_thing_product.extraData = extraData
 
             thing_products_by_name[name] = thing_product
+            thing_products_by_name[name + "_virtual_venue"] = virtual_venue_thing_product
 
-            id_at_providers += 1
+            id_at_providers += 2
 
         type_index += len(thing_type_dicts)
 

--- a/src/pcapi/sandboxes/scripts/sandbox_activation.py
+++ b/src/pcapi/sandboxes/scripts/sandbox_activation.py
@@ -1,8 +1,8 @@
+from pcapi.core.categories import subcategories
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
 from pcapi.model_creators.specific_creators import create_stock_with_thing_offer
-from pcapi.models import ThingType
 from pcapi.repository import repository
 
 
@@ -10,6 +10,6 @@ def save_sandbox():
 
     offerer = create_offerer()
     venue = create_venue(offerer, is_virtual=True, siret=None)
-    offer = create_offer_with_thing_product(venue, thing_type=ThingType.ACTIVATION)
+    offer = create_offer_with_thing_product(venue, thing_subcategory_id=subcategories.ACTIVATION_THING.id)
     stock = create_stock_with_thing_offer(offerer, venue, offer=offer, price=0, quantity=10000)
     repository.save(stock)

--- a/src/pcapi/sandboxes/scripts/sandbox_payment.py
+++ b/src/pcapi/sandboxes/scripts/sandbox_payment.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from datetime import timedelta
 import logging
 
+from pcapi.core.categories import subcategories
 import pcapi.core.payments.api as payments_api
 from pcapi.core.users import factories as users_factories
 from pcapi.model_creators.generic_creators import create_bank_information
@@ -13,8 +14,6 @@ from pcapi.model_creators.specific_creators import create_event_occurrence
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
 from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence
-from pcapi.models import EventType
-from pcapi.models import ThingType
 from pcapi.models import Venue
 from pcapi.repository import repository
 
@@ -94,7 +93,9 @@ def save_offerer_without_iban():
 
 def save_free_event_offer_with_stocks(venue: Venue):
     free_event_offer = create_offer_with_event_product(
-        venue, event_name="Free event", event_type=EventType.SPECTACLE_VIVANT
+        venue,
+        event_name="Free event",
+        event_subcategory_id=subcategories.SPECTACLE_REPRESENTATION.id,
     )
     past_occurrence = create_event_occurrence(free_event_offer, beginning_datetime=now - three_days)
     future_occurrence = create_event_occurrence(free_event_offer, beginning_datetime=now + three_days)
@@ -107,7 +108,10 @@ def save_free_event_offer_with_stocks(venue: Venue):
 
 def save_non_reimbursable_thing_offer(venue: Venue):
     paid_non_reimbursable_offer = create_offer_with_thing_product(
-        venue, thing_name="Concert en ligne", thing_type=ThingType.JEUX_VIDEO, url="http://my.game.fr"
+        venue,
+        thing_name="Concert en ligne",
+        thing_subcategory_id=subcategories.JEU_SUPPORT_PHYSIQUE.id,
+        url="http://my.game.fr",
     )
     non_reimbursable_stock = create_stock(offer=paid_non_reimbursable_offer, price=30)
     repository.save(non_reimbursable_stock)
@@ -117,7 +121,7 @@ def save_non_reimbursable_thing_offer(venue: Venue):
 
 def save_reimbursable_thing_offer(venue: Venue):
     paid_reimbursable_offer = create_offer_with_thing_product(
-        venue, thing_name="Roman cool", thing_type=ThingType.LIVRE_EDITION
+        venue, thing_name="Roman cool", thing_subcategory_id=subcategories.LIVRE_PAPIER.id
     )
     reimbursable_stock = create_stock(offer=paid_reimbursable_offer, price=30)
     repository.save(reimbursable_stock)
@@ -127,7 +131,7 @@ def save_reimbursable_thing_offer(venue: Venue):
 
 def save_paid_online_book_offer(venue: Venue):
     paid_reimbursable_offer = create_offer_with_thing_product(
-        venue, thing_name="Roman cool", thing_type=ThingType.LIVRE_EDITION, url="https://mycoolbook.fr"
+        venue, thing_name="Roman cool", thing_subcategory_id=subcategories.LIVRE_PAPIER.id, url="https://mycoolbook.fr"
     )
     reimbursable_stock = create_stock(offer=paid_reimbursable_offer, price=20)
     repository.save(reimbursable_stock)
@@ -137,7 +141,9 @@ def save_paid_online_book_offer(venue: Venue):
 
 def save_paid_reimbursable_event_offer(venue: Venue):
     paid_reimbursable_event_offer = create_offer_with_event_product(
-        venue, event_name="Paid event", event_type=EventType.SPECTACLE_VIVANT
+        venue,
+        event_name="Paid event",
+        event_subcategory_id=subcategories.SPECTACLE_REPRESENTATION.id,
     )
     past_occurrence = create_event_occurrence(paid_reimbursable_event_offer, beginning_datetime=now - three_days)
     future_occurrence = create_event_occurrence(paid_reimbursable_event_offer, beginning_datetime=now + three_days)

--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -15,6 +15,7 @@ from pcapi.core.bookings import models
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 import pcapi.core.mails.testing as mails_testing
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offers_models
@@ -149,9 +150,10 @@ class BookOfferTest:
         assert email_data2["MJ-TemplateID"] == 2996790  # to beneficiary
 
     def test_booked_categories_are_sent_to_batch_backend(self, app):
-        offer1 = offers_factories.OfferFactory(type="ThingType.AUDIOVISUEL")
-        offer2 = offers_factories.OfferFactory(type="ThingType.CINEMA_ABO")
-        offers_factories.OfferFactory(type="ThingType.INSTRUMENT")
+        offer1 = offers_factories.OfferFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
+        offer2 = offers_factories.OfferFactory(subcategoryId=subcategories.CARTE_CINE_ILLIMITE.id)
+
+        offers_factories.OfferFactory(subcategoryId=subcategories.ACHAT_INSTRUMENT.id)
 
         stock1 = offers_factories.StockFactory(price=10, dnBookedQuantity=5, offer=offer1)
         stock2 = offers_factories.StockFactory(price=10, dnBookedQuantity=5, offer=offer2)

--- a/tests/core/bookings/test_models.py
+++ b/tests/core/bookings/test_models.py
@@ -8,11 +8,10 @@ from pcapi.core.bookings import factories
 from pcapi.core.bookings import models
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import MediationFactory
 import pcapi.core.users.factories as users_factories
 from pcapi.models import ApiErrors
-from pcapi.models import EventType
-from pcapi.models import ThingType
 from pcapi.models import db
 from pcapi.repository import repository
 from pcapi.utils.human_ids import humanize
@@ -104,13 +103,13 @@ class BookingThumbUrlTest:
 class BookingQrCodeTest:
     def test_event_return_qr_code_if_event_is_not_expired_nor_cancelled(self):
         booking = factories.BookingFactory(
-            stock__offer__product__type=str(EventType.CINEMA),
+            stock__offer__product__subcategoryId=subcategories.SEANCE_CINE.id,
         )
         assert isinstance(booking.qrCode, str)
 
     def test_event_return_none_if_event_is_expired(self):
         booking = factories.BookingFactory(
-            stock__offer__type=str(EventType.CINEMA),
+            stock__offer__subcategoryId=subcategories.SEANCE_CINE.id,
             stock__beginningDatetime=datetime.now() - timedelta(days=1),
         )
         assert booking.qrCode is None
@@ -119,13 +118,13 @@ class BookingQrCodeTest:
         booking = factories.BookingFactory(
             isCancelled=True,
             status=BookingStatus.CANCELLED,
-            stock__offer__type=str(EventType.CINEMA),
+            stock__offer__subcategoryId=subcategories.SEANCE_CINE.id,
         )
         assert booking.qrCode is None
 
     def test_thing_return_qr_code_if_not_used_nor_cancelled(self):
         booking = factories.BookingFactory(
-            stock__offer__product__type=str(ThingType.JEUX),
+            stock__offer__subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id,
         )
         assert isinstance(booking.qrCode, str)
 
@@ -133,15 +132,15 @@ class BookingQrCodeTest:
         booking = factories.BookingFactory(
             isUsed=True,
             status=BookingStatus.USED,
-            stock__offer__product__type=str(ThingType.JEUX),
+            stock__offer__subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id,
         )
         assert booking.qrCode is None
 
     def test_thing_return_none_if_booking_is_cancelled(self):
         booking = factories.BookingFactory(
             isCancelled=True,
+            stock__offer__subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id,
             status=BookingStatus.CANCELLED,
-            stock__offer__product__type=str(ThingType.JEUX),
         )
         assert booking.qrCode is None
 

--- a/tests/core/bookings/test_repository.py
+++ b/tests/core/bookings/test_repository.py
@@ -11,6 +11,7 @@ import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.bookings.repository as booking_repository
 from pcapi.core.bookings.repository import find_by_pro_user_id
+from pcapi.core.categories import subcategories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.payments.factories import PaymentFactory
 from pcapi.core.payments.factories import PaymentStatusFactory
@@ -23,7 +24,6 @@ from pcapi.model_creators.generic_creators import create_payment
 from pcapi.models import Booking
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.api_errors import ResourceNotFoundError
-from pcapi.models.offer_type import ThingType
 from pcapi.models.payment_status import TransactionStatus
 from pcapi.repository import repository
 from pcapi.utils.date import utc_datetime_to_department_timezone
@@ -1274,17 +1274,21 @@ class FindSoonToBeExpiredBookingsTest:
         too_old_expired_creation_date = datetime.combine(too_old_expired_creation_date, time(12, 34, 17))
 
         expected_booking = bookings_factories.BookingFactory(
-            dateCreated=expired_creation_date, stock__offer__product__type=str(ThingType.AUDIOVISUEL)
+            dateCreated=expired_creation_date,
+            stock__offer__product__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         )
         # offer type not expirable
         bookings_factories.BookingFactory(
-            dateCreated=expired_creation_date, stock__offer__product__type=str(ThingType.LIVRE_AUDIO)
+            dateCreated=expired_creation_date,
+            stock__offer__product__subcategoryId=subcategories.LIVRE_AUDIO_PHYSIQUE.id,
         )
         bookings_factories.BookingFactory(
-            dateCreated=non_expired_creation_date, stock__offer__product__type=str(ThingType.AUDIOVISUEL)
+            dateCreated=non_expired_creation_date,
+            stock__offer__product__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         )
         bookings_factories.BookingFactory(
-            dateCreated=too_old_expired_creation_date, stock__offer__product__type=str(ThingType.AUDIOVISUEL)
+            dateCreated=too_old_expired_creation_date,
+            stock__offer__product__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         )
 
         # When

--- a/tests/core/bookings/test_validation.py
+++ b/tests/core/bookings/test_validation.py
@@ -11,10 +11,10 @@ from pcapi.core.bookings import factories
 from pcapi.core.bookings import models
 from pcapi.core.bookings import validation
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
 import pcapi.core.users.factories as users_factories
-from pcapi.models import ThingType
 from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.repository import repository
@@ -123,7 +123,7 @@ class CheckExpenseLimitsDepositVersion1Test:
 
     def test_physical_limit(self):
         beneficiary = self._get_beneficiary()
-        offer = offers_factories.OfferFactory(product__type=str(ThingType.INSTRUMENT))
+        offer = offers_factories.OfferFactory(product__subcategoryId=subcategories.ACHAT_INSTRUMENT.id)
         factories.BookingFactory(user=beneficiary, stock__price=190, stock__offer=offer)
 
         validation.check_expenses_limits(beneficiary, 10, offer)  # should not raise
@@ -136,7 +136,7 @@ class CheckExpenseLimitsDepositVersion1Test:
 
     def test_physical_limit_on_uncapped_type(self):
         beneficiary = self._get_beneficiary()
-        offer = offers_factories.OfferFactory(product__type=str(ThingType.CINEMA_ABO))
+        offer = offers_factories.OfferFactory(product__subcategoryId=subcategories.CARTE_CINE_ILLIMITE.id)
         factories.BookingFactory(user=beneficiary, stock__price=190, stock__offer=offer)
 
         # should not raise because CINEMA_ABO is not capped
@@ -144,7 +144,7 @@ class CheckExpenseLimitsDepositVersion1Test:
 
     def test_digital_limit(self):
         beneficiary = self._get_beneficiary()
-        product = offers_factories.DigitalProductFactory(type=str(ThingType.AUDIOVISUEL))
+        product = offers_factories.DigitalProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
         offer = offers_factories.OfferFactory(product=product)
         factories.BookingFactory(
             user=beneficiary,
@@ -162,7 +162,7 @@ class CheckExpenseLimitsDepositVersion1Test:
 
     def test_digital_limit_on_uncapped_type(self):
         beneficiary = self._get_beneficiary()
-        product = offers_factories.DigitalProductFactory(type=str(ThingType.OEUVRE_ART))
+        product = offers_factories.DigitalProductFactory(subcategoryId=subcategories.OEUVRE_ART.id)
         offer = offers_factories.OfferFactory(product=product)
         factories.BookingFactory(user=beneficiary, stock__price=190, stock__offer=offer)
 
@@ -172,7 +172,7 @@ class CheckExpenseLimitsDepositVersion1Test:
     def test_global_limit(self):
         beneficiary = self._get_beneficiary()
         factories.BookingFactory(user=beneficiary, stock__price=490)
-        offer = offers_factories.OfferFactory(type=str(ThingType.CINEMA_ABO))
+        offer = offers_factories.OfferFactory(subcategoryId=subcategories.CARTE_CINE_ILLIMITE.id)
 
         validation.check_expenses_limits(beneficiary, 10, offer)  # should not raise
 
@@ -191,20 +191,20 @@ class CheckExpenseLimitsDepositVersion2Test:
     def test_raise_if_deposit_expired(self):
         yesterday = datetime.now() - timedelta(days=1)
         beneficiary = self._get_beneficiary(deposit__expirationDate=yesterday)
-        offer = offers_factories.OfferFactory(product__type=str(ThingType.INSTRUMENT))
+        offer = offers_factories.OfferFactory(product__subcategoryId=subcategories.ACHAT_INSTRUMENT.id)
         with pytest.raises(exceptions.UserHasInsufficientFunds):
             validation.check_expenses_limits(beneficiary, 10, offer)
 
     def test_physical_limit(self):
         beneficiary = self._get_beneficiary()
-        offer = offers_factories.OfferFactory(product__type=str(ThingType.INSTRUMENT))
+        offer = offers_factories.OfferFactory(product__subcategoryId=subcategories.ACHAT_INSTRUMENT.id)
         factories.BookingFactory(user=beneficiary, stock__price=290, stock__offer=offer)
 
         validation.check_expenses_limits(beneficiary, 10, offer)  # should not raise
 
     def test_digital_limit(self):
         beneficiary = self._get_beneficiary()
-        product = offers_factories.DigitalProductFactory(type=str(ThingType.AUDIOVISUEL))
+        product = offers_factories.DigitalProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
         offer = offers_factories.OfferFactory(product=product)
         factories.BookingFactory(
             user=beneficiary,
@@ -222,7 +222,7 @@ class CheckExpenseLimitsDepositVersion2Test:
 
     def test_digital_limit_on_uncapped_type(self):
         beneficiary = self._get_beneficiary()
-        product = offers_factories.DigitalProductFactory(type=str(ThingType.OEUVRE_ART))
+        product = offers_factories.DigitalProductFactory(subcategoryId=subcategories.OEUVRE_ART.id)
         offer = offers_factories.OfferFactory(product=product)
         factories.BookingFactory(user=beneficiary, stock__price=190, stock__offer=offer)
 
@@ -232,7 +232,7 @@ class CheckExpenseLimitsDepositVersion2Test:
     def test_global_limit(self):
         beneficiary = self._get_beneficiary()
         factories.BookingFactory(user=beneficiary, stock__price=290)
-        offer = offers_factories.OfferFactory(type=str(ThingType.CINEMA_ABO))
+        offer = offers_factories.OfferFactory(subcategoryId=subcategories.CARTE_CINE_ILLIMITE.id)
 
         validation.check_expenses_limits(beneficiary, 10, offer)  # should not raise
 

--- a/tests/core/offers/test_repository.py
+++ b/tests/core/offers/test_repository.py
@@ -6,6 +6,7 @@ import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.categories import subcategories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.factories import ActivationCodeFactory
 from pcapi.core.offers.factories import EventStockFactory
@@ -97,10 +98,10 @@ class GetCappedOffersForFiltersTest:
     def should_return_offers_of_given_type(self):
         user_offerer = offers_factories.UserOffererFactory()
         requested_offer = offers_factories.OfferFactory(
-            type=str(ThingType.AUDIOVISUEL), venue__managingOfferer=user_offerer.offerer
+            subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id, venue__managingOfferer=user_offerer.offerer
         )
         other_offer = offers_factories.OfferFactory(
-            type=str(ThingType.JEUX), venue__managingOfferer=user_offerer.offerer
+            subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id, venue__managingOfferer=user_offerer.offerer
         )
 
         offers = get_capped_offers_for_filters(
@@ -935,7 +936,7 @@ class GetCappedOffersForFiltersTest:
             )
             offers_factories.StockFactory(bookingLimitDatetime=unexpired_booking_limit_date, offer=pending_offer)
 
-            offer = offers_factories.OfferFactory(product__type=str(ThingType.INSTRUMENT))
+            offer = offers_factories.OfferFactory(product__subcategoryId=subcategories.ACHAT_INSTRUMENT.id)
             offers_factories.StockFactory(bookingLimitDatetime=unexpired_booking_limit_date, offer=offer)
 
             user = pending_offer.venue.managingOfferer
@@ -960,7 +961,7 @@ class GetCappedOffersForFiltersTest:
             )
             offers_factories.StockFactory(bookingLimitDatetime=unexpired_booking_limit_date, offer=rejected_offer)
 
-            offer = offers_factories.OfferFactory(product__type=str(ThingType.INSTRUMENT))
+            offer = offers_factories.OfferFactory(product__subcategoryId=subcategories.ACHAT_INSTRUMENT.id)
             offers_factories.StockFactory(bookingLimitDatetime=unexpired_booking_limit_date, offer=offer)
 
             user = rejected_offer.venue.managingOfferer

--- a/tests/core/providers/test_api.py
+++ b/tests/core/providers/test_api.py
@@ -5,6 +5,7 @@ from freezegun.api import freeze_time
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.categories import subcategories
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offers import factories
 from pcapi.core.offers.factories import VenueFactory
@@ -12,7 +13,6 @@ from pcapi.core.offers.models import Offer
 from pcapi.core.providers import api
 from pcapi.local_providers.provider_api import synchronize_provider_api
 from pcapi.models import ApiErrors
-from pcapi.models import ThingType
 from pcapi.models.product import Product
 from pcapi.routes.serialization.venue_provider_serialize import PostVenueProviderBody
 
@@ -36,7 +36,7 @@ class CreateVenueProviderTest:
 def create_product(isbn, **kwargs):
     return factories.ProductFactory(
         idAtProviders=isbn,
-        type=str(ThingType.LIVRE_EDITION),
+        subcategoryId=subcategories.LIVRE_PAPIER.id,
         extraData={"prix_livre": 12},
         **kwargs,
     )
@@ -65,7 +65,7 @@ class SynchronizeStocksTest:
             {"ref": "3010000108124", "available": 17},
             {"ref": "3010000108125", "available": 17},
         ]
-        provider = offerers_factories.APIProviderFactory(apiUrl="https://provider_url", authToken="fake_token")
+        offerers_factories.APIProviderFactory(apiUrl="https://provider_url", authToken="fake_token")
         venue = VenueFactory()
         siret = venue.siret
         provider = offerers_factories.ProviderFactory()

--- a/tests/core/search/test_serialize_algolia.py
+++ b/tests/core/search/test_serialize_algolia.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from freezegun import freeze_time
 import pytest
 
+from pcapi.core.categories import subcategories
 from pcapi.core.search.backends.algolia import AlgoliaBackend
 from pcapi.model_creators.generic_creators import create_criterion
 from pcapi.model_creators.generic_creators import create_offerer
@@ -12,7 +13,6 @@ from pcapi.model_creators.generic_creators import create_stock
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.models import EventType
 from pcapi.repository import repository
 from pcapi.utils.human_ids import humanize
 
@@ -44,7 +44,7 @@ class BuildObjectTest:
             idx=3,
             is_active=True,
             event_name="Event name",
-            event_type=EventType.MUSIQUE,
+            event_subcategory_id=subcategories.EVENEMENT_MUSIQUE.id,
             thumb_count=1,
             date_created=datetime(2020, 1, 1, 10, 0, 0),
             ranking_weight=3,
@@ -437,7 +437,7 @@ class BuildObjectTest:
             idx=3,
             is_active=True,
             event_name="Event name",
-            event_type=EventType.MUSIQUE,
+            event_subcategory_id=subcategories.EVENEMENT_MUSIQUE.id,
             thumb_count=1,
             date_created=datetime(2020, 1, 1, 10, 0, 0),
             criteria=[criterion],
@@ -529,7 +529,7 @@ class BuildObjectTest:
             idx=3,
             is_active=True,
             event_name="Event name",
-            event_type=EventType.MUSIQUE,
+            event_subcategory_id=subcategories.EVENEMENT_MUSIQUE.id,
             thumb_count=1,
             date_created=datetime(2020, 1, 1, 10, 0, 0),
             criteria=[criterion1, criterion2],

--- a/tests/core/search/test_serialize_appsearch.py
+++ b/tests/core/search/test_serialize_appsearch.py
@@ -5,6 +5,7 @@ import json
 import pytest
 from sqlalchemy.orm import joinedload
 
+from pcapi.core.categories import subcategories
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offers_models
@@ -28,7 +29,7 @@ def test_serialize():
             "stageDirector": "Stage Director",
         },
         rankingWeight=2,
-        type="ThingType.LIVRE_EDITION",
+        subcategoryId=subcategories.LIVRE_PAPIER.id,
         venue__id=127,
         venue__name="La Moyenne Librairie SA",
         venue__publicName="La Moyenne Librairie",
@@ -79,7 +80,7 @@ def test_serialize_artist_empty():
 
 
 def test_serialize_dates_and_times():
-    offer = offers_factories.OfferFactory(type="EventType.CINEMA")
+    offer = offers_factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
     dt = datetime.datetime(2032, 1, 1, 12, 15)
     offers_factories.EventStockFactory(offer=offer, beginningDatetime=dt)
     serialized = appsearch.AppSearchBackend().serialize_offer(offer)

--- a/tests/core/users/test_api.py
+++ b/tests/core/users/test_api.py
@@ -15,6 +15,7 @@ from pcapi import settings
 from pcapi.connectors.serialization.api_adage_serializers import InstitutionalProjectRedactorResponse
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 import pcapi.core.fraud.factories as fraud_factories
 import pcapi.core.fraud.models as fraud_models
 from pcapi.core.mails import testing as mails_testing
@@ -56,8 +57,6 @@ from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.models import BeneficiaryImport
 from pcapi.models import ImportStatus
 from pcapi.models.beneficiary_import import BeneficiaryImportSources
-from pcapi.models.offer_type import EventType
-from pcapi.models.offer_type import ThingType
 from pcapi.models.user_session import UserSession
 from pcapi.repository import repository
 from pcapi.routes.serialization.users import ProUserCreationBodyModel
@@ -652,19 +651,19 @@ class DomainsCreditTest:
         bookings_factories.BookingFactory(
             user=user,
             amount=50,
-            stock__offer__type=str(EventType.CINEMA),
+            stock__offer__subcategoryId=subcategories.SEANCE_CINE.id,
         )
         bookings_factories.BookingFactory(
             user=user,
             amount=5,
-            stock__offer__type=str(EventType.CINEMA),
+            stock__offer__subcategoryId=subcategories.SEANCE_CINE.id,
         )
 
         # booking in digital domain
         bookings_factories.BookingFactory(
             user=user,
             amount=80,
-            stock__offer__type=str(ThingType.JEUX_VIDEO),
+            stock__offer__subcategoryId=subcategories.JEU_EN_LIGNE.id,
             stock__offer__url="http://on.line",
         )
 
@@ -672,16 +671,16 @@ class DomainsCreditTest:
         bookings_factories.BookingFactory(
             user=user,
             amount=150,
-            stock__offer__type=str(ThingType.JEUX),
+            stock__offer__subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id,
         )
 
         # cancelled booking
         bookings_factories.BookingFactory(
             user=user,
             amount=150,
-            stock__offer__type=str(ThingType.JEUX),
             isCancelled=True,
             status=BookingStatus.CANCELLED,
+            stock__offer__subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id,
         )
 
         assert get_domains_credit(user) == DomainsCredit(
@@ -697,7 +696,7 @@ class DomainsCreditTest:
         bookings_factories.BookingFactory(
             user=user,
             amount=250,
-            stock__offer__type=str(ThingType.JEUX),
+            stock__offer__subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id,
         )
 
         assert get_domains_credit(user) == DomainsCredit(
@@ -711,7 +710,7 @@ class DomainsCreditTest:
         bookings_factories.BookingFactory(
             user=user,
             amount=250,
-            stock__offer__type=str(ThingType.JEUX),
+            stock__offer__subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id,
         )
 
         with freeze_time(datetime.now() + relativedelta(years=DEPOSIT_VALIDITY_IN_YEARS, days=2)):

--- a/tests/domain/payments_csv_test.py
+++ b/tests/domain/payments_csv_test.py
@@ -3,12 +3,12 @@ from decimal import Decimal
 
 import pytest
 
+from pcapi.core.categories import subcategories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.domain.payments import generate_payment_details_csv
 from pcapi.domain.payments import generate_wallet_balances_csv
-from pcapi.models.offer_type import ThingType
 from pcapi.models.payment import Payment
 from pcapi.models.wallet_balance import WalletBalance
 from pcapi.utils.human_ids import humanize
@@ -32,7 +32,7 @@ class GeneratePaymentDetailsCsvTest:
             booking__dateUsed=used_date,
             booking__user__email="john.doe@example.com",
             booking__stock__offer__product__name="Une histoire formidable",
-            booking__stock__offer__product__type=str(ThingType.AUDIOVISUEL),
+            booking__stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
             booking__stock__offer__venue=venue1,
             iban="IBAN1",
             amount=9,
@@ -51,7 +51,7 @@ class GeneratePaymentDetailsCsvTest:
             booking__dateUsed=used_date,
             booking__user__email="jeanne.doux@example.com",
             booking__stock__offer__product__name="Une histoire plutôt bien",
-            booking__stock__offer__product__type=str(ThingType.AUDIOVISUEL),
+            booking__stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
             booking__stock__offer__venue=venue2,
             iban="IBAN2",
             amount=11,

--- a/tests/domain/user_emails_test.py
+++ b/tests/domain/user_emails_test.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.categories import subcategories
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.offers.factories import OfferFactory
 from pcapi.core.offers.factories import OffererFactory
@@ -42,7 +43,6 @@ from pcapi.model_creators.generic_creators import create_booking
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_stock_with_event_offer
-from pcapi.models import offer_type
 from pcapi.utils.human_ids import humanize
 
 from tests.domain_creators.generic_creators import create_domain_beneficiary_pre_subcription
@@ -453,7 +453,7 @@ class SendSoonToBeExpiredBookingsRecapEmailToBeneficiaryTest:
         user = users_factories.BeneficiaryFactory(email="isasimov@example.com")
         created_23_days_ago = now - timedelta(days=23)
 
-        dvd = ProductFactory(type=str(offer_type.ThingType.AUDIOVISUEL))
+        dvd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
         soon_to_be_expired_dvd_booking = BookingFactory(
             stock__offer__product=dvd,
             stock__offer__name="Fondation",
@@ -462,7 +462,7 @@ class SendSoonToBeExpiredBookingsRecapEmailToBeneficiaryTest:
             user=user,
         )
 
-        cd = ProductFactory(type=str(offer_type.ThingType.MUSIQUE))
+        cd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id)
         soon_to_be_expired_cd_booking = BookingFactory(
             stock__offer__product=cd,
             stock__offer__name="Fondation et Empire",

--- a/tests/emails/beneficiary_booking_confirmation_test.py
+++ b/tests/emails/beneficiary_booking_confirmation_test.py
@@ -3,9 +3,9 @@ from datetime import timezone
 
 import pytest
 
-from pcapi import models
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.testing import override_features
 from pcapi.emails.beneficiary_booking_confirmation import retrieve_data_for_beneficiary_booking_confirmation_email
@@ -20,7 +20,7 @@ def make_booking(**kwargs):
         stock__beginningDatetime=datetime(2019, 11, 6, 14, 59, 5, tzinfo=timezone.utc),
         stock__price=23.99,
         stock__offer__name="Super événement",
-        stock__offer__product__type=str(models.EventType.SPECTACLE_VIVANT),
+        stock__offer__product__subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id,
         stock__offer__venue__name="Lieu de l'offreur",
         stock__offer__venue__address="25 avenue du lieu",
         stock__offer__venue__postalCode="75010",
@@ -72,7 +72,6 @@ def get_expected_base_email_data(booking, mediation, **overrides):
 def test_should_return_event_specific_data_for_email_when_offer_is_an_event():
     booking = make_booking()
     mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
-
     email_data = retrieve_data_for_beneficiary_booking_confirmation_email(booking)
 
     expected = get_expected_base_email_data(booking, mediation)
@@ -99,7 +98,7 @@ def test_should_return_event_specific_data_for_email_when_offer_is_a_duo_event()
 @pytest.mark.usefixtures("db_session")
 def test_should_return_thing_specific_data_for_email_when_offer_is_a_thing():
     booking = make_booking(
-        stock__offer__product__type=str(models.ThingType.AUDIOVISUEL),
+        stock__offer__product__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         stock__offer__name="Super bien culturel",
     )
     mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
@@ -162,7 +161,7 @@ class DigitalOffersTest:
         booking = make_booking(
             quantity=10,
             stock__price=0,
-            stock__offer__product__type=str(models.ThingType.AUDIOVISUEL),
+            stock__offer__product__subcategoryId=subcategories.VOD.id,
             stock__offer__product__url="http://example.com",
             stock__offer__name="Super offre numérique",
         )
@@ -241,7 +240,7 @@ def test_use_activation_code_instead_of_token_if_possible():
         user__email="used-email@example.com",
         quantity=10,
         stock__price=0,
-        stock__offer__product__type=str(models.ThingType.AUDIOVISUEL),
+        stock__offer__product__subcategoryId=subcategories.VOD.id,
         stock__offer__product__url="http://example.com?token={token}&offerId={offerId}&email={email}",
         stock__offer__name="Super offre numérique",
     )
@@ -277,7 +276,7 @@ def test_add_expiration_date_from_activation_code():
     booking = make_booking(
         quantity=10,
         stock__price=0,
-        stock__offer__product__type=str(models.ThingType.AUDIOVISUEL),
+        stock__offer__product__subcategoryId=subcategories.VOD.id,
         stock__offer__product__url="http://example.com",
         stock__offer__name="Super offre numérique",
     )

--- a/tests/emails/beneficiary_expired_bookings_test.py
+++ b/tests/emails/beneficiary_expired_bookings_test.py
@@ -6,10 +6,10 @@ import pytest
 from pcapi.core.bookings.factories import BookingFactory
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import ProductFactory
 import pcapi.core.users.factories as users_factories
 from pcapi.emails.beneficiary_expired_bookings import build_expired_bookings_recap_email_data_for_beneficiary
-from pcapi.models import offer_type
 
 
 @pytest.mark.usefixtures("db_session")
@@ -17,7 +17,7 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled():
     now = datetime.utcnow()
     amnesiac_user = users_factories.UserFactory(email="dory@example.com", firstName="Dory")
     long_ago = now - timedelta(days=31)
-    dvd = ProductFactory(type=str(offer_type.ThingType.AUDIOVISUEL))
+    dvd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
     expired_today_dvd_booking = BookingFactory(
         stock__offer__product=dvd,
         stock__offer__name="Memento",
@@ -29,7 +29,7 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled():
         user=amnesiac_user,
     )
 
-    cd = ProductFactory(type=str(offer_type.ThingType.MUSIQUE))
+    cd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id)
     expired_today_cd_booking = BookingFactory(
         stock__offer__product=cd,
         stock__offer__name="Random Access Memories",

--- a/tests/emails/offerer_booking_recap_test.py
+++ b/tests/emails/offerer_booking_recap_test.py
@@ -3,9 +3,9 @@ from datetime import timezone
 
 import pytest
 
-from pcapi import models
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.factories import ActivationCodeFactory
 from pcapi.core.testing import override_features
@@ -24,7 +24,7 @@ def make_booking(**kwargs):
         stock__price=10,
         stock__offer__name="Super événement",
         stock__offer__product__name="Super événement",
-        stock__offer__product__type=str(models.EventType.SPECTACLE_VIVANT),
+        stock__offer__product__subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id,
         stock__offer__venue__name="Lieu de l'offreur",
         stock__offer__venue__address="25 avenue du lieu",
         stock__offer__venue__postalCode="75010",
@@ -85,7 +85,7 @@ def test_with_book():
         stock__offer__name="Le récit de voyage",
         stock__offer__product__extraData={"isbn": "123456789"},
         stock__offer__product__name="Le récit de voyage",
-        stock__offer__product__type=str(models.ThingType.LIVRE_EDITION),
+        stock__offer__product__subcategoryId=subcategories.LIVRE_PAPIER.id,
         stock__offer__venue__address=None,
         stock__offer__venue__city=None,
         stock__offer__venue__departementCode=None,
@@ -116,7 +116,7 @@ def test_non_digital_bookings_can_expire_after_30_days():
         stock__offer__name="Le récit de voyage",
         stock__offer__product__extraData={"isbn": "123456789"},
         stock__offer__product__name="Le récit de voyage",
-        stock__offer__product__type=str(models.ThingType.LIVRE_EDITION),
+        stock__offer__product__subcategoryId=subcategories.LIVRE_PAPIER.id,
         stock__offer__venue__address=None,
         stock__offer__venue__city=None,
         stock__offer__venue__departementCode=None,
@@ -146,7 +146,7 @@ def test_with_book_with_missing_isbn():
         stock__offer__name="Le récit de voyage",
         stock__offer__product__extraData={},  # no ISBN
         stock__offer__product__name="Le récit de voyage",
-        stock__offer__product__type=str(models.ThingType.LIVRE_EDITION),
+        stock__offer__product__subcategoryId=subcategories.LIVRE_PAPIER.id,
         stock__offer__venue__address=None,
         stock__offer__venue__city=None,
         stock__offer__venue__departementCode=None,
@@ -177,7 +177,7 @@ def test_a_digital_booking_expires_after_30_days():
     booking = make_booking(
         quantity=10,
         stock__price=0,
-        stock__offer__product__type=str(models.ThingType.AUDIOVISUEL),
+        stock__offer__product__subcategoryId=subcategories.VOD.id,
         stock__offer__product__url="http://example.com",
         stock__offer__name="Super offre numérique",
     )

--- a/tests/emails/offerer_bookings_recap_after_deleting_stock_test.py
+++ b/tests/emails/offerer_bookings_recap_after_deleting_stock_test.py
@@ -10,7 +10,7 @@ from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.model_creators.specific_creators import create_stock_from_offer
 
 
@@ -65,7 +65,7 @@ class RetrieveOffererBookingsRecapEmailDataAfterOffererCancellationTest:
         )
         offerer = create_offerer()
         venue = create_venue(offerer, name="La petite librairie", public_name="La grande librairie")
-        thing_product = create_product_with_thing_type(thing_name="Le récit de voyage")
+        thing_product = create_product_with_thing_subcategory(thing_name="Le récit de voyage")
         offer = create_offer_with_thing_product(venue=venue, product=thing_product)
         stock = create_stock_from_offer(offer, price=0)
         booking = create_booking(user=beneficiary, stock=stock, token="12346", quantity=6)

--- a/tests/emails/offerer_expired_bookings_test.py
+++ b/tests/emails/offerer_expired_bookings_test.py
@@ -7,10 +7,10 @@ import pytest
 from pcapi.core.bookings.factories import BookingFactory
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import OffererFactory
 from pcapi.core.offers.factories import ProductFactory
 from pcapi.emails.offerer_expired_bookings import build_expired_bookings_recap_email_data_for_offerer
-from pcapi.models import offer_type
 
 
 @pytest.mark.usefixtures("db_session")
@@ -22,7 +22,7 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled(self, app)
     now = datetime.utcnow()
     offerer = OffererFactory()
     long_ago = now - timedelta(days=31)
-    dvd = ProductFactory(type=str(offer_type.ThingType.AUDIOVISUEL))
+    dvd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
     expired_today_dvd_booking = BookingFactory(
         user__publicName="Dory",
         user__email="dory@example.com",
@@ -36,7 +36,7 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled(self, app)
         cancellationReason=BookingCancellationReasons.EXPIRED,
     )
 
-    cd = ProductFactory(type=str(offer_type.ThingType.MUSIQUE))
+    cd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id)
     expired_today_cd_booking = BookingFactory(
         user__publicName="Dorian",
         user__email="dorian@example.com",

--- a/tests/infrastructure/repository/beneficiary_bookings/beneficiary_bookings_sql_repository_test.py
+++ b/tests/infrastructure/repository/beneficiary_bookings/beneficiary_bookings_sql_repository_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import EventOfferFactory
 from pcapi.core.offers.factories import EventStockFactory
 from pcapi.core.offers.factories import ThingOfferFactory
@@ -89,9 +90,9 @@ class BeneficiaryBookingsSQLRepositoryTest:
     def test_should_not_return_activation_bookings(self, app):
         # Given
         beneficiary = BeneficiaryFactory()
-        offer1 = EventOfferFactory(type="ThingType.ACTIVATION")
-        offer2 = EventOfferFactory(type="ThingType.ACTIVATION")
-        offer3 = EventOfferFactory(type="ThingType.ANY")
+        offer1 = EventOfferFactory(subcategoryId=subcategories.ACTIVATION_THING.id)
+        offer2 = EventOfferFactory(subcategoryId=subcategories.ACTIVATION_THING.id)
+        offer3 = EventOfferFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
         stock1 = EventStockFactory(offer=offer1)
         stock2 = EventStockFactory(offer=offer2)
         stock3 = EventStockFactory(offer=offer3)

--- a/tests/local_providers/allocine_stocks_test.py
+++ b/tests/local_providers/allocine_stocks_test.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from freezegun import freeze_time
 import pytest
 
+from pcapi.core.categories import subcategories
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.local_providers import AllocineStocks
 from pcapi.model_creators.generic_creators import create_allocine_venue_provider
@@ -14,7 +15,7 @@ from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.provider_creators import activate_provider
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
-from pcapi.model_creators.specific_creators import create_product_with_event_type
+from pcapi.model_creators.specific_creators import create_product_with_event_subcategory
 from pcapi.models import EventType
 from pcapi.models import Offer
 from pcapi.models import Product
@@ -253,6 +254,7 @@ class UpdateObjectsTest:
         assert not created_offer.isDuo
         assert created_offer.name == "Les Contes de la mère poule - VF"
         assert created_offer.product == created_product
+        assert created_offer.subcategoryId == subcategories.SEANCE_CINE.id
         assert created_offer.type == str(EventType.CINEMA)
         assert created_offer.withdrawalDetails == venue.withdrawalDetails
 
@@ -276,6 +278,7 @@ class UpdateObjectsTest:
         }
 
         assert created_product.name == "Les Contes de la mère poule"
+        assert created_offer.subcategoryId == subcategories.SEANCE_CINE.id
         assert created_product.type == str(EventType.CINEMA)
 
     @patch("pcapi.local_providers.allocine.allocine_stocks.get_movie_poster")
@@ -355,6 +358,7 @@ class UpdateObjectsTest:
         assert not original_version_offer.isDuo
         assert original_version_offer.name == "Les Contes de la mère poule - VO"
         assert original_version_offer.product == created_products[0]
+        assert original_version_offer.subcategoryId == subcategories.SEANCE_CINE.id
         assert original_version_offer.type == str(EventType.CINEMA)
 
         dubbed_version_offer = created_offers[1]
@@ -369,6 +373,7 @@ class UpdateObjectsTest:
         assert not dubbed_version_offer.isDuo
         assert dubbed_version_offer.name == "Les Contes de la mère poule - VF"
         assert dubbed_version_offer.product == created_products[0]
+        assert dubbed_version_offer.subcategoryId == subcategories.SEANCE_CINE.id
         assert dubbed_version_offer.type == str(EventType.CINEMA)
 
     @patch("pcapi.local_providers.allocine.allocine_stocks.get_movie_poster")
@@ -457,9 +462,9 @@ class UpdateObjectsTest:
             ]
         )
 
-        product = create_product_with_event_type(
+        product = create_product_with_event_subcategory(
             event_name="Test event",
-            event_type=EventType.CINEMA,
+            event_subcategory_id=subcategories.SEANCE_CINE.id,
             duration_minutes=60,
             id_at_providers="TW92aWU6Mzc4MzI=",
         )
@@ -470,7 +475,7 @@ class UpdateObjectsTest:
         offer_vo = create_offer_with_event_product(
             product=product,
             event_name="Test event",
-            event_type=EventType.CINEMA,
+            event_subcategory_id=subcategories.SEANCE_CINE.id,
             duration_minutes=60,
             id_at_providers="TW92aWU6Mzc4MzI=%77567146400110-VO",
             venue=venue,
@@ -478,7 +483,7 @@ class UpdateObjectsTest:
         offer_vf = create_offer_with_event_product(
             product=product,
             event_name="Test event",
-            event_type=EventType.CINEMA,
+            event_subcategory_id=subcategories.SEANCE_CINE.id,
             duration_minutes=60,
             id_at_providers="TW92aWU6Mzc4MzI=%77567146400110-VF",
             venue=venue,
@@ -530,9 +535,9 @@ class UpdateObjectsTest:
             ]
         )
 
-        product = create_product_with_event_type(
+        product = create_product_with_event_subcategory(
             event_name="Test event",
-            event_type=EventType.CINEMA,
+            event_subcategory_id=subcategories.SEANCE_CINE.id,
             duration_minutes=60,
             id_at_providers="TW92aWU6Mzc4MzI=",
         )
@@ -633,6 +638,7 @@ class UpdateObjectsTest:
         }
 
         assert created_offer.type == str(EventType.CINEMA)
+        assert created_offer.subcategoryId == subcategories.SEANCE_CINE.id
         assert created_offer.name == "Les Contes de la mère poule - VF"
 
     @patch("pcapi.local_providers.allocine.allocine_stocks.get_movie_poster")
@@ -711,9 +717,9 @@ class UpdateObjectsTest:
         with open(file_path, "rb") as thumb_file:
             mock_get_object_thumb.return_value = thumb_file.read()
 
-        product = create_product_with_event_type(
+        product = create_product_with_event_subcategory(
             event_name="Test event",
-            event_type=EventType.CINEMA,
+            event_subcategory_id=subcategories.SEANCE_CINE.id,
             duration_minutes=60,
             id_at_providers="TW92aWU6Mzc4MzI=",
             thumb_count=0,
@@ -769,9 +775,9 @@ class UpdateObjectsTest:
         with open(file_path, "rb") as thumb_file:
             mock_get_object_thumb.return_value = thumb_file.read()
 
-        product = create_product_with_event_type(
+        product = create_product_with_event_subcategory(
             event_name="Test event",
-            event_type=EventType.CINEMA,
+            event_subcategory_id=subcategories.SEANCE_CINE.id,
             duration_minutes=60,
             id_at_providers="TW92aWU6Mzc4MzI=",
             thumb_count=1,

--- a/tests/local_providers/chunk_manager_test.py
+++ b/tests/local_providers/chunk_manager_test.py
@@ -6,7 +6,7 @@ from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_stock
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.models import Offer
 from pcapi.models import Stock
 from pcapi.models.db import db
@@ -19,7 +19,7 @@ class SaveChunksTest:
         # Given
         offerer = create_offerer()
         venue = create_venue(offerer)
-        product = create_product_with_thing_type()
+        product = create_product_with_thing_subcategory()
         repository.save(venue, product)
 
         offer = create_offer_with_thing_product(venue, product=product, id_at_providers="1%12345678912345")
@@ -40,7 +40,7 @@ class SaveChunksTest:
         # Given
         offerer = create_offerer()
         venue = create_venue(offerer)
-        product = create_product_with_thing_type()
+        product = create_product_with_thing_subcategory()
         repository.save(venue, product)
 
         offer = create_offer_with_thing_product(venue, product=product, id_at_providers="1%12345678912345")
@@ -72,7 +72,7 @@ class SaveChunksTest:
         # Given
         offerer = create_offerer()
         venue = create_venue(offerer)
-        product = create_product_with_thing_type()
+        product = create_product_with_thing_subcategory()
         offer = create_offer_with_thing_product(venue, product=product, id_at_providers="1%12345678912345")
         repository.save(venue, product, offer)
 
@@ -96,7 +96,7 @@ class SaveChunksTest:
         # Given
         offerer = create_offerer()
         venue = create_venue(offerer)
-        product = create_product_with_thing_type()
+        product = create_product_with_thing_subcategory()
         offer1 = create_offer_with_thing_product(venue, product=product, id_at_providers="1%12345678912345")
         offer2 = create_offer_with_thing_product(venue, product=product, id_at_providers="2%12345678912345")
         stock = create_stock(offer=offer1)

--- a/tests/local_providers/local_provider_test.py
+++ b/tests/local_providers/local_provider_test.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+from pcapi.core.categories import subcategories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.local_providers.local_provider import _save_same_thumb_from_thumb_count_to_index
@@ -61,6 +62,7 @@ class UpdateObjectsTest:
         # Then
         new_product = Product.query.one()
         assert new_product.name == "New Product"
+        assert new_product.subcategoryId == subcategories.LIVRE_PAPIER.id
         assert new_product.type == str(ThingType.LIVRE_EDITION)
 
     @patch("tests.local_providers.provider_test_utils.TestLocalProvider.__next__")
@@ -73,7 +75,7 @@ class UpdateObjectsTest:
             lastProvider=provider,
             idAtProviders=providable_info.id_at_providers,
             name="Old product name",
-            type=str(ThingType.INSTRUMENT),
+            subcategoryId=subcategories.ACHAT_INSTRUMENT.id,
         )
         local_provider = provider_test_utils.TestLocalProvider()
         next_function.side_effect = [[providable_info]]
@@ -97,7 +99,7 @@ class UpdateObjectsTest:
             lastProvider=provider,
             idAtProviders=providable_info.id_at_providers,
             name="Old product name",
-            type=str(ThingType.INSTRUMENT),
+            subcategoryId=subcategories.ACHAT_INSTRUMENT.id,
         )
         local_provider = provider_test_utils.TestLocalProvider()
         next_function.side_effect = [[providable_info]]
@@ -201,7 +203,7 @@ class CreateObjectTest:
 
         # Then
         assert api_errors.value.errors["url"] == [
-            "Une offre de type Jeux (support physique) ne peut pas être numérique"
+            "Une offre de type Vente et location d’instruments de musique ne peut pas être numérique"
         ]
         assert Product.query.count() == 0
         provider_event = LocalProviderEvent.query.one()
@@ -216,7 +218,7 @@ class HandleUpdateTest:
         providable_info = create_providable_info()
         product = offers_factories.ThingProductFactory(
             name="Old product name",
-            type=str(ThingType.INSTRUMENT),
+            subcategoryId=subcategories.ACHAT_INSTRUMENT.id,
             idAtProviders=providable_info.id_at_providers,
             lastProvider=provider,
         )
@@ -236,7 +238,7 @@ class HandleUpdateTest:
         providable_info = create_providable_info()
         product = offers_factories.ThingProductFactory(
             name="Old product name",
-            type=str(ThingType.INSTRUMENT),
+            subcategoryId=subcategories.ACHAT_INSTRUMENT.id,
             idAtProviders=providable_info.id_at_providers,
             lastProvider=provider,
         )
@@ -248,7 +250,7 @@ class HandleUpdateTest:
 
         # Then
         assert api_errors.value.errors["url"] == [
-            "Une offre de type Jeux (support physique) ne peut pas être numérique"
+            "Une offre de type Vente et location d’instruments de musique ne peut pas être numérique"
         ]
         provider_event = LocalProviderEvent.query.one()
         assert provider_event.type == LocalProviderEventType.SyncError

--- a/tests/local_providers/provider_test_utils.py
+++ b/tests/local_providers/provider_test_utils.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
+from pcapi.core.categories import subcategories
 from pcapi.core.providers.models import VenueProvider
 from pcapi.local_providers.local_provider import LocalProvider
-from pcapi.models import ThingType
 from pcapi.models.db import Model
 import pcapi.sandboxes
 
@@ -17,7 +17,8 @@ class TestLocalProvider(LocalProvider):
 
     def fill_object_attributes(self, obj):
         obj.name = "New Product"
-        obj.type = str(ThingType.LIVRE_EDITION)
+        obj.subcategoryId = subcategories.LIVRE_PAPIER.id
+        obj.type = subcategories.LIVRE_PAPIER.matching_type
 
     def __next__(self):
         pass
@@ -33,7 +34,8 @@ class TestLocalProviderWithApiErrors(LocalProvider):
 
     def fill_object_attributes(self, obj):
         obj.name = "New Product"
-        obj.type = str(ThingType.JEUX)
+        obj.subcategoryId = subcategories.ACHAT_INSTRUMENT.id
+        obj.type = subcategories.ACHAT_INSTRUMENT.matching_type
         obj.url = "http://url.com"
 
     def __next__(self):
@@ -50,7 +52,8 @@ class TestLocalProviderNoCreation(LocalProvider):
 
     def fill_object_attributes(self, obj):
         obj.name = "New Product"
-        obj.type = str(ThingType.LIVRE_EDITION)
+        obj.subcategoryId = subcategories.LIVRE_PAPIER.id
+        obj.type = subcategories.LIVRE_PAPIER.matching_type
 
     def __next__(self):
         pass
@@ -74,7 +77,7 @@ class TestLocalProviderWithThumb(LocalProvider):
 
     def fill_object_attributes(self, pc_object: Model):
         pc_object.name = "New Product"
-        pc_object.type = str(ThingType.LIVRE_EDITION)
+        pc_object.subcategoryId = subcategories.LIVRE_PAPIER.id
 
     def __next__(self):
         pass
@@ -98,7 +101,7 @@ class TestLocalProviderWithThumbIndexAt4(LocalProvider):
 
     def fill_object_attributes(self, pc_object):
         pc_object.name = "New Product"
-        pc_object.type = str(ThingType.LIVRE_EDITION)
+        pc_object.subcategoryId = subcategories.LIVRE_PAPIER.id
 
     def __next__(self):
         pass

--- a/tests/local_providers/synchronize_provider_api_test.py
+++ b/tests/local_providers/synchronize_provider_api_test.py
@@ -6,12 +6,12 @@ import pytest
 import requests_mock
 
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.categories import subcategories
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offers import factories
 from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.offers.models import Offer
 from pcapi.local_providers.provider_api import synchronize_provider_api
-from pcapi.models import ThingType
 
 
 ISBNs = [
@@ -55,7 +55,7 @@ provider_responses = [
 def create_product(isbn, product_price, **kwargs):
     return factories.ProductFactory(
         idAtProviders=isbn,
-        type=str(ThingType.LIVRE_EDITION),
+        subcategoryId=subcategories.LIVRE_PAPIER.id,
         extraData={"prix_livre": product_price},
         **kwargs,
     )

--- a/tests/local_providers/titelive_things_test.py
+++ b/tests/local_providers/titelive_things_test.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import OffererFactory
 from pcapi.core.offers.factories import ThingOfferFactory
 from pcapi.core.offers.factories import ThingProductFactory
@@ -18,12 +19,11 @@ from pcapi.model_creators.generic_creators import create_stock
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.provider_creators import activate_provider
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.models import BookFormat
 from pcapi.models import LocalProviderEvent
 from pcapi.models import Offer
 from pcapi.models import Product
-from pcapi.models import ThingType
 from pcapi.models.local_provider_event import LocalProviderEventType
 from pcapi.repository import repository
 
@@ -153,7 +153,7 @@ class TiteliveThingsTest:
 
         titelive_things_provider = get_provider_by_local_class("TiteLiveThings")
 
-        product = create_product_with_thing_type(
+        product = create_product_with_thing_subcategory(
             id_at_providers="9782895026310",
             thing_name="Toto à la playa",
             date_modified_at_last_provider=datetime(2001, 1, 1),
@@ -298,7 +298,7 @@ class TiteliveThingsTest:
 
         titelive_provider = activate_provider("TiteLiveThings")
         repository.save(titelive_provider)
-        product = create_product_with_thing_type(
+        product = create_product_with_thing_subcategory(
             id_at_providers="9782895026310",
             thing_name="Toto à la playa",
             date_modified_at_last_provider=datetime(2001, 1, 1),
@@ -339,7 +339,7 @@ class TiteliveThingsTest:
         get_lines_from_thing_file.return_value = iter([data_line])
 
         titelive_provider = activate_provider("TiteLiveThings")
-        product = create_product_with_thing_type(
+        product = create_product_with_thing_subcategory(
             id_at_providers="9782895026310",
             thing_name="Toto à la playa",
             date_modified_at_last_provider=datetime(2001, 1, 1),
@@ -382,7 +382,7 @@ class TiteliveThingsTest:
         venue = create_venue(offerer, name="Librairie Titelive", siret="77567146400110")
         titelive_provider = activate_provider("TiteLiveThings")
         repository.save(venue)
-        product = create_product_with_thing_type(
+        product = create_product_with_thing_subcategory(
             id_at_providers="9782895026310",
             thing_name="Toto à la playa",
             date_modified_at_last_provider=datetime(2001, 1, 1),
@@ -462,7 +462,7 @@ class TiteliveThingsTest:
 
         titelive_provider = activate_provider("TiteLiveThings")
         repository.save(titelive_provider)
-        product = create_product_with_thing_type(
+        product = create_product_with_thing_subcategory(
             id_at_providers="9782895026310",
             thing_name="Presse papier",
             date_modified_at_last_provider=datetime(2001, 1, 1),
@@ -507,7 +507,7 @@ class TiteliveThingsTest:
         product = ThingProductFactory(
             idAtProviders="9782895026310",
             name="Presse papier",
-            type=str(ThingType.LIVRE_EDITION),
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
             dateModifiedAtLastProvider=datetime(2001, 1, 1),
             lastProviderId=titelive_provider.id,
         )

--- a/tests/local_providers/titelive_thumbs_test.py
+++ b/tests/local_providers/titelive_thumbs_test.py
@@ -9,7 +9,7 @@ import pytest
 from pcapi.local_providers import TiteLiveThingThumbs
 from pcapi.local_providers.titelive_thing_thumbs.titelive_thing_thumbs import extract_thumb_index
 from pcapi.model_creators.provider_creators import provider_test
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.models import Product
 from pcapi.repository import repository
 import pcapi.sandboxes
@@ -44,8 +44,8 @@ class TiteliveThingThumbsTest:
         self, get_thumbs_zip_file_from_ftp, get_ordered_thumbs_zip_files, app
     ):
         # given
-        product1 = create_product_with_thing_type(id_at_providers="9780847858903", thumb_count=0)
-        product2 = create_product_with_thing_type(id_at_providers="9782016261903", thumb_count=0)
+        product1 = create_product_with_thing_subcategory(id_at_providers="9780847858903", thumb_count=0)
+        product2 = create_product_with_thing_subcategory(id_at_providers="9782016261903", thumb_count=0)
         repository.save(product1, product2)
         zip_thumb_file = get_zip_with_2_usable_thumb_files()
         get_ordered_thumbs_zip_files.return_value = [zip_thumb_file]
@@ -74,7 +74,7 @@ class TiteliveThingThumbsTest:
         self, get_thumbs_zip_file_from_ftp, get_ordered_thumbs_zip_files, app
     ):
         # Given
-        product1 = create_product_with_thing_type(id_at_providers="9780847858903", thumb_count=0)
+        product1 = create_product_with_thing_subcategory(id_at_providers="9780847858903", thumb_count=0)
         repository.save(product1)
         zip_thumb_file = get_zip_with_1_usable_thumb_file()
         get_ordered_thumbs_zip_files.return_value = [zip_thumb_file]

--- a/tests/models/event_test.py
+++ b/tests/models/event_test.py
@@ -1,5 +1,5 @@
-from pcapi.model_creators.specific_creators import create_product_with_event_type
-from pcapi.models import EventType
+from pcapi.core.categories import subcategories
+from pcapi.model_creators.specific_creators import create_product_with_event_subcategory
 from pcapi.models import Product
 
 
@@ -9,7 +9,9 @@ def test_an_event_is_always_physical_and_cannot_be_digital():
 
 def test_event_offerType_returns_dict_matching_EventType_enum():
     # given
-    event_product = create_product_with_event_type(event_type=EventType.SPECTACLE_VIVANT)
+    event_product = create_product_with_event_subcategory(
+        event_subcategory_id=subcategories.SPECTACLE_REPRESENTATION.id,
+    )
     expected_value = {
         "conditionalFields": ["author", "showType", "stageDirector", "performer"],
         "proLabel": "Spectacle vivant",
@@ -35,7 +37,7 @@ def test_event_offerType_returns_dict_matching_EventType_enum():
 
 def test_event_offerType_returns_None_if_type_does_not_match_EventType_enum():
     # given
-    event_product = create_product_with_event_type(event_type="Workshop")
+    event_product = create_product_with_event_subcategory(event_subcategory_id="Workshop")
 
     # when
     offer_type = event_product.offerType

--- a/tests/models/product_test.py
+++ b/tests/models/product_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.repository import repository
 from pcapi.utils.human_ids import humanize
 
@@ -8,7 +8,7 @@ from pcapi.utils.human_ids import humanize
 @pytest.mark.usefixtures("db_session")
 def when_product_has_one_thumb(app):
     # Given
-    product = create_product_with_thing_type(thumb_count=1)
+    product = create_product_with_thing_subcategory(thumb_count=1)
     repository.save(product)
     product_id = humanize(product.id)
 
@@ -22,7 +22,7 @@ def when_product_has_one_thumb(app):
 @pytest.mark.usefixtures("db_session")
 def when_product_has_no_thumb(app):
     # Given
-    product = create_product_with_thing_type(thumb_count=0)
+    product = create_product_with_thing_subcategory(thumb_count=0)
     repository.save(product)
 
     # When

--- a/tests/models/thing_test.py
+++ b/tests/models/thing_test.py
@@ -1,15 +1,17 @@
 import pytest
 
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.core.categories import subcategories
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.models import ApiErrors
-from pcapi.models import ThingType
 from pcapi.repository import repository
 
 
 @pytest.mark.usefixtures("db_session")
 def test_thing_error_when_thing_type_is_offlineOnly_but_has_url(app):
     # Given
-    thing_product = create_product_with_thing_type(thing_type=ThingType.JEUX, url="http://mygame.fr/offre")
+    thing_product = create_product_with_thing_subcategory(
+        thing_subcategory_id=subcategories.JEU_SUPPORT_PHYSIQUE.id, url="http://mygame.fr/offre"
+    )
 
     # When
     with pytest.raises(ApiErrors) as errors:
@@ -21,7 +23,7 @@ def test_thing_error_when_thing_type_is_offlineOnly_but_has_url(app):
 
 def test_thing_offerType_returns_dict_matching_ThingType_enum():
     # given
-    thing_product = create_product_with_thing_type(thing_type=ThingType.LIVRE_EDITION)
+    thing_product = create_product_with_thing_subcategory(thing_subcategory_id=subcategories.LIVRE_PAPIER.id)
     expected_value = {
         "conditionalFields": ["author", "isbn"],
         "proLabel": "Livres papier ou numérique, abonnements lecture",
@@ -49,7 +51,7 @@ def test_thing_offerType_returns_dict_matching_ThingType_enum():
 
 def test_thing_offerType_returns_None_if_type_does_not_match_ThingType_enum():
     # given
-    thing_product = create_product_with_thing_type(thing_type="")
+    thing_product = create_product_with_thing_subcategory(thing_subcategory_id="")
 
     # when
     offer_type = thing_product.offerType

--- a/tests/repository/offer_queries_test.py
+++ b/tests/repository/offer_queries_test.py
@@ -13,8 +13,8 @@ from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_event_occurrence
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.model_creators.specific_creators import create_product_with_event_type
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_event_subcategory
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence
 from pcapi.model_creators.specific_creators import create_stock_from_offer
 from pcapi.models import Offer
@@ -31,7 +31,7 @@ class FindOffersTest:
     @pytest.mark.usefixtures("db_session")
     def test_get_offers_by_venue_id_returns_offers_matching_venue_id(self, app):
         # Given
-        product = create_product_with_thing_type(thing_name="Lire un livre", is_national=True)
+        product = create_product_with_thing_subcategory(thing_name="Lire un livre", is_national=True)
         offerer = create_offerer()
         venue = create_venue(offerer, postal_code="34000", departement_code="34")
         offer = create_offer_with_thing_product(venue=venue, product=product)
@@ -147,7 +147,7 @@ class QueryOfferWithRemainingStocksTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_return_1_offer_when_there_are_one_full_stock_and_one_empty_stock(self):
         # Given
-        product = create_product_with_thing_type(thing_name="Lire un livre", is_national=True)
+        product = create_product_with_thing_subcategory(thing_name="Lire un livre", is_national=True)
         offerer = create_offerer()
         venue = create_venue(offerer, postal_code="34000", departement_code="34")
         offer = create_offer_with_thing_product(venue=venue, product=product)
@@ -171,7 +171,7 @@ class QueryOfferWithRemainingStocksTest:
 
 
 def _create_event_stock_and_offer_for_date(venue, date):
-    product = create_product_with_event_type()
+    product = create_product_with_event_subcategory()
     offer = create_offer_with_event_product(venue=venue, product=product)
     event_occurrence = create_event_occurrence(offer, beginning_datetime=date)
     stock = create_stock_from_event_occurrence(event_occurrence, booking_limit_date=date)

--- a/tests/repository/product_queries_test.py
+++ b/tests/repository/product_queries_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pcapi.core.categories import subcategories
 from pcapi.core.offers.models import Mediation
 from pcapi.core.users import factories as users_factories
 from pcapi.model_creators.generic_creators import create_booking
@@ -9,12 +10,11 @@ from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_stock
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.models import Favorite
 from pcapi.models import Offer
 from pcapi.models import Product
 from pcapi.models import Stock
-from pcapi.models.offer_type import ThingType
 from pcapi.repository import repository
 from pcapi.repository.product_queries import delete_unwanted_existing_product
 from pcapi.repository.product_queries import find_active_book_product_by_isbn
@@ -25,7 +25,7 @@ class DeleteUnwantedExistingProductTest:
     def test_should_delete_product_when_isbn_found(self, app):
         # Given
         isbn = "1111111111111"
-        product = create_product_with_thing_type(id_at_providers=isbn)
+        product = create_product_with_thing_subcategory(id_at_providers=isbn)
         repository.save(product)
 
         # When
@@ -38,7 +38,7 @@ class DeleteUnwantedExistingProductTest:
     def test_should_not_delete_product_when_isbn_not_found(self, app):
         # Given
         isbn = "1111111111111"
-        product = create_product_with_thing_type(id_at_providers=isbn)
+        product = create_product_with_thing_subcategory(id_at_providers=isbn)
         repository.save(product)
 
         # When
@@ -51,10 +51,10 @@ class DeleteUnwantedExistingProductTest:
     def test_should_delete_nothing_when_product_not_found(self, app):
         # Given
         isbn = "1111111111111"
-        product = create_product_with_thing_type(
+        product = create_product_with_thing_subcategory(
             id_at_providers=isbn,
             is_gcu_compatible=False,
-            thing_type=ThingType.LIVRE_EDITION,
+            thing_subcategory_id=subcategories.LIVRE_PAPIER.id,
         )
         repository.save(product)
 
@@ -70,7 +70,7 @@ class DeleteUnwantedExistingProductTest:
         isbn = "1111111111111"
         offerer = create_offerer(siren="775671464")
         venue = create_venue(offerer, name="Librairie Titelive", siret="77567146400110")
-        product = create_product_with_thing_type(id_at_providers=isbn)
+        product = create_product_with_thing_subcategory(id_at_providers=isbn)
         offer = create_offer_with_thing_product(venue, product=product)
         stock = create_stock(offer=offer, price=0)
         repository.save(venue, product, offer, stock)
@@ -92,7 +92,7 @@ class DeleteUnwantedExistingProductTest:
         beneficiary = users_factories.BeneficiaryFactory()
         offerer = create_offerer(siren="775671464")
         venue = create_venue(offerer, name="Librairie Titelive", siret="77567146400110")
-        product = create_product_with_thing_type(id_at_providers=isbn, is_gcu_compatible=True)
+        product = create_product_with_thing_subcategory(id_at_providers=isbn, is_gcu_compatible=True)
         offer = create_offer_with_thing_product(venue, product=product, is_active=True)
         stock = create_stock(offer=offer, price=0)
         booking = create_booking(user=beneficiary, is_cancelled=True, stock=stock)
@@ -114,7 +114,7 @@ class DeleteUnwantedExistingProductTest:
         isbn = "1111111111111"
         offerer = create_offerer(siren="775671464")
         venue = create_venue(offerer, name="Librairie Titelive", siret="77567146400110")
-        product = create_product_with_thing_type(id_at_providers=isbn)
+        product = create_product_with_thing_subcategory(id_at_providers=isbn)
         offer = create_offer_with_thing_product(venue, product=product)
         stock = create_stock(offer=offer, price=0)
         mediation = create_mediation(offer=offer)
@@ -137,7 +137,7 @@ class DeleteUnwantedExistingProductTest:
         beneficiary = users_factories.BeneficiaryFactory()
         offerer = create_offerer(siren="775671464")
         venue = create_venue(offerer, name="Librairie Titelive", siret="77567146400110")
-        product = create_product_with_thing_type(id_at_providers=isbn)
+        product = create_product_with_thing_subcategory(id_at_providers=isbn)
         offer = create_offer_with_thing_product(venue, product=product)
         stock = create_stock(offer=offer, price=0)
         mediation = create_mediation(offer=offer)
@@ -161,7 +161,10 @@ class FindActiveBookProductByIsbnTest:
     def test_should_return_active_book_product_when_existing_isbn_is_given(self, app):
         # Given
         isbn = "1111111111111"
-        product = create_product_with_thing_type(id_at_providers=isbn, thing_type=ThingType.LIVRE_EDITION)
+        product = create_product_with_thing_subcategory(
+            id_at_providers=isbn,
+            thing_subcategory_id=subcategories.LIVRE_PAPIER.id,
+        )
         repository.save(product)
 
         # When
@@ -175,7 +178,10 @@ class FindActiveBookProductByIsbnTest:
         # Given
         invalid_isbn = "99999999999"
         valid_isbn = "1111111111111"
-        product = create_product_with_thing_type(id_at_providers=valid_isbn, thing_type=ThingType.LIVRE_EDITION)
+        product = create_product_with_thing_subcategory(
+            id_at_providers=valid_isbn,
+            thing_subcategory_id=subcategories.LIVRE_PAPIER.id,
+        )
         repository.save(product)
 
         # When
@@ -188,8 +194,8 @@ class FindActiveBookProductByIsbnTest:
     def test_should_not_return_not_gcu_compatible_product(self, app):
         # Given
         valid_isbn = "1111111111111"
-        product = create_product_with_thing_type(
-            id_at_providers=valid_isbn, thing_type=ThingType.LIVRE_EDITION, is_gcu_compatible=False
+        product = create_product_with_thing_subcategory(
+            id_at_providers=valid_isbn, thing_subcategory_id=subcategories.LIVRE_PAPIER.id, is_gcu_compatible=False
         )
         repository.save(product)
 

--- a/tests/repository/user_offerer_queries_test.py
+++ b/tests/repository/user_offerer_queries_test.py
@@ -8,8 +8,8 @@ from pcapi.model_creators.generic_creators import create_user_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.model_creators.specific_creators import create_product_with_event_type
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_event_subcategory
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.models import Offer
 from pcapi.models import UserOfferer
 from pcapi.models import Venue
@@ -73,10 +73,10 @@ def test_filter_query_where_user_is_user_offerer_and_is_validated(app):
     user_offerer1 = create_user_offerer(pro, offerer1)
     user_offerer2 = create_user_offerer(pro, offerer2)
 
-    event1 = create_product_with_event_type(event_name="Rencontre avec Jacques Martin")
-    event2 = create_product_with_event_type(event_name="Concert de contrebasse")
-    thing1 = create_product_with_thing_type(thing_name="Jacques la fripouille")
-    thing2 = create_product_with_thing_type(thing_name="Belle du Seigneur")
+    event1 = create_product_with_event_subcategory(event_name="Rencontre avec Jacques Martin")
+    event2 = create_product_with_event_subcategory(event_name="Concert de contrebasse")
+    thing1 = create_product_with_thing_subcategory(thing_name="Jacques la fripouille")
+    thing2 = create_product_with_thing_subcategory(thing_name="Belle du Seigneur")
     venue1 = create_venue(offerer1, name="Bataclan", city="Paris", siret=offerer1.siren + "12345")
     venue2 = create_venue(offerer2, name="Librairie la Rencontre", city="Saint Denis", siret=offerer2.siren + "54321")
     venue3 = create_venue(

--- a/tests/routes/native/v1/bookings_test.py
+++ b/tests/routes/native/v1/bookings_test.py
@@ -9,6 +9,7 @@ from pcapi.core.bookings.factories import BookingFactory
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import EventStockFactory
 from pcapi.core.offers.factories import MediationFactory
 from pcapi.core.offers.factories import StockFactory
@@ -17,7 +18,6 @@ from pcapi.core.testing import assert_num_queries
 from pcapi.core.testing import override_features
 from pcapi.core.users import factories as users_factories
 from pcapi.models.db import db
-from pcapi.models.offer_type import ThingType
 from pcapi.utils.human_ids import humanize
 
 from tests.conftest import TestClient
@@ -94,9 +94,9 @@ class GetBookingsTest:
 
         permanent_booking = BookingFactory(
             user=user,
-            stock__offer__type=str(ThingType.LIVRE_AUDIO),
             isUsed=True,
             status=BookingStatus.USED,
+            stock__offer__subcategoryId=subcategories.TELECHARGEMENT_LIVRE_AUDIO.id,
             dateUsed=datetime(2021, 2, 3),
         )
 
@@ -133,7 +133,7 @@ class GetBookingsTest:
 
         cancelled_permanent_booking = BookingFactory(
             user=user,
-            stock__offer__type=str(ThingType.LIVRE_AUDIO),
+            stock__offer__subcategoryId=subcategories.TELECHARGEMENT_LIVRE_AUDIO.id,
             isCancelled=True,
             cancellation_date=datetime(2021, 3, 10),
         )
@@ -163,7 +163,6 @@ class GetBookingsTest:
             response = test_client.get("/native/v1/bookings")
 
         assert response.status_code == 200
-
         assert [b["id"] for b in response.json["ongoing_bookings"]] == [
             expire_tomorrow.id,
             event_booking.id,

--- a/tests/routes/pro/get_booking_by_token_test.py
+++ b/tests/routes/pro/get_booking_by_token_test.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.categories import subcategories
 from pcapi.core.payments.factories import PaymentFactory
 from pcapi.core.users import factories as users_factories
 from pcapi.model_creators.generic_creators import create_booking
@@ -16,7 +17,6 @@ from pcapi.model_creators.specific_creators import create_event_occurrence
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
 from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence
 from pcapi.model_creators.specific_creators import create_stock_with_thing_offer
-from pcapi.models import EventType
 from pcapi.models import api_errors
 from pcapi.repository import repository
 from pcapi.routes.serialization import serialize
@@ -34,7 +34,9 @@ class Returns200Test:
         offerer = create_offerer()
         user_offerer = create_user_offerer(admin_user, offerer)
         venue = create_venue(offerer)
-        offer = create_offer_with_event_product(venue, event_name="Event Name", event_type=EventType.CINEMA)
+        offer = create_offer_with_event_product(
+            venue, event_name="Event Name", event_subcategory_id=subcategories.SEANCE_CINE.id
+        )
         event_occurrence = create_event_occurrence(offer)
         stock = create_stock_from_event_occurrence(event_occurrence, price=0)
         booking = create_booking(user=user, stock=stock, venue=venue)
@@ -65,7 +67,9 @@ class Returns200Test:
         offerer = create_offerer()
         user_offerer = create_user_offerer(admin_user, offerer)
         venue = create_venue(offerer)
-        offer = create_offer_with_event_product(venue, event_name="Event Name", event_type=EventType.CINEMA)
+        offer = create_offer_with_event_product(
+            venue, event_name="Event Name", event_subcategory_id=subcategories.SEANCE_CINE.id
+        )
         event_occurrence = create_event_occurrence(offer)
         stock = create_stock_from_event_occurrence(event_occurrence, price=0)
         booking = create_booking(user=user, stock=stock, venue=venue)

--- a/tests/routes/pro/get_booking_by_token_v2_test.py
+++ b/tests/routes/pro/get_booking_by_token_v2_test.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
+from pcapi.core.categories import subcategories
 from pcapi.core.offerers.factories import ApiKeyFactory
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
@@ -19,7 +20,6 @@ from pcapi.model_creators.specific_creators import create_offer_with_event_produ
 from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence
 from pcapi.model_creators.specific_creators import create_stock_with_event_offer
 from pcapi.model_creators.specific_creators import create_stock_with_thing_offer
-from pcapi.models import EventType
 from pcapi.models import api_errors
 from pcapi.repository import repository
 from pcapi.utils.date import format_into_utc_date
@@ -41,7 +41,7 @@ class Returns200Test:
         offer = create_offer_with_event_product(
             venue=venue,
             event_name="Event Name",
-            event_type=EventType.CINEMA,
+            event_subcategory_id=subcategories.SEANCE_CINE.id,
             extra_data={
                 "theater": {
                     "allocine_movie_id": 165,
@@ -97,7 +97,9 @@ class Returns200Test:
         offerer = create_offerer()
         user_offerer = create_user_offerer(user2, offerer)
         venue = create_venue(offerer)
-        offer = create_offer_with_event_product(venue, event_name="Event Name", event_type=EventType.CINEMA)
+        offer = create_offer_with_event_product(
+            venue, event_name="Event Name", event_subcategory_id=subcategories.SEANCE_CINE.id
+        )
         event_occurrence = create_event_occurrence(offer)
         stock = create_stock_from_event_occurrence(event_occurrence, price=0)
         booking = create_booking(user=user, stock=stock, venue=venue)
@@ -123,7 +125,9 @@ class Returns200Test:
         offerer = create_offerer()
         user_offerer = create_user_offerer(admin_user, offerer)
         venue = create_venue(offerer)
-        offer = create_offer_with_event_product(venue, event_name="Event Name", event_type=EventType.CINEMA)
+        offer = create_offer_with_event_product(
+            venue, event_name="Event Name", event_subcategory_id=subcategories.SEANCE_CINE.id
+        )
         event_occurrence = create_event_occurrence(offer)
         stock = create_stock_from_event_occurrence(event_occurrence, price=0)
         booking = create_booking(user=user, stock=stock, venue=venue)
@@ -231,7 +235,7 @@ class Returns403Test:
         # Given
         user = users_factories.BeneficiaryFactory(email="user@example.com")
         offerer2 = offers_factories.OffererFactory(siren="987654321")
-        offer = offers_factories.EventOfferFactory(type="EventType.CINEMA")
+        offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
         stock = offers_factories.EventStockFactory(offer=offer, price=0)
         booking = bookings_factories.BookingFactory(user=user, stock=stock)
 

--- a/tests/routes/pro/patch_booking_use_by_token_test.py
+++ b/tests/routes/pro/patch_booking_use_by_token_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 from pcapi.core.offerers.factories import ApiKeyFactory
 from pcapi.core.offerers.factories import DEFAULT_CLEAR_API_KEY
 import pcapi.core.offers.factories as offers_factories
@@ -139,7 +140,7 @@ class Returns403Test:
             # Given
             user = users_factories.BeneficiaryFactory(email="user@example.com")
             offerer2 = offers_factories.OffererFactory(siren="987654321")
-            offer = offers_factories.EventOfferFactory(type="EventType.CINEMA")
+            offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
             stock = offers_factories.EventStockFactory(offer=offer, price=0)
             booking = BookingFactory(user=user, stock=stock)
 

--- a/tests/routes/pro/patch_offer_test.py
+++ b/tests/routes/pro/patch_offer_test.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytest
 
+from pcapi.core.categories import subcategories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import OfferValidationStatus
 import pcapi.core.users.factories as users_factories
@@ -9,12 +10,12 @@ from pcapi.models import Offer
 from pcapi.routes.serialization import serialize
 from pcapi.utils.human_ids import humanize
 
-from tests.conftest import TestClient
+
+pytestmark = pytest.mark.usefixtures("db_session")
 
 
-@pytest.mark.usefixtures("db_session")
 class Returns200Test:
-    def test_patch_offer(self, app):
+    def test_patch_offer(self, app, client):
         # Given
         offer = offers_factories.OfferFactory()
         offers_factories.UserOffererFactory(
@@ -23,13 +24,12 @@ class Returns200Test:
         )
 
         # When
-        client = TestClient(app.test_client()).with_auth("user@example.com")
         data = {
             "name": "New name",
             "externalTicketOfficeUrl": "http://example.net",
             "mentalDisabilityCompliant": True,
         }
-        response = client.patch(f"/offers/{humanize(offer.id)}", json=data)
+        response = client.with_auth("user@example.com").patch(f"/offers/{humanize(offer.id)}", json=data)
 
         # Then
         assert response.status_code == 200
@@ -42,9 +42,8 @@ class Returns200Test:
         assert updated_offer.mentalDisabilityCompliant
 
 
-@pytest.mark.usefixtures("db_session")
 class Returns400Test:
-    def when_trying_to_patch_forbidden_attributes(self, app):
+    def when_trying_to_patch_forbidden_attributes(self, app, client):
         # Given
         offer = offers_factories.OfferFactory()
         offers_factories.UserOffererFactory(
@@ -61,9 +60,10 @@ class Returns400Test:
             "lastProviderId": 1,
             "owningOffererId": "AA",
             "thumbCount": 2,
+            "subcategoryId": subcategories.LIVRE_PAPIER,
+            "type": subcategories.LIVRE_PAPIER.matching_type,
         }
-        client = TestClient(app.test_client()).with_auth("user@example.com")
-        response = client.patch(f"offers/{humanize(offer.id)}", json=data)
+        response = client.with_auth("user@example.com").patch(f"offers/{humanize(offer.id)}", json=data)
 
         # Then
         assert response.status_code == 400
@@ -76,11 +76,13 @@ class Returns400Test:
             "lastProviderId",
             "owningOffererId",
             "thumbCount",
+            "subcategoryId",
+            "type",
         }
         for key in forbidden_keys:
             assert key in response.json
 
-    def should_fail_when_url_has_no_scheme(self, app):
+    def should_fail_when_url_has_no_scheme(self, app, client):
         # Given
         virtual_venue = offers_factories.VirtualVenueFactory()
         offer = offers_factories.OfferFactory(venue=virtual_venue)
@@ -94,14 +96,13 @@ class Returns400Test:
             "name": "Les lièvres pas malins",
             "url": "missing.something",
         }
-        client = TestClient(app.test_client()).with_auth("user@example.com")
-        response = client.patch(f"offers/{humanize(offer.id)}", json=data)
+        response = client.with_auth("user@example.com").patch(f"offers/{humanize(offer.id)}", json=data)
 
         # Then
         assert response.status_code == 400
         assert response.json["url"] == ['L\'URL doit commencer par "http://" ou "https://"']
 
-    def should_fail_when_externalTicketOfficeUrl_has_no_scheme(self, app):
+    def should_fail_when_externalTicketOfficeUrl_has_no_scheme(self, app, client):
         # Given
         virtual_venue = offers_factories.VirtualVenueFactory()
         offer = offers_factories.OfferFactory(venue=virtual_venue)
@@ -115,14 +116,13 @@ class Returns400Test:
             "name": "Les lièvres pas malins",
             "externalTicketOfficeUrl": "missing.something",
         }
-        client = TestClient(app.test_client()).with_auth("user@example.com")
-        response = client.patch(f"offers/{humanize(offer.id)}", json=data)
+        response = client.with_auth("user@example.com").patch(f"offers/{humanize(offer.id)}", json=data)
 
         # Then
         assert response.status_code == 400
         assert response.json["externalTicketOfficeUrl"] == ['L\'URL doit commencer par "http://" ou "https://"']
 
-    def should_fail_when_url_has_no_host(self, app):
+    def should_fail_when_url_has_no_host(self, app, client):
         # Given
         virtual_venue = offers_factories.VirtualVenueFactory()
         offer = offers_factories.OfferFactory(venue=virtual_venue)
@@ -136,14 +136,13 @@ class Returns400Test:
             "name": "Les lièvres pas malins",
             "url": "https://missing",
         }
-        client = TestClient(app.test_client()).with_auth("user@example.com")
-        response = client.patch(f"offers/{humanize(offer.id)}", json=data)
+        response = client.with_auth("user@example.com").patch(f"offers/{humanize(offer.id)}", json=data)
 
         # Then
         assert response.status_code == 400
         assert response.json["url"] == ['L\'URL doit terminer par une extension (ex. ".fr")']
 
-    def should_fail_when_externalTicketOfficeUrl_has_no_host(self, app):
+    def should_fail_when_externalTicketOfficeUrl_has_no_host(self, app, client):
         # Given
         virtual_venue = offers_factories.VirtualVenueFactory()
         offer = offers_factories.OfferFactory(venue=virtual_venue)
@@ -157,41 +156,37 @@ class Returns400Test:
             "name": "Les lièvres pas malins",
             "externalTicketOfficeUrl": "https://missing",
         }
-        client = TestClient(app.test_client()).with_auth("user@example.com")
-        response = client.patch(f"offers/{humanize(offer.id)}", json=data)
+        response = client.with_auth("user@example.com").patch(f"offers/{humanize(offer.id)}", json=data)
 
         # Then
         assert response.status_code == 400
         assert response.json["externalTicketOfficeUrl"] == ['L\'URL doit terminer par une extension (ex. ".fr")']
 
-    def test_patch_non_approved_offer_fails(self, app):
+    def test_patch_non_approved_offer_fails(self, app, client):
         offer = offers_factories.OfferFactory(validation=OfferValidationStatus.PENDING)
         offers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
         )
 
-        client = TestClient(app.test_client()).with_auth("user@example.com")
         data = {
             "visualDisabilityCompliant": True,
         }
-        response = client.patch(f"/offers/{humanize(offer.id)}", json=data)
+        response = client.with_auth("user@example.com").patch(f"/offers/{humanize(offer.id)}", json=data)
 
         assert response.status_code == 400
         assert response.json["global"] == ["Les offres refusées ou en attente de validation ne sont pas modifiables"]
 
 
-@pytest.mark.usefixtures("db_session")
 class Returns403Test:
-    def when_user_is_not_attached_to_offerer(self, app):
+    def when_user_is_not_attached_to_offerer(self, app, client):
         # Given
         offer = offers_factories.OfferFactory(name="Old name")
         offers_factories.UserOffererFactory(user__email="user@example.com")
 
         # When
-        client = TestClient(app.test_client()).with_auth("user@example.com")
         data = {"name": "New name"}
-        response = client.patch(f"/offers/{humanize(offer.id)}", json=data)
+        response = client.with_auth("user@example.com").patch(f"/offers/{humanize(offer.id)}", json=data)
 
         # Then
         assert response.status_code == 403
@@ -202,13 +197,12 @@ class Returns403Test:
 
 
 class Returns404Test:
-    def test_returns_404_if_offer_does_not_exist(self, app, db_session):
+    def test_returns_404_if_offer_does_not_exist(self, app, client):
         # given
-        user = users_factories.UserFactory()
+        users_factories.UserFactory(email="user@example.com")
 
         # when
-        client = TestClient(app.test_client()).with_auth(email=user.email)
-        response = client.patch("/offers/ADFGA", json={})
+        response = client.with_auth("user@example.com").patch("/offers/ADFGA", json={})
 
         # then
         assert response.status_code == 404

--- a/tests/routes/serialization/bookings_serialize_test.py
+++ b/tests/routes/serialization/bookings_serialize_test.py
@@ -4,6 +4,7 @@ from freezegun import freeze_time
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import StockWithActivationCodesFactory
 from pcapi.core.users import factories as users_factories
 from pcapi.model_creators.generic_creators import create_booking
@@ -13,10 +14,8 @@ from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_event_occurrence
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence
-from pcapi.models import EventType
-from pcapi.models import ThingType
 from pcapi.routes.serialization import serialize_booking
 from pcapi.routes.serialization.bookings_serialize import serialize_booking_minimal
 from pcapi.utils.human_ids import humanize
@@ -34,7 +33,9 @@ class SerializeBookingTest:
         user = users_factories.BeneficiaryFactory.build(email="user@example.com", publicName="John Doe")
         offerer = create_offerer()
         venue = create_venue(offerer, name="Venue name", address="Venue address")
-        offer = create_offer_with_event_product(venue=venue, event_name="Event Name", event_type=EventType.CINEMA)
+        offer = create_offer_with_event_product(
+            venue=venue, event_name="Event Name", event_subcategory_id=subcategories.SEANCE_CINE.id
+        )
         event_occurrence = create_event_occurrence(offer, beginning_datetime=datetime.utcnow())
         stock = create_stock_from_event_occurrence(event_occurrence, price=12)
         booking = create_booking(user=user, quantity=3, stock=stock, venue=venue)
@@ -72,7 +73,7 @@ class SerializeBookingTest:
         offerer = create_offerer()
         venue = create_venue(offerer, name="Venue name", address="Venue address")
         offer = create_offer_with_event_product(
-            venue=venue, event_name="Event Name", event_type=EventType.CINEMA, idx=999
+            venue=venue, event_name="Event Name", event_subcategory_id=subcategories.SEANCE_CINE.id, idx=999
         )
         event_occurrence = create_event_occurrence(offer, beginning_datetime=datetime.utcnow())
         stock = create_stock_from_event_occurrence(event_occurrence, price=12)
@@ -91,8 +92,10 @@ class SerializeBookingTest:
         user = users_factories.BeneficiaryFactory.build(email="user@example.com", publicName="John Doe")
         offerer = create_offerer()
         venue = create_venue(offerer, name="Venue name", address="Venue address")
-        product = create_product_with_thing_type(
-            thing_name="Event Name", thing_type=ThingType.CINEMA_ABO, extra_data={"isbn": "123456789"}
+        product = create_product_with_thing_subcategory(
+            thing_name="Event Name",
+            thing_subcategory_id=subcategories.CARTE_CINE_ILLIMITE.id,
+            extra_data={"isbn": "123456789"},
         )
         offer = create_offer_with_thing_product(
             venue,
@@ -143,8 +146,8 @@ class SerializeBookingTest:
         user = users_factories.BeneficiaryFactory.build(email="user@example.com", publicName="John Doe")
         offerer = create_offerer()
         venue = create_venue(offerer, name="Venue name", address="Venue address")
-        product = create_product_with_thing_type(
-            thing_name="Event Name", thing_type=ThingType.CINEMA_ABO, extra_data={}
+        product = create_product_with_thing_subcategory(
+            thing_name="Event Name", thing_subcategory_id=subcategories.CARTE_CINE_ILLIMITE.id, extra_data={}
         )
         offer = create_offer_with_thing_product(venue, product=product, idx=999)
         stock = create_stock(offer=offer, price=12)
@@ -162,7 +165,9 @@ class SerializeBookingTest:
         user = users_factories.BeneficiaryFactory.build(email="user@example.com", publicName="John Doe")
         offerer = create_offerer()
         venue = create_venue(offerer, name="Venue name", address="Venue address")
-        offer = create_offer_with_event_product(venue=venue, event_name="Event Name", event_type=EventType.JEUX)
+        offer = create_offer_with_event_product(
+            venue=venue, event_name="Event Name", event_subcategory_id=subcategories.EVENEMENT_JEU.id
+        )
         event_occurrence = create_event_occurrence(offer, beginning_datetime=datetime.utcnow())
         stock = create_stock_from_event_occurrence(event_occurrence, price=12)
         booking = create_booking(user=user, quantity=3, stock=stock, venue=venue)
@@ -184,7 +189,9 @@ class SerializeBookingTest:
         )
         offerer = create_offerer()
         venue = create_venue(offerer, name="Venue name", address="Venue address")
-        offer = create_offer_with_event_product(venue=venue, event_name="Event Name", event_type=EventType.ACTIVATION)
+        offer = create_offer_with_event_product(
+            venue=venue, event_name="Event Name", event_subcategory_id=subcategories.ACTIVATION_EVENT.id
+        )
         event_occurrence = create_event_occurrence(offer, beginning_datetime=datetime.utcnow())
         stock = create_stock_from_event_occurrence(event_occurrence, price=12)
         booking = create_booking(user=user, quantity=3, stock=stock, venue=venue)

--- a/tests/routes/serialization/dictifier_test.py
+++ b/tests/routes/serialization/dictifier_test.py
@@ -7,7 +7,7 @@ from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_user_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
-from pcapi.model_creators.specific_creators import create_product_with_event_type
+from pcapi.model_creators.specific_creators import create_product_with_event_subcategory
 from pcapi.models import Stock
 from pcapi.repository import repository
 from pcapi.routes.serialization import as_dict
@@ -98,7 +98,7 @@ class AsDictTest:
         # given
         offerer = create_offerer()
         venue = create_venue(offerer)
-        event_product = create_product_with_event_type(event_name="My Event")
+        event_product = create_product_with_event_subcategory(event_name="My Event")
         offer = create_offer_with_event_product(venue, product=event_product)
         mediation = create_mediation(offer)
         repository.save(mediation)
@@ -115,7 +115,7 @@ class AsDictTest:
         # given
         offerer = create_offerer()
         venue = create_venue(offerer)
-        event_product = create_product_with_event_type(event_name="My Event")
+        event_product = create_product_with_event_subcategory(event_name="My Event")
         offer = create_offer_with_event_product(venue, product=event_product)
         mediation = create_mediation(offer)
         repository.save(mediation)

--- a/tests/routes/shared/get_user_profile_test.py
+++ b/tests/routes/shared/get_user_profile_test.py
@@ -2,12 +2,12 @@ import datetime
 
 import pytest
 
+from pcapi.core.categories import subcategories
 from pcapi.core.users import factories as users_factories
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_user_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.models import ThingType
 from pcapi.repository import repository
 from pcapi.utils.date import format_into_utc_date
 from pcapi.utils.human_ids import humanize
@@ -83,7 +83,7 @@ class Returns200Test:
         offerer2_physical_venue = create_venue(offerer2, siret="12345678856734")
         offerer2_virtual_venue = create_venue(offerer, is_virtual=True, siret=None)
         offer = create_offer_with_thing_product(
-            offerer_virtual_venue, thing_type=ThingType.JEUX_VIDEO_ABO, url="http://fake.url"
+            offerer_virtual_venue, thing_subcategory_id=subcategories.ABO_JEU_VIDEO.id, url="http://fake.url"
         )
         offer2 = create_offer_with_thing_product(offerer2_physical_venue)
 

--- a/tests/routes/webapp/get_booking_by_id_test.py
+++ b/tests/routes/webapp/get_booking_by_id_test.py
@@ -137,7 +137,7 @@ class Returns200Test:
                             "remainingQuantity": "unlimited",
                         }
                     ],
-                    "subcategoryId": None,
+                    "subcategoryId": "SUPPORT_PHYSIQUE_FILM",
                     "thumbUrl": None,
                     "type": "ThingType.AUDIOVISUEL",
                     "url": "https://host/path/{token}?offerId={offerId}&email={email}",

--- a/tests/sandboxes/scripts/getters/webapp_08_booking_test.py
+++ b/tests/sandboxes/scripts/getters/webapp_08_booking_test.py
@@ -6,8 +6,8 @@ from pcapi.model_creators.generic_creators import create_stock
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.model_creators.specific_creators import create_product_with_event_type
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_event_subcategory
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.repository import repository
 from pcapi.sandboxes.scripts.getters.webapp_08_booking import get_non_free_event_offer
 from pcapi.sandboxes.scripts.getters.webapp_08_booking import get_non_free_thing_offer_with_active_mediation
@@ -21,7 +21,7 @@ class GetNonFreeThingOfferWithActiveMediationTest:
         # Given
         offerer = create_offerer()
         venue = create_venue(offerer)
-        product = create_product_with_thing_type()
+        product = create_product_with_thing_subcategory()
         offer = create_offer_with_thing_product(venue, product=product)
         stock = create_stock(offer=offer)
         mediation = create_mediation(offer)
@@ -63,7 +63,7 @@ class GetNonFreeThingOfferWithActiveMediationTest:
                 "productId": humanize(product.id),
                 "rankingWeight": None,
                 "status": "ACTIVE",
-                "subcategoryId": None,
+                "subcategoryId": "LIVRE_PAPIER",
                 "thingName": "Test Book",
                 "type": "ThingType.LIVRE_EDITION",
                 "url": None,
@@ -81,7 +81,7 @@ class GetNonFreeThingOfferWithActiveMediationTest:
         # Given
         offerer = create_offerer(validation_token="validation_token")
         venue = create_venue(offerer)
-        product = create_product_with_thing_type()
+        product = create_product_with_thing_subcategory()
         offer = create_offer_with_thing_product(venue, product=product)
         stock = create_stock(offer=offer)
         mediation = create_mediation(offer)
@@ -100,7 +100,7 @@ class GetNonFreeEventOfferTest:
         # Given
         offerer = create_offerer()
         venue = create_venue(offerer)
-        product = create_product_with_event_type()
+        product = create_product_with_event_subcategory()
         offer = create_offer_with_event_product(venue, product=product)
         stock = create_stock(offer=offer)
         mediation = create_mediation(offer)
@@ -142,7 +142,7 @@ class GetNonFreeEventOfferTest:
                 "productId": humanize(product.id),
                 "rankingWeight": None,
                 "status": "ACTIVE",
-                "subcategoryId": None,
+                "subcategoryId": "SPECTACLE_REPRESENTATION",
                 "thingName": "Test event",
                 "type": "EventType.SPECTACLE_VIVANT",
                 "url": None,
@@ -160,7 +160,7 @@ class GetNonFreeEventOfferTest:
         # Given
         offerer = create_offerer(validation_token="validation_token")
         venue = create_venue(offerer)
-        product = create_product_with_event_type()
+        product = create_product_with_event_subcategory()
         offer = create_offer_with_event_product(venue, product=product)
         stock = create_stock(offer=offer)
         mediation = create_mediation(offer)

--- a/tests/scripts/booking/notify_soon_to_be_expired_bookings_test.py
+++ b/tests/scripts/booking/notify_soon_to_be_expired_bookings_test.py
@@ -5,8 +5,8 @@ from unittest import mock
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import ProductFactory
-from pcapi.models import offer_type
 from pcapi.repository import repository
 from pcapi.scripts.booking.notify_soon_to_be_expired_bookings import notify_users_of_soon_to_be_expired_bookings
 
@@ -22,13 +22,13 @@ class NotifyUsersOfSoonToBeExpiredBookingsTest:
         booking_date_23_days_ago = now - timedelta(days=23)
         booking_date_22_days_ago = now - timedelta(days=22)
 
-        dvd = ProductFactory(type=str(offer_type.ThingType.AUDIOVISUEL))
+        dvd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
         expire_in_7_days_dvd_booking = BookingFactory(
             stock__offer__product=dvd,
             dateCreated=booking_date_23_days_ago,
             isCancelled=False,
         )
-        non_expired_cd = ProductFactory(type=str(offer_type.ThingType.MUSIQUE))
+        non_expired_cd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id)
         dont_expire_in_7_days_cd_booking = BookingFactory(
             stock__offer__product=non_expired_cd,
             dateCreated=booking_date_22_days_ago,

--- a/tests/scripts/bulk_update_old_offers_with_new_subcategories_test.py
+++ b/tests/scripts/bulk_update_old_offers_with_new_subcategories_test.py
@@ -1,7 +1,12 @@
+from datetime import datetime
+
 import pytest
 
-from pcapi.core.offers.factories import OfferFactory
-from pcapi.models import offer_type
+from pcapi.core.offerers.models import Offerer
+from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.models import Offer
+from pcapi.models import Product
+from pcapi.repository import repository
 from pcapi.scripts.bulk_update_old_offers_with_new_subcategories import bulk_update_old_offers_with_new_subcategories
 
 
@@ -9,14 +14,42 @@ class UpdateOffersSubcatTest:
     @pytest.mark.usefixtures("db_session")
     def test_update_offers_subcategory(self):
         # Given
-        created_offers = OfferFactory.create_batch(
-            size=3, subcategoryId=None, type=str(offer_type.ThingType.LIVRE_EDITION)
+        created_product = Product(
+            type="ThingType.LIVRE_EDITION", name="product1", mediaUrls="toto", isNational=True, id=1
         )
-        # When
+        repository.save(created_product)
+        created_offerer = Offerer(
+            id=1, dateCreated=datetime(2021, 1, 1), name="offerer1", postalCode="75012", city="Paris", siren="123456789"
+        )
+        repository.save(created_offerer)
 
+        created_venue = Venue(
+            id=1,
+            name="venue1",
+            managingOffererId=1,
+            isVirtual=False,
+            siret="12345678932321",
+            postalCode="75012",
+            city="Paris",
+        )
+        repository.save(created_venue)
+
+        created_offers = Offer(
+            id=1,
+            productId=1,
+            venueId=1,
+            type="ThingType.LIVRE_EDITION",
+            name="offer1",
+            mediaUrls="toto",
+            isNational=True,
+            isDuo=False,
+            dateCreated=datetime(2021, 1, 1),
+            isEducational=True,
+        )
+        repository.save(created_offers)
+
+        # When
         bulk_update_old_offers_with_new_subcategories()
 
         # Then
-        assert created_offers[0].subcategoryId == "LIVRE_PAPIER"
-        assert created_offers[1].subcategoryId == "LIVRE_PAPIER"
-        assert created_offers[2].subcategoryId == "LIVRE_PAPIER"
+        assert created_offers.subcategoryId == "LIVRE_PAPIER"

--- a/tests/scripts/payment/generate_new_payments_test.py
+++ b/tests/scripts/payment/generate_new_payments_test.py
@@ -4,11 +4,11 @@ import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
 from pcapi.core.testing import assert_num_queries
 import pcapi.core.users.factories as users_factories
-from pcapi.models import ThingType
 from pcapi.models.payment import Payment
 from pcapi.models.payment_status import TransactionStatus
 from pcapi.repository import repository
@@ -285,9 +285,7 @@ class GenerateNewPaymentsTest:
         venue1 = offers_factories.VenueFactory(managingOfferer=offerer1, siret="12345678912345")
         venue2 = offers_factories.VenueFactory(managingOfferer=offerer1, siret="98765432154321")
         venue3 = offers_factories.VenueFactory(managingOfferer=offerer1, siret="98123432154321")
-        product = offers_factories.ThingProductFactory(
-            type=str(ThingType.LIVRE_EDITION),
-        )
+        product = offers_factories.ThingProductFactory(subcategoryId=subcategories.LIVRE_PAPIER.id)
         offer1 = offers_factories.ThingOfferFactory(venue=venue1, product=product)
         offer2 = offers_factories.ThingOfferFactory(venue=venue2, product=product)
         offer3 = offers_factories.ThingOfferFactory(venue=venue3, product=product)
@@ -331,9 +329,7 @@ class GenerateNewPaymentsTest:
         venue1 = offers_factories.VenueFactory(managingOfferer=offerer1, siret="12345678912345")
         venue2 = offers_factories.VenueFactory(managingOfferer=offerer1, siret="98765432154321")
         venue3 = offers_factories.VenueFactory(managingOfferer=offerer1, siret="98123432154321")
-        product = offers_factories.ThingProductFactory(
-            type=str(ThingType.LIVRE_EDITION),
-        )
+        product = offers_factories.ThingProductFactory(subcategoryId=subcategories.LIVRE_PAPIER.id)
         offer1 = offers_factories.ThingOfferFactory(venue=venue1, product=product)
         offer2 = offers_factories.ThingOfferFactory(venue=venue2, product=product)
         offer3 = offers_factories.ThingOfferFactory(venue=venue3, product=product)

--- a/tests/scripts/stock/fully_sync_venue_test.py
+++ b/tests/scripts/stock/fully_sync_venue_test.py
@@ -3,10 +3,10 @@ import requests_mock
 
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import subcategories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offers_models
-from pcapi.models.offer_type import ThingType
 from pcapi.scripts.stock import fully_sync_venue
 
 
@@ -21,7 +21,7 @@ def test_fully_sync_venue():
     product2 = offers_factories.ProductFactory(
         idAtProviders="1234",
         extraData={"prix_livre": 10},
-        type=str(ThingType.LIVRE_EDITION),
+        subcategoryId=subcategories.LIVRE_PAPIER.id,
     )
 
     with requests_mock.Mocker() as mock:
@@ -50,7 +50,7 @@ def test_fully_sync_venue_with_new_provider():
     product2 = offers_factories.ProductFactory(
         idAtProviders="1234",
         extraData={"prix_livre": 10},
-        type=str(ThingType.LIVRE_EDITION),
+        subcategoryId=subcategories.LIVRE_PAPIER.id,
     )
     new_provider = offerers_factories.APIProviderFactory(apiUrl=api_url)
 

--- a/tests/utils/mailing_test.py
+++ b/tests/utils/mailing_test.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from pcapi.core.categories import subcategories
 from pcapi.core.users import factories as users_factories
 from pcapi.model_creators.generic_creators import create_booking
 from pcapi.model_creators.generic_creators import create_offerer
@@ -13,7 +14,6 @@ from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
 from pcapi.model_creators.specific_creators import create_stock_from_offer
-from pcapi.models import ThingType
 from pcapi.repository import repository
 from pcapi.utils.human_ids import humanize
 from pcapi.utils.mailing import build_pc_pro_offer_link
@@ -74,7 +74,7 @@ class GetUsersInformationFromStockBookingsTest:
         venue = create_venue(
             offerer=offerer, name="Test offerer", booking_email="reservations@test.fr", is_virtual=True, siret=None
         )
-        thing_offer = create_offer_with_thing_product(venue, thing_type=ThingType.LIVRE_EDITION)
+        thing_offer = create_offer_with_thing_product(venue, thing_subcategory_id=subcategories.LIVRE_NUMERIQUE.id)
         beginning_datetime = datetime(2019, 11, 6, 14, 00, 0, tzinfo=timezone.utc)
         stock = create_stock_from_offer(thing_offer, price=0, quantity=10, beginning_datetime=beginning_datetime)
         booking_1 = create_booking(user=user_1, stock=stock, venue=venue, token="HELLO0")

--- a/tests/validation/models/entity_validator_test.py
+++ b/tests/validation/models/entity_validator_test.py
@@ -6,7 +6,7 @@ from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_stock
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.validation.models.entity_validator import validate
 
 
@@ -109,7 +109,7 @@ def test_should_not_return_errors_when_valid_offerer():
 
 def test_should_return_errors_when_invalid_product():
     # Given
-    product = create_product_with_thing_type(is_offline_only=True, is_digital=True)
+    product = create_product_with_thing_subcategory(is_offline_only=True, is_digital=True)
 
     # When
     api_errors = validate(product)
@@ -120,7 +120,7 @@ def test_should_return_errors_when_invalid_product():
 
 def test_should_return_errors_when_valid_product():
     # Given
-    product = create_product_with_thing_type()
+    product = create_product_with_thing_subcategory()
 
     # When
     api_errors = validate(product)

--- a/tests/validation/models/product_test.py
+++ b/tests/validation/models/product_test.py
@@ -1,11 +1,11 @@
-from pcapi.model_creators.specific_creators import create_product_with_thing_type
+from pcapi.model_creators.specific_creators import create_product_with_thing_subcategory
 from pcapi.models import ApiErrors
 from pcapi.validation.models.product import validate
 
 
 def test_should_return_error_message_when_product_is_digital_and_offline():
     # Given
-    product = create_product_with_thing_type(is_offline_only=True, is_digital=True)
+    product = create_product_with_thing_subcategory(is_offline_only=True, is_digital=True)
     api_errors = ApiErrors()
 
     # When
@@ -17,7 +17,7 @@ def test_should_return_error_message_when_product_is_digital_and_offline():
 
 def test_should_not_return_error_message_when_product_is_not_digital():
     # Given
-    product = create_product_with_thing_type(is_offline_only=True, is_digital=False)
+    product = create_product_with_thing_subcategory(is_offline_only=True, is_digital=False)
     api_errors = ApiErrors()
 
     # When
@@ -29,7 +29,7 @@ def test_should_not_return_error_message_when_product_is_not_digital():
 
 def test_should_not_return_error_message_when_product_is_online():
     # Given
-    product = create_product_with_thing_type(is_offline_only=False, is_digital=False)
+    product = create_product_with_thing_subcategory(is_offline_only=False, is_digital=False)
     api_errors = ApiErrors()
 
     # When


### PR DESCRIPTION
##  Objectif

Remplir la colonne `subcategoryId` lors de la création de `Product`

##  Implémentation

- Ajout de la colonne au modèle `Product`, avec index
- Ajout de la migration d'ajout de colonne, puis la migration d'ajout d'index
- Mettre à jour les Factories et autres créateurs d'objets pour les tests
- Mettre à jour les tests

##  Informations supplémentaires

- Un changement futur supprimera l'utilisation de `type` d'offre ou de produit dans tout le code, une fois que tous les produits et offres en DB auront une `subcategoryId`, qui deviendra _non nullable_.
