### PR TITLE
templates: tweak subcategories and categories list templates

### DIFF
--- a/src/pcapi/templates/admin/categories_list.html
+++ b/src/pcapi/templates/admin/categories_list.html
@@ -1,19 +1,26 @@
 {% extends 'admin/base.html' %}
 
 {% block body %}
+<style>
+    .sticky-top {
+        z-index: 0;
+    }
+</style>
 <br>
 <h2>Liste des catégories existantes</h2>
 <br>
-<table class="table table-striped table-bordered table-hover model-list">
-    <tr>
-        {% for column_name in column_names %}
-            {% if column_labels[column_name] %}
-                <th> {{ column_labels[column_name] }}</th>
-            {% else %}
-                <th> {{ column_name }}</th>
-            {% endif %}
-        {% endfor %}
-    </tr>
+<table class="table table-striped table-bordered table-hover">
+    <thead class="thead-dark sticky-top">
+        <tr>
+            {% for column_name in column_names %}
+                {% if column_labels[column_name] %}
+                    <th> {{ column_labels[column_name] }}</th>
+                {% else %}
+                    <th> {{ column_name }}</th>
+                {% endif %}
+            {% endfor %}
+        </tr>
+    </thead>
     {% for category in categories %}
     <tr>
         {% for column_name in column_names %}

--- a/src/pcapi/templates/admin/subcategories_list.html
+++ b/src/pcapi/templates/admin/subcategories_list.html
@@ -1,19 +1,27 @@
 {% extends 'admin/base.html' %}
 
+
 {% block body %}
+<style>
+    .sticky-top {
+        z-index: 0;
+    }
+</style>
 <br>
 <h2>Liste des sous-catégories existantes</h2>
 <br>
 <table class="table table-striped table-bordered table-hover">
-    <tr>
-        {% for column_name in column_names %}
-            {% if column_labels[column_name] %}
-                <th> {{ column_labels[column_name] }}</th>
-            {% else %}
-                <th> {{ column_name }}</th>
-            {% endif %}
-        {% endfor %}
-    </tr>
+    <thead class="thead-dark sticky-top">
+        <tr>
+            {% for column_name in column_names %}
+                {% if column_labels[column_name] %}
+                    <th> {{ column_labels[column_name] }}</th>
+                {% else %}
+                    <th> {{ column_name }}</th>
+                {% endif %}
+            {% endfor %}
+        </tr>
+    </thead >
     {% for subcategory in subcategories %}
     <tr>
         {% for column_name in column_names %}


### PR DESCRIPTION
##  Objectif

Améliorer l'affichage des templates de listes de catégories et sous-catégories


##  Implémentation

- figer les en-têtes de tableau lors du déroulement de la page
- rendre les cellules d'en-têtes gris foncé avec caractères blancs 
- surcharger le `z-index` à 0 de la classe `sticky-top` au sein du `body`, pour éviter que les th recouvrent les menus déroulants de la navbar

##  Captures d'écran

Before:
![FA before](https://user-images.githubusercontent.com/33030007/126182237-dd6904f6-a95c-4c03-98a9-acdae655cbaf.png)

After:
![FA after](https://user-images.githubusercontent.com/33030007/126182261-643b79b6-77df-40de-a0c3-d24a3dcc77bb.png)
