### PR TITLE
(PC-10027) circleci: improve configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ commands:
       version_file:
         type: string
     steps:
-    - run: echo "export CHART_VERSION=$(cat << parameters.version_file >> | tr -d '[:space:]')" >> $BASH_ENV
+      - run: echo "export CHART_VERSION=$(cat << parameters.version_file >> | tr -d '[:space:]')" >> $BASH_ENV
 
   deploy-helm-chart:
     description: Deploy Crons and worker via helm to Kubernetes Cluster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,7 +525,6 @@ jobs:
 ###################
 
 workflows:
-  version: 2
   commit:
     jobs:
       - run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,10 @@ jobs:
       is_nightly_build:
         type: boolean
         default: false
+      pytest_extra_args:
+        description: "directories to include and ignore"
+        default: "tests"
+        type: string
     working_directory: ~/pass-culture-api-ci
     docker:
       - image: circleci/python:3.9.4
@@ -250,7 +254,7 @@ jobs:
             - run:
                 name: Running tests
                 command: |
-                  RUN_ENV=tests venv/bin/pytest tests --junitxml=test-results/junit.xml
+                  RUN_ENV=tests venv/bin/pytest << parameters.pytest_extra_args >> --junitxml=test-results/junit.xml
       - store_test_results:
           path: test-results
       - store_artifacts:
@@ -528,7 +532,14 @@ workflows:
   commit:
     jobs:
       - run-tests:
-          name: "Run tests after commit"
+          name: "Run core tests after commit"
+          pytest_extra_args: "tests/core"
+      - run-tests:
+          name: "Run routes tests after commit"
+          pytest_extra_args: "tests/routes"
+      - run-tests:
+          name: "Run other tests after commit"
+          pytest_extra_args: "tests --ignore=tests/core --ignore=tests/routes"
       - quality:
           name: "Run quality checks after commit"
       - build-container:
@@ -538,7 +549,9 @@ workflows:
                 - master
       - build-and-push-image:
           requires:
-            - "Run tests after commit"
+            - "Run core tests after commit"
+            - "Run routes tests after commit"
+            - "Run other tests after commit"
             - "Run quality checks after commit"
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,8 +244,10 @@ jobs:
           steps:
             - run:
                 name: Running tests
-                command: |
-                  RUN_ENV=tests venv/bin/pytest tests --cov --cov-report html --junitxml=test-results/junit.xml
+                command: >
+                  RUN_ENV=tests venv/bin/pytest tests --durations=10  --cov --cov-report html
+                  --junitxml=test-results/junit.xml
+
                   venv/bin/coveralls
 
       - unless:
@@ -253,8 +255,10 @@ jobs:
           steps:
             - run:
                 name: Running tests
-                command: |
-                  RUN_ENV=tests venv/bin/pytest << parameters.pytest_extra_args >> --junitxml=test-results/junit.xml
+                command: >
+                  RUN_ENV=tests venv/bin/pytest << parameters.pytest_extra_args >> --durations=10
+                  --junitxml=test-results/junit.xml
+
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt
+            pip install -r requirements.txt --progress-bar off
       - unless:
           condition:
             equal: [ "master", << pipeline.git.branch >> ]

--- a/src/pcapi/scripts/batch_update_offer_withdrawal_details_for_offerer.py
+++ b/src/pcapi/scripts/batch_update_offer_withdrawal_details_for_offerer.py
@@ -10,12 +10,13 @@ from pcapi.models import db
 
 
 def batch_update_offer_withdrawal_details_for_offerer(
-    offerer_id: int, withdrawal_details: str, batch_size: int
+    offerer_id: int, withdrawal_details: str, batch_size: int = 1000
 ) -> None:
+    min_id = db.session.query(func.min(Offer.id)).scalar()
     max_id = db.session.query(func.max(Offer.id)).scalar()
     number_of_batch = math.ceil(max_id / batch_size)
     number_of_batch_done = 0
-    ranges = [(i, i + batch_size) for i in range(1, max_id + 1, batch_size)]
+    ranges = [(i, i + batch_size) for i in range(min_id, max_id + 1, batch_size)]
     for start, end in ranges:
         db.session.execute(
             """


### PR DESCRIPTION
##  Objectif

Raccourcir la durée d'exécution de la CI du dépôt `api`


##  Implémentation

Définir 3 jobs parallèles de tests au lien d'un seul:

- Le parallélisme est effectué manuellement en définissant des jobs pour tests/core, tests/routes, et le reste. 
- L'utilisation de `pytest-xdist` ou de `circleci tests split` ne s'est pas avérée concluante, et les temps d'exécution du _step_ `Running tests` sont assez homogènes (un peu plus d'une minute) contre environ 3 minutes auparavant.

##  Informations supplémentaires

Au passage, on a corrigé 2 erreurs de syntaxe, et on affiche les 10 tests les plus lents de chaque job, et on n'affiche plus la barre de progression de `pip`.