### PR TITLE
(PC-fix) Handle missing cancellation date for cancelled booking

### DIFF
--- a/src/pcapi/templates/admin/booking.html
+++ b/src/pcapi/templates/admin/booking.html
@@ -16,7 +16,11 @@
     <div><b>Offre :</b> {{ booking.stock.offer.name }}</div>
     <div><b>Date d'annulation :</b>
       {% if booking.isCancelled %}
-        {{ booking.cancellationDate.strftime('%d/%m/%Y %H:%M') }}
+        {% if booking.cancellationDate %}
+            {{ booking.cancellationDate.strftime('%d/%m/%Y %H:%M') }}
+        {% else %}
+            manquante
+        {% endif %}
       {% else %}
         non annulée
       {% endif %}


### PR DESCRIPTION
Seems that a cancelled booking should have a cancellation date but this
might not always be true.