### PR TITLE
[PC-8558] add an endpoint to update allocine venue provider mode

### DIFF
--- a/src/pcapi/core/providers/repository.py
+++ b/src/pcapi/core/providers/repository.py
@@ -11,6 +11,10 @@ def get_venue_provider_list(venue_id: int) -> list[VenueProvider]:
     return VenueProvider.query.filter_by(venueId=venue_id).all()
 
 
+def get_venue_provider_by_venue_and_provider_ids(venue_id: int, provider_id: int) -> VenueProvider:
+    return VenueProvider.query.filter_by(venueId=venue_id, providerId=provider_id).one()
+
+
 def get_provider_enabled_for_pro_by_id(provider_id: int) -> Optional[Provider]:
     return Provider.query.filter_by(id=provider_id, isActive=True, enabledForPro=True).one_or_none()
 

--- a/src/pcapi/utils/human_ids.py
+++ b/src/pcapi/utils/human_ids.py
@@ -2,7 +2,6 @@
 from base64 import b32decode
 from base64 import b32encode
 import binascii
-from typing import Optional
 
 
 # This library creates IDs for use in our URLs,
@@ -16,7 +15,7 @@ class NonDehumanizableId(Exception):
     pass
 
 
-def dehumanize(public_id: str) -> Optional[int]:
+def dehumanize(public_id: str) -> int:
     if public_id is None:
         return None
     missing_padding = len(public_id) % 8
@@ -29,7 +28,7 @@ def dehumanize(public_id: str) -> Optional[int]:
     return int_from_bytes(xbytes)
 
 
-def humanize(integer):
+def humanize(integer: int) -> str:
     """Create a human-compatible ID from and integer"""
     if integer is None:
         return None
@@ -37,13 +36,13 @@ def humanize(integer):
     return b32.decode("ascii").replace("O", "8").replace("I", "9").rstrip("=")
 
 
-def dehumanize_ids_list(humanized_list: list):
+def dehumanize_ids_list(humanized_list: list[str]) -> list[int]:
     return list(map(dehumanize, humanized_list)) if humanized_list else []
 
 
-def int_to_bytes(x):
+def int_to_bytes(x: int) -> bytes:
     return x.to_bytes((x.bit_length() + 7) // 8, "big")
 
 
-def int_from_bytes(xbytes):
+def int_from_bytes(xbytes: bytes) -> int:
     return int.from_bytes(xbytes, "big")

--- a/src/pcapi/validation/routes/users_authorizations.py
+++ b/src/pcapi/validation/routes/users_authorizations.py
@@ -1,8 +1,11 @@
+from pcapi.core.offerers.models import ApiKey
+from pcapi.core.offerers.models import Venue
+from pcapi.core.users.models import User
 from pcapi.models import ApiErrors
 from pcapi.models.api_errors import ForbiddenError
 
 
-def check_user_can_validate_bookings(user, offerer_id: int):
+def check_user_can_validate_bookings(user: User, offerer_id: int) -> bool:
     if not user.is_authenticated:
         return False
 
@@ -14,21 +17,29 @@ def check_user_can_validate_bookings(user, offerer_id: int):
     return True
 
 
-def check_user_can_validate_bookings_v2(user, offerer_id: int):
+def check_user_can_validate_bookings_v2(user: User, offerer_id: int) -> None:
     if not user.has_access(offerer_id):
         api_errors = ForbiddenError()
         api_errors.add_error("user", "Vous n'avez pas les droits suffisants pour valider cette contremarque.")
         raise api_errors
 
 
-def check_api_key_allows_to_validate_booking(valid_api_key, offerer_id: int):
+def check_user_can_alter_venue(user: User, venue_id: int) -> None:
+    venue = Venue.query.get(venue_id)
+    if not user.has_access(venue.managingOffererId):
+        api_errors = ForbiddenError()
+        api_errors.add_error("user", "Vous n'avez pas les droits suffisants pour modifier ce lieu.")
+        raise api_errors
+
+
+def check_api_key_allows_to_validate_booking(valid_api_key: ApiKey, offerer_id: int) -> None:
     if not valid_api_key.offererId == offerer_id:
         api_errors = ForbiddenError()
         api_errors.add_error("user", "Vous n'avez pas les droits suffisants pour valider cette contremarque.")
         raise api_errors
 
 
-def check_api_key_allows_to_cancel_booking(valid_api_key, offerer_id: int):
+def check_api_key_allows_to_cancel_booking(valid_api_key: ApiKey, offerer_id: int) -> None:
     if not valid_api_key.offererId == offerer_id:
         api_errors = ForbiddenError()
         api_errors.add_error("user", "Vous n'avez pas les droits suffisants pour annuler cette réservation.")

--- a/tests/routes/pro/put_venue_provider_test.py
+++ b/tests/routes/pro/put_venue_provider_test.py
@@ -1,0 +1,119 @@
+import pytest
+
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offers import factories as offer_factories
+from pcapi.core.users import factories as user_factories
+from pcapi.utils.human_ids import humanize
+
+from tests.conftest import TestClient
+
+
+class Returns200Test:
+    @pytest.mark.usefixtures("db_session")
+    def test_allocine_venue_provider_is_successfully_updated(self, app):
+        # Given
+        user_offerer = offer_factories.UserOffererFactory()
+        user = user_offerer.user
+        offerer = user_offerer.offerer
+        venue = offer_factories.VenueFactory(managingOfferer=offerer)
+        provider = offerers_factories.AllocineProviderFactory()
+        venue_provider = offerers_factories.AllocineVenueProviderFactory(
+            venue=venue,
+            provider=provider,
+            isDuo=False,
+            quantity=42,
+        )
+        offerers_factories.AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=venue_provider, price=10)
+
+        updated_venue_provider_data = {
+            "providerId": humanize(provider.id),
+            "venueId": humanize(venue.id),
+            "isDuo": True,
+            "quantity": 77,
+            "price": 64,
+        }
+
+        auth_request = TestClient(app.test_client()).with_session_auth(email=user.email)
+
+        # When
+        response = auth_request.put("/venueProviders", json=updated_venue_provider_data)
+
+        # Then
+        assert response.status_code == 200
+        assert response.json["provider"]["id"] == humanize(provider.id)
+        assert response.json["venueId"] == humanize(venue.id)
+        assert response.json["quantity"] == updated_venue_provider_data["quantity"]
+        assert response.json["price"] == updated_venue_provider_data["price"]
+        assert response.json["isDuo"] == updated_venue_provider_data["isDuo"]
+
+
+class Returns400Test:
+    @pytest.mark.usefixtures("db_session")
+    def test_provider_is_not_allocine(self, app):
+        # Given
+        user_offerer = offer_factories.UserOffererFactory()
+        user = user_offerer.user
+        offerer = user_offerer.offerer
+        venue = offer_factories.VenueFactory(managingOfferer=offerer)
+        provider = offerers_factories.ProviderFactory()
+        offerers_factories.VenueProviderFactory(venue=venue, provider=provider)
+
+        updated_venue_provider_data = {
+            "providerId": humanize(provider.id),
+            "venueId": humanize(venue.id),
+            "isDuo": True,
+            "quantity": 77,
+            "price": 64,
+        }
+
+        auth_request = TestClient(app.test_client()).with_session_auth(email=user.email)
+
+        # When
+        response = auth_request.put("/venueProviders", json=updated_venue_provider_data)
+
+        # then
+        assert response.status_code == 400
+
+
+class Returns401Test:
+    @pytest.mark.usefixtures("db_session")
+    def test_user_is_not_logged_in(self, app):
+        # when
+        response = TestClient(app.test_client()).put("/venueProviders")
+
+        # then
+        assert response.status_code == 401
+
+
+class Returns403Test:
+    @pytest.mark.usefixtures("db_session")
+    def test_user_has_right_on_venue(self, app):
+        # Given
+        user = user_factories.ProFactory()
+        owner_offerer = offer_factories.UserOffererFactory()
+        offerer = owner_offerer.offerer
+        venue = offer_factories.VenueFactory(managingOfferer=offerer)
+        provider = offerers_factories.AllocineProviderFactory()
+        venue_provider = offerers_factories.AllocineVenueProviderFactory(
+            venue=venue,
+            provider=provider,
+            isDuo=False,
+            quantity=42,
+        )
+        offerers_factories.AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=venue_provider, price=10)
+
+        updated_venue_provider_data = {
+            "providerId": humanize(provider.id),
+            "venueId": humanize(venue.id),
+            "isDuo": True,
+            "quantity": 77,
+            "price": 64,
+        }
+
+        auth_request = TestClient(app.test_client()).with_session_auth(email=user.email)
+
+        # When
+        response = auth_request.put("/venueProviders", json=updated_venue_provider_data)
+
+        # Then
+        assert response.status_code == 403


### PR DESCRIPTION
nouveau endpoint: `PUT /venueProviders`:

- attend en requête un [`PostVenueProviderBody`](https://github.com/pass-culture/pass-culture-api/blob/bc52b3d90762c0505c93863a834b48bf8c277a91/src/pcapi/routes/serialization/venue_provider_serialize.py#L13)
- renvoie en réponse un [`VenueProviderResponse`](https://github.com/pass-culture/pass-culture-api/blob/bc52b3d90762c0505c93863a834b48bf8c277a91/src/pcapi/routes/serialization/venue_provider_serialize.py#L36)

(+ pas mal d'avertissements MyPy corrigés)