### PR TITLE
Pc 9952 update token workflow

### DIFF
--- a/src/pcapi/routes/native/v1/authentication.py
+++ b/src/pcapi/routes/native/v1/authentication.py
@@ -89,9 +89,7 @@ def request_password_reset(body: RequestPasswordResetRequest) -> None:
 def reset_password(body: ResetPasswordRequest) -> None:
     check_password_strength("newPassword", body.new_password)
 
-    user = users_repo.get_user_with_valid_token(
-        body.reset_password_token, [TokenType.RESET_PASSWORD], delete_token=True
-    )
+    user = users_repo.get_user_with_valid_token(body.reset_password_token, [TokenType.RESET_PASSWORD])
 
     if not user:
         raise ApiErrors({"token": ["Le token de changement de mot de passe est invalide."]})
@@ -124,7 +122,9 @@ def change_password(user: User, body: ChangePasswordRequest) -> None:
 @blueprint.native_v1.route("/validate_email", methods=["POST"])
 @spectree_serialize(on_success_status=200, api=blueprint.api, response_model=ValidateEmailResponse)
 def validate_email(body: ValidateEmailRequest) -> ValidateEmailResponse:
-    user = users_repo.get_user_with_valid_token(body.email_validation_token, [TokenType.EMAIL_VALIDATION])
+    user = users_repo.get_user_with_valid_token(
+        body.email_validation_token, [TokenType.EMAIL_VALIDATION], use_token=False
+    )
 
     if not user:
         raise ApiErrors({"token": ["Le token de validation d'email est invalide."]})

--- a/src/pcapi/routes/shared/passwords.py
+++ b/src/pcapi/routes/shared/passwords.py
@@ -83,7 +83,7 @@ def post_new_password():
 
     check_password_strength("newPassword", new_password)
 
-    user = users_repo.get_user_with_valid_token(token, [TokenType.RESET_PASSWORD], delete_token=True)
+    user = users_repo.get_user_with_valid_token(token, [TokenType.RESET_PASSWORD])
 
     if not user:
         errors = ApiErrors()

--- a/src/pcapi/routes/shared/users.py
+++ b/src/pcapi/routes/shared/users.py
@@ -31,7 +31,7 @@ def get_profile():
 # @debt api-migration
 @private_api.route("/users/token/<token>", methods=["GET"])
 def check_activation_token_exists(token):
-    user = users_repo.get_user_with_valid_token(token, [TokenType.RESET_PASSWORD])
+    user = users_repo.get_user_with_valid_token(token, [TokenType.RESET_PASSWORD], use_token=False)
     if user is None:
         return jsonify(), 404
 

--- a/tests/routes/native/v1/authentication_test.py
+++ b/tests/routes/native/v1/authentication_test.py
@@ -202,7 +202,9 @@ def test_reset_password_success(app):
     assert response.status_code == 204
     db.session.refresh(user)
     assert user.password == crypto.hash_password(new_password)
-    assert Token.query.get(token.id) is None
+
+    token = Token.query.get(token.id)
+    assert token.isUsed
 
 
 def test_reset_password_for_unvalidated_email(app):
@@ -288,7 +290,7 @@ def test_validate_email_with_invalid_token(mock_get_user_with_valid_token, app):
 
     response = TestClient(app.test_client()).post("/native/v1/validate_email", json={"email_validation_token": token})
 
-    mock_get_user_with_valid_token.assert_called_once_with(token, [TokenType.EMAIL_VALIDATION])
+    mock_get_user_with_valid_token.assert_called_once_with(token, [TokenType.EMAIL_VALIDATION], use_token=False)
 
     assert response.status_code == 400
 

--- a/tests/routes/shared/post_new_password_test.py
+++ b/tests/routes/shared/post_new_password_test.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import pytest
 
 from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models
 from pcapi.core.users import testing as users_testing
 from pcapi.core.users.models import TokenType
 from pcapi.notifications.push import testing as push_testing
@@ -22,7 +23,10 @@ def test_change_password(app):
 
     assert response.status_code == 204
     assert user.checkPassword("N3W_p4ssw0rd")
-    assert len(user.tokens) == 0
+
+    assert len(user.tokens) == 1
+    token = models.Token.query.get(token.id)
+    assert token.isUsed
 
 
 @pytest.mark.usefixtures("db_session")
@@ -36,8 +40,9 @@ def test_change_password_validates_email(app):
 
     assert response.status_code == 204
     assert user.checkPassword("N3W_p4ssw0rd")
-    assert len(user.tokens) == 0
-    assert user.isEmailValidated
+    assert len(user.tokens) == 1
+    token = models.Token.query.get(token.id)
+    assert token.isUsed
 
     # One call should be sent to batch, and one to sendinblue
     assert len(push_testing.requests) == 1


### PR DESCRIPTION
Besoin

Unifier la manière d'utiliser les token à usage unique : le marquer comme utilisé dans les cas suivants 

* ré-initialisation du mot de passe ;
* id-check (comportement actuel)

**Note**

Reste la méthode `check_activation_token_exists` et la route `GET /users/token/<token>` : est-ce qu'on veut vraiment la garder, à quoi sert-elle ?

L'activation de l'email sera corrigée plus tard.