### PR TITLE
Catch JSONDecodeError in ratelimit_handler

### DIFF
--- a/src/pcapi/routes/error_handlers/generic_error_handlers.py
+++ b/src/pcapi/routes/error_handlers/generic_error_handlers.py
@@ -51,7 +51,7 @@ def internal_error(error: Exception) -> Union[tuple[dict, int], HTTPException]:
 
 @app.errorhandler(UnauthorizedError)
 def unauthorized_error(error: UnauthorizedError) -> Response:
-    headers = {}
+    headers: dict = {}
     if error.www_authenticate:
         headers["WWW-Authenticate"] = error.www_authenticate
         if error.realm:
@@ -110,8 +110,8 @@ def ratelimit_handler(error: Exception) -> tuple[dict, int]:
     try:
         if request.is_json and "identifier" in request.json:
             identifier = request.json["identifier"]
-    except json.JSONDecodeError:
-        pass
+    except json.JSONDecodeError as e:
+        logger.info("Could not extract user identifier from request: %s", e)
     auth = get_request_authorization()
     if auth and auth.username:
         identifier = auth.username


### PR DESCRIPTION
*Contexte:* On souhaite corriger [cette erreur Sentry](https://sentry.internal-passculture.app/organizations/sentry/issues/133192/?environment=production&project=5&query=is%3Aunresolved)

Il apparait qu'une erreur de décodage json raise une exception au niveau de `rate_limit_handler`
![Screenshot from 2021-09-02 11-19-57](https://user-images.githubusercontent.com/14235661/131818346-8a226602-54c3-4143-af75-87291badbb2b.png)
 
Après investigation, on souhaite:

- Dans un premier temps, avoir plus d'info sur le body de la requête qui raise une `JSONDecodeException`, pour comprendre d'où ça vient --> Ajouter un try/catch pour logguer les infos
- Dans un second temps, corriger le comportement et supprimmer le log


Lorque Sentry log la requête , il masque les champs password. On verra cependant toujours le champs 'identifier'. 

![Screenshot from 2021-09-01 16-49-28](https://user-images.githubusercontent.com/14235661/131798679-881bc419-1904-4706-a104-13f8ebae6d8e.png)
