### PR TITLE
(PC-10260) Use new format for webapp offer URL when webapp v2 is enabled

### DIFF
--- a/src/pcapi/core/offers/utils.py
+++ b/src/pcapi/core/offers/utils.py
@@ -1,7 +1,11 @@
+from pcapi import settings
 from pcapi.core.offers.models import Offer
+from pcapi.models.feature import FeatureToggle
 from pcapi.utils.human_ids import humanize
-from pcapi.utils.urls import get_webapp_url
+from pcapi.utils.urls import generate_firebase_dynamic_link
 
 
 def offer_webapp_link(offer: Offer) -> str:
-    return f"{get_webapp_url()}/offre/details/{humanize(offer.id)}"
+    if FeatureToggle.WEBAPP_V2_ENABLED.is_active():
+        return generate_firebase_dynamic_link(path=f"offre/{offer.id}", params=None)
+    return f"{settings.WEBAPP_URL}/offre/details/{humanize(offer.id)}"

--- a/src/pcapi/routes/adage/v1/serialization/prebooking.py
+++ b/src/pcapi/routes/adage/v1/serialization/prebooking.py
@@ -8,14 +8,13 @@ from pydantic.fields import Field
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.educational.models import EducationalBooking
 from pcapi.core.educational.models import EducationalBookingStatus
+from pcapi.core.offers.utils import offer_webapp_link
 from pcapi.routes.adage.v1.serialization.config import AdageBaseResponseModel
 from pcapi.routes.native.v1.serialization.common_models import Coordinates
 from pcapi.routes.native.v1.serialization.offers import OfferCategoryResponse
 from pcapi.routes.native.v1.serialization.offers import OfferImageResponse
 from pcapi.routes.native.v1.serialization.offers import get_serialized_offer_category
 from pcapi.serialization.utils import to_camel
-from pcapi.utils.human_ids import humanize
-from pcapi.utils.urls import get_webapp_url
 
 
 class GetEducationalBookingsRequest(BaseModel):
@@ -131,7 +130,7 @@ def serialize_educational_booking(educational_booking: EducationalBooking) -> Ed
         status=get_education_booking_status(educational_booking),
         venueTimezone=venue.timezone,
         totalAmount=booking.total_amount,
-        url=f"{get_webapp_url()}/accueil/details/{humanize(offer.id)}",
+        url=offer_webapp_link(offer),
         withdrawalDetails=offer.withdrawalDetails,
     )
 

--- a/src/pcapi/utils/mailing.py
+++ b/src/pcapi/utils/mailing.py
@@ -10,6 +10,7 @@ from pcapi import settings
 from pcapi.connectors import api_entreprises
 from pcapi.core.bookings.repository import find_ongoing_bookings_by_stock
 from pcapi.core.offerers.models import Offerer
+from pcapi.core.offers.utils import offer_webapp_link
 from pcapi.core.users.models import User
 from pcapi.domain.postal_code.postal_code import PostalCode
 from pcapi.models import Booking
@@ -239,10 +240,10 @@ def make_wallet_balances_email(csv: str) -> dict:
 
 def make_offer_creation_notification_email(offer: Offer) -> dict:
     author = offer.author or offer.venue.managingOfferer.UserOfferers[0].user
-    pro_link_to_offer = f"{settings.PRO_URL}/offres/{humanize(offer.id)}/edition"
-    webapp_link_to_offer = f"{get_webapp_url()}/offre/details/{humanize(offer.id)}"
     venue = offer.venue
+    pro_link_to_offer = f"{settings.PRO_URL}/offres/{humanize(offer.id)}/edition"
     pro_venue_link = f"{settings.PRO_URL}/structures/{humanize(venue.managingOffererId)}/lieux/{humanize(venue.id)}"
+    webapp_link_to_offer = offer_webapp_link(offer)
     html = render_template(
         "mails/offer_creation_notification_email.html",
         offer=offer,

--- a/src/pcapi/utils/urls.py
+++ b/src/pcapi/utils/urls.py
@@ -17,8 +17,10 @@ def get_webapp_url() -> Optional[str]:
     return settings.WEBAPP_URL
 
 
-def generate_firebase_dynamic_link(path: str, params: dict) -> str:
-    universal_link_query_string = urlencode(params)
-    universal_link_url = f"{get_webapp_for_native_redirection_url()}/{path}?{universal_link_query_string}"
+def generate_firebase_dynamic_link(path: str, params: Optional[dict]) -> str:
+    universal_link_url = f"{get_webapp_for_native_redirection_url()}/{path}"
+    if params:
+        universal_link_url = universal_link_url + f"?{urlencode(params)}"
+
     firebase_dynamic_query_string = urlencode({"link": universal_link_url})
     return f"{settings.FIREBASE_DYNAMIC_LINKS_URL}/?{firebase_dynamic_query_string}"

--- a/tests/core/offers/test_utils.py
+++ b/tests/core/offers/test_utils.py
@@ -1,0 +1,20 @@
+from pcapi import settings
+import pcapi.core.offers.factories as offers_factories
+from pcapi.core.offers.utils import offer_webapp_link
+from pcapi.core.testing import override_features
+from pcapi.utils.human_ids import humanize
+from pcapi.utils.urls import generate_firebase_dynamic_link
+
+
+class OffersUtilsTest:
+    @override_features(WEBAPP_V2_ENABLED=False)
+    def test_offer_webapp_link_when_webapp_V2_not_enabled(self):
+        offer = offers_factories.OffererFactory()
+        link = offer_webapp_link(offer)
+        assert link == f"{settings.WEBAPP_URL}/offre/details/{humanize(offer.id)}"
+
+    @override_features(WEBAPP_V2_ENABLED=True)
+    def test_offer_webapp_link_when_webapp_V2_enabled(self):
+        offer = offers_factories.OffererFactory()
+        link = offer_webapp_link(offer)
+        assert link == generate_firebase_dynamic_link(path=f"offre/{offer.id}", params=None)

--- a/tests/routes/adage/v1/confirm_prebooking_test.py
+++ b/tests/routes/adage/v1/confirm_prebooking_test.py
@@ -9,10 +9,9 @@ from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalRedactorFactory
 from pcapi.core.educational.factories import EducationalYearFactory
 from pcapi.core.educational.models import EducationalDeposit
+from pcapi.core.offers.utils import offer_webapp_link
 from pcapi.routes.native.v1.serialization.offers import get_serialized_offer_category
 from pcapi.utils.date import format_into_utc_date
-from pcapi.utils.human_ids import humanize
-from pcapi.utils.urls import get_webapp_url
 
 from tests.conftest import TestClient
 
@@ -96,7 +95,7 @@ class Returns200Test:
             "status": "CONFIRMED",
             "venueTimezone": venue.timezone,
             "totalAmount": booking.total_amount,
-            "url": f"{get_webapp_url()}/accueil/details/{humanize(offer.id)}",
+            "url": offer_webapp_link(offer),
             "withdrawalDetails": offer.withdrawalDetails,
         }
         assert Booking.query.filter(Booking.id == booking.id).one().status == BookingStatus.CONFIRMED

--- a/tests/routes/adage/v1/get_educational_institution_test.py
+++ b/tests/routes/adage/v1/get_educational_institution_test.py
@@ -6,9 +6,9 @@ from pcapi.core.educational.factories import EducationalDepositFactory
 from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalRedactorFactory
 from pcapi.core.educational.factories import EducationalYearFactory
+from pcapi.core.offers.utils import offer_webapp_link
 from pcapi.routes.native.v1.serialization.offers import get_serialized_offer_category
 from pcapi.utils.date import format_into_utc_date
-from pcapi.utils.human_ids import humanize
 
 from tests.conftest import TestClient
 
@@ -106,7 +106,7 @@ class Returns200Test:
                     "status": "CONFIRMED",
                     "venueTimezone": venue.timezone,
                     "totalAmount": booking.amount * booking.quantity,
-                    "url": f"{settings.WEBAPP_URL}/accueil/details/{humanize(offer.id)}",
+                    "url": offer_webapp_link(offer),
                     "withdrawalDetails": offer.withdrawalDetails,
                 }
             ],

--- a/tests/routes/adage/v1/get_prebookings_test.py
+++ b/tests/routes/adage/v1/get_prebookings_test.py
@@ -4,10 +4,9 @@ from pcapi.core.bookings.factories import EducationalBookingFactory
 from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalRedactorFactory
 from pcapi.core.educational.factories import EducationalYearFactory
+from pcapi.core.offers.utils import offer_webapp_link
 from pcapi.routes.native.v1.serialization.offers import get_serialized_offer_category
 from pcapi.utils.date import format_into_utc_date
-from pcapi.utils.human_ids import humanize
-from pcapi.utils.urls import get_webapp_url
 
 from tests.conftest import TestClient
 
@@ -82,7 +81,7 @@ class Returns200Test:
                     "status": "CONFIRMED",
                     "venueTimezone": venue.timezone,
                     "totalAmount": booking.amount * booking.quantity,
-                    "url": f"{get_webapp_url()}/accueil/details/{humanize(offer.id)}",
+                    "url": offer_webapp_link(offer),
                     "withdrawalDetails": offer.withdrawalDetails,
                 }
             ],
@@ -172,7 +171,7 @@ class Returns200Test:
                     "status": "USED_BY_INSTITUTE",
                     "venueTimezone": venue.timezone,
                     "totalAmount": booking.total_amount,
-                    "url": f"{get_webapp_url()}/accueil/details/{humanize(offer.id)}",
+                    "url": offer_webapp_link(offer),
                     "withdrawalDetails": offer.withdrawalDetails,
                 }
             ],

--- a/tests/routes/adage/v1/mark_prebookings_as_used_test.py
+++ b/tests/routes/adage/v1/mark_prebookings_as_used_test.py
@@ -3,10 +3,9 @@ import pytest
 from pcapi.core.bookings.factories import EducationalBookingFactory
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.educational.factories import EducationalRedactorFactory
+from pcapi.core.offers.utils import offer_webapp_link
 from pcapi.routes.native.v1.serialization.offers import get_serialized_offer_category
 from pcapi.utils.date import format_into_utc_date
-from pcapi.utils.human_ids import humanize
-from pcapi.utils.urls import get_webapp_url
 
 from tests.conftest import TestClient
 
@@ -70,7 +69,7 @@ class Returns200Test:
             "status": "USED_BY_INSTITUTE",
             "venueTimezone": venue.timezone,
             "totalAmount": booking.total_amount,
-            "url": f"{get_webapp_url()}/accueil/details/{humanize(offer.id)}",
+            "url": offer_webapp_link(offer),
             "withdrawalDetails": offer.withdrawalDetails,
         }
 

--- a/tests/routes/adage/v1/refuse_prebookings_as_used_test.py
+++ b/tests/routes/adage/v1/refuse_prebookings_as_used_test.py
@@ -9,10 +9,9 @@ from pcapi.core.educational.factories import EducationalRedactorFactory
 from pcapi.core.educational.models import EducationalBookingStatus
 from pcapi.core.offers.factories import EventStockFactory
 from pcapi.core.offers.models import Stock
+from pcapi.core.offers.utils import offer_webapp_link
 from pcapi.routes.native.v1.serialization.offers import get_serialized_offer_category
 from pcapi.utils.date import format_into_utc_date
-from pcapi.utils.human_ids import humanize
-from pcapi.utils.urls import get_webapp_url
 
 from tests.conftest import TestClient
 
@@ -81,7 +80,7 @@ class Returns200Test:
             "status": "REFUSED",
             "venueTimezone": venue.timezone,
             "totalAmount": booking.total_amount,
-            "url": f"{get_webapp_url()}/accueil/details/{humanize(offer.id)}",
+            "url": offer_webapp_link(offer),
             "withdrawalDetails": offer.withdrawalDetails,
         }
 

--- a/tests/utils/urls_test.py
+++ b/tests/utils/urls_test.py
@@ -4,7 +4,14 @@ from pcapi.utils import urls as utils
 
 
 class FirebaseLinksTest:
-    def test_generate_firebase_dynamic_link(self):
+    def test_generate_firebase_dynamic_link_without_params(self):
+        url = utils.generate_firebase_dynamic_link(path="signup-confirmation", params=None)
+        assert url == (
+            "https://passcultureapptestauto.page.link/"
+            "?link=https%3A%2F%2Fapp.passculture-testing.beta.gouv.fr%2Fsignup-confirmation"
+        )
+
+    def test_generate_firebase_dynamic_link_with_params(self):
         url = utils.generate_firebase_dynamic_link(
             path="signup-confirmation",
             params={


### PR DESCRIPTION
The new webapp will have the following format for its offers pages : `/offre/:not_humanized_offer_id`, therefore we have to adapt for it.