### PR TITLE
(PC-8285): scripts: edit bulk update of missing subcategoryIds

### DIFF
--- a/tests/scripts/bulk_update_old_offers_with_new_subcategories_test.py
+++ b/tests/scripts/bulk_update_old_offers_with_new_subcategories_test.py
@@ -1,12 +1,8 @@
-from datetime import datetime
-
 import pytest
 
-from pcapi.core.offerers.models import Offerer
-from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.factories import OfferFactory
 from pcapi.core.offers.models import Offer
-from pcapi.models import Product
-from pcapi.repository import repository
+from pcapi.models import db
 from pcapi.scripts.bulk_update_old_offers_with_new_subcategories import bulk_update_old_offers_with_new_subcategories
 
 
@@ -14,42 +10,21 @@ class UpdateOffersSubcatTest:
     @pytest.mark.usefixtures("db_session")
     def test_update_offers_subcategory(self):
         # Given
-        created_product = Product(
-            type="ThingType.LIVRE_EDITION", name="product1", mediaUrls="toto", isNational=True, id=1
-        )
-        repository.save(created_product)
-        created_offerer = Offerer(
-            id=1, dateCreated=datetime(2021, 1, 1), name="offerer1", postalCode="75012", city="Paris", siren="123456789"
-        )
-        repository.save(created_offerer)
-
-        created_venue = Venue(
-            id=1,
-            name="venue1",
-            managingOffererId=1,
-            isVirtual=False,
-            siret="12345678932321",
-            postalCode="75012",
-            city="Paris",
-        )
-        repository.save(created_venue)
-
-        created_offers = Offer(
-            id=1,
-            productId=1,
-            venueId=1,
-            type="ThingType.LIVRE_EDITION",
-            name="offer1",
-            mediaUrls="toto",
-            isNational=True,
-            isDuo=False,
-            dateCreated=datetime(2021, 1, 1),
-            isEducational=True,
-        )
-        repository.save(created_offers)
+        book_offers = OfferFactory.create_batch(size=3)
+        for offer in book_offers:
+            offer.subcategoryId = None
+            offer.type = "ThingType.LIVRE_EDITION"
+            db.session.add(offer)
+        concert_offers = OfferFactory.create_batch(size=2)
+        for offer in concert_offers:
+            offer.subcategoryId = None
+            offer.type = "EventType.MUSIQUE"
+            db.session.add(offer)
+        db.session.commit()
 
         # When
         bulk_update_old_offers_with_new_subcategories()
 
         # Then
-        assert created_offers.subcategoryId == "LIVRE_PAPIER"
+        assert Offer.query.filter(Offer.subcategoryId == "LIVRE_PAPIER").count() == 3
+        assert Offer.query.filter(Offer.subcategoryId == "CONCERT").count() == 2


### PR DESCRIPTION
##  Objectif

Optimiser le script de rattrapage (plusieurs dizaines de millions d'offres)

##  Implémentation

- utiliser [`bulk_update_mappings()` ](https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.Session.bulk_update_mappings)au lieu de `repository.save()`:

>   The bulk update feature allows plain Python dictionaries to be used as the source of simple UPDATE operations which can be more easily grouped together into higher performing “executemany” operations. Using dictionaries, there is no “history” or session state management features in use, reducing latency when updating large numbers of simple rows.

- afficher des informations d'avancement pendant l'exécution du script
- utiliser `OfferFactory` dans le test
