### PR TITLE
(PC-10653) : take the correct HTTP code to skip rate-limit

### DIFF
--- a/src/pcapi/routes/pro/bookings.py
+++ b/src/pcapi/routes/pro/bookings.py
@@ -135,8 +135,8 @@ def get_booking_by_token_v2(token: str):
 
 # @debt api-migration
 @public_api.route("/v2/bookings/use/token/<token>", methods=["PATCH"])
-@ip_rate_limiter(deduct_when=lambda response: response.status_code != 200)
-@email_rate_limiter(key_func=get_basic_auth_from_request, deduct_when=lambda response: response.status_code != 200)
+@ip_rate_limiter(deduct_when=lambda response: response.status_code != 204)
+@email_rate_limiter(key_func=get_basic_auth_from_request, deduct_when=lambda response: response.status_code != 204)
 @login_or_api_key_required
 def patch_booking_use_by_token(token: str):
     """Let a pro user mark a booking as used."""
@@ -156,8 +156,8 @@ def patch_booking_use_by_token(token: str):
 
 # @debt api-migration
 @private_api.route("/v2/bookings/cancel/token/<token>", methods=["PATCH"])
-@ip_rate_limiter(deduct_when=lambda response: response.status_code != 200)
-@email_rate_limiter(key_func=get_basic_auth_from_request, deduct_when=lambda response: response.status_code != 200)
+@ip_rate_limiter(deduct_when=lambda response: response.status_code != 204)
+@email_rate_limiter(key_func=get_basic_auth_from_request, deduct_when=lambda response: response.status_code != 204)
 @login_or_api_key_required
 def patch_cancel_booking_by_token(token: str):
     """Let a pro user cancel a booking."""
@@ -178,8 +178,8 @@ def patch_cancel_booking_by_token(token: str):
 
 # @debt api-migration
 @public_api.route("/v2/bookings/keep/token/<token>", methods=["PATCH"])
-@ip_rate_limiter(deduct_when=lambda response: response.status_code != 200)
-@email_rate_limiter(key_func=get_basic_auth_from_request, deduct_when=lambda response: response.status_code != 200)
+@ip_rate_limiter(deduct_when=lambda response: response.status_code != 204)
+@email_rate_limiter(key_func=get_basic_auth_from_request, deduct_when=lambda response: response.status_code != 204)
 @login_or_api_key_required
 def patch_booking_keep_by_token(token: str):
     """Let a pro user mark a booking as _not_ used."""


### PR DESCRIPTION
Rate limit was only skipping the HTTP 200 code while rate-limitting.
This means that endpoint returing 204 codes were counted as failed
attempts.