### PR TITLE
(PC-9832): Resend validation email from FA

### DIFF
--- a/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -10,6 +10,7 @@ from wtforms.validators import DataRequired
 
 from pcapi import settings
 from pcapi.admin.base_configuration import BaseAdminView
+from pcapi.admin.custom_views.mixins.resend_validation_email_mixin import ResendValidationEmailMixin
 from pcapi.admin.custom_views.mixins.suspension_mixin import SuspensionMixin
 from pcapi.core.users.api import create_reset_password_token
 from pcapi.core.users.models import User
@@ -26,7 +27,7 @@ def filter_email(value: Optional[str]) -> Optional[str]:
     return sanitize_email(value)
 
 
-class BeneficiaryUserView(SuspensionMixin, BaseAdminView):
+class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdminView):
     can_edit = True
 
     @property

--- a/src/pcapi/admin/custom_views/mixins/resend_validation_email_mixin.py
+++ b/src/pcapi/admin/custom_views/mixins/resend_validation_email_mixin.py
@@ -1,0 +1,63 @@
+from flask import flash
+from flask import redirect
+from flask import request
+from flask import url_for
+from flask_admin import expose
+from flask_admin.form import SecureForm
+from markupsafe import Markup
+
+import pcapi.core.users.api as users_api
+from pcapi.core.users.models import User
+
+
+class ResendValidationEmailForm(SecureForm):
+    pass  # empty form, only has the CSRF token field
+
+
+def _format_is_email_validated(view, context, model, name):
+    if model.isEmailValidated:
+        return True
+    url = url_for(".resend_validation_email_view")
+    _html = """
+     <a href="{url}?user_id={model_id}" title="Réenvoyer l'email de validation">Réenvoyer...</a>
+    """.format(
+        url=url, model_id=model.id
+    )
+    return Markup(_html)
+
+
+class ResendValidationEmailMixin:
+    @property
+    def column_formatters(self):
+        formatters = super().column_formatters
+        formatters.update(isEmailValidated=_format_is_email_validated)
+        return formatters
+
+    @property
+    def user_list_url(self):
+        return url_for(".index_view")
+
+    @expose("resend-validation-email", ["GET", "POST"])
+    def resend_validation_email_view(self):
+        user_id = request.args["user_id"]
+        user = User.query.get(user_id)
+        if user.has_admin_role or user.has_pro_role:
+            flash("Cette action n'est pas supportée pour les utilisateurs admin ou pro", "error")
+            return redirect(self.user_list_url)
+
+        if request.method == "POST":
+            form = ResendValidationEmailForm(request.form)
+            if form.validate():
+                flash(f"Un lien de confirmation d'email a été envoyé à l'adresse {user.email}.")
+                if not user.isEmailValidated:
+                    users_api.request_email_confirmation(user)
+                    return redirect(self.user_list_url)
+        else:
+            form = ResendValidationEmailForm()
+
+        context = {
+            "cancel_link_url": self.user_list_url,
+            "form": form,
+            "user": user,
+        }
+        return self.render("admin/resend_validation_email.html", **context)

--- a/src/pcapi/admin/custom_views/partner_user_view.py
+++ b/src/pcapi/admin/custom_views/partner_user_view.py
@@ -14,6 +14,7 @@ from wtforms.validators import DataRequired
 from wtforms.validators import Length
 
 from pcapi.admin.base_configuration import BaseAdminView
+from pcapi.admin.custom_views.mixins.resend_validation_email_mixin import ResendValidationEmailMixin
 from pcapi.admin.custom_views.mixins.suspension_mixin import SuspensionMixin
 from pcapi.core.users.api import create_reset_password_token
 from pcapi.core.users.api import fulfill_account_password
@@ -30,7 +31,7 @@ def filter_email(value: Optional[str]) -> Optional[str]:
     return sanitize_email(value)
 
 
-class PartnerUserView(SuspensionMixin, BaseAdminView):
+class PartnerUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdminView):
     can_edit = True
     can_create = True
     column_list = [

--- a/src/pcapi/templates/admin/resend_validation_email.html
+++ b/src/pcapi/templates/admin/resend_validation_email.html
@@ -1,0 +1,29 @@
+{% extends 'admin/master.html' %}
+{% block body %}
+<div class="alert alert-primary" role="alert">
+    Vous êtes sur le point de <strong>réenvoyer</strong> un nouveau lien de confirmation d'email à l'utilisateur suivant :
+</div>
+
+<p>
+    <div>Identifiant : {{ user.id }}</div>
+    <div>Adresse mail : {{ user.email }}</div>
+    <div>Nom : {{ user.lastName }}</div>
+    <div>Prénom : {{ user.firstName }}</div>
+</p>
+
+<form action="{{ action }}" method="POST">
+    {% for field in form %}
+        {% if field.name == "csrf_token" %}
+            {{ field }}
+        {% else %}
+            <div class="form-group">
+                <label>{{ field.label }} {% if field.flags.required %}*{% endif %}</label>
+                {{ field }}
+            </div>
+        {% endif %}
+    {% endfor %}
+    <a class="btn btn-default" href="{{ cancel_link_url }}" role="button">Annuler</a>
+    <input class="btn btn-success" type="submit" value="Réenvoyer lien de confirmation">
+</form>
+
+{% endblock %}

--- a/tests/admin/custom_views/partner_user_view_test.py
+++ b/tests/admin/custom_views/partner_user_view_test.py
@@ -117,3 +117,18 @@ class PartnerUserViewTest:
         unsuspend_response = client.post(url, form={"reason": "fraud", "csrf_token": "token"})
         assert unsuspend_response.status_code == 302
         assert partner.isActive
+
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("pcapi.admin.custom_views.mixins.resend_validation_email_mixin.users_api.request_email_confirmation")
+    def test_resend_validation_email_to_partner(
+        self, mocked_request_email_confirmation, mocked_validate_csrf_token, app
+    ):
+        admin = users_factories.UserFactory(email="admin@example.com", isAdmin=True)
+        partner = users_factories.UserFactory(email="partner@example.com", isEmailValidated=False)
+        client = TestClient(app.test_client()).with_auth(admin.email)
+
+        url = f"/pc/back-office/partner_users/resend-validation-email?user_id={partner.id}"
+        resend_validation_email_response = client.post(url, form={"csrf_token": "token"})
+        assert resend_validation_email_response.status_code == 302
+        mocked_request_email_confirmation.assert_called_once_with(partner)


### PR DESCRIPTION
Ajouter la possibilité de ré-envoyer un nouveau lien de validation d'email sur FA, pour autonomiser l'équipe support sur cette tâche.