### PR TITLE
test de fix test e2e

### DIFF
--- a/src/pcapi/sandboxes/scripts/getters/webapp_09_lost_password.py
+++ b/src/pcapi/sandboxes/scripts/getters/webapp_09_lost_password.py
@@ -5,9 +5,9 @@ from pcapi.repository.user_queries import keep_only_webapp_users
 from pcapi.sandboxes.scripts.utils.helpers import get_beneficiary_helper
 
 
-def get_webapp_user_with_not_validated_password():
+def get_webapp_user_with_not_validated_password() -> dict:
     query = keep_only_webapp_users(User.query)
-    query = query.join(Token).filter(Token.type == TokenType.RESET_PASSWORD)
+    query = query.join(Token).filter(Token.type == TokenType.RESET_PASSWORD, Token.isUsed.is_(False))
     user = query.first()
 
     return {"user": get_beneficiary_helper(user)}


### PR DESCRIPTION
correction d'un test e2e cassé à cause du changement de gestion des tokens.

avant, les tokens consommés étaient supprimés. maintenant les tokens consommés sont juste marqués comme utilisés. Il fallait juste en tenir compte lors de la récupération d'un utilisateur avec un token de changement de mot de passe