### PR TITLE
Pc 10125 nginx enable cors for maintenance page

### DIFF
--- a/helm/pcapi/values.testing.yaml
+++ b/helm/pcapi/values.testing.yaml
@@ -113,6 +113,8 @@ highLatencyApi:
     enabled: true
     annotations:
       kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/enable-cors: "true"
+      nginx.ingress.kubernetes.io/cors-allow-headers: AppName,AppVersion,X-Request-ID,content-type
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/proxy-body-size: 10m

--- a/helm/pcapi/values.testing.yaml
+++ b/helm/pcapi/values.testing.yaml
@@ -66,6 +66,12 @@ api:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/proxy-body-size: 10m
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        if ($http_origin ~* "^https?://((pro\.passculture-testing\.beta\.gouv\.fr)|(pro\.testing\.passculture\.team))$" ) {
+          more_set_headers -s 503 'Access-Control-Allow-Headers: AppName,AppVersion,X-Request-ID,Content-Type';
+          more_set_headers -s 503 'Access-Control-Allow-Origin: $http_origin';
+          more_set_headers -s 503 'Access-Control-Allow-Credentials: true';
+        }
       cert-manager.io/cluster-issuer: letsencrypt-production
     hosts:
       - host: backend.passculture-testing.beta.gouv.fr
@@ -113,11 +119,15 @@ highLatencyApi:
     enabled: true
     annotations:
       kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/enable-cors: "true"
-      nginx.ingress.kubernetes.io/cors-allow-headers: AppName,AppVersion,X-Request-ID,content-type
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/proxy-body-size: 10m
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        if ($http_origin ~* "^https?://((pro\.passculture-testing\.beta\.gouv\.fr)|(pro\.testing\.passculture\.team))$" ) {
+          more_set_headers -s 503 'Access-Control-Allow-Headers: AppName,AppVersion,X-Request-ID,Content-Type';
+          more_set_headers -s 503 'Access-Control-Allow-Origin: $http_origin';
+          more_set_headers -s 503 'Access-Control-Allow-Credentials: true';
+        }
       cert-manager.io/cluster-issuer: letsencrypt-production
     hosts:
       - host: backend.passculture-testing.beta.gouv.fr
@@ -172,6 +182,12 @@ admin:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/proxy-body-size: 10m
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        if ($http_origin ~* "^https?://((pro\.passculture-testing\.beta\.gouv\.fr)|(pro\.testing\.passculture\.team))$" ) {
+          more_set_headers -s 503 'Access-Control-Allow-Headers: AppName,AppVersion,X-Request-ID,Content-Type';
+          more_set_headers -s 503 'Access-Control-Allow-Origin: $http_origin';
+          more_set_headers -s 503 'Access-Control-Allow-Credentials: true';
+        }
       cert-manager.io/cluster-issuer: letsencrypt-production
     hosts:
       - host: backend.passculture-testing.beta.gouv.fr


### PR DESCRIPTION
Pour tester il faut faire en sorte que l'api soit indisponible, on peut la rendre indisponible paramétrant le rpm à 2 et en faisant de nombreux appels successifs à l'api. 
 
On rajoute cette annotation `nginx.ingress.kubernetes.io/limit-rpm: "2`" puis on lance cette commande pour que l'api soit indisponible` for i in $(seq 100); do curl https://backend.passculture-testing.beta.gouv.fr/health/api; done  `

Les pages https://pro.passculture-testing.beta.gouv.fr et https://pro.testing.passculture.team doivent la page de maintenance. 

Il faut bien enlever l'annotation nginx.ingress.kubernetes.io/limit-rpm: "2" après le test 