### PR TITLE
(PC-10269) add contact to venue

### DIFF
--- a/alembic_version_conflict_detection.txt
+++ b/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-f5997ab962be (head)
+2ed5959876f1 (head)

--- a/src/pcapi/alembic/versions/20210803_2ed5959876f1_create_venue_contact.py
+++ b/src/pcapi/alembic/versions/20210803_2ed5959876f1_create_venue_contact.py
@@ -1,0 +1,37 @@
+"""create_venue_contact
+
+Revision ID: 2ed5959876f1
+Revises: ff887e7b4f89
+Create Date: 2021-08-03 18:44:42.111488
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "2ed5959876f1"
+down_revision = "f5997ab962be"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "venue_contact",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("venueId", sa.BigInteger(), nullable=False),
+        sa.Column("email", sa.String(length=256), nullable=True),
+        sa.Column("website", sa.String(length=256), nullable=True),
+        sa.Column("phone_number", sa.String(length=64), nullable=True),
+        sa.Column("social_medias", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False),
+        sa.ForeignKeyConstraint(["venueId"], ["venue.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_venue_contact_venueId"), "venue_contact", ["venueId"], unique=True)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_venue_contact_venueId"), table_name="venue_contact")
+    op.drop_table("venue_contact")

--- a/src/pcapi/core/offerers/factories.py
+++ b/src/pcapi/core/offerers/factories.py
@@ -1,5 +1,6 @@
 import factory
 
+from pcapi.core.offerers import models
 from pcapi.core.offerers.models import ApiKey
 from pcapi.core.offerers.models import VenueLabel
 from pcapi.core.offerers.models import VenueType
@@ -92,6 +93,17 @@ class VenueLabelFactory(BaseFactory):
         model = VenueLabel
 
     label = "Cinéma d'art et d'essai"
+
+
+class VenueContactFactory(BaseFactory):
+    class Meta:
+        model = models.VenueContact
+
+    venue = factory.SubFactory(VenueFactory)
+    email = "contact@venue.com"
+    website = "https://my@website.com"
+    phone_number = "+33102030405"
+    social_medias = {"instagram": "http://instagram.com/@venue"}
 
 
 DEFAULT_PREFIX = "development_prefix"

--- a/src/pcapi/core/offers/factories.py
+++ b/src/pcapi/core/offers/factories.py
@@ -58,6 +58,8 @@ class VenueFactory(BaseFactory):
     venueTypeCode = offerers_models.VenueTypeCode.OTHER.value
     description = factory.Faker("text", max_nb_chars=64)
 
+    contact = factory.RelatedFactory("pcapi.core.offerers.factories.VenueContactFactory", factory_related_name="venue")
+
 
 class VirtualVenueFactory(VenueFactory):
     isVirtual = True

--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -46,9 +46,7 @@ from pcapi.core.users.repository import get_beneficiary_import_for_beneficiary
 from pcapi.core.users.utils import decode_jwt_token
 from pcapi.core.users.utils import delete_object
 from pcapi.core.users.utils import encode_jwt_payload
-from pcapi.core.users.utils import get_formatted_phone_number
 from pcapi.core.users.utils import get_object
-from pcapi.core.users.utils import parse_phone_number
 from pcapi.core.users.utils import sanitize_email
 from pcapi.core.users.utils import store_object
 from pcapi.domain import user_emails
@@ -72,6 +70,7 @@ from pcapi.repository import transaction
 from pcapi.repository.user_queries import find_user_by_email
 from pcapi.routes.serialization.users import ProUserCreationBodyModel
 from pcapi.tasks.account import verify_identity_document
+from pcapi.utils import phone_number as phone_number_utils
 from pcapi.utils.token import random_token
 from pcapi.utils.urls import get_webapp_url
 from pcapi.workers.apps_flyer_job import log_user_becomes_beneficiary_event_job
@@ -692,7 +691,7 @@ def set_pro_tuto_as_seen(user: User) -> None:
 def change_user_phone_number(user: User, phone_number: str) -> None:
     _check_phone_number_validation_is_authorized(user)
 
-    phone_data = ParsedPhoneNumber(phone_number)
+    phone_data = phone_number_utils.ParsedPhoneNumber(phone_number)
     with fraud_manager(user=user, phone_number=phone_data.phone_number):
         check_phone_number_is_legit(phone_data.phone_number, phone_data.country_code)
         check_phone_number_not_used(phone_data.phone_number)
@@ -705,7 +704,7 @@ def change_user_phone_number(user: User, phone_number: str) -> None:
 def send_phone_validation_code(user: User) -> None:
     _check_phone_number_validation_is_authorized(user)
 
-    phone_data = ParsedPhoneNumber(user.phoneNumber)
+    phone_data = phone_number_utils.ParsedPhoneNumber(user.phoneNumber)
     with fraud_manager(user=user, phone_number=phone_data.phone_number):
         check_phone_number_is_legit(phone_data.phone_number, phone_data.country_code)
         check_phone_number_not_used(phone_data.phone_number)
@@ -723,7 +722,7 @@ def send_phone_validation_code(user: User) -> None:
 def validate_phone_number(user: User, code: str) -> None:
     _check_phone_number_validation_is_authorized(user)
 
-    phone_data = ParsedPhoneNumber(user.phoneNumber)
+    phone_data = phone_number_utils.ParsedPhoneNumber(user.phoneNumber)
     with fraud_manager(user=user, phone_number=phone_data.phone_number):
         check_phone_number_is_legit(phone_data.phone_number, phone_data.country_code)
         check_and_update_phone_validation_attempts(app.redis_client, user)
@@ -864,13 +863,6 @@ def verify_identity_document_informations(image_storage_path: str) -> None:
         user_emails.send_document_verification_error_email(email, code)
         fraud_api.handle_document_validation_error(email, code)
     delete_object(image_storage_path)
-
-
-class ParsedPhoneNumber:
-    def __init__(self, base_phone_number: str):
-        self.parsed_phone_number = parse_phone_number(base_phone_number)
-        self.phone_number = get_formatted_phone_number(self.parsed_phone_number)
-        self.country_code = self.parsed_phone_number.country_code
 
 
 @contextmanager

--- a/src/pcapi/core/users/utils.py
+++ b/src/pcapi/core/users/utils.py
@@ -6,14 +6,10 @@ from google.cloud.storage import Client
 from google.cloud.storage.blob import Blob
 from google.cloud.storage.bucket import Bucket
 import jwt
-import phonenumbers
-from phonenumbers import PhoneNumber
-from phonenumbers.phonenumberutil import NumberParseException
 
 from pcapi import settings
 from pcapi.core.users.constants import METROPOLE_PHONE_PREFIX
 from pcapi.core.users.constants import PHONE_PREFIX_BY_DEPARTEMENT_CODE
-from pcapi.core.users.exceptions import InvalidPhoneNumber
 from pcapi.core.users.exceptions import UserWithoutPhoneNumberException
 from pcapi.core.users.models import ALGORITHM_HS_256
 from pcapi.core.users.models import ALGORITHM_RS_256
@@ -71,31 +67,6 @@ def format_phone_number_with_country_code(user: User) -> str:
         )
 
     return build_internationalized_phone_number(user, user.phoneNumber)
-
-
-def parse_phone_number(phone_number: Optional[str]) -> PhoneNumber:
-    """
-    Phone number must be correctly formatted in international format (E.164)
-    and be valid (number of digits, digit sequence)
-
-    Raises:
-        InvalidPhoneNumber
-    """
-    try:
-        parsed_phone_number = phonenumbers.parse(phone_number)
-    except NumberParseException as error:
-        raise InvalidPhoneNumber(str(phone_number)) from error
-    except TypeError as error:
-        raise InvalidPhoneNumber(str(phone_number)) from error
-
-    if not phonenumbers.is_valid_number(parsed_phone_number):
-        raise InvalidPhoneNumber(str(phone_number))
-
-    return parsed_phone_number
-
-
-def get_formatted_phone_number(phone_number: PhoneNumber) -> str:
-    return phonenumbers.format_number(phone_number, phonenumbers.PhoneNumberFormat.E164)
 
 
 def get_encrypted_gcp_storage_client_bucket() -> Bucket:

--- a/src/pcapi/routes/pro/venues.py
+++ b/src/pcapi/routes/pro/venues.py
@@ -85,8 +85,10 @@ def edit_venue(venue_id: str, body: EditVenueBodyModel) -> GetVenueResponseModel
 
     check_user_has_access_to_offerer(current_user, venue.managingOffererId)
 
-    not_venue_fields = {"isEmailAppliedOnAllOffers", "isWithdrawalAppliedOnAllOffers"}
+    not_venue_fields = {"isEmailAppliedOnAllOffers", "isWithdrawalAppliedOnAllOffers", "contact"}
     venue = offerers_api.update_venue(venue, **body.dict(exclude=not_venue_fields, exclude_unset=True))
+    if body.contact:
+        venue = offerers_api.upsert_venue_contact(venue, body.contact)
 
     if FeatureToggle.ENABLE_VENUE_WITHDRAWAL_DETAILS.is_active():
         if body.withdrawalDetails and body.isWithdrawalAppliedOnAllOffers:

--- a/src/pcapi/utils/phone_number.py
+++ b/src/pcapi/utils/phone_number.py
@@ -1,0 +1,42 @@
+from typing import Optional
+
+import phonenumbers
+from phonenumbers import PhoneNumber
+from phonenumbers.phonenumberutil import NumberParseException
+
+from pcapi.core.users.exceptions import InvalidPhoneNumber
+
+
+class ParsedPhoneNumber:
+    def __init__(self, base_phone_number: str, region: Optional[str] = None):
+        self.parsed_phone_number = parse_phone_number(base_phone_number, region)
+        self.phone_number = get_formatted_phone_number(self.parsed_phone_number)
+        self.country_code = self.parsed_phone_number.country_code
+
+
+def parse_phone_number(phone_number: Optional[str], region: Optional[str] = None) -> PhoneNumber:
+    """
+    Phone number must be correctly formatted in international format (E.164)
+    and be valid (number of digits, digit sequence)
+
+    Raises:
+        InvalidPhoneNumber
+    """
+    try:
+        if region:
+            parsed_phone_number = phonenumbers.parse(phone_number, region)
+        else:
+            parsed_phone_number = phonenumbers.parse(phone_number)
+    except NumberParseException as error:
+        raise InvalidPhoneNumber(str(phone_number)) from error
+    except TypeError as error:
+        raise InvalidPhoneNumber(str(phone_number)) from error
+
+    if not phonenumbers.is_valid_number(parsed_phone_number):
+        raise InvalidPhoneNumber(str(phone_number))
+
+    return parsed_phone_number
+
+
+def get_formatted_phone_number(phone_number: PhoneNumber) -> str:
+    return phonenumbers.format_number(phone_number, phonenumbers.PhoneNumberFormat.E164)

--- a/tests/routes/pro/get_venue_test.py
+++ b/tests/routes/pro/get_venue_test.py
@@ -21,6 +21,12 @@ class Returns200Test:
             "bic": bank_information.bic,
             "bookingEmail": venue.bookingEmail,
             "city": venue.city,
+            "contact": {
+                "email": venue.contact.email,
+                "website": venue.contact.website,
+                "phoneNumber": venue.contact.phone_number,
+                "socialMedias": venue.contact.social_medias,
+            },
             "comment": venue.comment,
             "dateCreated": format_into_utc_date(venue.dateCreated),
             "dateModifiedAtLastProvider": format_into_utc_date(venue.dateModifiedAtLastProvider),

--- a/tests/routes/pro/patch_venue_test.py
+++ b/tests/routes/pro/patch_venue_test.py
@@ -28,6 +28,7 @@ def populate_missing_data_from_venue(venue_data: dict, venue: offerers_models.Ve
         "withdrawalDetails": venue.withdrawalDetails,
         "isEmailAppliedOnAllOffers": False,
         "isWithdrawalAppliedOnAllOffers": False,
+        "contact": {"email": "no.contact.field@is.mandatory.com"},
         **venue_data,
     }
 
@@ -37,10 +38,7 @@ class Returns200Test:
     def test_should_update_venue(self, app) -> None:
         # given
         user_offerer = offers_factories.UserOffererFactory()
-        venue = offers_factories.VenueFactory(
-            name="old name",
-            managingOfferer=user_offerer.offerer,
-        )
+        venue = offers_factories.VenueFactory(name="old name", managingOfferer=user_offerer.offerer)
 
         venue_type = offerers_factories.VenueTypeFactory(label="Musée")
         venue_label = offerers_factories.VenueLabelFactory(label="CAC - Centre d'art contemporain d'intérêt national")

--- a/tests/utils/phone_number_test.py
+++ b/tests/utils/phone_number_test.py
@@ -1,0 +1,23 @@
+from pcapi.utils import phone_number as phone_number_utils
+
+
+def test_parsed_phone_number():
+    parsed_phone_number = phone_number_utils.ParsedPhoneNumber("+33102030405")
+    assert parsed_phone_number.phone_number == "+33102030405"
+
+    parsed_phone_number = phone_number_utils.ParsedPhoneNumber(" +33102030405 ")
+    assert parsed_phone_number.phone_number == "+33102030405"
+
+    parsed_phone_number = phone_number_utils.ParsedPhoneNumber("+262262161234")
+    assert parsed_phone_number.phone_number == "+262262161234"
+
+
+def test_parsed_phone_number_region():
+    parsed_phone_number = phone_number_utils.ParsedPhoneNumber("0102030405", "FR")
+    assert parsed_phone_number.phone_number == "+33102030405"
+
+    parsed_phone_number = phone_number_utils.ParsedPhoneNumber("0033102030405", "FR")
+    assert parsed_phone_number.phone_number == "+33102030405"
+
+    parsed_phone_number = phone_number_utils.ParsedPhoneNumber("0262161234", "RE")
+    assert parsed_phone_number.phone_number == "+262262161234"


### PR DESCRIPTION
**Besoin**

Côté PRO, on veut que l'utilisateur ait la possibilité de renseigner des informations de contact d'un lieu : email, site web, numéro de téléphone et réseaux sociaux.

Seule l'adresse email est obligatoire.

**Implémentation**

1. Création d'une table venue_contact qui contient ces informations.
2. Mise à jour de `PATCH /venues/<id>` qui va créer ou mettre à jour (écraser) les informations de contact d'un lieu.

**Note**

La partie validation du numéro de téléphone qui était dans users.api / users.utils a été déplacée dans un module à part puisque le modèle Pydantic de mise à jour des informations de contact en a besoin : ça évite d'avoir le module de sérialisation des lieux qui importe du code de user.api/utils (pas très logique).