### PR TITLE
security: Catch badly-encoded basic authentication headers to avoid password leak

### DIFF
--- a/src/pcapi/routes/error_handlers/generic_error_handlers.py
+++ b/src/pcapi/routes/error_handlers/generic_error_handlers.py
@@ -100,11 +100,17 @@ def already_activated_exception(error: AlreadyActivatedException) -> tuple[dict,
 
 @app.errorhandler(429)
 def ratelimit_handler(error: Exception) -> tuple[dict, int]:
+    # `pcapi.utis.login_manager` cannot be imported at module-scope,
+    # because the application context may not be available and that
+    # module needs it.
+    from pcapi.utils.login_manager import get_request_authorization
+
     identifier = None
     if request.json and "identifier" in request.json:
         identifier = request.json["identifier"]
-    if request.authorization and request.authorization.username:
-        identifier = request.authorization.username
+    auth = get_request_authorization()
+    if auth and auth.username:
+        identifier = auth.username
     extra = {
         "method": request.method,
         "identifier": identifier,

--- a/src/pcapi/utils/login_manager.py
+++ b/src/pcapi/utils/login_manager.py
@@ -4,6 +4,7 @@ import uuid
 
 from flask import current_app as app
 from flask import jsonify
+from flask import request
 from flask import session
 
 from pcapi.core.users.models import User
@@ -14,6 +15,18 @@ from pcapi.repository.user_session_queries import register_user_session
 
 
 logger = logging.getLogger(__name__)
+
+
+def get_request_authorization():
+    try:
+        return request.authorization
+    except UnicodeDecodeError:
+        # `werkzeug.http.parse_authorization_header()` raises a
+        # UnicodeDecodeError if the login or the password contains
+        # characters that have not been encoded in "utf-8", which
+        # we'll happily send to Sentry, where the password could
+        # appear as clear text.
+        return None
 
 
 @app.login_manager.user_loader

--- a/src/pcapi/utils/rate_limiting.py
+++ b/src/pcapi/utils/rate_limiting.py
@@ -13,7 +13,12 @@ def get_email_from_request() -> str:
 
 
 def get_basic_auth_from_request() -> Optional[str]:
-    auth = request.authorization
+    # `pcapi.utis.login_manager` cannot be imported at module-scope,
+    # because the application context may not be available and that
+    # module needs it.
+    from pcapi.utils.login_manager import get_request_authorization
+
+    auth = get_request_authorization()
     if not auth or not auth.username:
         return None
     return auth.username

--- a/src/pcapi/validation/routes/users_authentifications.py
+++ b/src/pcapi/validation/routes/users_authentifications.py
@@ -73,7 +73,12 @@ current_api_key = LocalProxy(_get_current_api_key)
 
 
 def basic_authentication(realm=None):
-    auth = request.authorization
+    # `pcapi.utis.login_manager` cannot be imported at module-scope,
+    # because the application context may not be available and that
+    # module needs it.
+    from pcapi.utils.login_manager import get_request_authorization
+
+    auth = get_request_authorization()
     # According to the Werkzeug documentation auth.password is None
     # for any auth that is not basic auth.
     if not auth or not auth.password:

--- a/tests/routes/login_manager_test.py
+++ b/tests/routes/login_manager_test.py
@@ -1,0 +1,29 @@
+import base64
+
+import pytest
+
+import pcapi.core.users.factories as users_factories
+
+
+@pytest.mark.usefixtures("db_session")
+class BasicAuthenticationTest:
+    def test_good_password(self, client):
+        password = "sécrét"
+        user = users_factories.UserFactory(password=password)
+        auth = base64.b64encode(f"{user.email}:{password}".encode("utf-8")).decode()
+        headers = {"Authorization": f"Basic {auth}"}
+        response = client.get("/v2/bookings/token/-", headers=headers)
+        assert response.status_code == 404
+
+    def test_wrong_password(self, client):
+        auth = base64.b64encode("unknown:wrøng".encode("utf-8")).decode()
+        headers = {"Authorization": f"Basic {auth}"}
+        response = client.get("/v2/bookings/token/-", headers=headers)
+        assert response.status_code == 401
+
+    def test_badly_encoded_header(self, client):
+        user = users_factories.UserFactory()
+        auth = base64.b64encode(f"{user.email}:wrøng".encode("latin1")).decode()
+        headers = {"Authorization": f"Basic {auth}"}
+        response = client.get("/v2/bookings/token/-", headers=headers)
+        assert response.status_code == 401  # no internal error


### PR DESCRIPTION
Exemple [ici](https://sentry.internal-passculture.app/organizations/sentry/issues/126541/) (entre autres)

---

`werkzeug.http.parse_authorization_header()` raises a
UnicodeDecodeError if the login or the password contains characters
that have not been encoded in "utf-8", which we'll happily send to
Sentry, where the password could appear as clear text.

Example (of the previous behaviour):

    $ AUTH=`python -c "import base64; print(base64.b64encode('login:é'.encode('latin1')).decode())"`
    $ echo $AUTH
    bG9naW466Q==
    $ curl -H "Authorization: Basic $AUTH" "http://localhost:5000/v2/bookings/token/-"
    {
      "global": [
        "Il semble que nous ayons des problèmes techniques :( On répare ça au plus vite."
      ]
    }

New behaviour:

    $ curl -H "Authorization: Basic $AUTH" "http://localhost:5000/v2/bookings/token/-"
    API key or login required