### PR TITLE
(MOB): Log to notion when a synchronisation error happen

### DIFF
--- a/helm/pcapi/values.integration.yaml
+++ b/helm/pcapi/values.integration.yaml
@@ -364,6 +364,8 @@ secrets:
     version: 2
   - name: MAILJET_API_SECRET
     version: 2
+  - name: NOTION_TOKEN
+    version: 1
   - name: OVH_BUCKET_NAME
     version: 2
   - name: OVH_PASSWORD

--- a/helm/pcapi/values.production.yaml
+++ b/helm/pcapi/values.production.yaml
@@ -425,6 +425,8 @@ secrets:
     version: 2
   - name: NATIVE_RECAPTCHA_SECRET
     version: 1
+  - name: NOTION_TOKEN
+    version: 1
   - name: OVH_BUCKET_NAME
     version: 2
   - name: OVH_PASSWORD

--- a/helm/pcapi/values.staging.yaml
+++ b/helm/pcapi/values.staging.yaml
@@ -431,6 +431,8 @@ secrets:
     version: 2
   - name: NATIVE_RECAPTCHA_SECRET
     version: 1
+  - name: NOTION_TOKEN
+    version: 1
   - name: OVH_BUCKET_NAME
     version: 2
   - name: OVH_PASSWORD

--- a/helm/pcapi/values.testing.yaml
+++ b/helm/pcapi/values.testing.yaml
@@ -436,6 +436,8 @@ secrets:
     version: 2
   - name: NATIVE_RECAPTCHA_SECRET
     version: 1
+  - name: NOTION_TOKEN
+    version: 1
   - name: OVH_BUCKET_NAME
     version: 2
   - name: OVH_PASSWORD

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ mailjet-rest==1.3.3
 MarkupSafe==1.1.1
 mypy==0.812
 nltk==3.5
+notion-client==0.4.0
 pgcli==2.2.0
 Pillow>=8.1.1
 pydantic[email]==1.8.2

--- a/src/pcapi/connectors/notion.py
+++ b/src/pcapi/connectors/notion.py
@@ -1,0 +1,48 @@
+import logging
+
+from notion_client import APIResponseError
+from notion_client import Client
+
+from pcapi import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+PROVIDER_API_ERRORS_DATABASE_ID = "e7bd2f6ddedf43f7a7bc87849caaa3ed"
+
+
+def add_to_synchronization_error_database(
+    title: str,
+    provider_name: str,
+    venue_id: str,
+    venue_id_at_offer_provider: str,
+):
+    if settings.IS_DEV:
+        return
+
+    try:
+        notion = Client(auth=settings.NOTION_TOKEN)
+        notion.pages.create(
+            parent={"database_id": PROVIDER_API_ERRORS_DATABASE_ID},
+            properties={
+                "Titre": {
+                    "title": [{"text": {"content": title}}],
+                },
+                "Provider": {"select": {"name": provider_name}},
+                "VenueId": {
+                    "rich_text": [{"text": {"content": str(venue_id)}}],
+                },
+                "VenueIdAtOfferProvider": {"rich_text": [{"text": {"content": str(venue_id_at_offer_provider)}}]},
+                "Environnement": {"select": {"name": settings.ENV}},
+                "Statut": {"select": {"name": "New"}},
+            },
+        )
+    except APIResponseError as error:
+        logger.exception(
+            "Could not create page to notion database",
+            extra={
+                "error": str(error),
+                "error_code": error.code,
+            },
+        )

--- a/src/pcapi/local_providers/provider_api/provider_api_stocks.py
+++ b/src/pcapi/local_providers/provider_api/provider_api_stocks.py
@@ -2,6 +2,7 @@ import logging
 
 from sqlalchemy.orm.util import aliased
 
+import pcapi.connectors.notion as notion_connector
 from pcapi.core.providers.models import Provider
 from pcapi.core.providers.models import VenueProvider
 from pcapi.models import db
@@ -25,11 +26,21 @@ def synchronize_stocks() -> None:
     )
 
     for venue_provider in venue_providers:
-        # We need to stock this value inside a variable to prevent a crash
-        # if the session is broken and we need to log the id
+        # We need to stock these values inside variables to prevent a crash
+        # if the session is broken and we need to log them
+        venue_id = venue_provider.venueId
         venue_provider_id = venue_provider.id
+        venue_id_at_offer_provider = venue_provider.venueIdAtOfferProvider
+        provider_name = venue_provider.provider.name
+
         try:
             synchronize_provider_api.synchronize_venue_provider(venue_provider)
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception("Could not synchronize venue_provider=%s: %s", venue_provider_id, exc)
+            notion_connector.add_to_synchronization_error_database(
+                title=exc,
+                provider_name=provider_name,
+                venue_id=venue_id,
+                venue_id_at_offer_provider=venue_id_at_offer_provider,
+            )
             db.session.rollback()

--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -306,3 +306,6 @@ APPSEARCH_HOST = os.environ.get("APPSEARCH_HOST", "")
 ADAGE_API_KEY = os.environ.get("ADAGE_API_KEY", None)
 ADAGE_API_URL = os.environ.get("ADAGE_API_URL", None)
 EAC_API_KEY = os.environ.get("EAC_API_KEY", None)
+
+# NOTION
+NOTION_TOKEN = os.environ.get("NOTION_TOKEN", "")


### PR DESCRIPTION
A débattre : 
Est ce qu'on ne catcherait pas que le ProviderAPIException, dans lequel on rajouterait des détails sur l'erreur (ISBN par exemple) qu'on pourrait du coup mettre dans le tableau ? Et avoir des erreurs plus précise qu'un champ texte qu'on ne pourra pas traiter automatiquement dans notion ?
Mon avis : commençons comme ça déjà et on voit après