### PR TITLE
fix e2e tests

### DIFF
--- a/src/pcapi/core/offers/factories.py
+++ b/src/pcapi/core/offers/factories.py
@@ -88,7 +88,7 @@ class ProductFactory(BaseFactory):
     def match_type(self, create, extracted, **kwargs):
         self.type = getattr(ALL_SUBCATEGORIES_DICT.get(self.subcategoryId, ""), "matching_type", None)
         db.session.add(self)
-        db.session.flush()
+        db.session.commit()
 
 
 class EventProductFactory(ProductFactory):
@@ -144,7 +144,7 @@ class OfferFactory(BaseFactory):
     def match_type(self, create, extracted, **kwargs):
         self.type = getattr(ALL_SUBCATEGORIES_DICT.get(self.subcategoryId, ""), "matching_type", None)
         db.session.add(self)
-        db.session.flush()
+        db.session.commit()
 
 
 class EventOfferFactory(OfferFactory):

--- a/start-api-when-database-is-ready.sh
+++ b/start-api-when-database-is-ready.sh
@@ -3,7 +3,7 @@ set -e
 
 >&2 echo -e "\n\033[0;32mInstalling prerequisite\n"
 
-apt update
+apt update -y
 apt-get install -y postgresql-client
 apt-get install -y libpq-dev
 

--- a/tests/routes/native/v1/offers_test.py
+++ b/tests/routes/native/v1/offers_test.py
@@ -322,6 +322,7 @@ class ReportOfferTest:
         offer = OfferFactory()
 
         # expected queries:
+        #   * select offer
         #   * get user
         #   * insert report
         #   * release savepoint
@@ -330,7 +331,7 @@ class ReportOfferTest:
         #   * select offer
         #   * insert email into db
         #   * release savepoint
-        with assert_num_queries(7):
+        with assert_num_queries(8):
             response = test_client.post(f"/native/v1/offer/{offer.id}/report", json={"reason": "INAPPROPRIATE"})
             assert response.status_code == 204
 
@@ -352,6 +353,7 @@ class ReportOfferTest:
         offer = OfferFactory()
 
         # expected queries:
+        #   * select offer
         #   * get user
         #   * insert report
         #   * release savepoint
@@ -360,7 +362,7 @@ class ReportOfferTest:
         #   * select offer
         #   * insert email into db
         #   * release savepoint
-        with assert_num_queries(7):
+        with assert_num_queries(8):
             data = {"reason": "OTHER", "customReason": "saynul"}
             response = test_client.post(f"/native/v1/offer/{offer.id}/report", json=data)
             assert response.status_code == 204


### PR DESCRIPTION
##  Objectif

Corriger les erreurs lors de l'exécution des tests e2e pro

##  Implémentation

- accepter les messages lors de `apt update`
- utiliser commit() au lieu de flush() dans les _post-generation hooks_ des _factories_ d'offres et produits.