### PR TITLE
search: Fix twice-enqueued offers on Algolia on venue reindex

### DIFF
--- a/src/pcapi/core/search/__init__.py
+++ b/src/pcapi/core/search/__init__.py
@@ -155,7 +155,7 @@ def _index_venues_in_queue(backend):
             )
             if not offer_ids:
                 break
-            reindex_offer_ids(offer_ids)
+            _reindex_offer_ids(backend, offer_ids)
             page += 1
         logger.info("Finished indexing offers of venue", extra={"venue": venue_id, "backend": str(backend)})
 
@@ -185,7 +185,7 @@ def _reindex_offer_ids(backend, offer_ids: Iterable[int]):
     to_add = []
     to_delete = []
     # FIXME (dbaty, 2021-07-05): join-load Stock, Venue, Offerer,
-    # etc. to avoid N+1 queries on each offer. See relayed comment in
+    # etc. to avoid N+1 queries on each offer. See related comment in
     # test_serialize_appsearch:test_check_number_of_sql_queries
     offers = Offer.query.filter(Offer.id.in_(offer_ids))
     for offer in offers:


### PR DESCRIPTION
When reindexing a venue, we did not call the right method. For _each_
backend, we enqueued all offers of the reindexed venue on _both_
backends. The queue is a _set_ for App Search, so the bug did not have
any impact there. However, on Algolia, the queue is a _list_: each
offer of a venue was enqueued twice for Algolia.
    
Spotted by Jérémie.

