### PR TITLE
(PC-10129): Log Document error in fraudcheck

### DIFF
--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -343,6 +343,18 @@ def handle_phone_validation_attempts_limit_reached(user: User, attempts_count: i
     return upsert_suspicious_fraud_result(user, reason)
 
 
+def handle_document_validation_error(email: str, code: str) -> None:
+    user = User.query.filter(User.email == email).one_or_none()
+    if user:
+        fraud_check_data = models.InternalReviewFraudData(
+            source=models.InternalReviewSource.DOCUMENT_VALIDATION_ERROR,
+            message=f"Erreur de lecture du document : {code}",
+        )
+        create_internal_review_fraud_check(user, fraud_check_data)
+    else:
+        logger.warning("fraud internal validation : Cannot find user with email %s", email)
+
+
 def validate_frauds(user: User, fraud_items: list[models.FraudItem]) -> models.BeneficiaryFraudResult:
     if all(fraud_item.status == models.FraudStatus.OK for fraud_item in fraud_items):
         status = models.FraudStatus.OK

--- a/src/pcapi/core/fraud/models.py
+++ b/src/pcapi/core/fraud/models.py
@@ -148,12 +148,13 @@ class InternalReviewSource(enum.Enum):
     PHONE_VALIDATION_ATTEMPTS_LIMIT_REACHED = "phone_validation_attempts_limit_reached"
     PHONE_ALREADY_EXISTS = "phone_already_exists"
     BLACKLISTED_PHONE_NUMBER = "blacklisted_phone_number"
+    DOCUMENT_VALIDATION_ERROR = "document_validation_error"
 
 
 class InternalReviewFraudData(pydantic.BaseModel):
     source: InternalReviewSource
     message: str
-    phone_number: str
+    phone_number: typing.Optional[str]
 
 
 class BeneficiaryFraudCheck(PcObject, Model):

--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -860,6 +860,7 @@ def verify_identity_document_informations(image_storage_path: str) -> None:
     valid, code = ask_for_identity_document_verification(email, image)
     if not valid:
         user_emails.send_document_verification_error_email(email, code)
+        fraud_api.handle_document_validation_error(email, code)
     delete_object(image_storage_path)
 
 

--- a/tests/core/users/test_api.py
+++ b/tests/core/users/test_api.py
@@ -15,6 +15,7 @@ from pcapi import settings
 from pcapi.connectors.serialization.api_adage_serializers import InstitutionalProjectRedactorResponse
 from pcapi.core.bookings import factories as bookings_factories
 import pcapi.core.fraud.factories as fraud_factories
+import pcapi.core.fraud.models as fraud_models
 from pcapi.core.mails import testing as mails_testing
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.payments.api import DEPOSIT_VALIDITY_IN_YEARS
@@ -928,7 +929,7 @@ class VerifyIdentityDocumentInformationsTest:
     @patch("pcapi.core.users.api.ask_for_identity_document_verification")
     @patch("pcapi.core.users.api._get_identity_document_informations")
     def test_email_sent_when_document_is_invalid(
-        self, mocked_get_identity_informations, mocked_ask_for_identity, mocked_delete_object, app
+        self, mocked_get_identity_informations, mocked_ask_for_identity, mocked_delete_object, app, caplog
     ):
         # Given
         mocked_get_identity_informations.return_value = ("py@test.com", b"")
@@ -941,6 +942,32 @@ class VerifyIdentityDocumentInformationsTest:
 
         assert sent_data["Vars"]["url"] == settings.DMS_USER_URL
         assert sent_data["MJ-TemplateID"] == 2958563
+        assert caplog.records[0].message == "fraud internal validation : Cannot find user with email py@test.com"
+
+    @patch("pcapi.core.users.api.delete_object")
+    @patch("pcapi.core.users.api.ask_for_identity_document_verification")
+    @patch("pcapi.core.users.api._get_identity_document_informations")
+    def test_known_user_email_sent_when_document_is_invalid(
+        self, mocked_get_identity_informations, mocked_ask_for_identity, mocked_delete_object, app
+    ):
+        # Given
+        existing_user = users_factories.BeneficiaryFactory(isBeneficiary=False)
+        mocked_get_identity_informations.return_value = (existing_user.email, b"")
+        mocked_ask_for_identity.return_value = (False, "invalid-document-date")
+
+        users_api.verify_identity_document_informations("some_path")
+
+        assert len(mails_testing.outbox) == 1
+        sent_data = mails_testing.outbox[0].sent_data
+
+        assert sent_data["Vars"]["url"] == settings.DMS_USER_URL
+        assert sent_data["MJ-TemplateID"] == 2958563
+
+        assert len(existing_user.beneficiaryFraudChecks) == 1
+        fraud_check = existing_user.beneficiaryFraudChecks[0]
+        assert fraud_check.type == fraud_models.FraudCheckType.INTERNAL_REVIEW
+        assert fraud_check.resultContent["message"] == "Erreur de lecture du document : invalid-document-date"
+        assert fraud_check.resultContent["source"] == fraud_models.InternalReviewSource.DOCUMENT_VALIDATION_ERROR.value
 
     @patch("pcapi.core.users.api.delete_object")
     @patch("pcapi.core.users.api.ask_for_identity_document_verification")


### PR DESCRIPTION
Objectif : logger les erreurs possibles de la validation des documents dans un fraud_check
afin que le support ait l'information