### PR TITLE
(PC-10481) Fix get /bookings route when an ended booking has no endDate

### DIFF
--- a/src/pcapi/routes/native/v1/bookings.py
+++ b/src/pcapi/routes/native/v1/bookings.py
@@ -118,7 +118,7 @@ def get_bookings(user: User) -> BookingsResponse:
             BookingReponse.from_orm(booking)
             for booking in sorted(
                 ended_bookings,
-                key=lambda b: b.stock.beginningDatetime or b.dateUsed or b.cancellationDate,
+                key=lambda b: b.stock.beginningDatetime or b.dateUsed or b.cancellationDate or datetime.min,
                 reverse=True,
             )
         ],


### PR DESCRIPTION
This is related to the issue https://sentry.internal-passculture.app/organizations/sentry/issues/118348. The bug occured when a booking is used but has not dateUsed, which is not supposed to happen. We have to fix this root cause (in production, there are 1625 bookings used but without dateUsed) but this PR provides a quick fix for this route issue.