### PR TITLE
(PC-10419) : update booking serialization method to take into account eac booking specificities regarding the user

### DIFF
--- a/src/pcapi/core/bookings/factories.py
+++ b/src/pcapi/core/bookings/factories.py
@@ -33,7 +33,7 @@ class BookingFactory(BaseFactory):
                 self.stock.beginningDatetime, self.dateCreated
             )
         db.session.add(self)
-        db.session.flush()
+        db.session.commit()
 
     @factory.post_generation
     def cancellation_date(self, create, extracted, **kwargs):

--- a/src/pcapi/routes/serialization/bookings_serialize.py
+++ b/src/pcapi/routes/serialization/bookings_serialize.py
@@ -13,10 +13,18 @@ from pcapi.utils.human_ids import humanize
 
 def serialize_booking(booking: Booking) -> dict:
     booking_id = humanize(booking.id)
-    user_email = booking.user.email
+    is_educational_booking = booking.educationalBookingId is not None
+    if is_educational_booking:
+        user_email = booking.educationalBooking.educationalRedactor.email
+    else:
+        user_email = booking.user.email
     is_used = booking.isUsed
     offer_name = booking.stock.offer.product.name
-    user_name = booking.user.publicName
+    if is_educational_booking:
+        redactor = booking.educationalBooking.educationalRedactor
+        user_name = f"{redactor.firstName} {redactor.lastName}"
+    else:
+        user_name = booking.user.publicName
     venue_departement_code = booking.stock.offer.venue.departementCode
     offer_id = booking.stock.offer.id
     venue_name = booking.stock.offer.venue.name
@@ -41,7 +49,7 @@ def serialize_booking(booking: Booking) -> dict:
 
     date_of_birth = ""
     phone_number = ""
-    if booking.stock.offer.product.type == str(EventType.ACTIVATION):
+    if booking.educationalBookingId is None and booking.stock.offer.product.type == str(EventType.ACTIVATION):
         date_of_birth = serialize(booking.user.dateOfBirth)
         phone_number = booking.user.phoneNumber
 

--- a/src/pcapi/sandboxes/scripts/getters/pro_10_desk.py
+++ b/src/pcapi/sandboxes/scripts/getters/pro_10_desk.py
@@ -1,19 +1,32 @@
+import datetime
+
 import pcapi.core.bookings.factories as bookings_factories
+from pcapi.core.educational.models import EducationalBookingStatus
 from pcapi.core.offers import factories as offers_factories
 from pcapi.sandboxes.scripts.utils.helpers import get_booking_helper
 from pcapi.sandboxes.scripts.utils.helpers import get_pro_helper
 
 
 def get_existing_pro_validated_user_with_validated_offerer_with_validated_user_offerer_with_thing_offer_with_stock_with_not_used_booking():
-    user_offerer = offers_factories.UserOffererFactory(
-        validationToken=None,
-        offerer__validationToken=None,
-        user__validationToken=None,
-    )
+    user_offerer = offers_factories.UserOffererFactory()
     venue = offers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
     offer = offers_factories.ThingOfferFactory(venue=venue, isActive=True)
     stock = offers_factories.StockFactory(offer=offer)
     booking = bookings_factories.BookingFactory(stock=stock, isUsed=False)
+
+    return {
+        "booking": get_booking_helper(booking),
+        "user": get_pro_helper(user_offerer.user),
+    }
+
+
+def get_existing_pro_validated_user_with_validated_offerer_with_validated_user_offerer_with_eac_offer_with_stock_with_not_used_booking_validated_by_principal():
+    user_offerer = offers_factories.UserOffererFactory()
+    booking = bookings_factories.EducationalBookingFactory(
+        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=5),
+        stock__offer__venue__managingOfferer=user_offerer.offerer,
+        educationalBooking__status=EducationalBookingStatus.USED_BY_INSTITUTE,
+    )
 
     return {
         "booking": get_booking_helper(booking),


### PR DESCRIPTION
- Sur la route de validation des contremarques, le front pro fait un premier appel à `GET /bookings/v2/token/<token>` qui permet de relever une éventuelle erreur et de désactiver le bouton de validation + afficher message erreur
- SI aucune erreur : la route renvoie un booking serialisé, avec notamment `booking.user.email` et `booking.user.publicName`
- Pas d'objet `User` dans les bookings eac => correction de la serialisation