### PR TITLE
(PC-10032)[FIX] pydantic: make postalCode optional

### DIFF
--- a/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -21,4 +21,4 @@ class VenueResponse(BaseModel):
     isPermanent: typing.Optional[bool]
     withdrawalDetails: typing.Optional[str]
     address: typing.Optional[str]
-    postalCode: str
+    postalCode: typing.Optional[str]


### PR DESCRIPTION
Venue.postalCode can be None, the pydantic model should have the same rule.