### PR TITLE
circleci: use CircleCi's next gen convenience Python image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
         type: string
     working_directory: ~/pass-culture-api-ci
     docker:
-      - image: circleci/python:3.9.4
+      - image: cimg/python:3.9.4
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD
@@ -267,7 +267,7 @@ jobs:
   quality:
     working_directory: ~/pass-culture-api-ci
     docker:
-      - image: circleci/python:3.9.4
+      - image: cimg/python:3.9.4
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD


### PR DESCRIPTION
It should be more stable and faster to spin up
https://circleci.com/docs/2.0/circleci-images/#next-generation-convenience-images