### PR TITLE
Pc 9727 fa add cancel booking button

### DIFF
--- a/src/pcapi/core/bookings/exceptions.py
+++ b/src/pcapi/core/bookings/exceptions.py
@@ -96,3 +96,11 @@ class CannotDeleteVenueWithBookingsException(ClientError):
             "cannotDeleteVenueWithBookingsException",
             "Lieu non supprimable car il contient des réservations",
         )
+
+
+class BookingAlreadyCancelled(Exception):
+    pass
+
+
+class BookingAlreadyRefunded(Exception):
+    pass

--- a/src/pcapi/templates/admin/booking.html
+++ b/src/pcapi/templates/admin/booking.html
@@ -16,7 +16,11 @@
     <div><b>Offre :</b> {{ booking.stock.offer.name }}</div>
     <div><b>Date d'annulation :</b>
       {% if booking.isCancelled %}
-        {{ booking.cancellationDate.strftime('%d/%m/%Y %H:%M') }}
+        {% if booking.cancellationDate %}
+            {{ booking.cancellationDate.strftime('%d/%m/%Y %H:%M') }}
+        {% else %}
+            inconnue
+        {% endif %}
       {% else %}
         non annulée
       {% endif %}
@@ -28,12 +32,21 @@
       Si cette réservation a été annulée par erreur (ou
       frauduleusement) alors qu'elle a en fait été utilisée, il est
       possible de la marquer comme utilisée.
-      <br>
-      <b>Attention : cette opération est irréversible.</b>
     </p>
-    <form action="mark-as-used" method="POST">
+    <form action={{ url_for(".uncancel_and_mark_as_used", booking_id=booking.id) }} method="POST">
       {{ forms.display_form(mark_as_used_form) }}
       <input class="btn btn-danger" type="submit" value="Marquer comme utilisée">
+    </form>
+  {% endif %}
+
+  {% if cancel_form %}
+    <p>
+      Annuler cette réservation manuellement.
+      <br>
+    </p>
+    <form action={{ url_for(".cancel", booking_id=booking.id) }} method="POST">
+      {{ forms.display_form(cancel_form) }}
+      <input class="btn btn-danger" type="submit" value="Marquer comme annulée">
     </form>
   {% endif %}
 


### PR DESCRIPTION
**Besoin**

Ajouter un bouton qui permet d'annuler une réservation, sur _FlaskAdmin_.
L'annulation doit déclencher l'envoi d'un email au responsable de la structure dont dépend l'offre.

**Au passage**

Correction d'un bug sur _FlaskAdmin_ : si une offre est annulée, le _template_ s'attend à ce qu'une date d'annulation existe, ce qui n'a pas l'air d'être tout le temps le cas.