### PR TITLE
(PC-10109) Allows Jouve users to validate fraud review

### DIFF
--- a/src/pcapi/admin/custom_views/fraud_view.py
+++ b/src/pcapi/admin/custom_views/fraud_view.py
@@ -13,6 +13,7 @@ import pcapi.core.fraud.api as fraud_api
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.users.api as users_api
 import pcapi.core.users.models as users_models
+from pcapi.domain import user_emails
 import pcapi.infrastructure.repository.beneficiary.beneficiary_sql_repository as beneficiary_repository
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
@@ -146,7 +147,10 @@ class FraudView(base_configuration.BaseAdminView):
 
     @flask_admin.expose("/validate/beneficiary/<user_id>", methods=["POST"])
     def validate_beneficiary(self, user_id):
-        if not self.check_super_admins() or not FeatureToggle.BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS.is_active():
+        if not FeatureToggle.BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS.is_active():
+            flask.flash("Fonctionnalité non activée", "error")
+            return flask.redirect(flask.url_for(".details_view", id=user_id))
+        if not self.check_super_admins() and not flask_login.current_user.has_jouve_role:
             flask.flash("Vous n'avez pas les droits suffisant pour activer ce bénéficiaire", "error")
             return flask.redirect(flask.url_for(".details_view", id=user_id))
         form = FraudReviewForm(flask.request.form)
@@ -161,17 +165,25 @@ class FraudView(base_configuration.BaseAdminView):
 
         if user.beneficiaryFraudReview:
             flask.flash(
-                "Une revue manuelle a déjà été réalisée sur l'utilisateur {user.id} {user.firstName} {user.lastName}"
+                f"Une revue manuelle a déjà été réalisée sur l'utilisateur {user.id} {user.firstName} {user.lastName}"
             )
             return flask.redirect(flask.url_for(".details_view", id=user_id))
 
         review = fraud_models.BeneficiaryFraudReview(
             user=user, author=flask_login.current_user, reason=form.data["reason"], review=form.data["review"]
         )
+        if review.review == fraud_models.FraudReviewStatus.OK.value:
+            users_api.update_user_information_from_external_source(user, fraud_api.get_source_data(user))
+            users_api.activate_beneficiary(user, "fraud_validation")
+            flask.flash(f"L'utilisateur à été activé comme bénéficiaire {user.firstName} {user.lastName}")
+
+        elif review.review == fraud_models.FraudReviewStatus.REDIRECTED_TO_DMS.value:
+            review.reason += " ; Redirigé vers DMS"
+            user_emails.send_document_verification_error_email(user.email, "unread-document")
+            flask.flash(f"L'utilisateur {user.firstName} {user.lastName} à été redirigé vers DMS")
         db.session.add(review)
         db.session.commit()
-        users_api.update_user_information_from_external_source(user, fraud_api.get_source_data(user))
-        users_api.activate_beneficiary(user, "fraud_validation")
+
         flask.flash(f"Une revue manuelle ajoutée pour le bénéficiaire {user.firstName} {user.lastName}")
         return flask.redirect(flask.url_for(".details_view", id=user_id))
 

--- a/src/pcapi/core/fraud/models.py
+++ b/src/pcapi/core/fraud/models.py
@@ -31,6 +31,7 @@ class FraudStatus(enum.Enum):
 class FraudReviewStatus(enum.Enum):
     OK = "OK"
     KO = "KO"
+    REDIRECTED_TO_DMS = "REDIRECTED_TO_DMS"
 
 
 def _parse_level(level: typing.Optional[str]) -> typing.Optional[None]:

--- a/src/pcapi/core/users/models.py
+++ b/src/pcapi/core/users/models.py
@@ -444,6 +444,14 @@ class User(PcObject, Model, NeedsValidationMixin):
     def has_pro_role(cls) -> bool:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.PRO])
 
+    @hybrid_property
+    def has_jouve_role(self) -> bool:
+        return UserRole.JOUVE in self.roles if self.roles else False
+
+    @has_jouve_role.expression
+    def has_jouve_role(cls) -> bool:  # pylint: disable=no-self-argument
+        return cls.roles.contains([UserRole.JOUVE])
+
     def get_notification_subscriptions(self) -> NotificationSubscriptions:
         return NotificationSubscriptions(**self.notificationSubscriptions or {})
 

--- a/src/pcapi/templates/admin/fraud_details.html
+++ b/src/pcapi/templates/admin/fraud_details.html
@@ -17,12 +17,13 @@
       <form method="POST" action="{{ url_for('beneficiary_fraud.validate_beneficiary', user_id=model.id)}}">
       <div class="modal-body">
           <div class="form-group row">
-            <label for="review" class="col-4 col-form-label">review</label>
+            <label for="review" class="col-4 col-form-label">Revue</label>
             <div class="col-8">
               <select id="review" name="review" class="form-control">
                 <option></option>
                 <option value="OK">OK</option>
                 <option value="KO">KO</option>
+                <option value="REDIRECTED_TO_DMS">Renvoi vers DMS</option>
               </select>
             </div>
           </div>
@@ -77,7 +78,7 @@
 </div>
 <div class="row">
   <div class="col">
-  {% if not model.beneficiaryFraudReview and current_user.is_super_user() %}
+  {% if not model.beneficiaryFraudReview and (current_user.has_jouve_role or current_user.is_super_user()) %}
   <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#userValidationModal">
     Soumettre une revue manuelle
   </button>


### PR DESCRIPTION
Objectif :
- Permettre aux opérateurs de jouve de pouvoir utiliser la fonctionnalité d'ajout de revue
- Ajouter un état à la revue "Renvoi vers DMS" et envoyer un mail à l'utilisateur