### PR TITLE
(PC-10027) speed up pylint job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,7 +309,7 @@ jobs:
       - run:
           name: Run pylint
           when: always
-          command: venv/bin/pylint src tests --jobs=4
+          command: venv/bin/pylint src tests --jobs=8
 
   build-container:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt
+            pip install -r requirements.txt --progress-bar off
       - unless:
           condition:
             equal: [ "master", << pipeline.git.branch >> ]


### PR DESCRIPTION
Afin d'accélérer le job `quality` de la CI, augmenter à 8 l'option `--jobs` de Pylint.