### PR TITLE
(PC-10439) Utilisation de Booking.dateUsed au lieu de Booking.dateCreated pour les remboursements

### DIFF
--- a/src/pcapi/core/bookings/factories.py
+++ b/src/pcapi/core/bookings/factories.py
@@ -1,3 +1,5 @@
+import datetime
+
 import factory
 
 from pcapi.core.educational.factories import EducationalBookingFactory as EducationalBookingSubFactory
@@ -50,6 +52,19 @@ class BookingFactory(BaseFactory):
         kwargs["venue"] = kwargs["stock"].offer.venue
         kwargs["offerer"] = kwargs["stock"].offer.venue.managingOfferer
         return super()._create(model_class, *args, **kwargs)
+
+
+class UsedBookingFactory(BookingFactory):
+    status = models.BookingStatus.USED
+    isUsed = True
+    dateUsed = factory.LazyFunction(datetime.datetime.now)
+
+
+class CancelledBookingFactory(BookingFactory):
+    status = models.BookingStatus.CANCELLED
+    isCancelled = True
+    cancellationDate = factory.LazyFunction(datetime.datetime.now)
+    cancellationReason = models.BookingCancellationReasons.BENEFICIARY
 
 
 class EducationalBookingFactory(BookingFactory):

--- a/src/pcapi/core/bookings/repository.py
+++ b/src/pcapi/core/bookings/repository.py
@@ -129,7 +129,7 @@ def find_bookings_eligible_for_payment_for_venue(venue_id: int, cutoff_date) -> 
             .joinedload(Offerer.bankInformation)
         )
         .options(joinedload(Booking.payments))
-        .order_by(Payment.id, Booking.dateCreated.asc())
+        .order_by(Payment.id, Booking.dateUsed.asc())
         .all()
     )
 

--- a/src/pcapi/core/payments/factories.py
+++ b/src/pcapi/core/payments/factories.py
@@ -45,7 +45,7 @@ class PaymentFactory(BaseFactory):
         model = models.Payment
 
     author = "batch"
-    booking = factory.SubFactory(bookings_factories.BookingFactory, isUsed=True)
+    booking = factory.SubFactory(bookings_factories.UsedBookingFactory)
     amount = factory.LazyAttribute(lambda payment: payment.booking.total_amount * Decimal(payment.reimbursementRate))
     recipientSiren = factory.SelfAttribute("booking.stock.offer.venue.managingOfferer.siren")
     reimbursementRule = factory.Iterator(REIMBURSEMENT_RULE_DESCRIPTIONS)

--- a/src/pcapi/domain/reimbursement.py
+++ b/src/pcapi/domain/reimbursement.py
@@ -17,7 +17,7 @@ class ReimbursementRule:
     def is_active(self, booking: Booking) -> bool:
         valid_from = self.valid_from or MIN_DATETIME
         valid_until = self.valid_until or MAX_DATETIME
-        return valid_from < booking.dateCreated <= valid_until
+        return valid_from < booking.dateUsed <= valid_until
 
     def is_relevant(self, booking: Booking, **kwargs: Decimal) -> bool:
         raise NotImplementedError()
@@ -145,7 +145,7 @@ def find_all_booking_reimbursements(
         custom_offer_rules[rule.offerId].append(rule)
 
     for booking in bookings:
-        year = booking.dateCreated.year
+        year = booking.dateUsed.year
 
         if PhysicalOffersReimbursement().is_relevant(booking):
             total_per_year[year] += booking.total_amount

--- a/src/pcapi/model_creators/generic_creators.py
+++ b/src/pcapi/model_creators/generic_creators.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from datetime import timedelta
 from decimal import Decimal
 from hashlib import sha256
 from typing import Optional
@@ -15,7 +14,6 @@ from pcapi.core.providers.models import Provider
 from pcapi.core.providers.models import VenueProvider
 from pcapi.core.users.models import TokenType
 from pcapi.core.users.models import User
-from pcapi.domain.payments import PaymentDetails
 from pcapi.domain.price_rule import PriceRule
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
 from pcapi.model_creators.specific_creators import create_stock_with_thing_offer
@@ -32,7 +30,6 @@ from pcapi.models import Payment
 from pcapi.models import PaymentMessage
 from pcapi.models import PaymentStatus
 from pcapi.models import Stock
-from pcapi.models import ThingType
 from pcapi.models import Token
 from pcapi.models import UserOfferer
 from pcapi.models import Venue
@@ -279,49 +276,6 @@ def create_payment(
     payment.transactionLabel = transaction_label
 
     return payment
-
-
-def create_payment_details(
-    booking_amount: int = 15,
-    booking_date: datetime = datetime.utcnow() - timedelta(days=10),
-    booking_used_date: datetime = datetime.utcnow() - timedelta(days=5),
-    booking_user_email: str = "john.doe@example.com",
-    booking_user_id: int = 1234,
-    offer_name: str = "Blake & Mortimer",
-    offer_type: ThingType = ThingType.LIVRE_EDITION,
-    offerer_name: str = "Les petites librairies",
-    offerer_siren: str = "123456789",
-    payment_iban: str = "FR7630001007941234567890185",
-    payment_id: int = 123,
-    payment_message_name: str = "AZERTY123456",
-    reimbursed_amount: float = 7.5,
-    reimbursement_rate: float = 0.5,
-    transaction_end_to_end_id: str = None,
-    venue_name: str = "Vive les BDs",
-    venue_siret: str = "12345678912345",
-    venue_humanized_id: str = "AE",
-) -> PaymentDetails:
-    payment_details = PaymentDetails()
-    payment_details.booking_amount = booking_amount
-    payment_details.booking_date = booking_date
-    payment_details.booking_used_date = booking_used_date
-    payment_details.booking_user_email = booking_user_email
-    payment_details.booking_user_id = booking_user_id
-    payment_details.offer_name = offer_name
-    payment_details.offer_type = str(offer_type)
-    payment_details.offerer_name = offerer_name
-    payment_details.offerer_siren = offerer_siren
-    payment_details.payment_iban = payment_iban
-    payment_details.payment_id = payment_id
-    payment_details.payment_message_name = payment_message_name
-    payment_details.reimbursed_amount = reimbursed_amount
-    payment_details.reimbursement_rate = reimbursement_rate
-    payment_details.transaction_end_to_end_id = transaction_end_to_end_id
-    payment_details.venue_name = venue_name
-    payment_details.venue_siret = venue_siret
-    payment_details.venue_humanized_id = venue_humanized_id
-
-    return payment_details
 
 
 def create_payment_message(checksum: str = None, idx: int = None, name: str = "ABCD123") -> PaymentMessage:

--- a/src/pcapi/sandboxes/scripts/creators/bookings_recap/bookings_recap.py
+++ b/src/pcapi/sandboxes/scripts/creators/bookings_recap/bookings_recap.py
@@ -5,6 +5,7 @@ import logging
 from pcapi.core.bookings.exceptions import BookingIsAlreadyCancelled
 from pcapi.core.bookings.exceptions import BookingIsAlreadyUsed
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import UsedBookingFactory
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import EventOfferFactory
 from pcapi.core.offers.factories import EventProductFactory
@@ -144,38 +145,34 @@ def save_bookings_recap_sandbox():
         isCancelled=False,
     )
 
-    booking3_beneficiary1 = BookingFactory(
+    booking3_beneficiary1 = UsedBookingFactory(
         user=beneficiary1, stock=stock_1_offer1_venue3, dateCreated=datetime(2020, 4, 12, 14, 31, 12, 0)
     )
 
     payment_booking3_beneficiary1 = PaymentFactory(booking=booking3_beneficiary1)
     PaymentStatusFactory(payment=payment_booking3_beneficiary1, status=TransactionStatus.PENDING)
 
-    booking3_beneficiary2 = BookingFactory(
+    booking3_beneficiary2 = UsedBookingFactory(
         user=beneficiary2,
         stock=stock_1_offer1_venue3,
         dateCreated=datetime(2020, 4, 12, 19, 31, 12, 0),
-        isUsed=True,
         dateUsed=datetime(2020, 4, 22, 17, 00, 10, 0),
-        isCancelled=False,
     )
 
     PaymentFactory(booking=booking3_beneficiary2)
     PaymentStatusFactory(payment=payment_booking3_beneficiary1, status=TransactionStatus.SENT)
 
-    booking3_beneficiary3 = BookingFactory(
+    booking3_beneficiary3 = UsedBookingFactory(
         user=beneficiary3, stock=stock_1_offer1_venue3, dateCreated=datetime(2020, 4, 12, 22, 9, 12, 0)
     )
 
     payment_booking3_beneficiary3 = PaymentFactory(booking=booking3_beneficiary3)
     PaymentStatusFactory(payment=payment_booking3_beneficiary3, status=TransactionStatus.ERROR)
 
-    BookingFactory(
+    UsedBookingFactory(
         user=beneficiary3,
         stock=stock_1_offer1_venue2,
         dateCreated=datetime(2020, 3, 21, 22, 9, 12, 0),
-        isUsed=True,
-        isCancelled=False,
     )
 
     booking5_beneficiary3 = BookingFactory(
@@ -185,33 +182,30 @@ def save_bookings_recap_sandbox():
         isCancelled=False,
     )
 
-    booking6_beneficiary3 = BookingFactory(
+    booking6_beneficiary3 = UsedBookingFactory(
         user=beneficiary3,
         stock=stock_1_offer2_venue2,
         dateCreated=datetime(2020, 3, 21, 22, 9, 12, 0),
-        isUsed=True,
         dateUsed=datetime(2020, 4, 22, 21, 9, 12, 0),
     )
 
     payment_booking6_beneficiary3 = PaymentFactory(booking=booking6_beneficiary3)
     PaymentStatusFactory(payment=payment_booking6_beneficiary3, status=TransactionStatus.SENT)
 
-    booking7_beneficiary2 = BookingFactory(
+    booking7_beneficiary2 = UsedBookingFactory(
         user=beneficiary2,
         stock=stock_1_offer2_venue2,
         dateCreated=datetime(2020, 4, 21, 22, 6, 12, 0),
-        isUsed=True,
         dateUsed=datetime(2020, 4, 22, 22, 9, 12, 0),
     )
 
     payment_booking7_beneficiary2 = PaymentFactory(booking=booking7_beneficiary2)
     PaymentStatusFactory(payment=payment_booking7_beneficiary2, status=TransactionStatus.RETRY)
 
-    BookingFactory(
+    UsedBookingFactory(
         user=beneficiary1,
         stock=stock_1_offer2_venue2,
         dateCreated=datetime(2020, 2, 21, 22, 6, 12, 0),
-        isUsed=True,
         dateUsed=datetime(2020, 4, 22, 23, 9, 12, 0),
     )
 

--- a/tests/admin/custom_views/booking_view_test.py
+++ b/tests/admin/custom_views/booking_view_test.py
@@ -28,7 +28,7 @@ class BookingViewTest:
 
     def test_show_mark_as_used_button(self, app):
         users_factories.AdminFactory(email="admin@example.com")
-        bookings_factories.BookingFactory(isCancelled=True, status=BookingStatus.CANCELLED, token="ABCDEF")
+        bookings_factories.CancelledBookingFactory(token="ABCDEF")
 
         client = TestClient(app.test_client()).with_auth("admin@example.com")
         response = client.post("/pc/back-office/bookings/", form={"token": "abcdeF"})
@@ -39,7 +39,7 @@ class BookingViewTest:
 
     def test_uncancel_and_mark_as_used(self, app):
         users_factories.AdminFactory(email="admin@example.com")
-        booking = bookings_factories.BookingFactory(isCancelled=True, status=BookingStatus.CANCELLED)
+        booking = bookings_factories.CancelledBookingFactory()
 
         client = TestClient(app.test_client()).with_auth("admin@example.com")
         route = f"/pc/back-office/bookings/mark-as-used/{booking.id}"
@@ -91,8 +91,7 @@ class BookingViewTest:
 
     def test_can_not_cancel_refunded_booking(self, app):
         users_factories.UserFactory(email="admin@example.com", isAdmin=True)
-        booking = bookings_factories.BookingFactory(isCancelled=False)
-        payments_factories.PaymentFactory(booking=booking)
+        booking = payments_factories.PaymentFactory().booking
 
         client = TestClient(app.test_client()).with_auth("admin@example.com")
         route = f"/pc/back-office/bookings/cancel/{booking.id}"
@@ -110,7 +109,7 @@ class BookingViewTest:
 
     def test_cant_cancel_cancelled_booking(self, app):
         users_factories.UserFactory(email="admin@example.com", isAdmin=True)
-        booking = bookings_factories.BookingFactory(isCancelled=True)
+        booking = bookings_factories.CancelledBookingFactory()
 
         client = TestClient(app.test_client()).with_auth("admin@example.com")
         route = f"/pc/back-office/bookings/cancel/{booking.id}"

--- a/tests/admin/custom_views/offer_view_test.py
+++ b/tests/admin/custom_views/offer_view_test.py
@@ -563,7 +563,7 @@ class OfferViewTest:
             offer = offers_factories.OfferFactory(validation=OfferValidationStatus.APPROVED, isActive=True)
             stock = offers_factories.StockFactory(offer=offer, price=10)
             unused_booking = booking_factories.BookingFactory(stock=stock)
-            used_booking = booking_factories.BookingFactory(stock=stock, isUsed=True)
+            used_booking = booking_factories.UsedBookingFactory(stock=stock)
             frozen_time.move_to("2020-12-20 15:00:00")
             data = dict(validation=OfferValidationStatus.REJECTED.value)
             client = TestClient(app.test_client()).with_auth("admin@example.com")

--- a/tests/core/bookings/test_models.py
+++ b/tests/core/bookings/test_models.py
@@ -7,7 +7,6 @@ import pytest
 from pcapi.core.bookings import factories
 from pcapi.core.bookings import models
 from pcapi.core.bookings.models import Booking
-from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import MediationFactory
 import pcapi.core.users.factories as users_factories
@@ -34,7 +33,8 @@ def test_save_cancellation_date_postgresql_function():
     db.session.commit()
     assert booking.cancellationDate is not None
 
-    # Don't change cancellationDate when another attribute is updated.
+    # `cancellationDate` should not be changed when another attribute
+    # is updated.
     previous = booking.cancellationDate
     booking.cancellationReason = "FRAUD"
     db.session.commit()
@@ -115,9 +115,7 @@ class BookingQrCodeTest:
         assert booking.qrCode is None
 
     def test_event_return_none_if_booking_is_cancelled(self):
-        booking = factories.BookingFactory(
-            isCancelled=True,
-            status=BookingStatus.CANCELLED,
+        booking = factories.CancelledBookingFactory(
             stock__offer__subcategoryId=subcategories.SEANCE_CINE.id,
         )
         assert booking.qrCode is None
@@ -129,18 +127,14 @@ class BookingQrCodeTest:
         assert isinstance(booking.qrCode, str)
 
     def test_thing_return_none_if_booking_is_used(self):
-        booking = factories.BookingFactory(
-            isUsed=True,
-            status=BookingStatus.USED,
+        booking = factories.UsedBookingFactory(
             stock__offer__subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id,
         )
         assert booking.qrCode is None
 
     def test_thing_return_none_if_booking_is_cancelled(self):
-        booking = factories.BookingFactory(
-            isCancelled=True,
+        booking = factories.CancelledBookingFactory(
             stock__offer__subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id,
-            status=BookingStatus.CANCELLED,
         )
         assert booking.qrCode is None
 

--- a/tests/core/bookings/test_repository.py
+++ b/tests/core/bookings/test_repository.py
@@ -69,7 +69,7 @@ def test_find_not_cancelled_bookings_by_stock(app):
 
 @pytest.mark.usefixtures("db_session")
 class FindPaymentEligibleBookingsForVenueTest:
-    def test_returns_used_past_event_and_thing_bookings_ordered_by_date_created(self, app: fixture):
+    def test_basics(self, app: fixture):
         # Given
         cutoff = datetime.now()
         before_cutoff = cutoff - timedelta(days=1)
@@ -87,7 +87,7 @@ class FindPaymentEligibleBookingsForVenueTest:
             user=beneficiary,
             stock=past_event_stock,
             dateCreated=YESTERDAY,
-            dateUsed=before_cutoff,
+            dateUsed=before_cutoff - timedelta(seconds=2),
         )
 
         future_event_booking = bookings_factories.UsedBookingFactory(
@@ -103,7 +103,7 @@ class FindPaymentEligibleBookingsForVenueTest:
             user=beneficiary,
             stock=stock_thing,
             dateCreated=NOW,
-            dateUsed=before_cutoff,
+            dateUsed=before_cutoff - timedelta(seconds=1),
         )
 
         another_offerer = offers_factories.OffererFactory(siren="987654321")

--- a/tests/core/bookings/test_validation.py
+++ b/tests/core/bookings/test_validation.py
@@ -47,7 +47,7 @@ class CheckOfferAlreadyBookedTest:
         validation.check_offer_already_booked(user, offer)  # should not raise
 
     def test_dont_raise_if_user_cancelled(self):
-        booking = factories.BookingFactory(isCancelled=True, status=BookingStatus.CANCELLED)
+        booking = factories.CancelledBookingFactory()
         validation.check_offer_already_booked(booking.user, booking.stock.offer)  # should not raise
 
     @pytest.mark.usefixtures("db_session")
@@ -325,7 +325,7 @@ class InsufficientFundsSQLCheckTest:
 
     def test_cannot_uncancel_with_expired_deposit(self):
         # The user once booked and cancelled their booking.
-        booking = factories.BookingFactory(isCancelled=True, status=BookingStatus.CANCELLED)
+        booking = factories.CancelledBookingFactory()
         user = booking.user
 
         # But now their deposit expired.
@@ -343,19 +343,19 @@ class InsufficientFundsSQLCheckTest:
 @pytest.mark.usefixtures("db_session")
 class CheckIsUsableTest:
     def should_raise_if_used(self):
-        booking = factories.BookingFactory(isUsed=True, status=BookingStatus.USED)
+        booking = factories.UsedBookingFactory()
         with pytest.raises(api_errors.ResourceGoneError) as exc:
             validation.check_is_usable(booking)
         assert exc.value.errors["booking"] == ["Cette réservation a déjà été validée"]
 
     def should_raise_if_cancelled(self):
-        booking = factories.BookingFactory(isCancelled=True, status=BookingStatus.CANCELLED)
+        booking = factories.CancelledBookingFactory()
         with pytest.raises(api_errors.ForbiddenError) as exc:
             validation.check_is_usable(booking)
         assert exc.value.errors["booking"] == ["Cette réservation a été annulée"]
 
     def should_raises_forbidden_error_if_payement_exists(self, app):
-        booking = factories.BookingFactory(isUsed=True, status=BookingStatus.USED)
+        booking = factories.UsedBookingFactory()
         payments_factories.PaymentFactory(booking=booking)
         with pytest.raises(api_errors.ForbiddenError) as exc:
             validation.check_is_usable(booking)
@@ -433,7 +433,7 @@ class CheckBeneficiaryCanCancelBookingTest:
             validation.check_beneficiary_can_cancel_booking(other_user, booking)
 
     def test_raise_if_already_used(self):
-        booking = factories.BookingFactory(isUsed=True, status=BookingStatus.USED)
+        booking = factories.UsedBookingFactory()
         with pytest.raises(exceptions.BookingIsAlreadyUsed):
             validation.check_beneficiary_can_cancel_booking(booking.user, booking)
 
@@ -480,13 +480,13 @@ class CheckOffererCanCancelBookingTest:
         validation.check_booking_can_be_cancelled(booking)  # should not raise
 
     def test_raise_if_already_cancelled(self):
-        booking = factories.BookingFactory(isCancelled=True, status=BookingStatus.CANCELLED)
+        booking = factories.CancelledBookingFactory()
         with pytest.raises(api_errors.ResourceGoneError) as exc:
             validation.check_booking_can_be_cancelled(booking)
         assert exc.value.errors["global"] == ["Cette contremarque a déjà été annulée"]
 
     def test_raise_if_already_used(self):
-        booking = factories.BookingFactory(isUsed=True, status=BookingStatus.USED)
+        booking = factories.UsedBookingFactory()
         with pytest.raises(api_errors.ForbiddenError) as exc:
             validation.check_booking_can_be_cancelled(booking)
         assert exc.value.errors["global"] == ["Impossible d'annuler une réservation consommée"]
@@ -500,15 +500,14 @@ class CheckCanBeMarkAsUnusedTest:
             validation.check_can_be_mark_as_unused(booking)
         assert exc.value.errors["booking"] == ["Cette réservation n'a pas encore été validée"]
 
-    def test_should_raises_forbidden_error_if_validated_and_cancelled(self, app):
-        booking = factories.BookingFactory(isUsed=True, isCancelled=True, status=BookingStatus.CANCELLED)
+    def test_should_raises_forbidden_error_if_cancelled(self, app):
+        booking = factories.CancelledBookingFactory()
         with pytest.raises(api_errors.ForbiddenError) as exc:
             validation.check_can_be_mark_as_unused(booking)
         assert exc.value.errors["booking"] == ["Cette réservation a été annulée"]
 
     def test_should_raises_resource_gone_error_if_payement_exists(self, app):
-        booking = factories.BookingFactory(isUsed=True, status=BookingStatus.USED)
-        payments_factories.PaymentFactory(booking=booking)
+        booking = payments_factories.PaymentFactory().booking
         with pytest.raises(api_errors.ResourceGoneError) as exc:
             validation.check_can_be_mark_as_unused(booking)
         assert exc.value.errors["payment"] == ["Le remboursement est en cours de traitement"]

--- a/tests/core/offers/test_models.py
+++ b/tests/core/offers/test_models.py
@@ -2,8 +2,7 @@ import datetime
 
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
-from pcapi.core.bookings.models import BookingStatus
+import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.categories import subcategories
 import pcapi.core.offerers.factories as providers_factories
 from pcapi.core.offers import factories
@@ -303,7 +302,7 @@ class StockBookingsQuantityTest:
     def test_bookings_quantity_with_booking(self):
         offer = factories.OfferFactory(product__subcategoryId=subcategories.ACHAT_INSTRUMENT.id)
         stock = factories.StockFactory(offer=offer, quantity=5)
-        BookingFactory(stock=stock)
+        bookings_factories.BookingFactory(stock=stock)
 
         assert Stock.query.filter(Stock.dnBookedQuantity == 0).count() == 0
         assert Stock.query.filter(Stock.dnBookedQuantity == 1).one() == stock
@@ -311,8 +310,8 @@ class StockBookingsQuantityTest:
     def test_bookings_quantity_with_a_cancelled_booking(self):
         offer = factories.OfferFactory(product__subcategoryId=subcategories.ACHAT_INSTRUMENT.id)
         stock = factories.StockFactory(offer=offer, quantity=5)
-        BookingFactory(stock=stock)
-        BookingFactory(stock=stock, isCancelled=True, status=BookingStatus.CANCELLED)
+        bookings_factories.BookingFactory(stock=stock)
+        bookings_factories.CancelledBookingFactory(stock=stock)
 
         assert Stock.query.filter(Stock.dnBookedQuantity == 1).one() == stock
 
@@ -337,7 +336,7 @@ class OfferIsSoldOutTest:
     def test_offer_with_fully_booked_stock(self):
         offer = factories.OfferFactory()
         stock = factories.StockFactory(offer=offer, quantity=1)
-        BookingFactory(stock=stock)
+        bookings_factories.BookingFactory(stock=stock)
 
         assert offer.isSoldOut
         assert Offer.query.filter(Offer.isSoldOut.is_(True)).one() == offer
@@ -380,7 +379,7 @@ class StockRemainingQuantityTest:
         offer = factories.OfferFactory()
         stock = factories.StockFactory(offer=offer, quantity=None)
 
-        BookingFactory(stock=stock)
+        bookings_factories.BookingFactory(stock=stock)
 
         assert stock.remainingQuantity == "unlimited"
         assert Offer.query.filter(Stock.remainingQuantity.is_(None)).one() == offer
@@ -396,7 +395,7 @@ class StockRemainingQuantityTest:
         offer = factories.OfferFactory()
         stock = factories.StockFactory(offer=offer, quantity=5)
 
-        BookingFactory(stock=stock, quantity=2)
+        bookings_factories.BookingFactory(stock=stock, quantity=2)
 
         assert stock.remainingQuantity == 3
         assert Offer.query.filter(Stock.remainingQuantity == 3).one() == offer
@@ -405,7 +404,7 @@ class StockRemainingQuantityTest:
         offer = factories.OfferFactory()
         stock = factories.StockFactory(offer=offer, quantity=1)
 
-        BookingFactory(stock=stock)
+        bookings_factories.BookingFactory(stock=stock)
 
         assert stock.remainingQuantity == 0
         assert Offer.query.filter(Stock.remainingQuantity == 0).one() == offer
@@ -414,7 +413,7 @@ class StockRemainingQuantityTest:
         offer = factories.OfferFactory()
         stock = factories.StockFactory(offer=offer, quantity=5)
 
-        BookingFactory(stock=stock, isCancelled=True, status=BookingStatus.CANCELLED)
+        bookings_factories.CancelledBookingFactory(stock=stock)
 
         assert stock.remainingQuantity == 5
         assert Offer.query.filter(Stock.remainingQuantity == 5).one() == offer

--- a/tests/core/users/test_api.py
+++ b/tests/core/users/test_api.py
@@ -283,7 +283,7 @@ class SuspendAccountTest:
         confirmed_booking = bookings_factories.BookingFactory(
             user=user, cancellation_limit_date=yesterday, status=BookingStatus.CONFIRMED
         )
-        used_booking = bookings_factories.BookingFactory(user=user, isUsed=True, status=BookingStatus.USED)
+        used_booking = bookings_factories.UsedBookingFactory(user=user)
         actor = users_factories.AdminFactory()
 
         users_api.suspend_account(user, users_constants.SuspensionReason.FRAUD, actor)
@@ -294,7 +294,7 @@ class SuspendAccountTest:
         assert confirmed_booking.isCancelled
         assert confirmed_booking.status is BookingStatus.CANCELLED
         assert not used_booking.isCancelled
-        assert used_booking.status is not BookingStatus.CANCELLED
+        assert used_booking.status is BookingStatus.USED
 
     def test_suspend_pro(self):
         booking = bookings_factories.BookingFactory()
@@ -675,11 +675,9 @@ class DomainsCreditTest:
         )
 
         # cancelled booking
-        bookings_factories.BookingFactory(
+        bookings_factories.CancelledBookingFactory(
             user=user,
             amount=150,
-            isCancelled=True,
-            status=BookingStatus.CANCELLED,
             stock__offer__subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id,
         )
 

--- a/tests/core/users/test_repository.py
+++ b/tests/core/users/test_repository.py
@@ -5,7 +5,6 @@ from freezegun import freeze_time
 import pytest
 
 from pcapi.core.bookings import factories as bookings_factories
-from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.testing import override_features
 from pcapi.core.users import exceptions
@@ -215,16 +214,12 @@ class FindByBeneficiaryTest:
     def test_should_not_return_booking_when_favorite_offer_booking_is_cancelled(self, app):
         # given
         beneficiary = factories.UserFactory()
-        venue = offers_factories.VenueFactory()
-        offer = offers_factories.ThingOfferFactory(venue=venue)
-        stock = offers_factories.StockFactory(offer=offer, price=0)
-        bookings_factories.BookingFactory(
+        stock = offers_factories.StockFactory()
+        bookings_factories.CancelledBookingFactory(
             stock=stock,
             user=beneficiary,
-            isCancelled=True,
-            status=BookingStatus.CANCELLED,
-            cancellationDate=datetime.now(),
         )
+        offer = stock.offer
         mediation = offers_factories.MediationFactory(offer=offer)
         favorite = factories.FavoriteFactory(mediation=mediation, offer=offer, user=beneficiary)
 

--- a/tests/core/users/test_users_sql_entity.py
+++ b/tests/core/users/test_users_sql_entity.py
@@ -4,7 +4,6 @@ from freezegun import freeze_time
 import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
-from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
 from pcapi.core.users import factories as users_factories
@@ -97,12 +96,10 @@ class WalletBalanceTest:
     def test_balance(self):
         # given
         user = users_factories.BeneficiaryFactory(deposit__version=1)
-        bookings_factories.BookingFactory(user=user, isUsed=True, status=BookingStatus.USED, quantity=1, amount=10)
-        bookings_factories.BookingFactory(user=user, isUsed=True, status=BookingStatus.USED, quantity=2, amount=20)
-        bookings_factories.BookingFactory(user=user, isUsed=False, quantity=3, amount=30)
-        bookings_factories.BookingFactory(
-            user=user, isCancelled=True, status=BookingStatus.CANCELLED, quantity=4, amount=40
-        )
+        bookings_factories.UsedBookingFactory(user=user, quantity=1, amount=10)
+        bookings_factories.UsedBookingFactory(user=user, quantity=2, amount=20)
+        bookings_factories.BookingFactory(user=user, quantity=3, amount=30)
+        bookings_factories.CancelledBookingFactory(user=user, quantity=4, amount=40)
 
         # then
         assert user.wallet_balance == 500 - (10 + 2 * 20 + 3 * 30)
@@ -122,7 +119,7 @@ class WalletBalanceTest:
     def test_balance_should_not_be_negative(self):
         # given
         user = users_factories.BeneficiaryFactory(deposit__version=1)
-        bookings_factories.BookingFactory(user=user, isUsed=True, quantity=1, amount=10)
+        bookings_factories.UsedBookingFactory(user=user, quantity=1, amount=10)
         deposit = user.deposit
         deposit.expirationDate = datetime(2000, 1, 1)
 

--- a/tests/domain/payments_test.py
+++ b/tests/domain/payments_test.py
@@ -10,10 +10,10 @@ from pcapi.core.offerers.models import Offerer
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
 import pcapi.core.users.factories as users_factories
+from pcapi.domain.payments import PaymentDetails
 from pcapi.domain.payments import UnmatchedPayments
 from pcapi.domain.payments import _set_end_to_end_id_and_group_into_transactions
 from pcapi.domain.payments import apply_banishment
-from pcapi.domain.payments import create_payment_details
 from pcapi.domain.payments import create_payment_for_booking
 from pcapi.domain.payments import filter_out_already_paid_for_bookings
 from pcapi.domain.payments import filter_out_bookings_without_cost
@@ -223,7 +223,7 @@ class CreatePaymentDetailsTest:
         payment = create_payment(booking, offerer, 35, iban="123456789")
 
         # when
-        details = create_payment_details(payment)
+        details = PaymentDetails(payment)
 
         # then
         assert details.payment_iban == "123456789"
@@ -240,7 +240,7 @@ class CreatePaymentDetailsTest:
         payment = payments_factories.PaymentFactory(booking=booking)
 
         # when
-        details = create_payment_details(payment)
+        details = PaymentDetails(payment)
 
         # then
         assert details.booking_date == datetime(2018, 2, 5)
@@ -258,7 +258,7 @@ class CreatePaymentDetailsTest:
         payment = create_payment(booking, offerer, 35)
 
         # when
-        details = create_payment_details(payment)
+        details = PaymentDetails(payment)
 
         # then
         assert details.offerer_name == "Joe le Libraire"
@@ -275,7 +275,7 @@ class CreatePaymentDetailsTest:
         payment = create_payment(booking, offerer, 35)
 
         # when
-        details = create_payment_details(payment)
+        details = PaymentDetails(payment)
 
         # then
         assert details.venue_name == "Jack le Sculpteur"
@@ -293,7 +293,7 @@ class CreatePaymentDetailsTest:
         payment = create_payment(booking, offerer, 35)
 
         # when
-        details = create_payment_details(payment)
+        details = PaymentDetails(payment)
 
         # then
         assert details.offer_name == "Test Book"

--- a/tests/domain/reimbursement_test.py
+++ b/tests/domain/reimbursement_test.py
@@ -28,7 +28,7 @@ def create_non_digital_thing_booking(quantity=1, price=10, user=None, date_creat
         price=price,
         offer=offers_factories.ThingOfferFactory(**offer_kwargs),
     )
-    return bookings_factories.BookingFactory(stock=stock, quantity=quantity, **booking_kwargs)
+    return bookings_factories.UsedBookingFactory(stock=stock, quantity=quantity, **booking_kwargs)
 
 
 def create_digital_booking(quantity=1, price=10, user=None, product_subcategory_id=None):
@@ -41,7 +41,7 @@ def create_digital_booking(quantity=1, price=10, user=None, product_subcategory_
         price=price,
         offer=offers_factories.ThingOfferFactory(product=product),
     )
-    return bookings_factories.BookingFactory(user=user, stock=stock, quantity=quantity)
+    return bookings_factories.UsedBookingFactory(user=user, stock=stock, quantity=quantity)
 
 
 def create_event_booking(quantity=1, price=10, user=None, date_created=None):
@@ -55,7 +55,7 @@ def create_event_booking(quantity=1, price=10, user=None, date_created=None):
         price=price,
         offer=offers_factories.EventOfferFactory(),
     )
-    return bookings_factories.BookingFactory(stock=stock, quantity=quantity, **booking_kwargs)
+    return bookings_factories.UsedBookingFactory(stock=stock, quantity=quantity, **booking_kwargs)
 
 
 def create_rich_user(total_deposit):
@@ -716,9 +716,9 @@ class FindAllBookingsReimbursementsTest:
     @pytest.mark.usefixtures("db_session")
     def test_select_custom_reimbursement_rule_if_applicable(self):
         offer1 = offers_factories.DigitalOfferFactory()
-        booking1 = bookings_factories.BookingFactory(stock__offer=offer1)
+        booking1 = bookings_factories.UsedBookingFactory(stock__offer=offer1)
         offer2 = offers_factories.DigitalOfferFactory()
-        booking2 = bookings_factories.BookingFactory(stock__offer=offer2)
+        booking2 = bookings_factories.UsedBookingFactory(stock__offer=offer2)
         rule1 = payments_factories.CustomReimbursementRuleFactory(offer=offer1, amount=5)
         payments_factories.CustomReimbursementRuleFactory(
             offer=offer2, timespan=[booking2.dateCreated + timedelta(days=2), None]

--- a/tests/domain/reimbursement_test.py
+++ b/tests/domain/reimbursement_test.py
@@ -15,12 +15,12 @@ from pcapi.models import Booking
 from pcapi.repository import repository
 
 
-def create_non_digital_thing_booking(quantity=1, price=10, user=None, date_created=None, product_subcategory_id=None):
+def create_non_digital_thing_booking(quantity=1, price=10, user=None, date_used=None, product_subcategory_id=None):
     booking_kwargs = {}
     if user:
         booking_kwargs["user"] = user
-    if date_created:
-        booking_kwargs["dateCreated"] = date_created
+    if date_used:
+        booking_kwargs["dateUsed"] = date_used
     offer_kwargs = {}
     if product_subcategory_id:
         offer_kwargs = {"product__subcategoryId": product_subcategory_id}
@@ -44,12 +44,12 @@ def create_digital_booking(quantity=1, price=10, user=None, product_subcategory_
     return bookings_factories.UsedBookingFactory(user=user, stock=stock, quantity=quantity)
 
 
-def create_event_booking(quantity=1, price=10, user=None, date_created=None):
+def create_event_booking(quantity=1, price=10, user=None, date_used=None):
     booking_kwargs = {}
     if user:
         booking_kwargs["user"] = user
-    if date_created:
-        booking_kwargs["dateCreated"] = date_created
+    if date_used:
+        booking_kwargs["dateUsed"] = date_used
     user = user or users_factories.BeneficiaryFactory()
     stock = offers_factories.StockFactory(
         price=price,
@@ -451,7 +451,7 @@ class ReimbursementRuleIsActiveTest:
         def is_relevant(self, booking, **kwargs):
             return True
 
-    booking = Booking()
+    booking = Booking(isUsed=True, dateCreated=datetime.now(), dateUsed=datetime.now())
 
     def test_is_active_if_valid_from_is_none_and_valid_until_is_none(self):
         # given
@@ -684,9 +684,9 @@ class FindAllBookingsReimbursementsTest:
     def test_returns_full_reimbursement_for_all_bookings_for_new_civil_year(self):
         # given
         user = create_rich_user(30000)
-        booking1 = create_event_booking(user=user, price=10000, date_created=datetime(2018, 1, 1))
-        booking2 = create_non_digital_thing_booking(user=user, price=10000, date_created=datetime(2018, 1, 1))
-        booking3 = create_event_booking(user=user, price=200, quantity=2, date_created=datetime(2019, 1, 1))
+        booking1 = create_event_booking(user=user, price=10000, date_used=datetime(2018, 1, 1))
+        booking2 = create_non_digital_thing_booking(user=user, price=10000, date_used=datetime(2018, 1, 1))
+        booking3 = create_event_booking(user=user, price=200, quantity=2, date_used=datetime(2019, 1, 1))
         bookings = [booking1, booking2, booking3]
 
         # when
@@ -700,9 +700,9 @@ class FindAllBookingsReimbursementsTest:
     def test_returns_85_reimbursement_rate_between_20000_and_40000_euros_for_this_civil_year(self):
         # given
         user = create_rich_user(50000)
-        booking1 = create_event_booking(user=user, price=20000, date_created=datetime(2018, 1, 1))
-        booking2 = create_non_digital_thing_booking(user=user, price=25000, date_created=datetime(2019, 1, 1))
-        booking3 = create_non_digital_thing_booking(user=user, price=2000, date_created=datetime(2019, 1, 1))
+        booking1 = create_event_booking(user=user, price=20000, date_used=datetime(2018, 1, 1))
+        booking2 = create_non_digital_thing_booking(user=user, price=25000, date_used=datetime(2019, 1, 1))
+        booking3 = create_non_digital_thing_booking(user=user, price=2000, date_used=datetime(2019, 1, 1))
         bookings = [booking1, booking2, booking3]
 
         # when

--- a/tests/emails/beneficiary_booking_cancellation_test.py
+++ b/tests/emails/beneficiary_booking_cancellation_test.py
@@ -5,7 +5,6 @@ from freezegun import freeze_time
 import pytest
 
 from pcapi.core.bookings import factories
-from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.offers.factories import EventStockFactory
 from pcapi.core.offers.factories import ThingStockFactory
 from pcapi.core.users.factories import BeneficiaryFactory
@@ -16,10 +15,8 @@ from pcapi.emails.beneficiary_booking_cancellation import make_beneficiary_booki
 class MakeBeneficiaryBookingCancellationEmailDataTest:
     def test_should_return_thing_data_when_booking_is_a_thing(self):
         # Given
-        booking = factories.BookingFactory(
+        booking = factories.CancelledBookingFactory(
             user=BeneficiaryFactory(email="fabien@example.com", firstName="Fabien"),
-            isCancelled=True,
-            status=BookingStatus.CANCELLED,
             stock=ThingStockFactory(
                 price=10.2,
                 beginningDatetime=datetime.now() - timedelta(days=1),
@@ -51,10 +48,8 @@ class MakeBeneficiaryBookingCancellationEmailDataTest:
     @freeze_time("2019-11-26 18:29:20.891028")
     def test_should_return_event_data_when_booking_is_an_event(self):
         # Given
-        booking = factories.BookingFactory(
+        booking = factories.CancelledBookingFactory(
             user=BeneficiaryFactory(email="fabien@example.com", firstName="Fabien"),
-            isCancelled=True,
-            status=BookingStatus.CANCELLED,
             stock=EventStockFactory(
                 price=10.2,
                 beginningDatetime=datetime.utcnow(),
@@ -85,13 +80,7 @@ class MakeBeneficiaryBookingCancellationEmailDataTest:
 
     def test_should_return_is_free_offer_when_offer_price_equals_to_zero(self):
         # Given
-        booking = factories.BookingFactory(
-            isCancelled=True,
-            status=BookingStatus.CANCELLED,
-            stock=EventStockFactory(
-                price=0,
-            ),
-        )
+        booking = factories.CancelledBookingFactory(stock__price=0)
 
         # When
         email_data = make_beneficiary_booking_cancellation_email_data(booking)
@@ -101,14 +90,7 @@ class MakeBeneficiaryBookingCancellationEmailDataTest:
 
     def test_should_return_the_price_multiplied_by_quantity_when_it_is_a_duo_offer(self):
         # Given
-        booking = factories.BookingFactory(
-            isCancelled=True,
-            status=BookingStatus.CANCELLED,
-            quantity=2,
-            stock=ThingStockFactory(
-                price=10,
-            ),
-        )
+        booking = factories.CancelledBookingFactory(quantity=2, stock__price=10)
 
         # When
         email_data = make_beneficiary_booking_cancellation_email_data(booking)

--- a/tests/emails/beneficiary_booking_confirmation_test.py
+++ b/tests/emails/beneficiary_booking_confirmation_test.py
@@ -4,7 +4,6 @@ from datetime import timezone
 import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
-from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.emails.beneficiary_booking_confirmation import retrieve_data_for_beneficiary_booking_confirmation_email
@@ -194,9 +193,7 @@ class DigitalOffersTest:
         )
         digital_stock = offers_factories.StockWithActivationCodesFactory()
         first_activation_code = digital_stock.activationCodes[0]
-        booking = bookings_factories.BookingFactory(
-            isUsed=True,
-            status=BookingStatus.USED,
+        booking = bookings_factories.UsedBookingFactory(
             stock__offer=offer,
             activationCode=first_activation_code,
             dateCreated=datetime(2018, 1, 1),

--- a/tests/emails/beneficiary_expired_bookings_test.py
+++ b/tests/emails/beneficiary_expired_bookings_test.py
@@ -3,9 +3,8 @@ from datetime import timedelta
 
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import CancelledBookingFactory
 from pcapi.core.bookings.models import BookingCancellationReasons
-from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import ProductFactory
 import pcapi.core.users.factories as users_factories
@@ -18,25 +17,21 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled():
     amnesiac_user = users_factories.UserFactory(email="dory@example.com", firstName="Dory")
     long_ago = now - timedelta(days=31)
     dvd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
-    expired_today_dvd_booking = BookingFactory(
+    expired_today_dvd_booking = CancelledBookingFactory(
         stock__offer__product=dvd,
         stock__offer__name="Memento",
         stock__offer__venue__name="Mnémosyne",
         dateCreated=long_ago,
-        isCancelled=True,
-        status=BookingStatus.CANCELLED,
         cancellationReason=BookingCancellationReasons.EXPIRED,
         user=amnesiac_user,
     )
 
     cd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id)
-    expired_today_cd_booking = BookingFactory(
+    expired_today_cd_booking = CancelledBookingFactory(
         stock__offer__product=cd,
         stock__offer__name="Random Access Memories",
         stock__offer__venue__name="Virgin Megastore",
         dateCreated=long_ago,
-        isCancelled=True,
-        status=BookingStatus.CANCELLED,
         cancellationReason=BookingCancellationReasons.EXPIRED,
         user=amnesiac_user,
     )

--- a/tests/emails/offerer_booking_recap_test.py
+++ b/tests/emails/offerer_booking_recap_test.py
@@ -4,7 +4,6 @@ from datetime import timezone
 import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
-from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.factories import ActivationCodeFactory
@@ -256,12 +255,10 @@ def test_no_need_when_booking_is_autovalidated():
     )
     digital_stock = offers_factories.StockWithActivationCodesFactory()
     first_activation_code = digital_stock.activationCodes[0]
-    booking = bookings_factories.BookingFactory(
+    booking = bookings_factories.UsedBookingFactory(
         user__email="john@example.com",
         user__firstName="John",
         user__lastName="Doe",
-        isUsed=True,
-        status=BookingStatus.USED,
         stock__offer=offer,
         activationCode=first_activation_code,
         dateCreated=datetime(2018, 1, 1),
@@ -295,12 +292,10 @@ def test_a_digital_booking_with_activation_code_is_automatically_used():
     )
     digital_stock = offers_factories.StockWithActivationCodesFactory()
     first_activation_code = digital_stock.activationCodes[0]
-    booking = bookings_factories.BookingFactory(
+    booking = bookings_factories.UsedBookingFactory(
         user__email="john@example.com",
         user__firstName="John",
         user__lastName="Doe",
-        isUsed=True,
-        status=BookingStatus.USED,
         stock__offer=offer,
         activationCode=first_activation_code,
         dateCreated=datetime(2018, 1, 1),

--- a/tests/emails/offerer_expired_bookings_test.py
+++ b/tests/emails/offerer_expired_bookings_test.py
@@ -4,9 +4,8 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import CancelledBookingFactory
 from pcapi.core.bookings.models import BookingCancellationReasons
-from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import OffererFactory
 from pcapi.core.offers.factories import ProductFactory
@@ -23,7 +22,7 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled(self, app)
     offerer = OffererFactory()
     long_ago = now - timedelta(days=31)
     dvd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
-    expired_today_dvd_booking = BookingFactory(
+    expired_today_dvd_booking = CancelledBookingFactory(
         user__publicName="Dory",
         user__email="dory@example.com",
         stock__offer__product=dvd,
@@ -31,13 +30,11 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled(self, app)
         stock__offer__venue__name="Mnémosyne",
         stock__offer__venue__managingOfferer=offerer,
         dateCreated=long_ago,
-        isCancelled=True,
-        status=BookingStatus.CANCELLED,
         cancellationReason=BookingCancellationReasons.EXPIRED,
     )
 
     cd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id)
-    expired_today_cd_booking = BookingFactory(
+    expired_today_cd_booking = CancelledBookingFactory(
         user__publicName="Dorian",
         user__email="dorian@example.com",
         stock__offer__product=cd,
@@ -45,8 +42,6 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled(self, app)
         stock__offer__venue__name="Virgin Megastore",
         stock__offer__venue__managingOfferer=offerer,
         dateCreated=long_ago,
-        isCancelled=True,
-        status=BookingStatus.CANCELLED,
         cancellationReason=BookingCancellationReasons.EXPIRED,
     )
 

--- a/tests/infrastructure/repository/beneficiary_bookings/beneficiary_bookings_sql_repository_test.py
+++ b/tests/infrastructure/repository/beneficiary_bookings/beneficiary_bookings_sql_repository_test.py
@@ -4,7 +4,8 @@ from datetime import timedelta
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
-from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.bookings.factories import CancelledBookingFactory
+from pcapi.core.bookings.factories import UsedBookingFactory
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import EventOfferFactory
 from pcapi.core.offers.factories import EventStockFactory
@@ -28,14 +29,12 @@ class BeneficiaryBookingsSQLRepositoryTest:
         beneficiary = BeneficiaryFactory()
         offer = ThingOfferFactory(isActive=True, url="http://url.com", product__thumbCount=1)
         stock = ThingStockFactory(offer=offer, price=0, quantity=10)
-        booking = BookingFactory(
+        booking = UsedBookingFactory(
             user=beneficiary,
             stock=stock,
             token="ABCDEF",
             dateCreated=datetime(2020, 4, 22, 0, 0),
             dateUsed=datetime(2020, 5, 5, 0, 0),
-            isUsed=True,
-            status=BookingStatus.USED,
             quantity=2,
         )
 
@@ -116,8 +115,8 @@ class BeneficiaryBookingsSQLRepositoryTest:
         beneficiary = BeneficiaryFactory()
         offer = EventOfferFactory()
         stock = EventStockFactory(offer=offer)
-        booking1 = BookingFactory(user=beneficiary, stock=stock, dateCreated=two_days_ago, isCancelled=True)
-        BookingFactory(user=beneficiary, stock=stock, dateCreated=three_days_ago, isCancelled=True)
+        booking1 = CancelledBookingFactory(user=beneficiary, stock=stock, dateCreated=two_days_ago)
+        CancelledBookingFactory(user=beneficiary, stock=stock, dateCreated=three_days_ago)
 
         # When
         result = BeneficiaryBookingsSQLRepository().get_beneficiary_bookings(beneficiary_id=beneficiary.id)

--- a/tests/models/stock_sql_entity_test.py
+++ b/tests/models/stock_sql_entity_test.py
@@ -114,10 +114,10 @@ def test_quantity_stocks_can_be_changed_even_when_bookings_with_cancellations_ex
     user1 = users_factories.BeneficiaryFactory()
     user2 = users_factories.BeneficiaryFactory()
 
-    bookings_factories.BookingFactory(user=user1, stock=stock, isCancelled=True, quantity=1)
-    bookings_factories.BookingFactory(user=user1, stock=stock, isCancelled=True, quantity=1)
-    bookings_factories.BookingFactory(user=user1, stock=stock, isCancelled=False, quantity=1)
-    bookings_factories.BookingFactory(user=user2, stock=stock, isCancelled=False, quantity=1)
+    bookings_factories.CancelledBookingFactory(user=user1, stock=stock, quantity=1)
+    bookings_factories.CancelledBookingFactory(user=user1, stock=stock, quantity=1)
+    bookings_factories.BookingFactory(user=user1, stock=stock, quantity=1)
+    bookings_factories.BookingFactory(user=user2, stock=stock, quantity=1)
 
     stock.quantity = 3
 

--- a/tests/notifications/push/user_attributes_updates_test.py
+++ b/tests/notifications/push/user_attributes_updates_test.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import CancelledBookingFactory
 from pcapi.core.offers.factories import OfferFactory
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users.factories import BeneficiaryFactory
@@ -22,7 +23,7 @@ class GetUserAttributesTest:
         offer = OfferFactory(product__id=list(TRACKED_PRODUCT_IDS.keys())[0])
         b1 = BookingFactory(user=user, amount=10, stock__offer=offer)
         b2 = BookingFactory(user=user, amount=10, dateUsed=datetime(2021, 5, 6), stock__offer=offer)
-        b3 = BookingFactory(user=user, amount=100, isCancelled=True)
+        b3 = CancelledBookingFactory(user=user, amount=100)
 
         n_query_get_user = 1
         n_query_get_bookings = 1

--- a/tests/repository/offer_queries_test.py
+++ b/tests/repository/offer_queries_test.py
@@ -2,6 +2,7 @@ import pytest
 from sqlalchemy import func
 
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import CancelledBookingFactory
 from pcapi.core.offers.factories import ThingOfferFactory
 from pcapi.core.offers.factories import ThingProductFactory
 from pcapi.core.offers.factories import ThingStockFactory
@@ -107,7 +108,7 @@ class QueryOfferWithRemainingStocksTest:
         venue = VenueFactory(postalCode="34000", departementCode="34")
         offer = ThingOfferFactory(product=product, venue=venue)
         stock = ThingStockFactory(offer=offer, price=0, quantity=2)
-        BookingFactory(user=beneficiary, stock=stock, quantity=2, isCancelled=True)
+        CancelledBookingFactory(user=beneficiary, stock=stock, quantity=2)
 
         # When
         bookings_quantity = _build_bookings_quantity_subquery()
@@ -129,7 +130,7 @@ class QueryOfferWithRemainingStocksTest:
         venue = VenueFactory(postalCode="34000", departementCode="34")
         offer = ThingOfferFactory(product=product, venue=venue)
         stock = ThingStockFactory(offer=offer, price=0, quantity=2)
-        BookingFactory(user=beneficiary, stock=stock, quantity=2, isCancelled=True)
+        CancelledBookingFactory(user=beneficiary, stock=stock, quantity=2)
         BookingFactory(user=beneficiary, stock=stock, quantity=2)
 
         # When

--- a/tests/repository/payment_queries_test.py
+++ b/tests/repository/payment_queries_test.py
@@ -77,8 +77,8 @@ class FindNotProcessableWithBankInformationTest:
         venue = offers_factories.VenueFactory(postalCode="34000", departementCode="34")
         offer = offers_factories.ThingOfferFactory(product=product, venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=0, quantity=2)
-        booking = bookings_factories.BookingFactory(stock=stock, quantity=2, isCancelled=True)
-        payment = factories.PaymentFactory(booking=booking, amount=10, iban="CF13QSDFGH456789", bic="QSDFGH8Z555")
+        booking = bookings_factories.UsedBookingFactory(stock=stock, quantity=2)
+        payment = factories.PaymentFactory(booking=booking, amount=10)
         factories.PaymentStatusFactory(payment=payment, status=TransactionStatus.NOT_PROCESSABLE)
 
         # When
@@ -99,10 +99,8 @@ class FindNotProcessableWithBankInformationTest:
         )
         offer = offers_factories.ThingOfferFactory(product=product, venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=0)
-        booking = bookings_factories.BookingFactory(stock=stock)
-        not_processable_payment = factories.PaymentFactory(
-            booking=booking, amount=10, iban="CF13QSDFGH456789", bic="QSDFGH8Z555"
-        )
+        booking = bookings_factories.UsedBookingFactory(stock=stock)
+        not_processable_payment = factories.PaymentFactory(booking=booking, amount=10)
         factories.PaymentStatusFactory(payment=not_processable_payment, status=TransactionStatus.NOT_PROCESSABLE)
         offers_factories.BankInformationFactory(offerer=user_offerer.offerer)
 
@@ -124,7 +122,7 @@ class FindNotProcessableWithBankInformationTest:
         )
         offer = offers_factories.ThingOfferFactory(product=product, venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=0)
-        booking = bookings_factories.BookingFactory(stock=stock)
+        booking = bookings_factories.UsedBookingFactory(stock=stock)
         not_processable_payment = factories.PaymentFactory(
             booking=booking, amount=10, iban="CF13QSDFGH456789", bic="QSDFGH8Z555"
         )
@@ -148,7 +146,7 @@ class FindNotProcessableWithBankInformationTest:
         )
         offer = offers_factories.ThingOfferFactory(product=product, venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=0)
-        booking = bookings_factories.BookingFactory(stock=stock)
+        booking = bookings_factories.UsedBookingFactory(stock=stock)
         not_processable_payment = factories.PaymentFactory(
             booking=booking, amount=10, iban="CF13QSDFGH456789", bic="QSDFGH8Z555"
         )
@@ -175,7 +173,7 @@ class FindNotProcessableWithBankInformationTest:
         )
         offer = offers_factories.ThingOfferFactory(product=product, venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=0)
-        booking = bookings_factories.BookingFactory(stock=stock)
+        booking = bookings_factories.UsedBookingFactory(stock=stock)
         not_processable_payment = factories.PaymentFactory(
             booking=booking, amount=10, iban="CF13QSDFGH456789", bic="QSDFGH8Z555"
         )
@@ -191,7 +189,7 @@ class FindNotProcessableWithBankInformationTest:
 
 @pytest.mark.usefixtures("db_session")
 def test_has_payment():
-    booking = bookings_factories.BookingFactory()
+    booking = bookings_factories.UsedBookingFactory()
     assert not payment_queries.has_payment(booking)
 
     factories.PaymentFactory(booking=booking)

--- a/tests/repository/reimbursement_queries_test.py
+++ b/tests/repository/reimbursement_queries_test.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 import pytest
 
 from pcapi.core.bookings import factories as bookings_factories
-from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers.factories import OffererFactory
 from pcapi.core.offers.factories import VenueFactory
@@ -27,11 +26,8 @@ class FindAllOffererPaymentsTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_not_return_payment_info_with_error_status(self, app):
         # Given
-        stock = offers_factories.ThingStockFactory(price=10)
-        now = datetime.utcnow()
-        booking = bookings_factories.BookingFactory(
-            stock=stock, isUsed=True, status=BookingStatus.USED, dateUsed=now, token="ABCDEF"
-        )
+        booking = bookings_factories.UsedBookingFactory()
+        offerer = booking.stock.offer.venue.managingOfferer
         payment = payments_factories.PaymentFactory(
             booking=booking, transactionLabel="pass Culture Pro - remboursement 1ère quinzaine 07-2019"
         )
@@ -40,7 +36,7 @@ class FindAllOffererPaymentsTest:
         )
 
         # When
-        payments = find_all_offerer_payments(stock.offer.venue.managingOfferer.id, reimbursement_period)
+        payments = find_all_offerer_payments(offerer.id, reimbursement_period)
 
         # Then
         assert len(payments) == 0
@@ -58,9 +54,7 @@ class FindAllOffererPaymentsTest:
             price=10,
         )
         now = datetime.utcnow()
-        booking = bookings_factories.BookingFactory(
-            user=beneficiary, stock=stock, isUsed=True, dateUsed=now, token="ABCDEF"
-        )
+        booking = bookings_factories.UsedBookingFactory(user=beneficiary, stock=stock, dateUsed=now, token="ABCDEF")
 
         payment = payments_factories.PaymentFactory(
             amount=50,
@@ -113,12 +107,8 @@ class FindAllOffererPaymentsTest:
             price=10,
         )
         now = datetime.utcnow()
-        booking1 = bookings_factories.BookingFactory(
-            user=beneficiary, stock=stock, isUsed=True, dateUsed=now, token="ABCDEF"
-        )
-        booking2 = bookings_factories.BookingFactory(
-            user=beneficiary, stock=stock, isUsed=True, dateUsed=now, token="ABCDFE"
-        )
+        booking1 = bookings_factories.UsedBookingFactory(user=beneficiary, stock=stock, dateUsed=now, token="ABCDEF")
+        booking2 = bookings_factories.UsedBookingFactory(user=beneficiary, stock=stock, dateUsed=now, token="ABCDFE")
 
         payment = payments_factories.PaymentFactory(
             amount=50,
@@ -251,9 +241,7 @@ class LegacyFindAllOffererPaymentsTest:
         # Given
         stock = offers_factories.ThingStockFactory(price=10)
         now = datetime.utcnow()
-        booking = bookings_factories.BookingFactory(
-            stock=stock, isUsed=True, status=BookingStatus.USED, dateUsed=now, token="ABCDEF"
-        )
+        booking = bookings_factories.UsedBookingFactory(stock=stock, dateUsed=now, token="ABCDEF")
         payment = payments_factories.PaymentFactory(
             booking=booking, transactionLabel="pass Culture Pro - remboursement 1ère quinzaine 07-2019"
         )
@@ -299,9 +287,7 @@ class LegacyFindAllOffererPaymentsTest:
             price=10,
         )
         now = datetime.utcnow()
-        booking = bookings_factories.BookingFactory(
-            user=beneficiary, stock=stock, isUsed=True, dateUsed=now, token="ABCDEF"
-        )
+        booking = bookings_factories.UsedBookingFactory(user=beneficiary, stock=stock, dateUsed=now, token="ABCDEF")
 
         payment = payments_factories.PaymentFactory(
             amount=50,
@@ -354,12 +340,8 @@ class LegacyFindAllOffererPaymentsTest:
             price=10,
         )
         now = datetime.utcnow()
-        booking1 = bookings_factories.BookingFactory(
-            user=beneficiary, stock=stock, isUsed=True, dateUsed=now, token="ABCDEF"
-        )
-        booking2 = bookings_factories.BookingFactory(
-            user=beneficiary, stock=stock, isUsed=True, dateUsed=now, token="ABCDFE"
-        )
+        booking1 = bookings_factories.UsedBookingFactory(user=beneficiary, stock=stock, dateUsed=now, token="ABCDEF")
+        booking2 = bookings_factories.UsedBookingFactory(user=beneficiary, stock=stock, dateUsed=now, token="ABCDFE")
 
         payment = payments_factories.PaymentFactory(
             amount=50,

--- a/tests/repository/user_queries_test.py
+++ b/tests/repository/user_queries_test.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
-from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.model_creators.generic_creators import create_beneficiary_import
@@ -56,8 +55,8 @@ class GetAllUsersWalletBalancesTest:
         user = users_factories.BeneficiaryFactory(deposit__version=1)
 
         bookings_factories.BookingFactory(user=user, stock=stock1)
-        bookings_factories.BookingFactory(user=user, stock=stock2, isCancelled=True)
-        bookings_factories.BookingFactory(user=user, stock=stock3, isUsed=True, status=BookingStatus.USED, quantity=2)
+        bookings_factories.CancelledBookingFactory(user=user, stock=stock2)
+        bookings_factories.UsedBookingFactory(user=user, stock=stock3, quantity=2)
 
         # when
         balances = get_all_users_wallet_balances()

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -17,6 +17,7 @@ from pcapi.connectors.api_adage import AdageException
 from pcapi.connectors.api_adage import InstitutionalProjectRedactorNotFoundException
 from pcapi.connectors.serialization.api_adage_serializers import InstitutionalProjectRedactorResponse
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import CancelledBookingFactory
 from pcapi.core.fraud import models as fraud_models
 from pcapi.core.fraud.models import BeneficiaryFraudCheck
 from pcapi.core.fraud.models import FraudCheckType
@@ -109,7 +110,7 @@ class AccountTest:
             **USER_DATA,
         )
         booking = BookingFactory(user=user, amount=Decimal("123.45"))
-        BookingFactory(user=user, amount=Decimal("123.45"), isCancelled=True)
+        CancelledBookingFactory(user=user, amount=Decimal("123.45"))
 
         access_token = create_access_token(identity=self.identifier)
         test_client = TestClient(app.test_client())

--- a/tests/routes/native/v1/bookings_test.py
+++ b/tests/routes/native/v1/bookings_test.py
@@ -6,9 +6,10 @@ from freezegun import freeze_time
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import CancelledBookingFactory
+from pcapi.core.bookings.factories import UsedBookingFactory
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
-from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import EventStockFactory
 from pcapi.core.offers.factories import MediationFactory
@@ -92,10 +93,8 @@ class GetBookingsTest:
         OFFER_URL = "https://demo.pass/some/path?token={token}&email={email}&offerId={offerId}"
         user = users_factories.BeneficiaryFactory(email=self.identifier)
 
-        permanent_booking = BookingFactory(
+        permanent_booking = UsedBookingFactory(
             user=user,
-            isUsed=True,
-            status=BookingStatus.USED,
             stock__offer__subcategoryId=subcategories.TELECHARGEMENT_LIVRE_AUDIO.id,
             dateUsed=datetime(2021, 2, 3),
         )
@@ -105,45 +104,34 @@ class GetBookingsTest:
         digital_stock = StockWithActivationCodesFactory()
         first_activation_code = digital_stock.activationCodes[0]
         second_activation_code = digital_stock.activationCodes[1]
-        digital_booking = BookingFactory(
+        digital_booking = UsedBookingFactory(
             user=user,
-            isUsed=True,
-            status=BookingStatus.USED,
-            dateUsed=datetime.now(),
             stock=digital_stock,
             activationCode=first_activation_code,
         )
-        ended_digital_booking = BookingFactory(
+        ended_digital_booking = UsedBookingFactory(
             user=user,
             displayAsEnded=True,
-            isUsed=True,
-            status=BookingStatus.USED,
-            dateUsed=datetime.now(),
             stock=digital_stock,
             activationCode=second_activation_code,
         )
         expire_tomorrow = BookingFactory(user=user, dateCreated=datetime.now() - timedelta(days=29))
-        used_but_in_future = BookingFactory(
+        used_but_in_future = UsedBookingFactory(
             user=user,
-            isUsed=True,
-            status=BookingStatus.USED,
             dateUsed=datetime(2021, 3, 11),
             stock=StockFactory(beginningDatetime=datetime(2021, 3, 15)),
         )
 
-        cancelled_permanent_booking = BookingFactory(
+        cancelled_permanent_booking = CancelledBookingFactory(
             user=user,
             stock__offer__subcategoryId=subcategories.TELECHARGEMENT_LIVRE_AUDIO.id,
-            isCancelled=True,
             cancellation_date=datetime(2021, 3, 10),
         )
-        cancelled = BookingFactory(user=user, isCancelled=True, cancellation_date=datetime(2021, 3, 8))
-        used1 = BookingFactory(user=user, isUsed=True, status=BookingStatus.USED, dateUsed=datetime(2021, 3, 1))
-        used2 = BookingFactory(
+        cancelled = CancelledBookingFactory(user=user, cancellation_date=datetime(2021, 3, 8))
+        used1 = UsedBookingFactory(user=user, dateUsed=datetime(2021, 3, 1))
+        used2 = UsedBookingFactory(
             user=user,
             displayAsEnded=True,
-            isUsed=True,
-            status=BookingStatus.USED,
             dateUsed=datetime(2021, 3, 2),
             stock__offer__url=OFFER_URL,
             cancellation_limit_date=datetime(2021, 3, 2),
@@ -302,11 +290,9 @@ class ToggleBookingVisibilityTest:
 
         stock = StockWithActivationCodesFactory()
         activation_code = stock.activationCodes[0]
-        booking = BookingFactory(
+        booking = UsedBookingFactory(
             user=user,
             displayAsEnded=None,
-            isUsed=True,
-            status=BookingStatus.USED,
             dateUsed=datetime.now(),
             stock=stock,
             activationCode=activation_code,

--- a/tests/routes/pro/get_all_bookings_test.py
+++ b/tests/routes/pro/get_all_bookings_test.py
@@ -7,7 +7,6 @@ import pytest
 
 from pcapi.core import testing
 import pcapi.core.bookings.factories as bookings_factories
-from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.testing import assert_num_queries
@@ -94,10 +93,8 @@ class Returns200Test:
         assert len(response.json["bookings_recap"]) == 1
 
     def when_user_is_linked_to_a_valid_offerer(self, app):
-        booking = bookings_factories.BookingFactory(
+        booking = bookings_factories.UsedBookingFactory(
             dateCreated=datetime(2020, 8, 11, 12, 0, 0),
-            isUsed=True,
-            status=BookingStatus.USED,
             dateUsed=datetime(2020, 8, 13, 12, 0, 0),
             token="ABCDEF",
             user__email="beneficiary@example.com",

--- a/tests/routes/pro/get_booking_by_token_test.py
+++ b/tests/routes/pro/get_booking_by_token_test.py
@@ -335,8 +335,7 @@ class Returns403Test:
     @pytest.mark.usefixtures("db_session")
     def when_booking_is_refunded(self, app):
         # Given
-        booking = BookingFactory()
-        PaymentFactory(booking=booking)
+        booking = PaymentFactory().booking
         url = (
             f"/bookings/token/{booking.token}?" f"email={booking.user.email}&offer_id={humanize(booking.stock.offerId)}"
         )

--- a/tests/routes/pro/get_venue_stats_test.py
+++ b/tests/routes/pro/get_venue_stats_test.py
@@ -1,7 +1,6 @@
 import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
-from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.utils.human_ids import humanize
@@ -14,7 +13,7 @@ class Returns200Test:
     def when_pro_user_has_rights_on_managing_offerer(self, app):
         # given
         booking = bookings_factories.BookingFactory()
-        bookings_factories.BookingFactory(isUsed=True, status=BookingStatus.USED, stock=booking.stock)
+        bookings_factories.UsedBookingFactory(stock=booking.stock)
         venue = booking.stock.offer.venue
         venue_owner = offers_factories.UserOffererFactory(offerer=venue.managingOfferer).user
 

--- a/tests/routes/pro/patch_booking_by_token_test.py
+++ b/tests/routes/pro/patch_booking_by_token_test.py
@@ -2,7 +2,7 @@ import urllib.parse
 
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
+import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.users import factories as users_factories
@@ -25,7 +25,7 @@ from tests.conftest import TestClient
 class Returns204Test:
     class WhenUserIsAnonymousTest:
         def expect_booking_to_be_used(self, app):
-            booking = BookingFactory(token="ABCDEF")
+            booking = bookings_factories.BookingFactory(token="ABCDEF")
 
             url = (
                 f"/bookings/token/{booking.token}?"
@@ -40,7 +40,7 @@ class Returns204Test:
 
     class WhenUserIsLoggedInTest:
         def expect_booking_to_be_used(self, app):
-            booking = BookingFactory(token="ABCDEF")
+            booking = bookings_factories.BookingFactory(token="ABCDEF")
             pro_user = users_factories.ProFactory(email="pro@example.com")
             offerer = booking.stock.offer.venue.managingOfferer
             offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
@@ -54,7 +54,7 @@ class Returns204Test:
             assert booking.status is BookingStatus.USED
 
         def expect_booking_with_token_in_lower_case_to_be_used(self, app):
-            booking = BookingFactory(token="ABCDEF")
+            booking = bookings_factories.BookingFactory(token="ABCDEF")
             pro_user = users_factories.ProFactory(email="pro@example.com")
             offerer = booking.stock.offer.venue.managingOfferer
             offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
@@ -68,7 +68,7 @@ class Returns204Test:
             assert booking.status is BookingStatus.USED
 
         def expect_booking_to_be_used_with_non_standard_origin_header(self, app):
-            booking = BookingFactory(token="ABCDEF")
+            booking = bookings_factories.BookingFactory(token="ABCDEF")
             pro_user = users_factories.ProFactory(email="pro@example.com")
             offerer = booking.stock.offer.venue.managingOfferer
             offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
@@ -85,7 +85,7 @@ class Returns204Test:
         # FIXME: what is the purpose of this test? Are we testing that
         # Flask knows how to URL-decode parameters?
         def expect_booking_to_be_used_with_special_char_in_url(self, app):
-            booking = BookingFactory(token="ABCDEF", user__email="user+plus@example.com")
+            booking = bookings_factories.BookingFactory(token="ABCDEF", user__email="user+plus@example.com")
             pro_user = users_factories.ProFactory(email="pro@example.com")
             offerer = booking.stock.offer.venue.managingOfferer
             offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
@@ -191,7 +191,7 @@ class Returns403Test:  # Forbidden
     def when_booking_has_been_cancelled_already(self, app):
         # Given
         admin = users_factories.AdminFactory()
-        booking = BookingFactory(isCancelled=True)
+        booking = bookings_factories.CancelledBookingFactory()
         url = f"/bookings/token/{booking.token}"
 
         # When

--- a/tests/routes/pro/patch_booking_use_by_token_test.py
+++ b/tests/routes/pro/patch_booking_use_by_token_test.py
@@ -1,7 +1,6 @@
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
-from pcapi.core.bookings.models import BookingStatus
+import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.categories import subcategories
 from pcapi.core.offerers.factories import ApiKeyFactory
 from pcapi.core.offerers.factories import DEFAULT_CLEAR_API_KEY
@@ -28,7 +27,7 @@ API_KEY_VALUE = random_token(64)
 class Returns204Test:
     class WithApiKeyAuthTest:
         def test_when_api_key_is_provided_and_rights_and_regular_offer(self, app):
-            booking = BookingFactory(token="ABCDEF")
+            booking = bookings_factories.BookingFactory(token="ABCDEF")
             offerer = booking.stock.offer.venue.managingOfferer
             ApiKeyFactory(offerer=offerer)
 
@@ -46,7 +45,7 @@ class Returns204Test:
             assert booking.isUsed
 
         def test_expect_booking_to_be_used_with_non_standard_origin_header(self, app):
-            booking = BookingFactory(token="ABCDEF")
+            booking = bookings_factories.BookingFactory(token="ABCDEF")
             offerer = booking.stock.offer.venue.managingOfferer
             ApiKeyFactory(offerer=offerer)
 
@@ -65,7 +64,7 @@ class Returns204Test:
 
     class WithBasicAuthTest:
         def test_when_user_is_logged_in_and_regular_offer(self, app):
-            booking = BookingFactory(token="ABCDEF")
+            booking = bookings_factories.BookingFactory(token="ABCDEF")
             pro_user = users_factories.ProFactory(email="pro@example.com")
             offerer = booking.stock.offer.venue.managingOfferer
             offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
@@ -78,7 +77,7 @@ class Returns204Test:
             assert booking.isUsed
 
         def test_when_user_is_logged_in_expect_booking_with_token_in_lower_case_to_be_used(self, app):
-            booking = BookingFactory(token="ABCDEF")
+            booking = bookings_factories.BookingFactory(token="ABCDEF")
             pro_user = users_factories.ProFactory(email="pro@example.com")
             offerer = booking.stock.offer.venue.managingOfferer
             offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
@@ -142,7 +141,7 @@ class Returns403Test:
             offerer2 = offers_factories.OffererFactory(siren="987654321")
             offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
             stock = offers_factories.EventStockFactory(offer=offer, price=0)
-            booking = BookingFactory(user=user, stock=stock)
+            booking = bookings_factories.BookingFactory(user=user, stock=stock)
 
             ApiKeyFactory(offerer=offerer2)
 
@@ -205,7 +204,7 @@ class Returns403Test:
         def test_when_user_is_logged_in_and_booking_has_been_cancelled_already(self, app):
             # Given
             admin = users_factories.AdminFactory()
-            booking = BookingFactory(isCancelled=True, status=BookingStatus.CANCELLED)
+            booking = bookings_factories.CancelledBookingFactory()
             url = f"/v2/bookings/use/token/{booking.token}"
 
             # When

--- a/tests/routes/pro/patch_cancel_booking_by_token_test.py
+++ b/tests/routes/pro/patch_cancel_booking_by_token_test.py
@@ -212,8 +212,8 @@ class Returns403Test:
         def test_should_prevent_a_used_booking_from_being_cancelled(self, app):
             # Given
             user_offerer = offers_factories.UserOffererFactory()
-            booking = bookings_factories.BookingFactory(
-                stock__offer__venue__managingOfferer=user_offerer.offerer, isUsed=True, status=BookingStatus.USED
+            booking = bookings_factories.UsedBookingFactory(
+                stock__offer__venue__managingOfferer=user_offerer.offerer,
             )
 
             ApiKeyFactory(offerer=user_offerer.offerer)

--- a/tests/routes/pro/validate_bookings_test.py
+++ b/tests/routes/pro/validate_bookings_test.py
@@ -5,7 +5,7 @@ import urllib.parse
 
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
+import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.bookings.models as bookings_models
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.users import factories as users_factories
@@ -32,7 +32,7 @@ tomorrow_minus_one_hour = tomorrow - timedelta(hours=1)
 @pytest.mark.usefixtures("db_session")
 class Returns204Test:  # No Content
     def when_user_has_rights(self, app):
-        booking = BookingFactory(token="ABCDEF")
+        booking = bookings_factories.BookingFactory(token="ABCDEF")
         pro_user = users_factories.ProFactory(email="pro@example.com")
         offerer = booking.stock.offer.venue.managingOfferer
         offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
@@ -46,7 +46,7 @@ class Returns204Test:  # No Content
         assert booking.dateUsed is not None
 
     def when_header_is_not_standard_but_request_is_valid(self, app):
-        booking = BookingFactory(token="ABCDEF")
+        booking = bookings_factories.BookingFactory(token="ABCDEF")
         pro_user = users_factories.ProFactory(email="pro@example.com")
         offerer = booking.stock.offer.venue.managingOfferer
         offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
@@ -62,7 +62,7 @@ class Returns204Test:  # No Content
     # FIXME: what is the purpose of this test? Are we testing that
     # Flask knows how to URL-decode parameters?
     def when_booking_user_email_has_special_character_url_encoded(self, app):
-        booking = BookingFactory(
+        booking = bookings_factories.BookingFactory(
             token="ABCDEF",
             user__email="user+plus@example.com",
         )
@@ -112,7 +112,7 @@ class Returns403Test:
     def when_booking_not_confirmed(self, mocked_check_is_usable, app):
         # Given
         next_week = datetime.utcnow() + timedelta(weeks=1)
-        booking = BookingFactory(stock__beginningDatetime=next_week)
+        booking = bookings_factories.BookingFactory(stock__beginningDatetime=next_week)
         pro_user = users_factories.ProFactory(email="pro@example.com")
         offerer = booking.stock.offer.venue.managingOfferer
         offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
@@ -130,7 +130,7 @@ class Returns403Test:
     def when_booking_is_cancelled(self, app):
         # Given
         admin = users_factories.AdminFactory()
-        booking = BookingFactory(isCancelled=True, status=bookings_models.BookingStatus.CANCELLED)
+        booking = bookings_factories.CancelledBookingFactory()
         url = f"/bookings/token/{booking.token}"
 
         # When

--- a/tests/routes/serialization/reimbursement_csv_test.py
+++ b/tests/routes/serialization/reimbursement_csv_test.py
@@ -124,6 +124,7 @@ def test_generate_reimbursement_details_csv():
         booking__token="0E2722",
         booking__amount=10.5,
         booking__quantity=2,
+        booking__dateUsed=datetime(2021, 1, 1, 12, 0),
         iban="iban-1234",
         transactionLabel="pass Culture Pro - remboursement 1ère quinzaine 07-2019",
     )
@@ -142,7 +143,7 @@ def test_generate_reimbursement_details_csv():
     )
     assert (
         rows[1]
-        == '"2019";"Juillet : remboursement 1ère quinzaine";"Mon lieu ; un peu ""spécial""";"siret-1234";"1 boulevard Poissonnière";"iban-1234";"Mon lieu ; un peu ""spécial""";"Mon titre ; un peu ""spécial""";"Doux";"Jeanne";"0E2722";"";"21,00";"100%";"21,00";"Remboursement envoyé"'
+        == '"2019";"Juillet : remboursement 1ère quinzaine";"Mon lieu ; un peu ""spécial""";"siret-1234";"1 boulevard Poissonnière";"iban-1234";"Mon lieu ; un peu ""spécial""";"Mon titre ; un peu ""spécial""";"Doux";"Jeanne";"0E2722";"2021-01-01 12:00:00";"21,00";"100%";"21,00";"Remboursement envoyé"'
     )
 
 

--- a/tests/routes/webapp/get_beneficiary_profile_test.py
+++ b/tests/routes/webapp/get_beneficiary_profile_test.py
@@ -2,8 +2,7 @@ from datetime import datetime
 
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
-from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.bookings.factories import CancelledBookingFactory
 from pcapi.core.users.factories import AdminFactory
 from pcapi.core.users.factories import BeneficiaryFactory
 from pcapi.core.users.factories import ProFactory
@@ -115,9 +114,7 @@ class Returns200Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_has_cancelled_some_offers(self, app):
         # Given
-        BookingFactory(
-            isCancelled=True,
-            status=BookingStatus.CANCELLED,
+        CancelledBookingFactory(
             user__email="wallet_test@email.com",
             user__postalCode="75130",
         )

--- a/tests/routes/webapp/put_cancel_booking_by_id_test.py
+++ b/tests/routes/webapp/put_cancel_booking_by_id_test.py
@@ -48,7 +48,7 @@ class Returns400Test:
     @pytest.mark.usefixtures("db_session")
     def when_the_booking_cannot_be_cancelled(self, app):
         # Given
-        booking = bookings_factories.BookingFactory(isUsed=True, status=BookingStatus.USED)
+        booking = bookings_factories.UsedBookingFactory()
 
         # When
         client = TestClient(app.test_client()).with_auth(booking.user.email)
@@ -66,7 +66,7 @@ class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     def when_cancelling_a_booking_of_someone_else(self, app):
         # Given
-        booking = bookings_factories.BookingFactory(isUsed=True, status=BookingStatus.USED)
+        booking = bookings_factories.UsedBookingFactory()
         user2 = users_factories.BeneficiaryFactory()
 
         # When

--- a/tests/scripts/booking/cancel_old_unused_bookings_for_venue_test.py
+++ b/tests/scripts/booking/cancel_old_unused_bookings_for_venue_test.py
@@ -21,11 +21,9 @@ def test_should_cancel_old_unused_bookings_for_venue():
         dateCreated=(datetime.now() - timedelta(days=40)), stock__offer__venue=venue
     )
 
-    used_booking = bookings_factories.BookingFactory(
+    used_booking = bookings_factories.UsedBookingFactory(
         dateCreated=(datetime.now() - timedelta(days=40)),
         stock__offer__venue=venue,
-        isUsed=True,
-        status=BookingStatus.USED,
     )
 
     recent_booking = bookings_factories.BookingFactory(

--- a/tests/scripts/booking/canceling_token_validation_test.py
+++ b/tests/scripts/booking/canceling_token_validation_test.py
@@ -11,7 +11,7 @@ from pcapi.scripts.booking.canceling_token_validation import canceling_token_val
 def test_should_update_booking_when_valid_token_is_given_and_no_payment_associated(app):
     # Given
     token = "123456"
-    booking = bookings_factories.BookingFactory(isUsed=True, status=BookingStatus.USED, token=token)
+    booking = bookings_factories.UsedBookingFactory(token=token)
 
     # When
     canceling_token_validation(token=token)
@@ -27,9 +27,8 @@ def test_should_update_booking_when_valid_token_is_given_and_no_payment_associat
 def test_should_do_nothing_when_valid_token_is_given_but_the_booking_is_linked_to_a_payment(app):
     # Given
     token = "123456"
-    booking = bookings_factories.BookingFactory(isUsed=True, status=BookingStatus.USED, token=token)
+    booking = payments_factories.PaymentFactory(booking__token=token).booking
     initial_date_used = booking.dateUsed
-    payments_factories.PaymentFactory(booking=booking)
 
     # When
     canceling_token_validation(token=token)

--- a/tests/scripts/payment/batch_test.py
+++ b/tests/scripts/payment/batch_test.py
@@ -7,7 +7,6 @@ import pytest
 from sqlalchemy import func
 
 import pcapi.core.bookings.factories as bookings_factories
-from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.mails.testing as mails_testing
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
@@ -28,24 +27,18 @@ def test_generate_and_send_payments():
     # 1 new payment + 1 retried payment for venue 1
     venue1 = offers_factories.VenueFactory(name="venue1")
     offers_factories.BankInformationFactory(venue=venue1)
-    booking11 = bookings_factories.BookingFactory(
-        isUsed=True, status=BookingStatus.USED, dateUsed=before_cutoff, stock__offer__venue=venue1
-    )
-    booking12 = bookings_factories.BookingFactory(
-        isUsed=True, status=BookingStatus.USED, dateUsed=before_cutoff, stock__offer__venue=venue1
-    )
+    booking11 = bookings_factories.UsedBookingFactory(dateUsed=before_cutoff, stock__offer__venue=venue1)
+    booking12 = bookings_factories.UsedBookingFactory(dateUsed=before_cutoff, stock__offer__venue=venue1)
     payment12 = payments_factories.PaymentFactory(booking=booking12)
     payments_factories.PaymentStatusFactory(payment=payment12, status=TransactionStatus.ERROR)
     payment13 = payments_factories.PaymentFactory(booking__stock__offer__venue=venue1)
     payments_factories.PaymentStatusFactory(payment=payment13, status=TransactionStatus.SENT)
-    bookings_factories.BookingFactory(isUsed=False, stock__offer__venue=venue1)
+    bookings_factories.BookingFactory(stock__offer__venue=venue1)
 
     # 1 new payment for venue 2
     venue2 = offers_factories.VenueFactory(name="venue2")
     offers_factories.BankInformationFactory(offerer=venue2.managingOfferer)
-    booking2 = bookings_factories.BookingFactory(
-        isUsed=True, status=BookingStatus.USED, dateUsed=before_cutoff, stock__offer__venue=venue2
-    )
+    booking2 = bookings_factories.UsedBookingFactory(dateUsed=before_cutoff, stock__offer__venue=venue2)
 
     # 0 payment for venue 3 (existing booking has already been reimbursed)
     payment3 = payments_factories.PaymentFactory()
@@ -53,9 +46,7 @@ def test_generate_and_send_payments():
 
     # 1 new payment (not processable) for venue 4 (no IBAN nor BIC)
     venue4 = offers_factories.VenueFactory()
-    booking4 = bookings_factories.BookingFactory(
-        isUsed=True, status=BookingStatus.USED, dateUsed=before_cutoff, stock__offer__venue=venue4
-    )
+    booking4 = bookings_factories.UsedBookingFactory(dateUsed=before_cutoff, stock__offer__venue=venue4)
 
     # 0 payment for venue 5 (booking is not used)
     venue5 = offers_factories.VenueFactory()
@@ -64,9 +55,7 @@ def test_generate_and_send_payments():
     # 0 payment for venue 6 (booking has been used after cutoff)
     venue6 = offers_factories.VenueFactory(name="venue2")
     offers_factories.BankInformationFactory(offerer=venue6.managingOfferer)
-    bookings_factories.BookingFactory(
-        isUsed=True, status=BookingStatus.USED, dateUsed=cutoff, stock__offer__venue=venue2
-    )
+    bookings_factories.UsedBookingFactory(dateUsed=cutoff, stock__offer__venue=venue2)
 
     last_payment_id = Payment.query.with_entities(func.max(Payment.id)).scalar()
     last_status_id = PaymentStatus.query.with_entities(func.max(PaymentStatus.id)).scalar()

--- a/tests/scripts/payment/generate_new_payments_test.py
+++ b/tests/scripts/payment/generate_new_payments_test.py
@@ -3,7 +3,6 @@ import datetime
 import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
-from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
@@ -39,21 +38,11 @@ class GenerateNewPaymentsTest:
         offer = offers_factories.ThingOfferFactory(venue__managingOfferer=offerer)
         paying_stock = offers_factories.ThingStockFactory(offer=offer)
         free_stock = offers_factories.ThingStockFactory(offer=offer, price=0)
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock, isUsed=True, status=BookingStatus.USED, dateUsed=before_cutoff
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock, isUsed=True, status=BookingStatus.USED, dateUsed=before_cutoff
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=free_stock, isUsed=True, status=BookingStatus.USED, dateUsed=before_cutoff
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=free_stock, isUsed=True, status=BookingStatus.USED, dateUsed=before_cutoff
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock, isUsed=True, status=BookingStatus.USED, dateUsed=cutoff
-        )
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock, dateUsed=before_cutoff)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock, dateUsed=before_cutoff)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=free_stock, dateUsed=before_cutoff)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=free_stock, dateUsed=before_cutoff)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock, dateUsed=cutoff)
 
         payment_message = payments_factories.PaymentMessageFactory(name="ABCD123")
         payments_factories.PaymentFactory(paymentMessage=payment_message)
@@ -94,10 +83,10 @@ class GenerateNewPaymentsTest:
         paying_stock1 = offers_factories.ThingStockFactory(offer=offer1)
         paying_stock2 = offers_factories.ThingStockFactory(offer=offer2)
         free_stock1 = offers_factories.ThingStockFactory(offer=offer1, price=0)
-        bookings_factories.BookingFactory(user=beneficiary, stock=paying_stock1, isUsed=True, dateUsed=before_cutoff)
-        bookings_factories.BookingFactory(user=beneficiary, stock=paying_stock1, isUsed=True, dateUsed=before_cutoff)
-        bookings_factories.BookingFactory(user=beneficiary, stock=paying_stock2, isUsed=True, dateUsed=before_cutoff)
-        bookings_factories.BookingFactory(user=beneficiary, stock=free_stock1, isUsed=True, dateUsed=before_cutoff)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock1, dateUsed=before_cutoff)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock1, dateUsed=before_cutoff)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock2, dateUsed=before_cutoff)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=free_stock1, dateUsed=before_cutoff)
 
         # When
         generate_new_payments(cutoff, batch_date=datetime.datetime.now())
@@ -130,15 +119,9 @@ class GenerateNewPaymentsTest:
         beneficiary.deposit.amount = 50000
         repository.save(beneficiary.deposit)
 
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock1, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock2, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock3, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock1, dateUsed=before_cutoff, quantity=1)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock2, dateUsed=before_cutoff, quantity=1)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock3, dateUsed=before_cutoff, quantity=1)
 
         # When
         generate_new_payments(cutoff, batch_date=datetime.datetime.now())
@@ -173,15 +156,9 @@ class GenerateNewPaymentsTest:
         beneficiary.deposit.amount = 50000
         repository.save(beneficiary.deposit)
 
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock1, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock2, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock3, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock1, dateUsed=before_cutoff, quantity=1)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock2, dateUsed=before_cutoff, quantity=1)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock3, dateUsed=before_cutoff, quantity=1)
 
         # When
         generate_new_payments(cutoff, batch_date=datetime.datetime.now())
@@ -214,12 +191,8 @@ class GenerateNewPaymentsTest:
         beneficiary.deposit.amount = 50000
         repository.save(beneficiary.deposit)
 
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock1, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock2, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock1, dateUsed=before_cutoff, quantity=1)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock2, dateUsed=before_cutoff, quantity=1)
 
         # When
         generate_new_payments(cutoff, batch_date=datetime.datetime.now())
@@ -254,15 +227,9 @@ class GenerateNewPaymentsTest:
         beneficiary.deposit.amount = 50000
         repository.save(beneficiary.deposit)
 
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock1, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock2, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock3, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock1, dateUsed=before_cutoff, quantity=1)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock2, dateUsed=before_cutoff, quantity=1)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock3, dateUsed=before_cutoff, quantity=1)
 
         # When
         generate_new_payments(cutoff, batch_date=datetime.datetime.now())
@@ -298,15 +265,9 @@ class GenerateNewPaymentsTest:
         beneficiary.deposit.amount = 80000
         repository.save(beneficiary.deposit)
 
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock1, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock2, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock3, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock1, dateUsed=before_cutoff, quantity=1)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock2, dateUsed=before_cutoff, quantity=1)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock3, dateUsed=before_cutoff, quantity=1)
 
         # When
         generate_new_payments(cutoff, batch_date=datetime.datetime.now())
@@ -342,15 +303,9 @@ class GenerateNewPaymentsTest:
         beneficiary.deposit.amount = 120000
         repository.save(beneficiary.deposit)
 
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock1, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock2, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
-        bookings_factories.BookingFactory(
-            user=beneficiary, stock=paying_stock3, isUsed=True, dateUsed=before_cutoff, quantity=1
-        )
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock1, dateUsed=before_cutoff, quantity=1)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock2, dateUsed=before_cutoff, quantity=1)
+        bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock3, dateUsed=before_cutoff, quantity=1)
 
         # When
         generate_new_payments(cutoff, batch_date=datetime.datetime.now())
@@ -365,9 +320,7 @@ class GenerateNewPaymentsTest:
     def test_use_custom_reimbursement_rule(self):
         offer = offers_factories.DigitalOfferFactory()
         offers_factories.BankInformationFactory(venue=offer.venue, iban="iban1", bic="bic1")
-        bookings_factories.BookingFactory(
-            amount=10, quantity=2, isUsed=True, dateUsed=datetime.datetime.now(), stock__offer=offer
-        )
+        bookings_factories.UsedBookingFactory(amount=10, quantity=2, stock__offer=offer)
         rule = payments_factories.CustomReimbursementRuleFactory(offer=offer, amount=7)
 
         cutoff = batch_date = datetime.datetime.now()

--- a/tests/scripts/stock/fully_sync_venue_test.py
+++ b/tests/scripts/stock/fully_sync_venue_test.py
@@ -2,7 +2,6 @@ import pytest
 import requests_mock
 
 import pcapi.core.bookings.factories as bookings_factories
-from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
@@ -80,12 +79,10 @@ def test_reset_stock_quantity():
     venue = offer.venue
     stock1_no_bookings = offers_factories.StockFactory(offer=offer, quantity=10)
     stock2_only_cancelled_bookings = offers_factories.StockFactory(offer=offer, quantity=10)
-    bookings_factories.BookingFactory(
-        stock=stock2_only_cancelled_bookings, isCancelled=True, status=BookingStatus.CANCELLED
-    )
+    bookings_factories.CancelledBookingFactory(stock=stock2_only_cancelled_bookings)
     stock3_mix_of_bookings = offers_factories.StockFactory(offer=offer, quantity=10)
     bookings_factories.BookingFactory(stock=stock3_mix_of_bookings)
-    bookings_factories.BookingFactory(stock=stock3_mix_of_bookings, isCancelled=True, status=BookingStatus.CANCELLED)
+    bookings_factories.CancelledBookingFactory(stock=stock3_mix_of_bookings)
     manually_added_offer = offers_factories.OfferFactory(venue=venue)
     stock4_manually_added = offers_factories.StockFactory(offer=manually_added_offer, quantity=10)
     stock5_other_venue = offers_factories.StockFactory(quantity=10)

--- a/tests/scripts/stock/soft_delete_stock_test.py
+++ b/tests/scripts/stock/soft_delete_stock_test.py
@@ -9,9 +9,9 @@ from pcapi.scripts.stock.soft_delete_stock import soft_delete_stock
 
 class SoftDeleteStockTest:
     @pytest.mark.usefixtures("db_session")
-    def should_return_ko_if_at_least_one_booking_is_used(self, app):
+    def should_return_ko_if_at_least_one_booking_is_used(self):
         # Given
-        booking = bookings_factories.BookingFactory(isUsed=True, status=BookingStatus.USED)
+        booking = bookings_factories.UsedBookingFactory()
 
         # When
         soft_delete_stock(booking.stock.id)
@@ -20,19 +20,18 @@ class SoftDeleteStockTest:
         assert not booking.stock.isSoftDeleted
 
     @pytest.mark.usefixtures("db_session")
-    def should_return_ko_if_at_least_one_booking_has_payments(self, app):
+    def should_return_ko_if_at_least_one_booking_has_payments(self):
         # Given
-        booking = bookings_factories.BookingFactory(isUsed=True, status=BookingStatus.USED)
-        payment = payment_factories.PaymentFactory(booking=booking)
+        booking = payment_factories.PaymentFactory().booking
 
         # When
-        soft_delete_stock(payment.booking.stock.id)
+        soft_delete_stock(booking.stock.id)
 
         # Then
         assert not booking.stock.isSoftDeleted
 
     @pytest.mark.usefixtures("db_session")
-    def should_return_ok_if_stock_has_no_bookings_and_soft_delete_it(self, app):
+    def should_return_ok_if_stock_has_no_bookings_and_soft_delete_it(self):
         # Given
         stock = offer_factories.StockFactory()
 
@@ -43,7 +42,7 @@ class SoftDeleteStockTest:
         assert stock.isSoftDeleted
 
     @pytest.mark.usefixtures("db_session")
-    def should_cancel_every_bookings_for_target_stock(self, app):
+    def should_cancel_every_bookings_for_target_stock(self):
         # Given
         booking = bookings_factories.BookingFactory()
 

--- a/tests/scripts/suspend_suspected_fraudulent_beneficiary_users_test.py
+++ b/tests/scripts/suspend_suspected_fraudulent_beneficiary_users_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import UsedBookingFactory
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.users.factories import AdminFactory
 from pcapi.core.users.factories import BeneficiaryFactory
@@ -53,7 +54,7 @@ class SuspendFraudulentBeneficiaryUsersByEmailProvidersTest:
         fraudulent_emails_providers = ["example.com"]
         admin_user = AdminFactory()
         fraudulent_user = BeneficiaryFactory(email="jesuisunefraude@example.com")
-        uncancellable_booking = BookingFactory(user=fraudulent_user, stock__price=1, isUsed=True)
+        uncancellable_booking = UsedBookingFactory(user=fraudulent_user, stock__price=1)
 
         # When
         suspend_fraudulent_beneficiary_users_by_email_providers(

--- a/tests/scripts/update_bookings_during_quarantine_test.py
+++ b/tests/scripts/update_bookings_during_quarantine_test.py
@@ -11,7 +11,7 @@ from pcapi.scripts.cancel_bookings_during_quarantine import cancel_booking_statu
 @pytest.mark.usefixtures("db_session")
 def test_should_update_booking_if_happening_during_quarantine():
     yesterday = datetime.utcnow() - timedelta(days=1)
-    bookings_factories.BookingFactory(isUsed=True, stock__beginningDatetime=yesterday)
+    bookings_factories.UsedBookingFactory(stock__beginningDatetime=yesterday)
 
     cancel_booking_status_for_events_happening_during_quarantine()
 
@@ -23,7 +23,7 @@ def test_should_update_booking_if_happening_during_quarantine():
 @pytest.mark.usefixtures("db_session")
 def test_should_not_update_booking_if_happened_before_quarantine():
     long_ago = datetime(2018, 1, 1)
-    bookings_factories.BookingFactory(isUsed=True, dateUsed=long_ago, stock__beginningDatetime=long_ago)
+    bookings_factories.UsedBookingFactory(dateUsed=long_ago, stock__beginningDatetime=long_ago)
 
     cancel_booking_status_for_events_happening_during_quarantine()
 


### PR DESCRIPTION
**Commits à relire séparément.**

J'en ai profité pour faire du nettoyage et, surtout, introduire 2 nouvelles factories `UsedBookingFactory` et `CancelledBookingFactory` qui simplifie sensiblement l'écriture des tests (et s'assurent qu'on définit bien tous les attributs relatifs à l'utilisation ou l'annulation d'une réservation, car il y en a plusieurs).