### PR TITLE
(PC-9687) providers: fix Offer creation when syncing stocks

### DIFF
--- a/src/pcapi/core/providers/api.py
+++ b/src/pcapi/core/providers/api.py
@@ -291,6 +291,7 @@ def _build_new_offer(
         productId=product.id,
         venueId=venue.id,
         type=product.type,
+        subcategoryId=product.subcategoryId,
         withdrawalDetails=venue.withdrawalDetails,
     )
 

--- a/tests/core/providers/test_api.py
+++ b/tests/core/providers/test_api.py
@@ -161,7 +161,12 @@ class SynchronizeStocksTest:
         provider = offerers_factories.APIProviderFactory(apiUrl="https://provider_url", authToken="fake_token")
         venue = VenueFactory(bookingEmail="booking_email", withdrawalDetails="My withdrawal details")
         product = Product(
-            id=456, name="product_name", description="product_desc", extraData="extra", type="product_type"
+            id=456,
+            name="product_name",
+            description="product_desc",
+            extraData="extra",
+            type="ThingType.LIVRE_EDITION",
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
         )
         products_by_provider_reference = {"isbn_product_ref": product}
 
@@ -185,7 +190,8 @@ class SynchronizeStocksTest:
                 name="product_name",
                 productId=456,
                 venueId=venue.id,
-                type="product_type",
+                type="ThingType.LIVRE_EDITION",
+                subcategoryId=subcategories.LIVRE_PAPIER.id,
                 withdrawalDetails=venue.withdrawalDetails,
             ),
         ]
@@ -199,7 +205,8 @@ class SynchronizeStocksTest:
         assert new_offer.name == "product_name"
         assert new_offer.productId == 456
         assert new_offer.venueId == venue.id
-        assert new_offer.type == "product_type"
+        assert new_offer.type == "ThingType.LIVRE_EDITION"
+        assert new_offer.subcategoryId == subcategories.LIVRE_PAPIER.id
         assert new_offer.withdrawalDetails == venue.withdrawalDetails
 
     def test_get_stocks_to_upsert(self):

--- a/tests/local_providers/local_provider_test.py
+++ b/tests/local_providers/local_provider_test.py
@@ -189,6 +189,7 @@ class CreateObjectTest:
         assert isinstance(product, Product)
         assert product.name == "New Product"
         assert product.type == str(ThingType.LIVRE_EDITION)
+        assert product.subcategoryId == subcategories.LIVRE_PAPIER.id
         assert product.lastProviderId == provider.id
 
     def test_raises_api_errors_exception_when_errors_occur_on_model_and_log_error(self):
@@ -231,6 +232,7 @@ class HandleUpdateTest:
         product = Product.query.one()
         assert product.name == "New Product"
         assert product.type == str(ThingType.LIVRE_EDITION)
+        assert product.subcategoryId == subcategories.LIVRE_PAPIER.id
 
     def test_raises_api_errors_exception_when_errors_occur_on_model(self):
         # Given

--- a/tests/local_providers/titelive_things_test.py
+++ b/tests/local_providers/titelive_things_test.py
@@ -103,6 +103,7 @@ class TiteliveThingsTest:
         product = Product.query.one()
         assert product.extraData.get("bookFormat") == BookFormat.BEAUX_LIVRES.value
         assert product.type == "ThingType.LIVRE_EDITION"
+        assert product.subcategoryId == subcategories.LIVRE_PAPIER.id
         assert product.extraData.get("isbn") == "9782895026310"
 
     @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
##  Objectif

Enregistrer la `subcategoryId` d'une offre lors de sa création pendant une synchronisation de stocks

##  Implémentation

- modification de `_build_new_offer()`
- ajout de tests manquants
