### PR TITLE
(PC-9995) payments: Include humanized venue id in venues CSV file

### DIFF
--- a/src/pcapi/domain/payments.py
+++ b/src/pcapi/domain/payments.py
@@ -178,7 +178,7 @@ def generate_venues_csv(payment_query) -> str:
     writer.writerow(header)
     for group in payment_queries.group_by_venue(payment_query):
         row = (
-            str(group.venue_id),
+            humanize(group.venue_id),
             group.siren,
             group.offerer_name,
             group.siret,

--- a/tests/domain/payments_test.py
+++ b/tests/domain/payments_test.py
@@ -351,7 +351,7 @@ def test_generate_venues_csv():
     assert rows[0].startswith('"ID lieu","SIREN"')
     assert rows[1] == ",".join(
         [
-            f'"{venue1.id}"',
+            f'"{humanize(venue1.id)}"',
             '"siren1"',
             '"Offerer 1"',
             '"siret1"',
@@ -364,7 +364,7 @@ def test_generate_venues_csv():
     )
     assert rows[2] == ",".join(
         [
-            f'"{venue2.id}"',
+            f'"{humanize(venue2.id)}"',
             '"siren2"',
             '"Offerer 2"',
             '"siret2"',


### PR DESCRIPTION
Accounting wants the humanized id of the venue, not the raw id.