### PR TITLE
(PC-10444) Fix cloud task payload conversion from pydantic to json

### DIFF
--- a/src/pcapi/tasks/decorator.py
+++ b/src/pcapi/tasks/decorator.py
@@ -1,4 +1,5 @@
 from functools import wraps
+import json
 import logging
 
 from flask.blueprints import Blueprint
@@ -33,7 +34,7 @@ def task(queue: str, path: str):
                 return
 
             if isinstance(payload, pydantic.BaseModel):
-                payload = payload.dict()
+                payload = json.loads(payload.json())
 
             task_id = _enqueue_task(queue, path, payload)
             logger.info("Enqueued cloud task", extra={"queue": queue, "handler": path, "task": task_id})


### PR DESCRIPTION
We need to use `json.loads(payload.json())` because payload.dict() does not output a json but a dict where values could be datetime objects which lead to a TypeError(f'Object of type {o.__class__.__name__} ' is not JSON serializable')