### PR TITLE
(PC-10994) run e2e tests on commits to master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,12 +461,6 @@ jobs:
             yarn test:cafe
       - store_artifacts:
           path: ~/pass-culture-main/webapp/testcafe_screenshots
-      - run:
-          name: Notify PC Ops Bot
-          when: on_fail
-          command: |
-            export BOT_MESSAGE="'Build *$CIRCLE_JOB* fail : $CIRCLE_BUILD_URL'"
-            curl -X POST -H 'Content-type: application/json' --data "{'text': $BOT_MESSAGE}" $SLACK_OPS_BOT_URL
 
   functional-tests-pro:
     machine:
@@ -526,12 +520,6 @@ jobs:
             yarn test:cafe
       - store_artifacts:
           path: ~/pass-culture-main/pro/testcafe_screenshots
-      - run:
-          name: Notify PC Ops Bot
-          when: on_fail
-          command: |
-            export BOT_MESSAGE="'Build *$CIRCLE_JOB* fail : $CIRCLE_BUILD_URL'"
-            curl -X POST -H 'Content-type: application/json' --data "{'text': $BOT_MESSAGE}" $SLACK_OPS_BOT_URL
 
   restart-pcapi:
     executor: gcp-sdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,3 +606,22 @@ workflows:
       - quality:
           context: Slack
           <<: *slack-fail-post-step
+
+  e2e:
+    jobs:
+      - functional-tests-webapp:
+          name: "Run webapp e2e tests after commit to master"
+          filters:
+            branches:
+              only:
+                - master
+          context: Slack
+          <<: *slack-fail-post-step
+      - functional-tests-pro:
+          name: "Run pro e2e tests after commit to master"
+          filters:
+            branches:
+              only:
+                - master
+          context: Slack
+          <<: *slack-fail-post-step

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,37 +12,7 @@ slack-fail-post-step: &slack-fail-post-step
     - slack/notify:
         event: fail
         channel: shérif
-        custom: |
-          {
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Oups, `nightly` a eu un soucis cette nuit :pleurs:"
-                },
-                "accessory": {
-                  "type": "image",
-                  "image_url": "https://upload.wikimedia.org/wikipedia/commons/f/f3/Airport-firefighters-drill.jpg",
-                  "alt_text": "Nightly down"
-                }
-              },
-              {
-                "type": "actions",
-                "elements": [
-                  {
-                    "type": "button",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "View job",
-                      "emoji": true
-                    },
-                    "url": "$CIRCLE_BUILD_URL"
-                  }
-                ]
-              }
-            ]
-          }
+        template: basic_fail_1
 
 slack-send-deployment-notification: &slack-send-deployment-notification
   - slack/notify:


### PR DESCRIPTION
##  Objectif

Lancer les tests e2e de pro et webapp lorsque l'on commit sur master, afin de détecter plus rapidement et précisément les effets de bord, sans bloquer le deploy

##  Implémentation

- modifier la config circleci afin de jouer les 2 jobs de tests e2e
- notifier sur le canal shérif les échecs de ces jobs

##  Informations supplémentaires

TODO avant merge de PR:

- [x] changer le nom de la branche dans la config (fseguin/poc-ci -> master)
- [x] changer le canal de notifications
- [x] supprimer le commit qui casse volontairement le backend :)
- [x] discuter de ce changement avec les devs, en particulier backend
