### PR TITLE
(PC-10612) api_entreprises: handle errors on non prod

### DIFF
--- a/src/pcapi/connectors/api_entreprises.py
+++ b/src/pcapi/connectors/api_entreprises.py
@@ -1,5 +1,6 @@
 import typing
 
+from pcapi import settings
 from pcapi.connectors.utils.legal_category_code_to_labels import CODE_TO_CATEGORY_MAPPING
 from pcapi.utils import requests
 
@@ -35,7 +36,13 @@ def _extract_etablissements_communs_siren(etablissements: list[dict]) -> list[di
 
 
 def get_offerer_legal_category(offerer: "Offerer") -> dict:
-    legal_category = get_by_offerer(offerer)["unite_legale"]["categorie_juridique"]
-    legal_category_label = CODE_TO_CATEGORY_MAPPING.get(int(legal_category)) if legal_category else None
+    try:
+        legal_category = get_by_offerer(offerer)["unite_legale"]["categorie_juridique"]
+        legal_category_label = CODE_TO_CATEGORY_MAPPING.get(int(legal_category)) if legal_category else None
+    except ApiEntrepriseException:
+        if settings.IS_PROD:
+            raise
+        legal_category = "XXXX"
+        legal_category_label = "Catégorie factice (hors Prod)"
 
     return {"legal_category_code": legal_category, "legal_category_label": legal_category_label}

--- a/src/pcapi/core/offerers/models.py
+++ b/src/pcapi/core/offerers/models.py
@@ -32,8 +32,6 @@ from sqlalchemy.sql.sqltypes import CHAR
 from sqlalchemy.sql.sqltypes import LargeBinary
 from werkzeug.utils import cached_property
 
-from pcapi import settings
-from pcapi.connectors.api_entreprises import ApiEntrepriseException
 from pcapi.connectors.api_entreprises import get_offerer_legal_category
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import OfferValidationStatus
@@ -422,13 +420,7 @@ class Offerer(
 
     @cached_property
     def legal_category(self) -> str:
-        try:
-            legal_category = get_offerer_legal_category(self)
-        except ApiEntrepriseException:
-            if settings.IS_PROD:
-                raise
-            legal_category = {"legal_category_code": "XXXX", "legal_category_label": "Catégorie factice (hors Prod)"}
-        return legal_category["legal_category_code"]
+        return get_offerer_legal_category(self)["legal_category_code"]
 
 
 offerer_ts_indexes = [

--- a/tests/connectors/api_entreprises_test.py
+++ b/tests/connectors/api_entreprises_test.py
@@ -7,6 +7,8 @@ from pcapi.connectors.api_entreprises import ApiEntrepriseException
 from pcapi.connectors.api_entreprises import get_by_offerer
 from pcapi.connectors.api_entreprises import get_offerer_legal_category
 from pcapi.connectors.utils.legal_category_code_to_labels import CODE_TO_CATEGORY_MAPPING
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.testing import override_settings
 from pcapi.model_creators.generic_creators import create_offerer
 
 
@@ -307,3 +309,43 @@ class GetByOffererTest:
         legal_category = get_offerer_legal_category(offerer)
         assert legal_category["legal_category_code"] is None
         assert legal_category["legal_category_label"] is None
+
+
+@pytest.mark.usefixtures("db_session")
+class GetOffererLegalCategoryTest:
+    @patch("pcapi.connectors.api_entreprises.get_by_offerer")
+    def test_successful_get_by_offerer(self, mocked_get_by_offerer):
+        mocked_get_by_offerer.return_value = {
+            "unite_legale": {
+                "categorie_juridique": "5202",
+            }
+        }
+        offerer = offers_factories.OffererFactory()
+
+        assert get_offerer_legal_category(offerer) == {
+            "legal_category_code": "5202",
+            "legal_category_label": "Société en nom collectif",
+        }
+
+    @patch("pcapi.connectors.api_entreprises.get_by_offerer")
+    @override_settings(IS_PROD=True)
+    def test_error_get_by_offerer_on_prod_env(self, mocked_get_by_offerer):
+        mocked_get_by_offerer.side_effect = [
+            ApiEntrepriseException("Error getting API entreprise DATA for SIREN : xxx")
+        ]
+        offerer = offers_factories.OffererFactory()
+
+        with pytest.raises(ApiEntrepriseException) as error:
+            get_offerer_legal_category(offerer)
+
+        assert "Error getting API entreprise DATA for SIREN : xxx" in str(error.value)
+
+    @patch("pcapi.connectors.api_entreprises.get_offerer_legal_category")
+    def test_error_get_by_offerer_on_non_prod_env(self, mocked_get_offerer_legal_category):
+        mocked_get_offerer_legal_category.side_effect = [ApiEntrepriseException]
+        offerer = offers_factories.OffererFactory()
+
+        assert get_offerer_legal_category(offerer) == {
+            "legal_category_code": "XXXX",
+            "legal_category_label": "Catégorie factice (hors Prod)",
+        }

--- a/tests/core/offerers/test_models.py
+++ b/tests/core/offerers/test_models.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.connectors.api_entreprises import ApiEntrepriseException
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offers import factories as offers_factories
@@ -108,40 +107,6 @@ class OffererNValidatedOffersTest:
 
 @pytest.mark.usefixtures("db_session")
 class OffererLegalCategoryTest:
-    @patch("pcapi.core.offerers.models.get_offerer_legal_category")
-    def test_offerer_legal_category_with_success_get_legal_category(self, mocked_get_offerer_legal_category):
-        mocked_get_offerer_legal_category.return_value = {
-            "legal_category_code": "5202",
-            "legal_category_label": "Société en nom collectif",
-        }
-        offerer = offers_factories.OffererFactory()
-
-        assert offerer.legal_category == "5202"
-
-    @patch("pcapi.core.offerers.models.get_offerer_legal_category")
-    @patch("pcapi.settings.IS_PROD", True)
-    def test_offerer_legal_category_when_get_legal_category_raise_error_on_prod_env(
-        self, mocked_get_offerer_legal_category
-    ):
-        mocked_get_offerer_legal_category.side_effect = [
-            ApiEntrepriseException("Error getting API entreprise DATA for SIREN")
-        ]
-        offerer = offers_factories.OffererFactory()
-
-        with pytest.raises(ApiEntrepriseException) as error:
-            offerer.legal_category()
-
-        assert "Error getting API entreprise DATA for SIREN" in str(error.value)
-
-    @patch("pcapi.core.offerers.models.get_offerer_legal_category")
-    def test_offerer_legal_category_when_get_legal_category_raise_error_on_non_prod_env(
-        self, mocked_get_offerer_legal_category
-    ):
-        mocked_get_offerer_legal_category.side_effect = [ApiEntrepriseException]
-        offerer = offers_factories.OffererFactory()
-
-        assert offerer.legal_category == "XXXX"
-
     @patch("pcapi.core.offerers.models.get_offerer_legal_category")
     def test_offerer_legal_category_called_many_times(self, mocked_get_offerer_legal_category):
         mocked_get_offerer_legal_category.return_value = {


### PR DESCRIPTION
##  Objectif

Permettre d'afficher la page de Validation lorsqu'un lieu à un SIRET factice

##  Implémentation

- gérer les erreurs lors de l'appel à l'API Entreprises hors environnement PROD
