### PR TITLE
(PC-10078) add new venue information to GET /venue/<venue_id>

### DIFF
--- a/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -1,6 +1,7 @@
 import typing
 
 from pcapi.core.offerers import models as offerers_models
+from pcapi.routes.serialization import venues_serialize
 from pcapi.serialization.utils import to_camel
 
 from . import BaseModel
@@ -24,3 +25,9 @@ class VenueResponse(BaseModel):
     address: typing.Optional[str]
     postalCode: typing.Optional[str]
     venueTypeCode: typing.Optional[offerers_models.VenueTypeCode]
+    description: typing.Optional[venues_serialize.VenueDescription]  # type: ignore
+    audioDisabilityCompliant: typing.Optional[bool]
+    mentalDisabilityCompliant: typing.Optional[bool]
+    motorDisabilityCompliant: typing.Optional[bool]
+    visualDisabilityCompliant: typing.Optional[bool]
+    contact: typing.Optional[venues_serialize.VenueContactModel]

--- a/src/pcapi/routes/serialization/venues_serialize.py
+++ b/src/pcapi/routes/serialization/venues_serialize.py
@@ -134,6 +134,9 @@ class VenueContactModel(BaseModel):
             raise ValueError(f"numéro de téléphone invalide: {phone_number}")
 
 
+VenueDescription = pydantic.constr(max_length=1000, strip_whitespace=True)
+
+
 class GetVenueResponseModel(BaseModel):
     address: Optional[str]
     bic: Optional[str]
@@ -190,7 +193,7 @@ class EditVenueBodyModel(BaseModel):
     withdrawalDetails: Optional[str]
     isWithdrawalAppliedOnAllOffers: Optional[bool]
     isEmailAppliedOnAllOffers: Optional[bool]
-    description: Optional[pydantic.constr(max_length=1000, strip_whitespace=True)]  # type: ignore
+    description: Optional[VenueDescription]  # type: ignore
     audioDisabilityCompliant: Optional[bool]
     mentalDisabilityCompliant: Optional[bool]
     motorDisabilityCompliant: Optional[bool]

--- a/tests/routes/native/v1/offerers_test.py
+++ b/tests/routes/native/v1/offerers_test.py
@@ -26,6 +26,17 @@ class VenuesTest:
             "address": venue.address,
             "postalCode": venue.postalCode,
             "venueTypeCode": venue.venueTypeCode.value,
+            "description": venue.description,
+            "audioDisabilityCompliant": venue.audioDisabilityCompliant,
+            "mentalDisabilityCompliant": venue.mentalDisabilityCompliant,
+            "motorDisabilityCompliant": venue.motorDisabilityCompliant,
+            "visualDisabilityCompliant": venue.visualDisabilityCompliant,
+            "contact": {
+                "email": venue.contact.email,
+                "phoneNumber": venue.contact.phone_number,
+                "website": venue.contact.website,
+                "socialMedias": venue.contact.social_medias,
+            },
         }
 
     def test_get_non_existing_venue(self, client):


### PR DESCRIPTION
**Besoin**

Renvoyer les nouvelles informations d'un lieu  :

* description ;
* informations d'accessibilité ;
* informations de contact

**Contexte**

Ces informations ont été ajoutée par ces deux PRs récentes : 

* [(PC-10269) add contact to venue](https://github.com/pass-culture/pass-culture-api/pull/2947)
* [(PC-10404) add description and accessibility to Venue](https://github.com/pass-culture/pass-culture-api/pull/2977)