### PR TITLE
(PC-fix) import_users: do not updated SIB user

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -165,6 +165,7 @@ def create_account(
     marketing_email_subscription: bool = False,
     is_email_validated: bool = False,
     send_activation_mail: bool = True,
+    remote_updates: bool = True,
     postal_code: str = None,
     phone_number: str = None,
     apps_flyer_user_id: str = None,
@@ -200,8 +201,9 @@ def create_account(
     repository.save(user)
     logger.info("Created user account", extra={"user": user.id})
 
-    update_user_attributes_job.delay(user.id)
-    update_external_user(user)
+    if remote_updates:
+        update_user_attributes_job.delay(user.id)
+        update_external_user(user)
 
     if not is_email_validated and send_activation_mail:
         request_email_confirmation(user)

--- a/src/pcapi/scripts/beneficiary/import_users.py
+++ b/src/pcapi/scripts/beneficiary/import_users.py
@@ -39,6 +39,7 @@ def create_or_update_users(rows: Iterable[dict]) -> list[User]:
                 birthdate=birthdate,
                 is_email_validated=True,
                 send_activation_mail=False,
+                remote_updates=False,
             )
             deposit = payments_api.create_deposit(user, "import_users (csv)")
             repository.save(deposit)
@@ -63,6 +64,7 @@ def create_or_update_users(rows: Iterable[dict]) -> list[User]:
             birthdate=datetime(1946, 12, 24),
             is_email_validated=True,
             send_activation_mail=False,
+            remote_updates=False,
         )
     admin.setPassword(settings.STAGING_TEST_USER_PASSWORD)
     admin.remove_beneficiary_role()


### PR DESCRIPTION
**Besoin**

Ne pas mettre à jour les informations, côté Sendinblue, des utilisateurs créés en staging via import_users : on n'en a pas besoin et ça nous cause quelques soucis.
