### PR TITLE
(PC-10158) fix type to subcategory matching

### DIFF
--- a/src/pcapi/core/categories/conf.py
+++ b/src/pcapi/core/categories/conf.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from pcapi.models import ThingType
+from pcapi.models.offer_type import ALL_OFFER_TYPES_DICT
 
 from . import subcategories
 
@@ -19,11 +20,15 @@ def can_create_from_isbn(subcategory_id: Optional[str], offer_type: Optional[str
     return offer_type == str(ThingType.LIVRE_EDITION)
 
 
-def get_subcategory_from_type(offer_type: str):
-    return MAPPING_SUBCATEGORY_FROM_TYPE[offer_type]
+def get_subcategory_from_type(offer_type: str, is_virtual_venue: bool):
+    if not ALL_OFFER_TYPES_DICT[offer_type]["offlineOnly"] and not ALL_OFFER_TYPES_DICT[offer_type]["onlineOnly"]:
+        if is_virtual_venue:
+            return ONLINE_MAPPING_SUBCATEGORY_FROM_TYPE[offer_type]
+        return OFFLINE_MAPPING_SUBCATEGORY_FROM_TYPE[offer_type]
+    return REGULAR_MAPPING_SUBCATEGORY_FROM_TYPE[offer_type]
 
 
-MAPPING_SUBCATEGORY_FROM_TYPE = {
+REGULAR_MAPPING_SUBCATEGORY_FROM_TYPE = {
     "EventType.ACTIVATION": subcategories.ACTIVATION_EVENT.id,
     "EventType.CINEMA": subcategories.SEANCE_CINE.id,
     "EventType.CONFERENCE_DEBAT_DEDICACE": subcategories.CONFERENCE.id,
@@ -33,7 +38,6 @@ MAPPING_SUBCATEGORY_FROM_TYPE = {
     "EventType.PRATIQUE_ARTISTIQUE": subcategories.ATELIER_PRATIQUE_ART.id,
     "EventType.SPECTACLE_VIVANT": subcategories.SPECTACLE_REPRESENTATION.id,
     "ThingType.ACTIVATION": subcategories.ACTIVATION_THING.id,
-    "ThingType.AUDIOVISUEL": subcategories.SUPPORT_PHYSIQUE_FILM.id,
     "ThingType.CINEMA_ABO": subcategories.CARTE_CINE_MULTISEANCES.id,
     "ThingType.CINEMA_CARD": subcategories.CINE_VENTE_DISTANCE.id,
     "ThingType.INSTRUMENT": subcategories.ACHAT_INSTRUMENT.id,
@@ -41,13 +45,22 @@ MAPPING_SUBCATEGORY_FROM_TYPE = {
     "ThingType.JEUX_VIDEO": subcategories.JEU_EN_LIGNE.id,
     "ThingType.JEUX_VIDEO_ABO": subcategories.ABO_JEU_VIDEO.id,
     "ThingType.LIVRE_AUDIO": subcategories.LIVRE_NUMERIQUE.id,
-    "ThingType.LIVRE_EDITION": subcategories.LIVRE_PAPIER.id,
     "ThingType.MATERIEL_ART_CREA": subcategories.MATERIEL_ART_CREATIF.id,
-    "ThingType.MUSEES_PATRIMOINE_ABO": subcategories.CARTE_MUSEE.id,
-    "ThingType.MUSIQUE": subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id,
     "ThingType.MUSIQUE_ABO": subcategories.ABO_CONCERT.id,
     "ThingType.OEUVRE_ART": subcategories.OEUVRE_ART.id,
     "ThingType.PRATIQUE_ARTISTIQUE_ABO": subcategories.ABO_PRATIQUE_ART.id,
     "ThingType.PRESSE_ABO": subcategories.ABO_PRESSE_EN_LIGNE.id,
     "ThingType.SPECTACLE_VIVANT_ABO": subcategories.ABO_SPECTACLE.id,
+}
+OFFLINE_MAPPING_SUBCATEGORY_FROM_TYPE = {
+    "ThingType.MUSEES_PATRIMOINE_ABO": subcategories.CARTE_MUSEE.id,
+    "ThingType.MUSIQUE": subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id,
+    "ThingType.AUDIOVISUEL": subcategories.SUPPORT_PHYSIQUE_FILM.id,
+    "ThingType.LIVRE_EDITION": subcategories.LIVRE_PAPIER.id,
+}
+ONLINE_MAPPING_SUBCATEGORY_FROM_TYPE = {
+    "ThingType.MUSEES_PATRIMOINE_ABO": subcategories.MUSEE_VENTE_DISTANCE.id,
+    "ThingType.MUSIQUE": subcategories.TELECHARGEMENT_MUSIQUE.id,
+    "ThingType.AUDIOVISUEL": subcategories.VOD.id,
+    "ThingType.LIVRE_EDITION": subcategories.LIVRE_NUMERIQUE.id,
 }

--- a/src/pcapi/routes/serialization/offers_recap_serialize.py
+++ b/src/pcapi/routes/serialization/offers_recap_serialize.py
@@ -25,7 +25,7 @@ def _serialize_offer_paginated(offer: OfferRecap) -> dict:
         "stocks": serialized_stocks,
         "thumbUrl": offer.thumb_url,
         "type": offer.offer_type,
-        "subcategoryId": offer.subcategoryId or get_subcategory_from_type(offer.offer_type),
+        "subcategoryId": offer.subcategoryId or get_subcategory_from_type(offer.offer_type, offer.venue.is_virtual),
         "venue": _serialize_venue(offer.venue),
         "venueId": humanize(offer.venue.id),
         "status": offer.status,

--- a/src/pcapi/routes/serialization/offers_serialize.py
+++ b/src/pcapi/routes/serialization/offers_serialize.py
@@ -530,7 +530,7 @@ class GetOfferResponseModel(BaseModel):
 
     @classmethod
     def from_orm(cls, offer):  # type: ignore
-        offer.subcategoryId = offer.subcategoryId or get_subcategory_from_type(offer.type)
+        offer.subcategoryId = offer.subcategoryId or get_subcategory_from_type(offer.type, offer.venue.isVirtual)
         return super().from_orm(offer)
 
     class Config:

--- a/tests/core/categories/test_conf.py
+++ b/tests/core/categories/test_conf.py
@@ -1,0 +1,25 @@
+import pytest
+
+from pcapi.core.categories import subcategories
+from pcapi.core.categories.conf import get_subcategory_from_type
+import pcapi.core.offers.factories as offers_factories
+from pcapi.models import ThingType
+
+
+@pytest.mark.parametrize(
+    "offer_type, virtual_venue, expected_subcategoryId",
+    [
+        (ThingType.INSTRUMENT, False, subcategories.ACHAT_INSTRUMENT.id),
+        (ThingType.PRESSE_ABO, True, subcategories.ABO_PRESSE_EN_LIGNE.id),
+        (ThingType.AUDIOVISUEL, True, subcategories.VOD.id),
+        (ThingType.AUDIOVISUEL, False, subcategories.SUPPORT_PHYSIQUE_FILM.id),
+    ],
+)
+def test_get_subcategory_from_type(offer_type, virtual_venue, expected_subcategoryId, db_session):
+    venue = offers_factories.VirtualVenueFactory() if virtual_venue else offers_factories.VenueFactory()
+    offer = offers_factories.OfferFactory(subcategoryId=None, type=str(offer_type), venue=venue)
+
+    assert (
+        get_subcategory_from_type(offer_type=offer.type, is_virtual_venue=offer.venue.isVirtual)
+        == expected_subcategoryId
+    )


### PR DESCRIPTION
##  Objectif

Corriger une erreur dans le formulaire d'édition (structure avec lieu obligatoire alors que l'offre est numérique) pour les offres numériques n'ayant pas de `subcategoryId` en DB


##  Implémentation

- Corriger la correspondance `type` -> `subcategoryId` pour les offres n'ayant pas encore cette dernière, dans le cas où l'offre peut être numérique ou physique.
- Ajouter des tests

##  Informations supplémentaires

Avant:
![Capture d’écran 2021-07-27 à 11 46 31](https://user-images.githubusercontent.com/33030007/127133979-b9bfa167-8fcf-4a0e-8ad9-e288e576cb93.png)

Après:
![Capture d’écran 2021-07-27 à 11 46 38](https://user-images.githubusercontent.com/33030007/127134006-be19148f-b9ac-429a-90aa-a37769620515.png)

