### PR TITLE
[PC-9693] Add delete offerer and venue to FA

### DIFF
--- a/src/pcapi/admin/custom_views/offerer_view.py
+++ b/src/pcapi/admin/custom_views/offerer_view.py
@@ -1,10 +1,24 @@
+from flask import flash
+
 from pcapi.admin.base_configuration import BaseAdminView
+from pcapi.core.bookings.exceptions import CannotDeleteOffererWithBookingsException
+from pcapi.core.offerers.models import Offerer
+from pcapi.scripts.offerer.delete_cascade_offerer_by_id import delete_cascade_offerer_by_id
 
 
 class OffererView(BaseAdminView):
     can_edit = True
+    can_delete = True
     column_list = ["id", "name", "siren", "city", "postalCode", "address"]
     column_labels = dict(name="Nom", siren="SIREN", city="Ville", postalCode="Code postal", address="Adresse")
     column_searchable_list = ["name", "siren"]
     column_filters = ["postalCode", "city", "id", "name"]
     form_columns = ["name", "siren", "city", "postalCode", "address"]
+
+    def delete_model(self, offerer: Offerer) -> bool:
+        try:
+            delete_cascade_offerer_by_id(offerer.id)
+            return True
+        except CannotDeleteOffererWithBookingsException:
+            flash("Impossible d'effacer une structure juridique pour lequel il existe des reservations.", "error")
+        return False

--- a/src/pcapi/scripts/offerer/delete_cascade_venue_by_id.py
+++ b/src/pcapi/scripts/offerer/delete_cascade_venue_by_id.py
@@ -73,18 +73,21 @@ def delete_cascade_venue_by_id(venue_id: int) -> None:
 
     db.session.commit()
 
+    recap_data = {
+        "venue_id": venue_id,
+        "deleted_bank_informations_count": deleted_bank_informations_count,
+        "deleted_venues_count": deleted_venues_count,
+        "deleted_venue_providers_count": deleted_venue_providers_count,
+        "deleted_allocine_venue_providers_count": deleted_allocine_venue_providers_count,
+        "deleted_offers_count": deleted_offers_count,
+        "deleted_mediations_count": deleted_mediations_count,
+        "deleted_favorites_count": deleted_favorites_count,
+        "deleted_offer_criteria_count": deleted_offer_criteria_count,
+        "deleted_stocks_count": deleted_stocks_count,
+    }
     logger.info(
         "Deleted venue",
-        extra={
-            "venue_id": venue_id,
-            "deleted_bank_informations_count": deleted_bank_informations_count,
-            "deleted_venues_count": deleted_venues_count,
-            "deleted_venue_providers_count": deleted_venue_providers_count,
-            "deleted_allocine_venue_providers_count": deleted_allocine_venue_providers_count,
-            "deleted_offers_count": deleted_offers_count,
-            "deleted_mediations_count": deleted_mediations_count,
-            "deleted_favorites_count": deleted_favorites_count,
-            "deleted_offer_criteria_count": deleted_offer_criteria_count,
-            "deleted_stocks_count": deleted_stocks_count,
-        },
+        extra=recap_data,
     )
+
+    return recap_data


### PR DESCRIPTION
Je ne sais pas si on veux que le support puisse effacer aussi simplement un lieu ou une structure.
Ceci dis, il y à beaucoup de ticket en ce sens coté sherif.

J'ai un soucie de redirection sur cette PR que je ne sais pas comment fixé, suite à une erreur je suis redirigé vers `localhost, localhost/{suite de l'url}`, au lieu de simplement `localhost/{suite de l'url}` 

![FA_delete_venue](https://user-images.githubusercontent.com/139848/127162836-710c1af8-848b-4340-ad03-dbca6a4e3b50.png)
