### PR TITLE
[PC-9693] add script to delete a venue

### DIFF
--- a/src/pcapi/core/bookings/exceptions.py
+++ b/src/pcapi/core/bookings/exceptions.py
@@ -69,3 +69,11 @@ class CannotDeleteOffererWithBookingsException(ClientError):
             "cannotDeleteOffererWithBookingsException",
             "Structure juridique non supprimable car elle contient des réservations",
         )
+
+
+class CannotDeleteVenueWithBookingsException(ClientError):
+    def __init__(self):
+        super().__init__(
+            "cannotDeleteVenueWithBookingsException",
+            "Lieu non supprimable car il contient des réservations",
+        )

--- a/src/pcapi/scripts/offerer/commands.py
+++ b/src/pcapi/scripts/offerer/commands.py
@@ -1,6 +1,7 @@
 from flask import current_app as app
 
 from pcapi.scripts.offerer.delete_cascade_offerer_by_id import delete_cascade_offerer_by_id
+from pcapi.scripts.offerer.delete_cascade_venue_by_id import delete_cascade_venue_by_id
 
 
 @app.manager.option(
@@ -8,3 +9,8 @@ from pcapi.scripts.offerer.delete_cascade_offerer_by_id import delete_cascade_of
 )
 def delete_offerer(offerer_id: int) -> None:
     delete_cascade_offerer_by_id(offerer_id)
+
+
+@app.manager.option("-i", "--id", dest="venue_id", required=True, help="Id of the venue to cascade delete", type=int)
+def delete_venue(venue_id: int) -> None:
+    delete_cascade_venue_by_id(venue_id)

--- a/src/pcapi/scripts/offerer/delete_cascade_venue_by_id.py
+++ b/src/pcapi/scripts/offerer/delete_cascade_venue_by_id.py
@@ -1,0 +1,90 @@
+import logging
+
+from pcapi.core.bookings.exceptions import CannotDeleteVenueWithBookingsException
+from pcapi.core.bookings.models import Booking
+from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.models import Mediation
+from pcapi.core.offers.models import Offer
+from pcapi.core.offers.models import Stock
+from pcapi.core.users.models import Favorite
+from pcapi.models import AllocineVenueProvider
+from pcapi.models import AllocineVenueProviderPriceRule
+from pcapi.models import BankInformation
+from pcapi.models import OfferCriterion
+from pcapi.models import VenueProvider
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+
+def delete_cascade_venue_by_id(venue_id: int) -> None:
+    venue_has_bookings = db.session.query(
+        Booking.query.join(Stock).join(Offer).join(Venue).filter(Venue.id == venue_id).exists()
+    ).scalar()
+
+    if venue_has_bookings:
+        raise CannotDeleteVenueWithBookingsException()
+
+    deleted_stocks_count = Stock.query.filter(Stock.offerId == Offer.id, Offer.venueId == venue_id).delete(
+        synchronize_session=False
+    )
+
+    deleted_favorites_count = Favorite.query.filter(Favorite.offerId == Offer.id, Offer.venueId == venue_id).delete(
+        synchronize_session=False
+    )
+
+    deleted_offer_criteria_count = OfferCriterion.query.filter(
+        OfferCriterion.offerId == Offer.id, Offer.venueId == venue_id
+    ).delete(synchronize_session=False)
+
+    deleted_mediations_count = Mediation.query.filter(Mediation.offerId == Offer.id, Offer.venueId == venue_id).delete(
+        synchronize_session=False
+    )
+
+    AllocineVenueProviderPriceRule.query.filter(
+        AllocineVenueProviderPriceRule.allocineVenueProviderId == AllocineVenueProvider.id,
+        AllocineVenueProvider.id == VenueProvider.id,
+        VenueProvider.venueId == venue_id,
+        Venue.id == venue_id,
+    ).delete(synchronize_session=False)
+    deleted_allocine_venue_providers_count = AllocineVenueProvider.query.filter(
+        AllocineVenueProvider.id == VenueProvider.id,
+        VenueProvider.venueId == venue_id,
+        Venue.id == venue_id,
+    ).delete(synchronize_session=False)
+
+    deleted_offers_count = Offer.query.filter(Offer.venueId == venue_id).delete(synchronize_session=False)
+
+    deleted_venue_providers_count = VenueProvider.query.filter(VenueProvider.venueId == venue_id).delete(
+        synchronize_session=False
+    )
+
+    deleted_bank_informations_count = 0
+    deleted_bank_informations_count += BankInformation.query.filter(BankInformation.venueId == venue_id).delete(
+        synchronize_session=False
+    )
+
+    deleted_venues_count = Venue.query.filter(Venue.id == venue_id).delete(synchronize_session=False)
+
+    deleted_bank_informations_count += BankInformation.query.filter(BankInformation.venueId == venue_id).delete(
+        synchronize_session=False
+    )
+
+    db.session.commit()
+
+    logger.info(
+        "Deleted venue",
+        extra={
+            "venue_id": venue_id,
+            "deleted_bank_informations_count": deleted_bank_informations_count,
+            "deleted_venues_count": deleted_venues_count,
+            "deleted_venue_providers_count": deleted_venue_providers_count,
+            "deleted_allocine_venue_providers_count": deleted_allocine_venue_providers_count,
+            "deleted_offers_count": deleted_offers_count,
+            "deleted_mediations_count": deleted_mediations_count,
+            "deleted_favorites_count": deleted_favorites_count,
+            "deleted_offer_criteria_count": deleted_offer_criteria_count,
+            "deleted_stocks_count": deleted_stocks_count,
+        },
+    )

--- a/tests/scripts/offerer/delete_cascade_offerer_by_id_test.py
+++ b/tests/scripts/offerer/delete_cascade_offerer_by_id_test.py
@@ -223,7 +223,6 @@ def test_delete_cascade_offerer_should_remove_venue_synchronization_to_allocine_
         allocineVenueProvider__venue__managingOfferer=offerer_to_delete
     )
     offerers_factories.AllocineVenueProviderPriceRuleFactory()
-    AllocineVenueProvider.query.all()
 
     # When
     delete_cascade_offerer_by_id(offerer_to_delete.id)

--- a/tests/scripts/offerer/delete_cascade_venue_by_id_test.py
+++ b/tests/scripts/offerer/delete_cascade_venue_by_id_test.py
@@ -1,0 +1,169 @@
+import pytest
+
+from pcapi.core.bookings.exceptions import CannotDeleteVenueWithBookingsException
+import pcapi.core.bookings.factories as bookings_factories
+from pcapi.core.bookings.models import Booking
+import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.offerers.models import Offerer
+from pcapi.core.offerers.models import Venue
+import pcapi.core.offers.factories as offers_factories
+from pcapi.core.offers.models import Mediation
+from pcapi.core.offers.models import Offer
+from pcapi.core.offers.models import Stock
+import pcapi.core.users.factories as users_factories
+from pcapi.core.users.models import Favorite
+from pcapi.models import AllocineVenueProvider
+from pcapi.models import AllocineVenueProviderPriceRule
+from pcapi.models import BankInformation
+from pcapi.models import Criterion
+from pcapi.models import OfferCriterion
+from pcapi.models import Provider
+from pcapi.models import VenueProvider
+from pcapi.scripts.offerer.delete_cascade_venue_by_id import delete_cascade_venue_by_id
+
+
+@pytest.mark.usefixtures("db_session")
+def test_delete_cascade_venue_should_abort_when_offerer_has_any_bookings():
+    # Given
+    booking = bookings_factories.BookingFactory()
+    venue_to_delete = booking.stock.offer.venue
+
+    # When
+    with pytest.raises(CannotDeleteVenueWithBookingsException) as exception:
+        delete_cascade_venue_by_id(venue_to_delete.id)
+
+    # Then
+    assert exception.value.errors["cannotDeleteVenueWithBookingsException"] == [
+        "Lieu non supprimable car il contient des réservations"
+    ]
+    assert Offerer.query.count() == 1
+    assert Venue.query.count() == 1
+    assert Stock.query.count() == 1
+    assert Booking.query.count() == 1
+
+
+@pytest.mark.usefixtures("db_session")
+def test_delete_cascade_venue_should_remove_offers_and_stocks():
+    # Given
+    venue_to_delete = offers_factories.VenueFactory()
+    offers_factories.OfferFactory(venue=venue_to_delete)
+    offers_factories.StockFactory(offer__venue=venue_to_delete)
+    offers_factories.StockFactory(offer__venue__managingOfferer=venue_to_delete.managingOfferer)
+
+    # When
+    delete_cascade_venue_by_id(venue_to_delete.id)
+
+    # Then
+    assert Offerer.query.count() == 1
+    assert Venue.query.count() == 1
+    assert Offer.query.count() == 1
+    assert Stock.query.count() == 1
+
+
+@pytest.mark.usefixtures("db_session")
+def test_delete_cascade_venue_should_remove_bank_informations_of_venue():
+    # Given
+    venue_to_delete = offers_factories.VenueFactory()
+    offers_factories.BankInformationFactory(venue=venue_to_delete)
+    offers_factories.BankInformationFactory()
+
+    # When
+    delete_cascade_venue_by_id(venue_to_delete.id)
+
+    # Then
+    assert Venue.query.count() == 0
+    assert Offerer.query.count() == 1
+    assert BankInformation.query.count() == 1
+
+
+@pytest.mark.usefixtures("db_session")
+def test_delete_cascade_venue_should_remove_mediations_of_managed_offers():
+    # Given
+    venue = offers_factories.VenueFactory()
+    venue_to_delete = offers_factories.VenueFactory()
+    offers_factories.MediationFactory(offer__venue=venue_to_delete)
+    offers_factories.MediationFactory(offer__venue=venue)
+
+    # When
+    delete_cascade_venue_by_id(venue_to_delete.id)
+
+    # Then
+    assert Offerer.query.count() == 2
+    assert Venue.query.count() == 1
+    assert Offer.query.count() == 1
+    assert Mediation.query.count() == 1
+
+
+@pytest.mark.usefixtures("db_session")
+def test_delete_cascade_venue_should_remove_favorites_of_managed_offers():
+    # Given
+    venue = offers_factories.VenueFactory()
+    venue_to_delete = offers_factories.VenueFactory()
+    users_factories.FavoriteFactory(offer__venue=venue_to_delete)
+    users_factories.FavoriteFactory(offer__venue=venue)
+
+    # When
+    delete_cascade_venue_by_id(venue_to_delete.id)
+
+    # Then
+    assert Offerer.query.count() == 2
+    assert Venue.query.count() == 1
+    assert Offer.query.count() == 1
+    assert Favorite.query.count() == 1
+
+
+@pytest.mark.usefixtures("db_session")
+def test_delete_cascade_venue_should_remove_criterions():
+    # Given
+    venue = offers_factories.VenueFactory()
+    venue_to_delete = offers_factories.VenueFactory()
+    offers_factories.OfferCriterionFactory(offer__venue=venue_to_delete)
+    offers_factories.OfferCriterionFactory(offer__venue=venue)
+
+    # When
+    delete_cascade_venue_by_id(venue_to_delete.id)
+
+    # Then
+    assert Offerer.query.count() == 2
+    assert Venue.query.count() == 1
+    assert Offer.query.count() == 1
+    assert OfferCriterion.query.count() == 1
+    assert Criterion.query.count() == 2
+
+
+@pytest.mark.usefixtures("db_session")
+def test_delete_cascade_venue_should_remove_synchronization_to_provider():
+    # Given
+    venue = offers_factories.VenueFactory()
+    venue_to_delete = offers_factories.VenueFactory()
+    offerers_factories.VenueProviderFactory(venue=venue_to_delete)
+    offerers_factories.VenueProviderFactory(venue=venue)
+
+    # When
+    delete_cascade_venue_by_id(venue_to_delete.id)
+
+    # Then
+    assert Offerer.query.count() == 2
+    assert Venue.query.count() == 1
+    assert VenueProvider.query.count() == 1
+    assert Provider.query.count() > 0
+
+
+@pytest.mark.usefixtures("db_session")
+def test_delete_cascade_venue_should_remove_synchronization_to_allocine_provider():
+    # Given
+    venue = offers_factories.VenueFactory()
+    venue_to_delete = offers_factories.VenueFactory()
+    offerers_factories.AllocineVenueProviderPriceRuleFactory(allocineVenueProvider__venue=venue_to_delete)
+    offerers_factories.AllocineVenueProviderPriceRuleFactory(allocineVenueProvider__venue=venue)
+
+    # When
+    delete_cascade_venue_by_id(venue_to_delete.id)
+
+    # Then
+    assert Offerer.query.count() == 2
+    assert Venue.query.count() == 1
+    assert VenueProvider.query.count() == 1
+    assert AllocineVenueProvider.query.count() == 1
+    assert AllocineVenueProviderPriceRule.query.count() == 1
+    assert Provider.query.count() > 0


### PR DESCRIPTION
Voila un outils pour répondre au PC-9693
Nous avons actuellement une commande pour tenter d'effacer une structure et tout ces liens, mais la version lieu uniquement est manquante.

* [doc notion](https://www.notion.so/passcultureapp/Suppression-d-une-structure-juridique-et-de-tous-ses-descendants-bf6194a6455f47eebf8a6497acabdf91)
* [commande pour les structures](https://github.com/pass-culture/pass-culture-api/blob/master/src/pcapi/scripts/offerer/delete_cascade_offerer_by_id.py)

A l'image de la commande offerer, voila l'utilisation:
```shell
pc -e ENVIRONMENT bash
python src/pcapi/scripts/pc.py delete_venue --id <id_du_lieu>

# Exemple
pc -e staging -bash
python src/pcapi/scripts/pc.py delete_venue --id 1
``` 

Note post merge: pensez à mettre à jours la documentation dans notion.