### PR TITLE
repository: edit typing for arbitrary argument lists

### DIFF
--- a/src/pcapi/repository/repository.py
+++ b/src/pcapi/repository/repository.py
@@ -9,13 +9,13 @@ from pcapi.models.pc_object import PcObject
 from pcapi.validation.models import entity_validator
 
 
-def delete(*models: list[Model]) -> None:
+def delete(*models: Model) -> None:
     for model in models:
         db.session.delete(model)
     db.session.commit()
 
 
-def save(*models: list[Model]) -> None:
+def save(*models: Model) -> None:
     if not models:
         return None
 


### PR DESCRIPTION
As stated in [PEP 484](https://www.python.org/dev/peps/pep-0484/#arbitrary-argument-lists-and-default-argument-values), arbitrary argument lists can be annotated with the type of the expected arguments, be they one or several.