### PR TITLE
(PC-9832): Fix build error url pro and admin views

### DIFF
--- a/src/pcapi/admin/custom_views/mixins/resend_validation_email_mixin.py
+++ b/src/pcapi/admin/custom_views/mixins/resend_validation_email_mixin.py
@@ -15,6 +15,9 @@ class ResendValidationEmailForm(SecureForm):
 
 
 def _format_is_email_validated(view, context, model, name):
+    if model.has_admin_role or model.has_pro_role:
+        return model.isEmailValidated
+
     if model.isEmailValidated:
         return True
     url = url_for(".resend_validation_email_view")


### PR DESCRIPTION
**Problème:**
Could not build url for endpoint `/pro_users.resend_validation_email_view` et `admin_users.resend_validation_email_view` car la fonctin `_format_is_email_validated` est appelée aussi pour les acteurs PRO et les admins.

**Changements:**
Ajouter une vérification dans la fonction `_format_is_email_validated` pour garder le comportement par défaut quand il s'agit d'user PRO ou admin.
