### PR TITLE
(PC-10302) : Fix admin's column_formatters to avoid later conflicts

### DIFF
--- a/src/pcapi/admin/base_configuration.py
+++ b/src/pcapi/admin/base_configuration.py
@@ -19,6 +19,10 @@ class BaseAdminMixin:
     # for us because we want the form to be different depending on the
     # logged-in user's privileges (see `form_columns()`). Thus, we
     # don't use the cache.
+    @property
+    def column_formatters(self):
+        return {}
+
     def create_form(self, obj=None):
         form_class = self.get_create_form()
         return form_class(get_form_data(), obj=obj)

--- a/src/pcapi/admin/custom_views/fraud_view.py
+++ b/src/pcapi/admin/custom_views/fraud_view.py
@@ -112,7 +112,7 @@ class FraudView(base_configuration.BaseAdminView):
 
     @property
     def column_formatters(self):
-        formatters = super().column_formatters.copy()
+        formatters = super().column_formatters
         formatters.update(
             {
                 "beneficiaryFraudChecks": beneficiary_fraud_checks_formatter,

--- a/src/pcapi/admin/custom_views/offer_view.py
+++ b/src/pcapi/admin/custom_views/offer_view.py
@@ -129,7 +129,7 @@ class OfferView(BaseAdminView):
 
     @property
     def column_formatters(self):
-        formatters = super().column_formatters.copy()
+        formatters = super().column_formatters
         formatters.update(
             {
                 "categoryId": offer_category_formatter,


### PR DESCRIPTION
Since the admin mixin update the column_formatters dict, we need
to make sure they are unique for each view.
The default is a BaseAdmin's dict which means formatters are
commun for most admin view which may lead to issues when one
formatter is specific to a single view.
In order to avoid dealing with those nasty side effects, ensure
any admin view has an isolated column_formatters dict.