### PR TITLE
(PC-10199) add venue type enum to GET /venue/<id>

### DIFF
--- a/alembic_version_conflict_detection.txt
+++ b/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-ff887e7b4f89 (head)
+cd3392bcd798 (head)

--- a/src/pcapi/alembic/versions/20210802_cd3392bcd798_add_code_to_venue_type.py
+++ b/src/pcapi/alembic/versions/20210802_cd3392bcd798_add_code_to_venue_type.py
@@ -1,0 +1,24 @@
+"""add_code_to_venue_type
+
+Revision ID: cd3392bcd798
+Revises: 19b36a0b880a
+Create Date: 2021-08-02 12:00:40.814484
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "cd3392bcd798"
+down_revision = "ff887e7b4f89"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("venue_type", sa.Column("code", sa.String(length=64), nullable=True))
+
+
+def downgrade():
+    op.drop_column("venue_type", "code")

--- a/src/pcapi/core/offerers/factories.py
+++ b/src/pcapi/core/offerers/factories.py
@@ -1,5 +1,6 @@
 import factory
 
+from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.models import ApiKey
 from pcapi.core.offerers.models import VenueLabel
 from pcapi.core.offerers.models import VenueType
@@ -77,14 +78,16 @@ class VirtualVenueTypeFactory(BaseFactory):
     class Meta:
         model = VenueType
 
-    label = "Offre numérique"
+    code = offerers_models.VenueTypeEnum.DIGITAL.name
+    label = offerers_models.VenueTypeEnum.DIGITAL.value
 
 
 class VenueTypeFactory(BaseFactory):
     class Meta:
         model = VenueType
 
-    label = "Librairie"
+    code = offerers_models.VenueTypeEnum.BOOKSTORE.name
+    label = offerers_models.VenueTypeEnum.BOOKSTORE.value
 
 
 class VenueLabelFactory(BaseFactory):

--- a/src/pcapi/core/offerers/models.py
+++ b/src/pcapi/core/offerers/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import enum
 from typing import Optional
 
 from sqlalchemy import BigInteger
@@ -213,8 +214,44 @@ class VenueLabel(PcObject, Model):
     venue = relationship("Venue")
 
 
+class VenueTypeEnum(enum.Enum):
+    """
+    Define all the codes and label allowed for a VenueType.
+    Format: <CODE> = "<label>"
+    """
+
+    VISUAL_ARTS = "Arts visuels, arts plastiques et galeries"
+    CULTURAL_CENTRE = "Centre culturel"
+    ARTISTIC_COURSE = "Cours et pratique artistiques"
+    SCIENTIFIC_CULTURE = "Culture scientifique"
+    FESTIVAL = "Festival"
+    GAMES = "Jeux / Jeux vidéos"
+    BOOKSTORE = "Librairie"
+    LIBRARY = "Bibliothèque ou médiathèque"
+    MUSEUM = "Musée"
+    RECORD_STORE = "Musique - Disquaire"
+    MUSICAL_INSTRUMENT_STORE = "Musique - Magasin d’instruments"
+    CONCERT_HALL = "Musique - Salle de concerts"
+    DIGITAL = "Offre numérique"
+    PATRIMONY_TOURISM = "Patrimoine et tourisme"
+    MOVIE = "Cinéma - Salle de projections"
+    PERFORMING_ARTS = "Spectacle vivant"
+    CREATIVE_ARTS_STORE = "Magasin arts créatifs"
+    OTHER = "Autre"
+
+    @staticmethod
+    def get(code: str) -> enum.Enum:
+        return VenueTypeEnum.__members__.get(code, VenueTypeEnum.OTHER)
+
+    @staticmethod
+    def get_codes() -> list[str]:
+        return list(VenueTypeEnum.__members__.keys())
+
+
 class VenueType(PcObject, Model):
     label = Column(String(100), nullable=False)
+
+    code = Column(String(64), nullable=True)
 
     venue = relationship("Venue")
 

--- a/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -1,8 +1,16 @@
+import enum
 import typing
 
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.offerers.models import VenueTypeEnum as VenueTypeBaseEnum
 from pcapi.serialization.utils import to_camel
 
 from . import BaseModel
+
+
+# this dynamically build class should not be used elsewhere,
+# its only purpose is to help the openapi build.
+VenueTypeEnum = enum.Enum("VenueTypeEnum", {code: code for code in VenueTypeBaseEnum.get_codes()})  # type: ignore
 
 
 class VenueResponse(BaseModel):
@@ -22,3 +30,14 @@ class VenueResponse(BaseModel):
     withdrawalDetails: typing.Optional[str]
     address: typing.Optional[str]
     postalCode: typing.Optional[str]
+    venueTypeEnum: VenueTypeEnum
+
+    @classmethod
+    def from_orm(cls, venue: offerers_models.Venue) -> "VenueResponse":
+        try:
+            venue_type_enum = getattr(VenueTypeEnum, venue.venueType.code)
+        except (AttributeError, TypeError):
+            venue_type_enum = VenueTypeEnum.OTHER  # type: ignore
+
+        venue.venueTypeEnum = venue_type_enum
+        return super().from_orm(venue)

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venue_types.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venue_types.py
@@ -1,37 +1,47 @@
 import logging
 
+from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.factories import VenueTypeFactory
-from pcapi.core.offerers.models import VenueType
+from pcapi.models import db
 
 
 logger = logging.getLogger(__name__)
 
 
-def create_industrial_venue_types() -> list[VenueType]:
+def create_industrial_venue_types() -> list[offerers_models.VenueType]:
     logger.info("create_industrial_venue_types")
 
-    labels = [
-        "Arts visuels, arts plastiques et galeries",
-        "Centre culturel",
-        "Cours et pratique artistiques",
-        "Culture scientifique",
-        "Festival",
-        "Jeux / Jeux vidéos",
-        "Librairie",
-        "Bibliothèque ou médiathèque",
-        "Musée",
-        "Musique - Disquaire",
-        "Musique - Magasin d’instruments",
-        "Musique - Salle de concerts",
-        "Offre numérique",
-        "Patrimoine et tourisme",
-        "Cinéma - Salle de projections",
-        "Spectacle vivant",
-        "Autre",
-    ]
-
-    venue_types = [VenueTypeFactory(label=label) for label in labels]
+    venue_types_data = get_venue_types_data()
+    venue_types = [VenueTypeFactory(code=code, label=label) for code, label in venue_types_data]
 
     logger.info("created %i venue types", len(venue_types))
 
     return venue_types
+
+
+def update_industrial_venue_types(commit: bool = True) -> None:
+    """
+    Helper function that runs a data migration for an existing environment that
+    ran the previous version of create_industrial_venue_types which was written
+    before venue_type has a code column.
+
+    Note: the function uses db.session which could handle other pending
+    objects. Pass commit=False if you don't want to run a commit at the end of
+    this function.
+    """
+    logger.info("update_industrial_venue_types")
+
+    venue_types_data = get_venue_types_data()
+    for code, label in venue_types_data:
+        venue_type = offerers_models.VenueType.query.filter_by(label=label).one()
+        venue_type.code = code
+        db.session.add(venue_type)
+
+    if commit:
+        db.session.commit()
+
+    logger.info("updated %i venue types", len(venue_types_data))
+
+
+def get_venue_types_data() -> list[tuple[str, str]]:
+    return [(e.name, e.value) for e in offerers_models.VenueTypeEnum]

--- a/tests/routes/native/v1/offerers_test.py
+++ b/tests/routes/native/v1/offerers_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-import pcapi.core.offerers.factories as offerer_factories
+import pcapi.core.offerers.factories as offerers_factories
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -8,7 +8,8 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 class VenuesTest:
     def test_get_venue(self, client):
-        venue = offerer_factories.VenueFactory()
+        venue_type = offerers_factories.VenueTypeFactory()
+        venue = offerers_factories.VenueFactory(venueType=venue_type)
 
         response = client.get(f"/native/v1/venue/{venue.id}")
 
@@ -25,6 +26,7 @@ class VenuesTest:
             "withdrawalDetails": venue.withdrawalDetails,
             "address": venue.address,
             "postalCode": venue.postalCode,
+            "venueTypeEnum": venue.venueType.code,
         }
 
     def test_get_non_existing_venue(self, client):


### PR DESCRIPTION
**Besoin**

Renvoyer le type du lieu, en utilisant un enum (pour la partie openAPI) afin de remonter les valeurs possibles.

**Changements**

1. ajouter d'une colonne code à VenueType ;
2. renvoyer cette information (`null` si absent) dans un nouveau champ de l'api `venueTypeEnum`
3. centraliser les différentes paires code-label pour un VenueType au sein d'un enum : VenueTypeEnum
4. mise à jour de la sandbox venue_types : create utilise cette nouvelle colonne + ajout d'une fonction qui permet de mettre à jour une table venue_type existante.

**Note**

VenueTypeEnum est une première étape pour centraliser et définir clairement les types de lieux existants et autorisés. Cependant, répondre au besoin initial de la PR sans trop chambouler est assez délicat : il serait intéressant de reprendre la gestion des types de lieu plus en profondeur.

**Migration de données**

Lancer la fonction de mise à jour de venue_type si celle-ci a été remplie précédemment à l'aide de la sandbox.

```python
from pcapi.sandboxes.scripts.creators.industrial.create_industrial_venue_types import update_industrial_venue_types
update_industrial_venue_types()
```

