### PR TITLE
(PC-10270) add description to Venue

### DIFF
--- a/alembic_version_conflict_detection.txt
+++ b/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-1c5bec8d2aec
+8c93c25caac1 (head)

--- a/src/pcapi/alembic/versions/20210809_8c93c25caac1_add_description_to_venue.py
+++ b/src/pcapi/alembic/versions/20210809_8c93c25caac1_add_description_to_venue.py
@@ -1,0 +1,24 @@
+"""add_description_to_venue
+
+Revision ID: 8c93c25caac1
+Revises: 1c5bec8d2aec
+Create Date: 2021-08-09 18:59:37.025464
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8c93c25caac1"
+down_revision = "1c5bec8d2aec"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("venue", sa.Column("description", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("venue", "description")

--- a/src/pcapi/core/offerers/api.py
+++ b/src/pcapi/core/offerers/api.py
@@ -9,6 +9,7 @@ from pcapi.core.offerers.models import VenueType
 from pcapi.core.users.models import User
 from pcapi.models.db import db
 from pcapi.repository import repository
+from pcapi.routes.serialization import venues_serialize
 from pcapi.routes.serialization.venues_serialize import PostVenueBodyModel
 from pcapi.utils import crypto
 
@@ -80,6 +81,11 @@ def update_venue(
         search.async_index_venue_ids([venue.id])
 
     return venue
+
+
+def update_venue_description(venue: Venue, data: venues_serialize.EditVenueDescriptionBodyModel) -> None:
+    venue.description = data.description
+    repository.save(venue)
 
 
 def create_venue(venue_data: PostVenueBodyModel) -> Venue:

--- a/src/pcapi/core/offerers/models.py
+++ b/src/pcapi/core/offerers/models.py
@@ -165,6 +165,8 @@ class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, Ne
 
     withdrawalDetails = Column(Text, nullable=True)
 
+    description = Column(Text, nullable=True)
+
     def store_departement_code(self) -> None:
         self.departementCode = PostalCode(self.postalCode).get_departement_code()
 

--- a/src/pcapi/routes/pro/venues.py
+++ b/src/pcapi/routes/pro/venues.py
@@ -10,6 +10,7 @@ from pcapi.core.offers.repository import get_active_offers_count_for_venue
 from pcapi.core.offers.repository import get_sold_out_offers_count_for_venue
 from pcapi.flask_app import private_api
 from pcapi.models.feature import FeatureToggle
+from pcapi.routes.serialization import venues_serialize
 from pcapi.routes.serialization.venues_serialize import EditVenueBodyModel
 from pcapi.routes.serialization.venues_serialize import GetVenueListResponseModel
 from pcapi.routes.serialization.venues_serialize import GetVenueResponseModel
@@ -96,6 +97,16 @@ def edit_venue(venue_id: str, body: EditVenueBodyModel) -> GetVenueResponseModel
         update_all_venue_offers_email_job.delay(venue, body.bookingEmail)
 
     return GetVenueResponseModel.from_orm(venue)
+
+
+@private_api.route("/venues/<venue_id>/description", methods=["PUT"])
+@login_required
+@spectree_serialize(on_success_status=204, on_error_statuses=[400])
+def edit_venue_description(venue_id: str, body: venues_serialize.EditVenueDescriptionBodyModel) -> None:
+    venue = load_or_404(Venue, venue_id)
+
+    check_user_has_access_to_offerer(current_user, venue.managingOffererId)
+    offerers_api.update_venue_description(venue, body)
 
 
 @private_api.route("/venues/<humanized_venue_id>/stats", methods=["GET"])

--- a/src/pcapi/routes/serialization/venues_serialize.py
+++ b/src/pcapi/routes/serialization/venues_serialize.py
@@ -4,6 +4,7 @@ from decimal import InvalidOperation
 from typing import Optional
 from typing import Union
 
+import pydantic
 from pydantic import BaseModel
 from pydantic import validator
 
@@ -161,6 +162,14 @@ class EditVenueBodyModel(BaseModel):
 
     _dehumanize_venue_label_id = dehumanize_field("venueLabelId")
     _dehumanize_venue_type_id = dehumanize_field("venueTypeId")
+
+
+class EditVenueDescriptionBodyModel(BaseModel):
+    class Config:
+        alias_generator = to_camel
+        extra = pydantic.Extra.forbid
+
+    description: pydantic.constr(max_length=1000, strip_whitespace=True)  # type: ignore
 
 
 class VenueListItemResponseModel(BaseModel):

--- a/tests/routes/pro/put_venue_test.py
+++ b/tests/routes/pro/put_venue_test.py
@@ -1,0 +1,52 @@
+import pytest
+
+import pcapi.core.offers.factories as offers_factories
+from pcapi.utils.human_ids import humanize
+
+
+@pytest.mark.usefixtures("db_session")
+class DescriptionTest:
+    def test_update_venue_description(self, app, client):
+        user_offerer = offers_factories.UserOffererFactory()
+        venue = offers_factories.VenueFactory(
+            managingOfferer=user_offerer.offerer,
+        )
+
+        data = {"description": "some random description"}
+
+        client = client.with_auth(user_offerer.user.email)
+        venue_id = humanize(venue.id)
+        response = client.put(f"/venues/{venue_id}/description", json=data)
+
+        assert response.status_code == 204
+        assert venue.description == "some random description"
+
+    def test_update_venue_description_unknown_field(self, app, client):
+        user_offerer = offers_factories.UserOffererFactory()
+        venue = offers_factories.VenueFactory(
+            managingOfferer=user_offerer.offerer,
+        )
+
+        data = {"desc": "wrong key"}
+
+        client = client.with_auth(user_offerer.user.email)
+        venue_id = humanize(venue.id)
+        response = client.put(f"/venues/{venue_id}/description", json=data)
+
+        assert response.status_code == 400
+        assert "desc" in response.json
+
+    def test_update_venue_description_too_long(self, app, client):
+        user_offerer = offers_factories.UserOffererFactory()
+        venue = offers_factories.VenueFactory(
+            managingOfferer=user_offerer.offerer,
+        )
+
+        data = {"description": "a" * 1024}
+
+        client = client.with_auth(user_offerer.user.email)
+        venue_id = humanize(venue.id)
+        response = client.put(f"/venues/{venue_id}/description", json=data)
+
+        assert response.status_code == 400
+        assert "description" in response.json

--- a/tests/routes/webapp/get_booking_by_id_test.py
+++ b/tests/routes/webapp/get_booking_by_id_test.py
@@ -150,6 +150,7 @@ class Returns200Test:
                         "dateCreated": format_into_utc_date(offer.venue.dateCreated),
                         "dateModifiedAtLastProvider": format_into_utc_date(offer.venue.dateModifiedAtLastProvider),
                         "departementCode": "75",
+                        "description": None,
                         "fieldsUpdated": [],
                         "id": humanize(offer.venue.id),
                         "idAtProviders": None,


### PR DESCRIPTION
**Besoins**

Ajouter une description à un lieu.
Permettre à un utilisateur PRO de la mettre à jour.

**Implémentation**

La limite max est de 1000 caractères, celle-ci a été mise au niveau du modèle Pydantic uniquement (aucune restriction en base de données). A voir si on veut vraiment sécuriser cet aspect ou si on laisse comme ça pour garder plus de flexibilité (plus facile de faire évoluer le nombre max de caractères côté Pydantic).