### PR TITLE
BSR - make date of birth relative in beneficary factory to always com…

### DIFF
--- a/src/pcapi/core/bookings/factories.py
+++ b/src/pcapi/core/bookings/factories.py
@@ -74,7 +74,7 @@ class EducationalBookingFactory(BookingFactory):
     user = None
 
 
-class IndividualBookingSubFactory(BookingFactory):
+class IndividualBookingSubFactory(BaseFactory):
     class Meta:
         model = models.IndividualBooking
 

--- a/src/pcapi/core/users/factories.py
+++ b/src/pcapi/core/users/factories.py
@@ -96,7 +96,7 @@ class BeneficiaryFactory(BaseFactory):
     email = factory.Sequence("jeanne.doux{}@example.com".format)
     address = factory.Sequence("{} rue des machines".format)
     city = "Paris"
-    dateOfBirth = datetime.datetime(2000, 1, 1)
+    dateOfBirth = datetime.datetime.today() - relativedelta(years=18, months=1)
     departementCode = "75"
     firstName = "Jeanne"
     lastName = "Doux"

--- a/tests/admin/custom_views/beneficiary_user_view_test.py
+++ b/tests/admin/custom_views/beneficiary_user_view_test.py
@@ -263,7 +263,7 @@ class BeneficiaryUserViewTest:
             email="edited@email.com",
             firstName=user_to_edit.firstName,
             lastName=user_to_edit.lastName,
-            dateOfBirth=user_to_edit.dateOfBirth,
+            dateOfBirth=user_to_edit.dateOfBirth.isoformat(sep=" ", timespec="seconds"),
             departementCode=user_to_edit.departementCode,
             postalCode="76000",
         )

--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -352,14 +352,14 @@ class BookOfferTest:
 class CancelByBeneficiaryTest:
     def test_cancel_booking(self):
         stock = offers_factories.StockFactory(offer__bookingEmail="offerer@example.com")
-        booking = factories.BookingFactory.create_batch(20, stock=stock)[0]
+        booking = factories.IndividualBookingFactory.create_batch(20, stock=stock)[0]
 
         queries = 1  # select booking
         queries += 1  # select user
         queries += 1  # select stock for update
         queries += 1  # refresh booking
         queries += 3  # update stock ; update booking ; release savepoint
-        queries += 7  # (update batch attributes): select booking ; user ; user.bookings ; deposit ; user_offerer ; favorites ; stock
+        queries += 8  # (update batch attributes): select booking ; user ; user.bookings ; deposit ; user_offerer ; favorites ; stock; check feature WHOLE_FRANCE_OPENING
         queries += 1  # select offer
         queries += 2  # insert email ; release savepoint
         queries += 4  # (TODO: optimize) select booking ; stock ; offer ; user

--- a/tests/core/users/external/external_users_test.py
+++ b/tests/core/users/external/external_users_test.py
@@ -35,9 +35,15 @@ def test_update_external_user():
     n_query_get_deposit = 1
     n_query_is_pro = 1
     n_query_get_last_favorite = 1
+    n_query_check_feature_WHOLE_FRANCE_OPENING_active = 1
 
     with assert_num_queries(
-        n_query_get_user + n_query_get_bookings + n_query_get_deposit + n_query_is_pro + n_query_get_last_favorite
+        n_query_get_user
+        + n_query_get_bookings
+        + n_query_get_deposit
+        + n_query_is_pro
+        + n_query_get_last_favorite
+        + n_query_check_feature_WHOLE_FRANCE_OPENING_active
     ):
         update_external_user(user)
 

--- a/tests/routes/webapp/patch_beneficiary_test.py
+++ b/tests/routes/webapp/patch_beneficiary_test.py
@@ -36,7 +36,7 @@ def test_patch_beneficiary(app):
             "physical": {"initial": 200.0, "remaining": 200.0},
         },
         "dateCreated": format_into_utc_date(user.dateCreated),
-        "dateOfBirth": "2000-01-01T00:00:00Z",
+        "dateOfBirth": format_into_utc_date(user.dateOfBirth),
         "departementCode": user.departementCode,
         "deposit_version": 1,
         "email": user.email,


### PR DESCRIPTION
- La date de naissance d'un bénéficiaire dans la `BeneficiaryFactory` était figée au 01/01/2020.
- Elle a été rendue relative à `now()`
- Fix de certains tests