### PR TITLE
notion: Truncate synchronization error message to max size

### DIFF
--- a/src/pcapi/connectors/notion.py
+++ b/src/pcapi/connectors/notion.py
@@ -27,7 +27,7 @@ def add_to_synchronization_error_database(
             parent={"database_id": PROVIDER_API_ERRORS_DATABASE_ID},
             properties={
                 "Détail": {
-                    "title": [{"text": {"content": str(exception)}}],
+                    "title": [{"text": {"content": str(exception)[:2000]}}],
                 },
                 "Type": {"select": {"name": exception.__class__.__name__}},
                 "Provider": {"select": {"name": provider_name}},


### PR DESCRIPTION
The max length in Notion for this field is 2000 characters.

---

Erreur dans Sentry : https://sentry.internal-passculture.app/organizations/sentry/issues/116517

Un champ est trop long, d'après la réponse de l'API de Notion :

    body failed validation: body.properties.Détail.title[0].text.content.length should be ≤ `2000`, instead was `13514`.

Je suis incapable de retrouve dans Notion le template pour,
éventuellement, modifier la longueur maximale du champ. À défaut, je
propose d'envoyer une version tronquée. (Je ne sais pas trop qui
utilise cette page Notion.)