### PR TITLE
requests: Log as INFO, not ERROR, when a user-provided URL is not available

### DIFF
--- a/src/pcapi/core/offers/validation.py
+++ b/src/pcapi/core/offers/validation.py
@@ -177,7 +177,9 @@ def get_distant_image(
     max_size: int = MAX_THUMBNAIL_SIZE,
 ) -> bytes:
     try:
-        streaming_response = pcapi_requests.get(url, timeout=DISTANT_IMAGE_REQUEST_TIMEOUT, stream=True)
+        streaming_response = pcapi_requests.get(
+            url, timeout=DISTANT_IMAGE_REQUEST_TIMEOUT, stream=True, log_at_error_level=False
+        )
         streaming_response.raise_for_status()
     except Exception:
         raise exceptions.FailureToRetrieve()


### PR DESCRIPTION
Users often mistype URLs. In that case, logging an exception means
sending the error to Sentry, but it's useless: we cannot do anything
about it. An INFO message is enough if we ever need to debug.

---

Je ne suis pas tout à fait convaincu par le nom de l'argument, mais je
n'ai pas trouvé aussi concis et explicite. (`log_errors_at_error_level`
serait plus explicite, mais ça serait un peu long, je trouve. :) )

---

Exemples Sentry : 
- https://sentry.internal-passculture.app/organizations/sentry/issues/136135/
- https://sentry.internal-passculture.app/organizations/sentry/issues/126448/
- etc.