### PR TITLE
(PC-10199) add venueTypeCode to Venue

### DIFF
--- a/alembic_version_conflict_detection.txt
+++ b/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-bebba9216847 (head)
+ffce4944b6b7 (head)

--- a/src/pcapi/alembic/versions/20210805_ffce4944b6b7_add_venue_type_code.py
+++ b/src/pcapi/alembic/versions/20210805_ffce4944b6b7_add_venue_type_code.py
@@ -1,0 +1,31 @@
+"""add_venue_type_code
+
+Revision ID: ffce4944b6b7
+Revises: ff887e7b4f89
+Create Date: 2021-08-05 16:08:11.291471
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "ffce4944b6b7"
+down_revision = "bebba9216847"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "venue",
+        sa.Column(
+            "venueTypeCode",
+            sa.String(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("venue", "venueTypeCode")

--- a/src/pcapi/core/offerers/models.py
+++ b/src/pcapi/core/offerers/models.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+import enum
 from typing import Optional
 
+import sqlalchemy as sa
 from sqlalchemy import BigInteger
 from sqlalchemy import Boolean
 from sqlalchemy import CheckConstraint
@@ -79,6 +81,27 @@ CONSTRAINT_CHECK_HAS_SIRET_XOR_HAS_COMMENT_XOR_IS_VIRTUAL = """
 """
 
 
+class VenueTypeCode(enum.Enum):
+    VISUAL_ARTS = "VISUAL_ARTS"
+    CULTURAL_CENTRE = "CULTURAL_CENTRE"
+    ARTISTIC_COURSE = "ARTISTIC_COURSE"
+    SCIENTIFIC_CULTURE = "SCIENTIFIC_CULTURE"
+    FESTIVAL = "FESTIVAL"
+    GAMES = "GAMES"
+    BOOKSTORE = "BOOKSTORE"
+    LIBRARY = "LIBRARY"
+    MUSEUM = "MUSEUM"
+    RECORD_STORE = "RECORD_STORE"
+    MUSICAL_INSTRUMENT_STORE = "MUSICAL_INSTRUMENT_STORE"
+    CONCERT_HALL = "CONCERT_HALL"
+    DIGITAL = "DIGITAL"
+    PATRIMONY_TOURISM = "PATRIMONY_TOURISM"
+    MOVIE = "MOVIE"
+    PERFORMING_ARTS = "PERFORMING_ARTS"
+    CREATIVE_ARTS_STORE = "CREATIVE_ARTS_STORE"
+    OTHER = "OTHER"
+
+
 class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, NeedsValidationMixin):
     __tablename__ = "venue"
 
@@ -133,6 +156,8 @@ class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, Ne
     venueTypeId = Column(Integer, ForeignKey("venue_type.id"), nullable=True)
 
     venueType = relationship("VenueType", foreign_keys=[venueTypeId])
+
+    venueTypeCode = Column(sa.Enum(VenueTypeCode, create_constraint=False), nullable=True, default=VenueTypeCode.OTHER)
 
     venueLabelId = Column(Integer, ForeignKey("venue_label.id"), nullable=True)
 

--- a/src/pcapi/core/offers/factories.py
+++ b/src/pcapi/core/offers/factories.py
@@ -4,7 +4,7 @@ import uuid
 import factory
 
 from pcapi import models
-import pcapi.core.offerers.models
+import pcapi.core.offerers.models as offerers_models
 from pcapi.core.offers.models import OfferReport
 from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.core.testing import BaseFactory
@@ -19,7 +19,7 @@ ALL_TYPES = {
 
 class OffererFactory(BaseFactory):
     class Meta:
-        model = pcapi.core.offerers.models.Offerer
+        model = offerers_models.Offerer
 
     name = factory.Sequence("Le Petit Rintintin Management {}".format)
     address = "1 boulevard Poissonnière"
@@ -51,6 +51,7 @@ class VenueFactory(BaseFactory):
     publicName = factory.SelfAttribute("name")
     siret = factory.LazyAttributeSequence(lambda o, n: f"{o.managingOfferer.siren}{n:05}")
     isVirtual = False
+    venueTypeCode = offerers_models.VenueTypeCode.OTHER.value
 
 
 class VirtualVenueFactory(VenueFactory):

--- a/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -1,5 +1,6 @@
 import typing
 
+from pcapi.core.offerers import models as offerers_models
 from pcapi.serialization.utils import to_camel
 
 from . import BaseModel
@@ -22,3 +23,4 @@ class VenueResponse(BaseModel):
     withdrawalDetails: typing.Optional[str]
     address: typing.Optional[str]
     postalCode: typing.Optional[str]
+    venueTypeCode: typing.Optional[offerers_models.VenueTypeCode]

--- a/src/pcapi/scripts/update_venue_type_codes.py
+++ b/src/pcapi/scripts/update_venue_type_codes.py
@@ -1,0 +1,78 @@
+"""
+The main goal of this module is to provide a safe way to change the way a
+venue's type was handled: from a venue_type table with one 'label' field which
+was updated from time to time, to a more centralised enum-based approach.
+
+Therefore this code should not be used after this shift is done, it might break
+because of column and/or table (little) changes or be incomplete because of
+missing codes and/or labels.
+"""
+import logging
+
+from sqlalchemy import exc
+
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+
+UPDATE_VENUES_WITH_LABEL_SQL = """
+UPDATE venue
+SET "venueTypeCode" = :code
+WHERE
+    "id" in (
+        SELECT venue.id
+        FROM venue
+        LEFT JOIN venue_type
+            ON venue_type.id = venue."venueTypeId"
+        WHERE venue_type.label = :label
+    )
+RETURNING id
+"""
+
+
+def _update_venues_with_label(code: str, label: str) -> set[int]:
+    res = db.session.execute(UPDATE_VENUES_WITH_LABEL_SQL, {"code": code, "label": label})
+    return {row[0] for row in res}
+
+
+def update_venues_codes() -> set[int]:
+    logger.info("update venues codes: start")
+    codes_labels = [
+        ("VISUAL_ARTS", "Arts visuels, arts plastiques et galeries"),
+        ("CULTURAL_CENTRE", "Centre culturel"),
+        ("ARTISTIC_COURSE", "Cours et pratique artistiques"),
+        ("SCIENTIFIC_CULTURE", "Culture scientifique"),
+        ("FESTIVAL", "Festival"),
+        ("GAMES", "Jeux / Jeux vidéos"),
+        ("BOOKSTORE", "Librairie"),
+        ("LIBRARY", "Bibliothèque ou médiathèque"),
+        ("MUSEUM", "Musée"),
+        ("RECORD_STORE", "Musique - Disquaire"),
+        ("MUSICAL_INSTRUMENT_STORE", "Musique - Magasin d’instruments"),
+        ("CONCERT_HALL", "Musique - Salle de concerts"),
+        ("DIGITAL", "Offre numérique"),
+        ("PATRIMONY_TOURISM", "Patrimoine et tourisme"),
+        ("MOVIE", "Cinéma - Salle de projections"),
+        ("PERFORMING_ARTS", "Spectacle vivant"),
+        ("CREATIVE_ARTS_STORE", "Magasin arts créatifs"),
+        ("OTHER", "Autre"),
+    ]
+
+    updated_ids = set()
+    for code, label in codes_labels:
+        print(f"update venues codes: {label} -> {code} ongoing")
+
+        try:
+            updated_ids |= _update_venues_with_label(code=code, label=label)
+        except exc.SQLAlchemyError as e:
+            logger.exception("update venues codes: FAILURE", extra={"code": code, "label": label, "error": str(e)})
+            db.session.rollback()
+
+    db.session.commit()
+
+    logger.info(
+        "update venues codes: end", extra={"script": "update_venues_codes", "updatedIdsCount": len(updated_ids)}
+    )
+    return updated_ids

--- a/tests/routes/native/v1/offerers_test.py
+++ b/tests/routes/native/v1/offerers_test.py
@@ -25,6 +25,7 @@ class VenuesTest:
             "withdrawalDetails": venue.withdrawalDetails,
             "address": venue.address,
             "postalCode": venue.postalCode,
+            "venueTypeCode": venue.venueTypeCode.value,
         }
 
     def test_get_non_existing_venue(self, client):

--- a/tests/routes/webapp/get_booking_by_id_test.py
+++ b/tests/routes/webapp/get_booking_by_id_test.py
@@ -166,6 +166,7 @@ class Returns200Test:
                         "thumbCount": 0,
                         "venueLabelId": None,
                         "venueTypeId": None,
+                        "venueTypeCode": "OTHER",
                         "withdrawalDetails": None,
                     },
                     "venueId": humanize(offer.venue.id),

--- a/tests/scripts/update_venue_type_codes_test.py
+++ b/tests/scripts/update_venue_type_codes_test.py
@@ -1,0 +1,25 @@
+import pytest
+
+from pcapi.core.offerers.factories import VenueTypeFactory
+from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.factories import VenueFactory
+from pcapi.scripts.update_venue_type_codes import update_venues_codes
+
+
+@pytest.mark.usefixtures("db_session")
+def test_update_venue_codes(app):
+    bookstore_type = VenueTypeFactory(label="Librairie")
+    museum_type = VenueTypeFactory(label="Musée")
+    digital_type = VenueTypeFactory(label="Offre numérique")
+
+    bookstore = VenueFactory(venueType=bookstore_type, venueTypeCode=None)
+    museum = VenueFactory(venueType=museum_type, venueTypeCode=None)
+    digital = VenueFactory(venueType=digital_type, venueTypeCode=None)
+    undefined = VenueFactory(venueType=None, venueTypeCode=None)
+
+    update_venues_codes()
+
+    assert Venue.query.get(bookstore.id).venueTypeCode.value == "BOOKSTORE"
+    assert Venue.query.get(museum.id).venueTypeCode.value == "MUSEUM"
+    assert Venue.query.get(digital.id).venueTypeCode.value == "DIGITAL"
+    assert Venue.query.get(undefined.id).venueTypeCode.value == "OTHER"


### PR DESCRIPTION
**Besoin**

Disposer d'une clé stable (enum) pour le type d'un lieu et renvoyer cette information dans `GET /venue/<venue_id>`

**Contexte**

La table venue_type n'est pas utilisable puisqu'elle ne contient qu'un label qu'on ne peut donc pas utiliser comme code pour le type d'un lieu.

Le problème est qu'aujourd'hui le front a besoin d'un code pour effectuer le mapping (code -> icône/image par défaut/etc), alors que le code existant fait une sorte de mapping côté back. Il faudrait uniformiser et clarifier l'utilisation de VenueType. En attendant, cette PR propose une étape intermédiaire qui permet de centraliser les informations, notamment les types de lieux existants et valides.

**Implémentation**

1. ajout d'un colonne venueTypeCode (enum mais juste du texte pour PG) ;
2. ajout de cette colonne dans la réponse de `GET /venue/<venue_id>` ;
3. ajout d'un script qui permet de remplir cette colonne en fonction du label (venue.venu_type.label).