### PR TITLE
[FIX] - errors in e2e tests webapp - use of UserFactory instead of Pr…

### DIFF
--- a/src/pcapi/sandboxes/scripts/creators/beneficiary_import/beneficiary_import.py
+++ b/src/pcapi/sandboxes/scripts/creators/beneficiary_import/beneficiary_import.py
@@ -21,7 +21,7 @@ def create_beneficiary_user() -> users_models.User:
 
 
 def create_admin_user():
-    users_factories.UserFactory(isBeneficiary=False, isAdmin=True, email="pctest.admin93.0@example.com")
+    users_factories.AdminFactory(email="pctest.admin93.0@example.com")
     logger.info("created 1 admin user")
 
 

--- a/src/pcapi/sandboxes/scripts/creators/bookings_recap/bookings_recap.py
+++ b/src/pcapi/sandboxes/scripts/creators/bookings_recap/bookings_recap.py
@@ -14,6 +14,7 @@ from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.payments.factories import DepositFactory
 from pcapi.core.payments.factories import PaymentFactory
 from pcapi.core.payments.factories import PaymentStatusFactory
+from pcapi.core.users.factories import ProFactory
 from pcapi.core.users.factories import UserFactory
 from pcapi.models import EventType
 from pcapi.models import ThingType
@@ -44,7 +45,7 @@ def save_bookings_recap_sandbox():
     DepositFactory(user=beneficiary1, version=1)
     DepositFactory(user=beneficiary1, version=1)
 
-    pro = UserFactory(
+    pro = ProFactory(
         publicName="Balthazar Picsou",
         firstName="Balthazar",
         lastName="Picsou",

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerers_with_pro_users.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerers_with_pro_users.py
@@ -62,7 +62,7 @@ def create_industrial_offerers_with_pro_users():
         last_name = MOCK_LAST_NAMES[user_index]
         email = get_email(first_name, last_name, domain)
         user_name = "{} {}".format(first_name, last_name)
-        user = users_factories.UserFactory(
+        user = users_factories.ProFactory(
             resetPasswordTokenValidityLimit=datetime.utcnow() + timedelta(hours=24),
             departementCode=str(departement_code),
             email=email,
@@ -135,7 +135,7 @@ def create_industrial_offerers_with_pro_users():
         if location_index % VALIDATED_OFFERERS_REMOVE_MODULO == 0:
             offerer.generate_validation_token()
 
-        user = users_factories.UserFactory(
+        user = users_factories.ProFactory(
             resetPasswordTokenValidityLimit=datetime.utcnow() + timedelta(hours=24),
             departementCode=str(departement_code),
             email=email,
@@ -169,7 +169,7 @@ def create_industrial_offerers_with_pro_users():
             else:
                 user_validation_token = "{}{}".format(user_validation_prefix, user_validation_suffix)
             user_name = "{} {}".format(first_name, last_name)
-            user = users_factories.UserFactory(
+            user = users_factories.ProFactory(
                 resetPasswordTokenValidityLimit=datetime.utcnow() + timedelta(hours=24),
                 departementCode=str(departement_code),
                 email=email,

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_pro_users.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_pro_users.py
@@ -25,9 +25,8 @@ def create_industrial_pro_users(offerers_by_name: dict) -> dict:
 
         for pro_count in range(PROS_COUNT):
             email = "pctest.pro{}.{}@example.com".format(departement_code, pro_count)
-            user = users_factories.UserFactory(
+            user = users_factories.ProFactory(
                 resetPasswordTokenValidityLimit=datetime.utcnow() + timedelta(hours=24),
-                isBeneficiary=False,
                 dateOfBirth=None,
                 departementCode=str(departement_code),
                 email=email,

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_webapp_users.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_webapp_users.py
@@ -137,6 +137,7 @@ def create_industrial_webapp_general_public_users():
             dateOfBirth=date_of_birth,
             hasSeenTutorials=False,
             isBeneficiary=False,
+            roles=[],
             lastName=f"{short_age} {deposit_version}",
             needsToFillCulturalSurvey=True,
             postalCode="{}100".format(departement_code),


### PR DESCRIPTION
The webapp end-to-end tests failed because there was no test users returned by the api.
Indeed, as part of a refactoring effort, `create_user()` function was replaced by `UserFactory` to simplify data used for test. But for pro user, we need to use the `ProFactory` so that the role is properly set