### PR TITLE
(PC-9991) Use new Booking.venueId and Booking.offererId attributes in SQL queries

### DIFF
--- a/src/pcapi/repository/payment_queries.py
+++ b/src/pcapi/repository/payment_queries.py
@@ -44,14 +44,12 @@ def find_not_processable_with_bank_information() -> list[Payment]:
     )
 
     predicate_matches_venue_or_offerer = (
-        (Venue.id == BankInformation.venueId) | (Offerer.id == BankInformation.offererId)
+        (Booking.venueId == BankInformation.venueId) | (Booking.offererId == BankInformation.offererId)
     ) & (BankInformation.status == BankInformationStatus.ACCEPTED)
 
     not_processable_payments_with_bank_information = (
         Payment.query.filter(Payment.id.in_(not_processable_payment_ids))
         .join(Booking)
-        .join(Venue)
-        .join(Offerer)
         .join(BankInformation, predicate_matches_venue_or_offerer)
         .all()
     )
@@ -148,8 +146,6 @@ def group_by_iban_and_bic(payment_query):
 def group_by_venue(payment_query) -> list:
     query = (
         payment_query.join(Booking)
-        .join(Stock)
-        .join(Offer)
         .join(Venue)
         .join(Offerer)
         .group_by(Venue.id, Offerer.name, Offerer.siren, Payment.iban, Payment.bic)

--- a/src/pcapi/routes/pro/bookings.py
+++ b/src/pcapi/routes/pro/bookings.py
@@ -55,7 +55,7 @@ def get_booking_by_token(token: str):
     booking = booking_repository.find_by(token, email, offer_id)
     bookings_validation.check_is_usable(booking)
 
-    if check_user_can_validate_bookings(current_user, booking.stock.offer.venue.managingOffererId):
+    if check_user_can_validate_bookings(current_user, booking.offererId):
         response = _create_response_to_get_booking_by_token(booking)
         return jsonify(response), 200
 
@@ -70,7 +70,7 @@ def patch_booking_by_token(token: str):
     booking = booking_repository.find_by(token, email, offer_id)
 
     if current_user.is_authenticated:
-        check_user_has_access_to_offerer(current_user, booking.stock.offer.venue.managingOffererId)
+        check_user_has_access_to_offerer(current_user, booking.offererId)
     else:
         check_email_and_offer_id_for_anonymous_user(email, offer_id)
 
@@ -129,14 +129,13 @@ def get_booking_by_token_v2(token: str) -> GetBookingResponse:
     Ce code unique est généré pour chaque réservation d'un utilisateur sur l'application et lui est transmis à cette occasion.
     """
     booking = booking_repository.find_by(token=token)
-    offerer_id = booking.stock.offer.venue.managingOffererId
 
     if current_user.is_authenticated:
         # warning : current user is not none when user is not logged in
-        check_user_can_validate_bookings_v2(current_user, offerer_id)
+        check_user_can_validate_bookings_v2(current_user, booking.offererId)
 
     if current_api_key:
-        check_api_key_allows_to_validate_booking(current_api_key, offerer_id)
+        check_api_key_allows_to_validate_booking(current_api_key, booking.offererId)
 
     bookings_validation.check_is_usable(booking)
 
@@ -160,13 +159,12 @@ def patch_booking_use_by_token(token: str):
     Pour confirmer que la réservation a bien été utilisée par le jeune.
     """
     booking = booking_repository.find_by(token=token)
-    offerer_id = booking.stock.offer.venue.managingOffererId
 
     if current_user.is_authenticated:
-        check_user_can_validate_bookings_v2(current_user, offerer_id)
+        check_user_can_validate_bookings_v2(current_user, booking.offererId)
 
     if current_api_key:
-        check_api_key_allows_to_validate_booking(current_api_key, offerer_id)
+        check_api_key_allows_to_validate_booking(current_api_key, booking.offererId)
 
     bookings_api.mark_as_used(booking)
 
@@ -195,13 +193,12 @@ def patch_cancel_booking_by_token(token: str):
     """
     token = token.upper()
     booking = booking_repository.find_by(token=token)
-    offerer_id = booking.stock.offer.venue.managingOffererId
 
     if current_user.is_authenticated:
-        check_user_has_access_to_offerer(current_user, offerer_id)
+        check_user_has_access_to_offerer(current_user, booking.offererId)
 
     if current_api_key:
-        check_api_key_allows_to_cancel_booking(current_api_key, offerer_id)
+        check_api_key_allows_to_cancel_booking(current_api_key, booking.offererId)
 
     bookings_api.cancel_booking_by_offerer(booking)
 
@@ -224,13 +221,12 @@ def patch_booking_keep_by_token(token: str):
     # in French, to be used by Swagger for the API documentation
     """Annulation de la validation d'une réservation."""
     booking = booking_repository.find_by(token=token)
-    offerer_id = booking.stock.offer.venue.managingOffererId
 
     if current_user.is_authenticated:
-        check_user_can_validate_bookings_v2(current_user, offerer_id)
+        check_user_can_validate_bookings_v2(current_user, booking.offererId)
 
     if current_api_key:
-        check_api_key_allows_to_validate_booking(current_api_key, offerer_id)
+        check_api_key_allows_to_validate_booking(current_api_key, booking.offererId)
 
     bookings_api.mark_as_unused(booking)
 

--- a/src/pcapi/scripts/booking/cancel_old_unused_bookings_for_venue.py
+++ b/src/pcapi/scripts/booking/cancel_old_unused_bookings_for_venue.py
@@ -7,8 +7,6 @@ from sqlalchemy.sql.sqltypes import DateTime
 from pcapi.core.bookings.api import _cancel_booking
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
-from pcapi.core.offers.models import Offer
-from pcapi.core.offers.models import Stock
 from pcapi.repository import repository
 from pcapi.repository.venue_queries import find_by_id
 from pcapi.utils.human_ids import dehumanize
@@ -40,12 +38,9 @@ def cancel_old_unused_bookings_for_venue(humanized_venue_id: str, reason: Bookin
 
 
 def _get_old_unused_bookings_from_venue_id(venue_id: int, limit_date: DateTime) -> list[Booking]:
-    return (
-        Booking.query.join(Stock, Stock.id == Booking.stockId)
-        .join(Offer, Offer.id == Stock.offerId)
-        .filter(Offer.venueId == venue_id)
-        .filter(~Booking.isCancelled)
-        .filter(~Booking.isUsed)
-        .filter(Booking.dateCreated < limit_date)
-        .all()
-    )
+    return Booking.query.filter(
+        ~Booking.isCancelled,
+        ~Booking.isUsed,
+        Booking.dateCreated < limit_date,
+        Booking.venueId == venue_id,
+    ).all()

--- a/tests/routes/pro/get_all_bookings_test.py
+++ b/tests/routes/pro/get_all_bookings_test.py
@@ -148,7 +148,7 @@ class Returns200Test:
                     "name": offerer.name,
                 },
                 "venue": {
-                    "identifier": humanize(booking.stock.offer.venue.id),
+                    "identifier": humanize(booking.venueId),
                     "is_virtual": booking.stock.offer.venue.isVirtual,
                     "name": booking.stock.offer.venue.name,
                 },

--- a/tests/routes/pro/get_booking_by_token_v2_test.py
+++ b/tests/routes/pro/get_booking_by_token_v2_test.py
@@ -20,7 +20,6 @@ from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_event_occurrence
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
 from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence
-from pcapi.model_creators.specific_creators import create_stock_with_event_offer
 from pcapi.model_creators.specific_creators import create_stock_with_thing_offer
 from pcapi.models import api_errors
 from pcapi.repository import repository
@@ -160,9 +159,7 @@ class Returns200Test:
         url = f"/v2/bookings/token/{booking_token}"
 
         # When
-        response = TestClient(app.test_client()).get(
-            url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-        )
+        response = TestClient(app.test_client()).get(url, headers={"Authorization": user2ApiKey})
 
         # Then
         assert response.status_code == 200
@@ -190,34 +187,6 @@ class Returns200Test:
         # Then
         assert response.status_code == 200
 
-    def test_when_non_standard_origin_header(self, app):
-        # Given
-        user = users_factories.BeneficiaryGrant18Factory()
-        admin_user = users_factories.AdminFactory(email="admin@example.com")
-        offerer = create_offerer()
-        user_offerer = create_user_offerer(admin_user, offerer)
-        venue = create_venue(offerer)
-        stock = create_stock_with_event_offer(
-            offerer,
-            venue,
-            price=0,
-            beginning_datetime=datetime.utcnow() + timedelta(hours=46),
-            booking_limit_datetime=datetime.utcnow() + timedelta(hours=24),
-        )
-        booking = create_booking(user=user, stock=stock, venue=venue)
-        repository.save(booking, user_offerer)
-        url = f"/v2/bookings/token/{booking.token}"
-
-        # When
-        response = (
-            TestClient(app.test_client())
-            .with_basic_auth("admin@example.com")
-            .get(url, headers={"origin": "http://random_header.fr"})
-        )
-
-        # Then
-        assert response.status_code == 200
-
 
 class Returns401Test:
     def test_when_user_not_logged_in_and_doesnt_give_api_key(self, app):
@@ -235,9 +204,7 @@ class Returns401Test:
         url = "/v2/bookings/token/FAKETOKEN"
 
         # When
-        response = TestClient(app.test_client()).get(
-            url, headers={"Authorization": "Bearer WrongApiKey1234567", "Origin": "http://localhost"}
-        )
+        response = TestClient(app.test_client()).get(url, headers={"Authorization": "Bearer WrongApiKey1234567"})
 
         # Then
         assert response.status_code == 401
@@ -247,9 +214,7 @@ class Returns401Test:
         url = "/v2/bookings/token/FAKETOKEN"
 
         # When
-        response = TestClient(app.test_client()).get(
-            url, headers={"Authorization": "development_prefix_clearSecret", "Origin": "http://localhost"}
-        )
+        response = TestClient(app.test_client()).get(url, headers={"Authorization": "development_prefix_clearSecret"})
 
         # Then
         assert response.status_code == 401
@@ -289,9 +254,7 @@ class Returns403Test:
         url = f"/v2/bookings/token/{booking.token}"
 
         # When
-        response = TestClient(app.test_client()).get(
-            url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-        )
+        response = TestClient(app.test_client()).get(url, headers={"Authorization": user2ApiKey})
 
         # Then
         assert response.status_code == 403
@@ -330,9 +293,7 @@ class Returns403Test:
         url = f"/v2/bookings/token/{booking.token}"
 
         # When
-        response = TestClient(app.test_client()).get(
-            url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-        )
+        response = TestClient(app.test_client()).get(url, headers={"Authorization": user2ApiKey})
 
         # Then
         assert response.status_code == 403
@@ -354,9 +315,7 @@ class Returns403Test:
         url = f"/v2/bookings/token/{booking.token}"
 
         # When
-        response = TestClient(app.test_client()).get(
-            url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-        )
+        response = TestClient(app.test_client()).get(url, headers={"Authorization": user2ApiKey})
 
         # Then
         assert response.status_code == 403
@@ -470,9 +429,7 @@ class Returns404Test:
         url = "/v2/bookings/token/12345"
 
         # When
-        response = TestClient(app.test_client()).get(
-            url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-        )
+        response = TestClient(app.test_client()).get(url, headers={"Authorization": user2ApiKey})
 
         # Then
         assert response.status_code == 404
@@ -495,9 +452,7 @@ class Returns410Test:
         url = f"/v2/bookings/token/{booking.token}"
 
         # When
-        response = TestClient(app.test_client()).get(
-            url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-        )
+        response = TestClient(app.test_client()).get(url, headers={"Authorization": user2ApiKey})
 
         # Then
         assert response.status_code == 410

--- a/tests/routes/pro/patch_booking_by_token_test.py
+++ b/tests/routes/pro/patch_booking_by_token_test.py
@@ -67,21 +67,6 @@ class Returns204Test:
             assert booking.isUsed
             assert booking.status is BookingStatus.USED
 
-        def expect_booking_to_be_used_with_non_standard_origin_header(self, app):
-            booking = bookings_factories.BookingFactory(token="ABCDEF")
-            pro_user = users_factories.ProFactory(email="pro@example.com")
-            offerer = booking.stock.offer.venue.managingOfferer
-            offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-
-            url = f"/bookings/token/{booking.token.lower()}"
-            client = TestClient(app.test_client()).with_session_auth("pro@example.com")
-            response = client.patch(url, headers={"origin": "http://random_header.fr"})
-
-            assert response.status_code == 204
-            booking = Booking.query.one()
-            assert booking.isUsed
-            assert booking.status is BookingStatus.USED
-
         # FIXME: what is the purpose of this test? Are we testing that
         # Flask knows how to URL-decode parameters?
         def expect_booking_to_be_used_with_special_char_in_url(self, app):

--- a/tests/routes/pro/patch_booking_keep_by_token_test.py
+++ b/tests/routes/pro/patch_booking_keep_by_token_test.py
@@ -1,44 +1,25 @@
-from decimal import Decimal
-
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
-from pcapi.core.bookings.factories import CancelledBookingFactory
-from pcapi.core.bookings.factories import UsedBookingFactory
+from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.offerers.factories import ApiKeyFactory
 from pcapi.core.offerers.factories import DEFAULT_CLEAR_API_KEY
 import pcapi.core.offers.factories as offers_factories
+from pcapi.core.payments import factories as payments_factories
 from pcapi.core.users import factories as users_factories
-from pcapi.model_creators.generic_creators import create_booking
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_payment
-from pcapi.model_creators.generic_creators import create_user_offerer
-from pcapi.model_creators.generic_creators import create_venue
-from pcapi.model_creators.specific_creators import create_event_occurrence
-from pcapi.model_creators.specific_creators import create_offer_with_event_product
-from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence
-from pcapi.model_creators.specific_creators import create_stock_with_event_offer
 from pcapi.models import Booking
-from pcapi.repository import repository
-from pcapi.utils.token import random_token
-
-from tests.conftest import TestClient
-
-
-API_KEY_VALUE = random_token(64)
 
 
 @pytest.mark.usefixtures("db_session")
 class Returns204Test:
     class WithApiKeyAuthTest:
-        def test_when_api_key_provided_is_related_to_regular_offer_with_rights(self, app):
-            booking = UsedBookingFactory()
+        def test_when_api_key_provided_is_related_to_regular_offer_with_rights(self, client):
+            booking = bookings_factories.UsedBookingFactory()
             offerer = booking.stock.offer.venue.managingOfferer
             ApiKeyFactory(offerer=offerer)
 
             url = f"/v2/bookings/keep/token/{booking.token}"
-            response = TestClient(app.test_client()).patch(
+            response = client.patch(
                 url,
                 headers={
                     "Authorization": f"Bearer {DEFAULT_CLEAR_API_KEY}",
@@ -52,14 +33,12 @@ class Returns204Test:
             assert booking.dateUsed is None
 
     class WithBasicAuthTest:
-        def test_when_user_is_logged_in_and_regular_offer(self, app):
-            booking = UsedBookingFactory()
-            pro_user = users_factories.ProFactory(email="pro@example.com")
-            offerer = booking.stock.offer.venue.managingOfferer
-            offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+        def test_when_user_is_logged_in_and_regular_offer(self, client):
+            booking = bookings_factories.UsedBookingFactory()
+            pro_user = offers_factories.UserOffererFactory(offerer=booking.offerer).user
 
             url = f"/v2/bookings/keep/token/{booking.token}"
-            response = TestClient(app.test_client()).with_session_auth("pro@example.com").patch(url)
+            response = client.with_session_auth(pro_user.email).patch(url)
 
             assert response.status_code == 204
             booking = Booking.query.one()
@@ -67,14 +46,12 @@ class Returns204Test:
             assert booking.status is not BookingStatus.USED
             assert booking.dateUsed is None
 
-        def test_when_user_is_logged_in_expect_booking_with_token_in_lower_case_to_be_used(self, app):
-            booking = UsedBookingFactory()
-            pro_user = users_factories.ProFactory(email="pro@example.com")
-            offerer = booking.stock.offer.venue.managingOfferer
-            offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+        def test_when_user_is_logged_in_expect_booking_with_token_in_lower_case_to_be_used(self, client):
+            booking = bookings_factories.UsedBookingFactory()
+            pro_user = offers_factories.UserOffererFactory(offerer=booking.offerer).user
 
             url = f"/v2/bookings/keep/token/{booking.token.lower()}"
-            response = TestClient(app.test_client()).with_session_auth("pro@example.com").patch(url)
+            response = client.with_session_auth(pro_user.email).patch(url)
 
             assert response.status_code == 204
             booking = Booking.query.one()
@@ -83,14 +60,12 @@ class Returns204Test:
             assert booking.dateUsed is None
 
         # FIXME: I don't understand what we're trying to test, here.
-        def test_when_there_is_no_remaining_quantity_after_validating(self, app):
-            booking = UsedBookingFactory(stock__quantity=1)
-            pro_user = users_factories.ProFactory(email="pro@example.com")
-            offerer = booking.stock.offer.venue.managingOfferer
-            offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+        def test_when_there_is_no_remaining_quantity_after_validating(self, client):
+            booking = bookings_factories.UsedBookingFactory(stock__quantity=1)
+            pro_user = offers_factories.UserOffererFactory(offerer=booking.offerer).user
 
             url = f"/v2/bookings/keep/token/{booking.token.lower()}"
-            response = TestClient(app.test_client()).with_session_auth("pro@example.com").patch(url)
+            response = client.with_session_auth(pro_user.email).patch(url)
 
             assert response.status_code == 204
             booking = Booking.query.one()
@@ -101,42 +76,20 @@ class Returns204Test:
 
 class Returns401Test:
     @pytest.mark.usefixtures("db_session")
-    def test_when_user_not_logged_in_and_doesnt_give_api_key(self, app):
-        # Given
-        user = users_factories.BeneficiaryGrant18Factory(email="user@example.net")
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        offer = create_offer_with_event_product(venue, event_name="Event Name")
-        event_occurrence = create_event_occurrence(offer)
-        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-        booking = create_booking(user=user, stock=stock, venue=venue)
-
-        repository.save(booking)
-
-        # When
-        url = "/v2/bookings/keep/token/{}".format(booking.token)
-        response = TestClient(app.test_client()).patch(url)
-
-        # Then
+    def test_when_user_not_logged_in_and_doesnt_give_api_key(self, client):
+        booking = bookings_factories.BookingFactory()
+        response = client.patch(f"/v2/bookings/keep/token/{booking.token}")
         assert response.status_code == 401
 
     @pytest.mark.usefixtures("db_session")
-    def test_when_user_not_logged_in_and_given_api_key_that_does_not_exists(self, app):
+    def test_when_user_not_logged_in_and_given_api_key_that_does_not_exists(self, client):
         # Given
-        user = users_factories.BeneficiaryGrant18Factory(email="user@example.net")
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        offer = create_offer_with_event_product(venue, event_name="Event Name")
-        event_occurrence = create_event_occurrence(offer)
-        stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-        booking = create_booking(user=user, stock=stock, venue=venue)
-
-        repository.save(booking)
+        booking = bookings_factories.BookingFactory()
 
         # When
-        wrong_api_key = "Bearer WrongApiKey1234567"
+        unknown_auth = "Bearer WrongApiKey1234567"
         url = "/v2/bookings/keep/token/{}".format(booking.token)
-        response = TestClient(app.test_client()).patch(url, headers={"Authorization": wrong_api_key})
+        response = client.patch(url, headers={"Authorization": unknown_auth})
 
         # Then
         assert response.status_code == 401
@@ -145,268 +98,115 @@ class Returns401Test:
 class Returns403Test:
     class WithApiKeyAuthTest:
         @pytest.mark.usefixtures("db_session")
-        def test_when_the_api_key_is_not_linked_to_the_right_offerer(self, app):
+        def test_when_the_api_key_is_not_linked_to_the_right_offerer(self, client):
             # Given
-            user = users_factories.BeneficiaryGrant18Factory(email="user@example.net")
-            pro_user = users_factories.ProFactory(email="pro@example.net")
-
-            offerer = offers_factories.OffererFactory(siren="123456789")
-            offerer2 = offers_factories.OffererFactory(siren="987654321")
-            offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-
-            venue = offers_factories.VenueFactory(managingOfferer=offerer)
-            offer = offers_factories.ThingOfferFactory(venue=venue)
-            stock = offers_factories.ThingStockFactory(offer=offer, price=0)
-            booking = BookingFactory(user=user, stock=stock)
-
-            ApiKeyFactory(offerer=offerer2)
+            booking = bookings_factories.BookingFactory()
+            ApiKeyFactory()  # another offerer's API key
 
             # When
-            user2_api_key = f"Bearer {DEFAULT_CLEAR_API_KEY}"
-            url = "/v2/bookings/keep/token/{}".format(booking.token)
-
-            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2_api_key})
+            wrong_auth = f"Bearer {DEFAULT_CLEAR_API_KEY}"
+            url = f"/v2/bookings/keep/token/{booking.token}"
+            response = client.patch(url, headers={"Authorization": wrong_auth})
 
             # Then
             assert response.status_code == 403
             assert response.json["user"] == ["Vous n'avez pas les droits suffisants pour valider cette contremarque."]
 
         @pytest.mark.usefixtures("db_session")
-        def test_when_api_key_is_provided_and_booking_has_been_cancelled_already(self, app):
+        def test_when_api_key_is_provided_and_booking_has_been_cancelled_already(self, client):
             # Given
-            booking = CancelledBookingFactory()
+            booking = bookings_factories.CancelledBookingFactory()
             offerer = booking.stock.offer.venue.managingOfferer
-
             ApiKeyFactory(offerer=offerer)
-            url = f"/v2/bookings/keep/token/{booking.token}"
-            user2_api_key = f"Bearer {DEFAULT_CLEAR_API_KEY}"
 
             # When
-            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2_api_key})
+            url = f"/v2/bookings/keep/token/{booking.token}"
+            auth = f"Bearer {DEFAULT_CLEAR_API_KEY}"
+            response = client.patch(url, headers={"Authorization": auth})
 
             # Then
             booking = Booking.query.get(booking.id)
             assert response.status_code == 403
             assert response.json["booking"] == ["Cette réservation a été annulée"]
-            assert booking.isUsed is False
+            assert not booking.isUsed
             assert booking.status is BookingStatus.CANCELLED
 
     class WithBasicAuthTest:
         @pytest.mark.usefixtures("db_session")
-        def test_when_user_is_not_attached_to_linked_offerer(self, app):
+        def test_when_user_is_not_attached_to_linked_offerer(self, client):
             # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            pro_user = users_factories.ProFactory(email="pro@example.net")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking, pro_user)
+            booking = bookings_factories.BookingFactory()
+            another_pro_user = offers_factories.UserOffererFactory().user
 
             # When
-            url = "/v2/bookings/keep/token/{}?email={}".format(booking.token, user.email)
-            response = TestClient(app.test_client()).with_session_auth("pro@example.net").patch(url)
+            url = f"/v2/bookings/keep/token/{booking.token}?email={booking.user.email}"
+            response = client.with_session_auth(another_pro_user.email).patch(url)
 
             # Then
             assert response.status_code == 403
             assert response.json["user"] == ["Vous n'avez pas les droits suffisants pour valider cette contremarque."]
-            assert Booking.query.get(booking.id).isUsed is False
+            assert not booking.isUsed
 
         @pytest.mark.usefixtures("db_session")
-        def test_when_user_is_logged_in_and_booking_has_been_cancelled_already(self, app):
+        def test_when_user_is_logged_in_and_booking_has_been_cancelled_already(self, client):
             # Given
             admin = users_factories.UserFactory(isAdmin=True)
-            booking = CancelledBookingFactory()
+            booking = bookings_factories.CancelledBookingFactory()
             url = f"/v2/bookings/keep/token/{booking.token}"
 
             # When
-            response = TestClient(app.test_client()).with_session_auth(admin.email).patch(url)
+            response = client.with_session_auth(admin.email).patch(url)
 
             # Then
             booking = Booking.query.get(booking.id)
             assert response.status_code == 403
             assert response.json["booking"] == ["Cette réservation a été annulée"]
-            assert booking.isUsed is False
+            assert not booking.isUsed
             assert booking.status is BookingStatus.CANCELLED
 
 
 class Returns404Test:
-    class WithApiKeyAuthTest:
-        @pytest.mark.usefixtures("db_session")
-        def test_when_booking_is_not_provided_at_all(self, app):
-            # When
-            url = "/v2/bookings/keep/token/"
-            user2_api_key = f"Bearer {DEFAULT_CLEAR_API_KEY}"
+    @pytest.mark.usefixtures("db_session")
+    def test_missing_token(self, client):
+        user = users_factories.ProFactory()
+        response = client.with_basic_auth(user.email).patch("/v2/bookings/keep/token/")
+        assert response.status_code == 404
 
-            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2_api_key})
-
-            # Then
-            assert response.status_code == 404
-
-        @pytest.mark.usefixtures("db_session")
-        def test_when_api_key_is_provided_and_booking_does_not_exist(self, app):
-            # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking)
-
-            ApiKeyFactory(offerer=offerer)
-
-            # When
-            url = "/v2/bookings/keep/token/{}".format("456789")
-            user2_api_key = f"Bearer {DEFAULT_CLEAR_API_KEY}"
-
-            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2_api_key})
-
-            # Then
-            assert response.status_code == 404
-            assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
-
-    class WithBasicAuthTest:
-        @pytest.mark.usefixtures("db_session")
-        def test_when_user_is_logged_in_and_booking_does_not_exist(self, app):
-            # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            pro_user = users_factories.ProFactory(email="pro@example.net")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(pro_user, offerer)
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking, user_offerer)
-
-            # When
-            url = "/v2/bookings/keep/token/{}".format("123456")
-            response = TestClient(app.test_client()).with_session_auth("pro@example.net").patch(url)
-
-            # Then
-            assert response.status_code == 404
-            assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
-
-        @pytest.mark.usefixtures("db_session")
-        def test_when_user_is_logged_in_and_booking_token_is_null(self, app):
-            # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            pro_user = users_factories.ProFactory(email="pro@example.net")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(pro_user, offerer)
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-
-            booking = create_booking(user=user, stock=stock, venue=venue)
-
-            repository.save(booking, user_offerer)
-
-            # When
-            url = "/v2/bookings/keep/token/"
-            response = TestClient(app.test_client()).with_session_auth("pro@example.net").patch(url)
-
-            # Then
-            assert response.status_code == 404
+    @pytest.mark.usefixtures("db_session")
+    def test_unknown_token(self, client):
+        user = users_factories.ProFactory()
+        response = client.with_basic_auth(user.email).patch("/v2/bookings/keep/token/UNKNOWN")
+        assert response.status_code == 404
+        assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
 
 
 class Returns410Test:
-    class WithBasicAuthTest:
-        @pytest.mark.usefixtures("db_session")
-        def test_when_user_is_logged_in_and_booking_has_not_been_validated_already(self, app):
-            # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            pro_user = users_factories.ProFactory(email="pro@example.net")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(pro_user, offerer)
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
+    @pytest.mark.usefixtures("db_session")
+    def test_when_booking_has_not_been_used_yet(self, client):
+        # Given
+        booking = bookings_factories.BookingFactory()
+        pro_user = offers_factories.UserOffererFactory(offerer=booking.offerer).user
 
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking, user_offerer)
+        # When
+        url = f"/v2/bookings/keep/token/{booking.token}"
+        response = client.with_session_auth(pro_user.email).patch(url)
 
-            # When
-            url = "/v2/bookings/keep/token/{}".format(booking.token)
-            response = TestClient(app.test_client()).with_session_auth("pro@example.net").patch(url)
+        # Then
+        assert response.status_code == 410
+        assert response.json["booking"] == ["Cette réservation n'a pas encore été validée"]
+        assert not booking.isUsed
 
-            # Then
-            assert response.status_code == 410
-            assert response.json["booking"] == ["Cette réservation n'a pas encore été validée"]
-            assert Booking.query.get(booking.id).isUsed is False
+    @pytest.mark.usefixtures("db_session")
+    def test_when_user_is_logged_in_and_booking_payment_exists(self, client):
+        # Given
+        booking = payments_factories.PaymentFactory().booking
+        pro_user = offers_factories.UserOffererFactory(offerer=booking.offerer).user
 
-        @pytest.mark.usefixtures("db_session")
-        def test_when_user_is_logged_in_and_booking_payment_exists(self, app):
-            # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            pro_user = users_factories.ProFactory(email="pro@example.net")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(pro_user, offerer)
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
+        # When
+        url = f"/v2/bookings/keep/token/{booking.token}"
+        response = client.with_session_auth(pro_user.email).patch(url)
 
-            booking = create_booking(user=user, stock=stock, venue=venue, is_used=True)
-            payment = create_payment(booking, offerer, Decimal(10), iban="CF13QSDFGH456789", bic="QSDFGH8Z555")
-
-            repository.save(booking, user_offerer, payment)
-
-            # When
-            url = "/v2/bookings/keep/token/{}".format(booking.token)
-            response = TestClient(app.test_client()).with_session_auth("pro@example.net").patch(url)
-
-            # Then
-            assert response.status_code == 410
-            assert response.json["payment"] == ["Le remboursement est en cours de traitement"]
-            assert Booking.query.get(booking.id).isUsed is True
-
-    class WithApiKeyAuthTest:
-        @pytest.mark.usefixtures("db_session")
-        def test_when_api_key_is_provided_and_booking_has_not_been_validated_already(self, app):
-            # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            pro_user = users_factories.ProFactory(email="pro@example.net")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(pro_user, offerer)
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking, user_offerer)
-
-            ApiKeyFactory(offerer=offerer)
-
-            # When
-            url = "/v2/bookings/keep/token/{}".format(booking.token)
-            user2_api_key = f"Bearer {DEFAULT_CLEAR_API_KEY}"
-
-            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2_api_key})
-            # Then
-            assert response.status_code == 410
-            assert response.json["booking"] == ["Cette réservation n'a pas encore été validée"]
-            assert Booking.query.get(booking.id).isUsed is False
-
-        @pytest.mark.usefixtures("db_session")
-        def test_when_api_key_is_provided_and_booking_payment_exists(self, app):
-            # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            pro_user = users_factories.ProFactory(email="pro@example.net")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(pro_user, offerer)
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-
-            booking = create_booking(user=user, stock=stock, venue=venue, is_used=True)
-            payment = create_payment(booking, offerer, Decimal(10), iban="CF13QSDFGH456789", bic="QSDFGH8Z555")
-
-            repository.save(booking, user_offerer, payment)
-
-            ApiKeyFactory(offerer=offerer)
-
-            # When
-            url = "/v2/bookings/keep/token/{}".format(booking.token)
-            user2_api_key = f"Bearer {DEFAULT_CLEAR_API_KEY}"
-
-            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2_api_key})
-            # Then
-            assert response.status_code == 410
-            assert response.json["payment"] == ["Le remboursement est en cours de traitement"]
-            assert Booking.query.get(booking.id).isUsed is True
+        # Then
+        assert response.status_code == 410
+        assert response.json["payment"] == ["Le remboursement est en cours de traitement"]
+        assert booking.isUsed

--- a/tests/routes/pro/patch_booking_keep_by_token_test.py
+++ b/tests/routes/pro/patch_booking_keep_by_token_test.py
@@ -42,27 +42,6 @@ class Returns204Test:
                 url,
                 headers={
                     "Authorization": f"Bearer {DEFAULT_CLEAR_API_KEY}",
-                    "Origin": "http://localhost",
-                },
-            )
-
-            assert response.status_code == 204
-            booking = Booking.query.one()
-            assert not booking.isUsed
-            assert booking.status is not BookingStatus.USED
-            assert booking.dateUsed is None
-
-        def test_expect_booking_to_be_used_with_non_standard_origin_header(self, app):
-            booking = UsedBookingFactory()
-            offerer = booking.stock.offer.venue.managingOfferer
-            ApiKeyFactory(offerer=offerer)
-
-            url = f"/v2/bookings/keep/token/{booking.token}"
-            response = TestClient(app.test_client()).patch(
-                url,
-                headers={
-                    "Authorization": f"Bearer {DEFAULT_CLEAR_API_KEY}",
-                    "Origin": "http://example.com",
                 },
             )
 
@@ -157,9 +136,7 @@ class Returns401Test:
         # When
         wrong_api_key = "Bearer WrongApiKey1234567"
         url = "/v2/bookings/keep/token/{}".format(booking.token)
-        response = TestClient(app.test_client()).patch(
-            url, headers={"Authorization": wrong_api_key, "Origin": "http://localhost"}
-        )
+        response = TestClient(app.test_client()).patch(url, headers={"Authorization": wrong_api_key})
 
         # Then
         assert response.status_code == 401
@@ -188,9 +165,7 @@ class Returns403Test:
             user2_api_key = f"Bearer {DEFAULT_CLEAR_API_KEY}"
             url = "/v2/bookings/keep/token/{}".format(booking.token)
 
-            response = TestClient(app.test_client()).patch(
-                url, headers={"Authorization": user2_api_key, "Origin": "http://localhost"}
-            )
+            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2_api_key})
 
             # Then
             assert response.status_code == 403
@@ -207,9 +182,7 @@ class Returns403Test:
             user2_api_key = f"Bearer {DEFAULT_CLEAR_API_KEY}"
 
             # When
-            response = TestClient(app.test_client()).patch(
-                url, headers={"Authorization": user2_api_key, "Origin": "http://localhost"}
-            )
+            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2_api_key})
 
             # Then
             booking = Booking.query.get(booking.id)
@@ -266,9 +239,7 @@ class Returns404Test:
             url = "/v2/bookings/keep/token/"
             user2_api_key = f"Bearer {DEFAULT_CLEAR_API_KEY}"
 
-            response = TestClient(app.test_client()).patch(
-                url, headers={"Authorization": user2_api_key, "Origin": "http://localhost"}
-            )
+            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2_api_key})
 
             # Then
             assert response.status_code == 404
@@ -290,9 +261,7 @@ class Returns404Test:
             url = "/v2/bookings/keep/token/{}".format("456789")
             user2_api_key = f"Bearer {DEFAULT_CLEAR_API_KEY}"
 
-            response = TestClient(app.test_client()).patch(
-                url, headers={"Authorization": user2_api_key, "Origin": "http://localhost"}
-            )
+            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2_api_key})
 
             # Then
             assert response.status_code == 404
@@ -409,9 +378,7 @@ class Returns410Test:
             url = "/v2/bookings/keep/token/{}".format(booking.token)
             user2_api_key = f"Bearer {DEFAULT_CLEAR_API_KEY}"
 
-            response = TestClient(app.test_client()).patch(
-                url, headers={"Authorization": user2_api_key, "Origin": "http://localhost"}
-            )
+            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2_api_key})
             # Then
             assert response.status_code == 410
             assert response.json["booking"] == ["Cette réservation n'a pas encore été validée"]
@@ -438,9 +405,7 @@ class Returns410Test:
             url = "/v2/bookings/keep/token/{}".format(booking.token)
             user2_api_key = f"Bearer {DEFAULT_CLEAR_API_KEY}"
 
-            response = TestClient(app.test_client()).patch(
-                url, headers={"Authorization": user2_api_key, "Origin": "http://localhost"}
-            )
+            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2_api_key})
             # Then
             assert response.status_code == 410
             assert response.json["payment"] == ["Le remboursement est en cours de traitement"]

--- a/tests/routes/pro/patch_booking_use_by_token_test.py
+++ b/tests/routes/pro/patch_booking_use_by_token_test.py
@@ -4,40 +4,26 @@ import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
-from pcapi.core.categories import subcategories
 from pcapi.core.educational.models import EducationalBookingStatus
 from pcapi.core.offerers.factories import ApiKeyFactory
 from pcapi.core.offerers.factories import DEFAULT_CLEAR_API_KEY
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.users import factories as users_factories
-from pcapi.model_creators.generic_creators import create_booking
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_stock
-from pcapi.model_creators.generic_creators import create_user_offerer
-from pcapi.model_creators.generic_creators import create_venue
-from pcapi.model_creators.specific_creators import create_offer_with_thing_product
-from pcapi.model_creators.specific_creators import create_stock_with_event_offer
 from pcapi.models import Booking
-from pcapi.repository import repository
-from pcapi.utils.token import random_token
-
-from tests.conftest import TestClient
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
-API_KEY_VALUE = random_token(64)
-
 
 class Returns204Test:
     class WithApiKeyAuthTest:
-        def test_when_api_key_is_provided_and_rights_and_regular_offer(self, app):
+        def test_when_api_key_is_provided_and_rights_and_regular_offer(self, client):
             booking = bookings_factories.BookingFactory(token="ABCDEF")
             offerer = booking.stock.offer.venue.managingOfferer
             ApiKeyFactory(offerer=offerer)
 
             url = f"/v2/bookings/use/token/{booking.token}"
-            response = TestClient(app.test_client()).patch(
+            response = client.patch(
                 url,
                 headers={
                     "Authorization": f"Bearer {DEFAULT_CLEAR_API_KEY}",
@@ -50,35 +36,35 @@ class Returns204Test:
             assert booking.status == BookingStatus.USED
 
     class WithBasicAuthTest:
-        def test_when_user_is_logged_in_and_regular_offer(self, app):
+        def test_when_user_is_logged_in_and_regular_offer(self, client):
             booking = bookings_factories.BookingFactory(token="ABCDEF")
             pro_user = users_factories.ProFactory(email="pro@example.com")
             offerer = booking.stock.offer.venue.managingOfferer
             offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
 
             url = f"/v2/bookings/use/token/{booking.token}"
-            response = TestClient(app.test_client()).with_session_auth("pro@example.com").patch(url)
+            response = client.with_session_auth("pro@example.com").patch(url)
 
             assert response.status_code == 204
             booking = Booking.query.one()
             assert booking.isUsed
             assert booking.status == BookingStatus.USED
 
-        def test_when_user_is_logged_in_expect_booking_with_token_in_lower_case_to_be_used(self, app):
+        def test_when_user_is_logged_in_expect_booking_with_token_in_lower_case_to_be_used(self, client):
             booking = bookings_factories.BookingFactory(token="ABCDEF")
             pro_user = users_factories.ProFactory(email="pro@example.com")
             offerer = booking.stock.offer.venue.managingOfferer
             offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
 
             url = f"/v2/bookings/use/token/{booking.token.lower()}"
-            response = TestClient(app.test_client()).with_session_auth("pro@example.com").patch(url)
+            response = client.with_session_auth("pro@example.com").patch(url)
 
             assert response.status_code == 204
             booking = Booking.query.one()
             assert booking.isUsed
             assert booking.status == BookingStatus.USED
 
-        def test_when_user_is_logged_in_and_offer_is_educational_validated_by_institution(self, app):
+        def test_when_user_is_logged_in_and_offer_is_educational_validated_by_institution(self, client):
             # Given
             booking = bookings_factories.EducationalBookingFactory(
                 token="ABCDEF",
@@ -91,7 +77,7 @@ class Returns204Test:
 
             # When
             url = f"/v2/bookings/use/token/{booking.token}"
-            response = TestClient(app.test_client()).with_session_auth("pro@example.com").patch(url)
+            response = client.with_session_auth("pro@example.com").patch(url)
 
             # Then
             assert response.status_code == 204
@@ -101,79 +87,41 @@ class Returns204Test:
 
 
 class Returns401Test:
-    def test_when_user_not_logged_in_and_doesnt_give_api_key(self, app):
-        # Given
-        user = users_factories.BeneficiaryGrant18Factory(email="user@example.com")
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        stock = create_stock_with_event_offer(offerer, venue, price=0)
-        booking = create_booking(user=user, stock=stock, venue=venue)
-
-        repository.save(booking)
-
-        # When
-        url = "/v2/bookings/use/token/{}".format(booking.token)
-        response = TestClient(app.test_client()).patch(url)
-
-        # Then
+    def test_when_user_not_logged_in_and_doesnt_give_api_key(self, client):
+        response = client.patch("/v2/bookings/use/token/TOKEN")
         assert response.status_code == 401
 
-    def test_when_user_not_logged_in_and_not_existing_api_key_given(self, app):
-        # Given
-        user = users_factories.BeneficiaryGrant18Factory(email="user@example.com")
-        users_factories.ProFactory(email="pro@example.com")
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        offer = create_offer_with_thing_product(venue)
-        stock = create_stock(offer=offer, price=0)
-        booking = create_booking(user=user, stock=stock, venue=venue)
-
-        repository.save(booking)
-
-        # When
-        url = "/v2/bookings/use/token/{}".format(booking.token)
-        response = TestClient(app.test_client()).patch(url, headers={"Authorization": "Bearer WrongApiKey1234567"})
-
-        # Then
+    def test_when_user_not_logged_in_and_not_existing_api_key_given(self, client):
+        url = "/v2/bookings/use/token/TOKEN"
+        response = client.patch(url, headers={"Authorization": "Bearer WrongApiKey1234567"})
         assert response.status_code == 401
 
 
 class Returns403Test:
     class WithApiKeyAuthTest:
-        def test_when_api_key_given_not_related_to_booking_offerer(self, app):
+        def test_when_api_key_given_not_related_to_booking_offerer(self, client):
             # Given
-            user = users_factories.BeneficiaryGrant18Factory(email="user@example.com")
-            offerer2 = offers_factories.OffererFactory(siren="987654321")
-            offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
-            stock = offers_factories.EventStockFactory(offer=offer, price=0)
-            booking = bookings_factories.BookingFactory(user=user, stock=stock)
-
-            ApiKeyFactory(offerer=offerer2)
-
-            user2ApiKey = "Bearer " + DEFAULT_CLEAR_API_KEY
+            booking = bookings_factories.BookingFactory()
+            ApiKeyFactory()  # another offerer's API key
 
             # When
-            url = "/v2/bookings/use/token/{}".format(booking.token)
-            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2ApiKey})
+            auth = "Bearer " + DEFAULT_CLEAR_API_KEY
+            url = f"/v2/bookings/use/token/{booking.token}"
+            response = client.patch(url, headers={"Authorization": auth})
 
             # Then
             assert response.status_code == 403
             assert response.json["user"] == ["Vous n'avez pas les droits suffisants pour valider cette contremarque."]
 
-        def test_when_api_key_is_provided_and_booking_has_been_cancelled_already(self, app):
+        def test_when_api_key_is_provided_and_booking_has_been_cancelled_already(self, client):
             # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            pro_user = users_factories.ProFactory(email="pro@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(pro_user, offerer)
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue, is_cancelled=True)
-            repository.save(booking, user_offerer)
-            url = f"/v2/bookings/use/token/{booking.token}"
+            booking = bookings_factories.CancelledBookingFactory()
+            ApiKeyFactory(offerer=booking.offerer)
 
             # When
-            response = TestClient(app.test_client()).with_session_auth(pro_user.email).patch(url)
+            url = f"/v2/bookings/use/token/{booking.token}"
+            auth = "Bearer development_prefix_clearSecret"
+            response = client.patch(url, headers={"Authorization": auth})
 
             # Then
             assert response.status_code == 403
@@ -183,19 +131,14 @@ class Returns403Test:
             assert booking.status is not BookingStatus.USED
 
     class WithBasicAuthTest:
-        def test_when_user_is_not_attached_to_linked_offerer(self, app):
+        def test_when_user_is_not_attached_to_linked_offerer(self, client):
             # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            users_factories.ProFactory(email="pro@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking)
-            url = f"/v2/bookings/use/token/{booking.token}"
+            booking = bookings_factories.BookingFactory()
+            another_pro_user = offers_factories.UserOffererFactory().user
 
             # When
-            response = TestClient(app.test_client()).with_session_auth("pro@example.com").patch(url)
+            url = f"/v2/bookings/use/token/{booking.token}"
+            response = client.with_session_auth(another_pro_user.email).patch(url)
 
             # Then
             assert response.status_code == 403
@@ -204,14 +147,14 @@ class Returns403Test:
             assert not booking.isUsed
             assert booking.status is not BookingStatus.USED
 
-        def test_when_user_is_logged_in_and_booking_has_been_cancelled_already(self, app):
+        def test_when_user_is_logged_in_and_booking_has_been_cancelled_already(self, client):
             # Given
             admin = users_factories.AdminFactory()
             booking = bookings_factories.CancelledBookingFactory()
             url = f"/v2/bookings/use/token/{booking.token}"
 
             # When
-            response = TestClient(app.test_client()).with_session_auth(admin.email).patch(url)
+            response = client.with_session_auth(admin.email).patch(url)
 
             # Then
             assert response.status_code == 403
@@ -220,7 +163,7 @@ class Returns403Test:
             assert not booking.isUsed
             assert booking.status is not BookingStatus.USED
 
-        def test_when_user_is_logged_in_and_offer_is_educational_but_not_validated_by_institution_yet(self, app):
+        def test_when_user_is_logged_in_and_offer_is_educational_but_not_validated_by_institution_yet(self, client):
             # Given
             booking = bookings_factories.EducationalBookingFactory(
                 token="ABCDEF",
@@ -233,7 +176,7 @@ class Returns403Test:
 
             # When
             url = f"/v2/bookings/use/token/{booking.token}"
-            response = TestClient(app.test_client()).with_session_auth("pro@example.com").patch(url)
+            response = client.with_session_auth("pro@example.com").patch(url)
 
             # Then
             assert response.status_code == 403
@@ -245,7 +188,7 @@ class Returns403Test:
             assert not booking.isUsed
             assert booking.status is not BookingStatus.USED
 
-        def test_when_user_is_logged_in_and_offer_is_educational_but_has_been_refused_by_institution(self, app):
+        def test_when_user_is_logged_in_and_offer_is_educational_but_has_been_refused_by_institution(self, client):
             # Given
             booking = bookings_factories.EducationalBookingFactory(
                 token="ABCDEF",
@@ -258,7 +201,7 @@ class Returns403Test:
 
             # When
             url = f"/v2/bookings/use/token/{booking.token}"
-            response = TestClient(app.test_client()).with_session_auth("pro@example.com").patch(url)
+            response = client.with_session_auth("pro@example.com").patch(url)
 
             # Then
             assert response.status_code == 403
@@ -272,61 +215,12 @@ class Returns403Test:
 
 
 class Returns404Test:
-    def test_when_booking_is_not_provided_at_all(self, app):
-        # Given
-        user = users_factories.BeneficiaryGrant18Factory(email="user@example.com")
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        stock = create_stock_with_event_offer(offerer, venue, price=0)
-        booking = create_booking(user=user, stock=stock, venue=venue)
-
-        repository.save(booking)
-
-        # When
-        url = "/v2/bookings/use/token/"
-        response = TestClient(app.test_client()).patch(url)
-
-        # Then
+    def test_missing_token(self, client):
+        response = client.patch("/v2/bookings/use/token/")
         assert response.status_code == 404
 
-    class WithApiKeyAuthTest:
-        def test_when_api_key_is_provided_and_booking_does_not_exist(self, app):
-            # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking)
-
-            ApiKeyFactory(offerer=offerer)
-
-            user2ApiKey = "Bearer " + DEFAULT_CLEAR_API_KEY
-
-            # When
-            url = "/v2/bookings/use/token/{}".format("456789")
-            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2ApiKey})
-
-            # Then
-            assert response.status_code == 404
-            assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
-
-    class WithBasicAuthTest:
-        def test_when_user_is_logged_in_and_booking_does_not_exist(self, app):
-            # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            pro_user = users_factories.ProFactory(email="pro@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(pro_user, offerer)
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking, user_offerer)
-
-            # When
-            url = "/v2/bookings/use/token/{}".format("123456")
-            response = TestClient(app.test_client()).with_session_auth("pro@example.com").patch(url)
-
-            # Then
-            assert response.status_code == 404
-            assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
+    def test_unknown_token(self, client):
+        pro_user = users_factories.ProFactory()
+        response = client.with_basic_auth(pro_user.email).patch("/v2/bookings/use/token/UNKNOWN")
+        assert response.status_code == 404
+        assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]

--- a/tests/routes/pro/patch_booking_use_by_token_test.py
+++ b/tests/routes/pro/patch_booking_use_by_token_test.py
@@ -41,26 +41,6 @@ class Returns204Test:
                 url,
                 headers={
                     "Authorization": f"Bearer {DEFAULT_CLEAR_API_KEY}",
-                    "Origin": "http://localhost",
-                },
-            )
-
-            assert response.status_code == 204
-            booking = Booking.query.one()
-            assert booking.isUsed
-            assert booking.status == BookingStatus.USED
-
-        def test_expect_booking_to_be_used_with_non_standard_origin_header(self, app):
-            booking = bookings_factories.BookingFactory(token="ABCDEF")
-            offerer = booking.stock.offer.venue.managingOfferer
-            ApiKeyFactory(offerer=offerer)
-
-            url = f"/v2/bookings/use/token/{booking.token}"
-            response = TestClient(app.test_client()).patch(
-                url,
-                headers={
-                    "Authorization": f"Bearer {DEFAULT_CLEAR_API_KEY}",
-                    "Origin": "http://example.com",
                 },
             )
 
@@ -152,9 +132,7 @@ class Returns401Test:
 
         # When
         url = "/v2/bookings/use/token/{}".format(booking.token)
-        response = TestClient(app.test_client()).patch(
-            url, headers={"Authorization": "Bearer WrongApiKey1234567", "Origin": "http://localhost"}
-        )
+        response = TestClient(app.test_client()).patch(url, headers={"Authorization": "Bearer WrongApiKey1234567"})
 
         # Then
         assert response.status_code == 401
@@ -176,9 +154,7 @@ class Returns403Test:
 
             # When
             url = "/v2/bookings/use/token/{}".format(booking.token)
-            response = TestClient(app.test_client()).patch(
-                url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-            )
+            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2ApiKey})
 
             # Then
             assert response.status_code == 403
@@ -329,9 +305,7 @@ class Returns404Test:
 
             # When
             url = "/v2/bookings/use/token/{}".format("456789")
-            response = TestClient(app.test_client()).patch(
-                url, headers={"Authorization": user2ApiKey, "Origin": "http://localhost"}
-            )
+            response = TestClient(app.test_client()).patch(url, headers={"Authorization": user2ApiKey})
 
             # Then
             assert response.status_code == 404

--- a/tests/routes/pro/patch_cancel_booking_by_token_test.py
+++ b/tests/routes/pro/patch_cancel_booking_by_token_test.py
@@ -41,7 +41,7 @@ class Returns204Test:
         # When
         response = TestClient(app.test_client()).patch(
             "/v2/bookings/cancel/token/{}".format(booking.token),
-            headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY, "Origin": "http://localhost"},
+            headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY},
         )
 
         # cancellation can trigger more than one request to Batch
@@ -82,7 +82,7 @@ class Returns204Test:
         token = booking.token.lower()
         response = TestClient(app.test_client()).patch(
             "/v2/bookings/cancel/token/{}".format(token),
-            headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY, "Origin": "http://localhost"},
+            headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY},
         )
 
         # cancellation can trigger more than one request to Batch
@@ -133,9 +133,7 @@ class Returns401Test:
         # When
         url = "/v2/bookings/cancel/token/{}".format(booking.token)
         wrong_api_key = "Bearer WrongApiKey1234567"
-        response = TestClient(app.test_client()).patch(
-            url, headers={"Authorization": wrong_api_key, "Origin": "http://localhost"}
-        )
+        response = TestClient(app.test_client()).patch(url, headers={"Authorization": wrong_api_key})
 
         assert response.status_code == 401
         assert push_testing.requests == []
@@ -165,7 +163,7 @@ class Returns403Test:
         # When
         response = TestClient(app.test_client()).patch(
             "/v2/bookings/cancel/token/{}".format(booking.token),
-            headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY, "Origin": "http://localhost"},
+            headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY},
         )
 
         # Then
@@ -221,7 +219,7 @@ class Returns403Test:
             # When
             response = TestClient(app.test_client()).patch(
                 "/v2/bookings/cancel/token/{}".format(booking.token),
-                headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY, "Origin": "http://localhost"},
+                headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY},
             )
 
             # Then
@@ -253,7 +251,7 @@ class Returns404Test:
         # When
         response = TestClient(app.test_client()).patch(
             "/v2/bookings/cancel/token/FAKETOKEN",
-            headers={"Authorization": f"Bearer {DEFAULT_CLEAR_API_KEY}", "Origin": "http://localhost"},
+            headers={"Authorization": f"Bearer {DEFAULT_CLEAR_API_KEY}"},
         )
 
         # Then
@@ -282,7 +280,7 @@ class Returns410Test:
         # When
         response = TestClient(app.test_client()).patch(
             "/v2/bookings/cancel/token/{}".format(booking.token),
-            headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY, "Origin": "http://localhost"},
+            headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY},
         )
 
         # Then

--- a/tests/routes/pro/patch_cancel_booking_by_token_test.py
+++ b/tests/routes/pro/patch_cancel_booking_by_token_test.py
@@ -6,284 +6,146 @@ from pcapi.core.offerers.factories import ApiKeyFactory
 from pcapi.core.offerers.factories import DEFAULT_CLEAR_API_KEY
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
-from pcapi.model_creators.generic_creators import create_booking
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_stock
-from pcapi.model_creators.generic_creators import create_user_offerer
-from pcapi.model_creators.generic_creators import create_venue
-from pcapi.model_creators.specific_creators import create_offer_with_event_product
-from pcapi.model_creators.specific_creators import create_offer_with_thing_product
 from pcapi.models import Booking
 import pcapi.notifications.push.testing as push_testing
-from pcapi.repository import repository
-
-from tests.conftest import TestClient
 
 
 class Returns204Test:
     @pytest.mark.usefixtures("db_session")
-    def test_should_returns_204_with_cancellation_allowed(self, app):
+    def test_should_returns_204_with_cancellation_allowed(self, client):
         # Given
-        pro_user = users_factories.ProFactory(email="Mr Books@example.net", publicName="Mr Books")
-        offerer = create_offerer(siren="793875030")
-        user_offerer = create_user_offerer(pro_user, offerer)
-        venue = create_venue(offerer)
-        book_offer = create_offer_with_event_product(venue)
-        stock = create_stock(offer=book_offer)
-
-        beneficiary = users_factories.BeneficiaryGrant18Factory()
-        booking = create_booking(user=beneficiary, stock=stock, venue=venue)
-
-        repository.save(booking, user_offerer)
-
-        ApiKeyFactory(offerer=offerer)
+        stock = offers_factories.EventStockFactory(offer__name="Chouette concert")
+        booking = bookings_factories.BookingFactory(stock=stock)
+        ApiKeyFactory(offerer=booking.offerer)
 
         # When
-        response = TestClient(app.test_client()).patch(
-            "/v2/bookings/cancel/token/{}".format(booking.token),
+        response = client.patch(
+            f"/v2/bookings/cancel/token/{booking.token}",
             headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY},
         )
 
+        # Then
         # cancellation can trigger more than one request to Batch
         assert len(push_testing.requests) >= 1
-
-        # Then
         assert response.status_code == 204
-        updated_booking = Booking.query.first()
+        updated_booking = Booking.query.one()
         assert updated_booking.isCancelled
         assert updated_booking.status is BookingStatus.CANCELLED
 
         assert push_testing.requests[-1] == {
             "group_id": "Cancel_booking",
             "message": {
-                "body": 'Ta réservation "Test event" a été annulée par l\'offreur.',
+                "body": """Ta réservation "Chouette concert" a été annulée par l'offreur.""",
                 "title": "Réservation annulée",
             },
-            "user_ids": [beneficiary.id],
+            "user_ids": [booking.userId],
         }
 
     @pytest.mark.usefixtures("db_session")
-    def test_should_returns_204_with_lowercase_token(self, app):
+    def test_should_returns_204_with_lowercase_token(self, client):
         # Given
-        pro_user = users_factories.ProFactory(email="Mr Books@example.net", publicName="Mr Books")
-        offerer = create_offerer(siren="793875030")
-        user_offerer = create_user_offerer(pro_user, offerer)
-        venue = create_venue(offerer)
-        book_offer = create_offer_with_event_product(venue)
-        stock = create_stock(offer=book_offer)
-
-        user = users_factories.BeneficiaryGrant18Factory()
-        booking = create_booking(user=user, stock=stock, venue=venue)
-
-        repository.save(booking, user_offerer)
-        ApiKeyFactory(offerer=offerer)
+        booking = bookings_factories.BookingFactory()
+        ApiKeyFactory(offerer=booking.offerer)
 
         # When
-        token = booking.token.lower()
-        response = TestClient(app.test_client()).patch(
-            "/v2/bookings/cancel/token/{}".format(token),
+        response = client.patch(
+            f"/v2/bookings/cancel/token/{booking.token.lower()}",
             headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY},
         )
 
-        # cancellation can trigger more than one request to Batch
-        assert len(push_testing.requests) >= 1
-
-        # Then
         assert response.status_code == 204
-        updated_booking = Booking.query.first()
-        assert updated_booking.isCancelled
-        assert updated_booking.status is BookingStatus.CANCELLED
+        booking = Booking.query.one()
+        assert booking.isCancelled
+        assert booking.status is BookingStatus.CANCELLED
 
 
 class Returns401Test:
     @pytest.mark.usefixtures("db_session")
-    def when_not_authenticated_used_api_key_or_login(self, app):
-        # Given
-        pro = users_factories.ProFactory()
-        offerer = create_offerer()
-        user_offerer = create_user_offerer(pro, offerer)
-        venue = create_venue(offerer)
-        offer = create_offer_with_event_product(venue)
-        stock = create_stock(offer=offer)
-        beneficiary = users_factories.BeneficiaryGrant18Factory()
-        booking = create_booking(user=beneficiary, stock=stock, venue=venue)
-        repository.save(user_offerer, booking)
-
-        # When
-        url = "/v2/bookings/cancel/token/{}".format(booking.token)
-        response = TestClient(app.test_client()).patch(url)
-
-        # Then
+    def when_not_authenticated_used_api_key_or_login(self, client):
+        response = client.patch("/v2/bookings/cancel/token/TOKEN")
         assert response.status_code == 401
-        assert push_testing.requests == []
 
     @pytest.mark.usefixtures("db_session")
-    def when_giving_an_api_key_that_does_not_exists(self, app):
-        # Given
-        pro = users_factories.ProFactory()
-        offerer = create_offerer()
-        user_offerer = create_user_offerer(pro, offerer)
-        venue = create_venue(offerer)
-        offer = create_offer_with_event_product(venue)
-        stock = create_stock(offer=offer)
-        beneficiary = users_factories.BeneficiaryGrant18Factory()
-        booking = create_booking(user=beneficiary, stock=stock, venue=venue)
-        repository.save(user_offerer, booking)
-
-        # When
-        url = "/v2/bookings/cancel/token/{}".format(booking.token)
-        wrong_api_key = "Bearer WrongApiKey1234567"
-        response = TestClient(app.test_client()).patch(url, headers={"Authorization": wrong_api_key})
-
+    def when_giving_an_api_key_that_does_not_exists(self, client):
+        headers = {"Authorization": "Bearer WrongApiKey1234567"}
+        response = client.patch("/v2/bookings/cancel/token/TOKEN", headers=headers)
         assert response.status_code == 401
-        assert push_testing.requests == []
 
 
 class Returns403Test:
     @pytest.mark.usefixtures("db_session")
-    def when_the_api_key_is_not_linked_to_the_right_offerer(self, app):
+    def when_the_api_key_is_not_linked_to_the_right_offerer(self, client):
         # Given
-        pro_user = users_factories.ProFactory(email="Mr Books@example.net", publicName="Mr Books")
-        offerer = create_offerer(siren="793875030")
-        user_offerer = create_user_offerer(pro_user, offerer)
-        venue = create_venue(offerer)
-        book_offer = create_offer_with_event_product(venue)
-        stock = create_stock(offer=book_offer)
-
-        user = users_factories.BeneficiaryGrant18Factory()
-        booking = create_booking(user=user, stock=stock, venue=venue)
-
-        repository.save(booking, user_offerer)
-
-        offerer_with_api_key = create_offerer()
-        repository.save(offerer_with_api_key)
-
-        ApiKeyFactory(offerer=offerer_with_api_key)
+        booking = bookings_factories.BookingFactory()
+        ApiKeyFactory()  # another offerer's API key
 
         # When
-        response = TestClient(app.test_client()).patch(
-            "/v2/bookings/cancel/token/{}".format(booking.token),
+        response = client.patch(
+            f"/v2/bookings/cancel/token/{booking.token}",
             headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY},
         )
 
         # Then
         assert response.status_code == 403
         assert response.json["user"] == ["Vous n'avez pas les droits suffisants pour annuler cette réservation."]
-        assert push_testing.requests == []
 
     @pytest.mark.usefixtures("db_session")
-    def when_the_logged_user_has_not_rights_on_offerer(self, app):
+    def when_the_logged_user_has_not_rights_on_offerer(self, client):
         # Given
-        pro_user = users_factories.ProFactory(email="mr.book@example.net", publicName="Mr Books")
-        offerer = create_offerer(siren="793875030")
-        user_offerer = create_user_offerer(pro_user, offerer)
-        venue = create_venue(offerer)
-        book_offer = create_offer_with_event_product(venue)
-        stock = create_stock(offer=book_offer)
-
-        user = users_factories.BeneficiaryGrant18Factory()
-        booking = create_booking(user=user, stock=stock, venue=venue)
-
-        repository.save(booking, user_offerer)
-
-        offerer_with_api_key = create_offerer()
-        repository.save(offerer_with_api_key)
-
-        ApiKeyFactory(offerer=offerer)
+        booking = bookings_factories.BookingFactory()
+        another_pro_user = offers_factories.UserOffererFactory().user
 
         # When
-        response = (
-            TestClient(app.test_client())
-            .with_session_auth(user.email)
-            .patch("/v2/bookings/cancel/token/{}".format(booking.token))
-        )
+        url = f"/v2/bookings/cancel/token/{booking.token}"
+        response = client.with_session_auth(another_pro_user.email).patch(url)
 
         # Then
         assert response.status_code == 403
         assert response.json["global"] == [
             "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
         ]
+
+    @pytest.mark.usefixtures("db_session")
+    def test_should_prevent_a_used_booking_from_being_cancelled(self, client):
+        # Given
+        booking = bookings_factories.UsedBookingFactory()
+        pro_user = offers_factories.UserOffererFactory(offerer=booking.offerer).user
+
+        # When
+        url = f"/v2/bookings/cancel/token/{booking.token}"
+        response = client.with_basic_auth(pro_user.email).patch(url)
+
+        # Then
+        assert response.status_code == 403
+        assert response.json["global"] == ["Impossible d'annuler une réservation consommée"]
+        booking = Booking.query.first()
+        assert booking.isUsed
+        assert not booking.isCancelled
+        assert booking.status is BookingStatus.USED
         assert push_testing.requests == []
-
-    class WhenTheBookingIsUsedTest:
-        @pytest.mark.usefixtures("db_session")
-        def test_should_prevent_a_used_booking_from_being_cancelled(self, app):
-            # Given
-            user_offerer = offers_factories.UserOffererFactory()
-            booking = bookings_factories.UsedBookingFactory(
-                stock__offer__venue__managingOfferer=user_offerer.offerer,
-            )
-
-            ApiKeyFactory(offerer=user_offerer.offerer)
-
-            # When
-            response = TestClient(app.test_client()).patch(
-                "/v2/bookings/cancel/token/{}".format(booking.token),
-                headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY},
-            )
-
-            # Then
-            assert response.status_code == 403
-            assert response.json["global"] == ["Impossible d'annuler une réservation consommée"]
-            updated_booking = Booking.query.first()
-            assert updated_booking.isUsed
-            assert updated_booking.isCancelled is False
-            assert updated_booking.status is BookingStatus.USED
-            assert push_testing.requests == []
 
 
 class Returns404Test:
     @pytest.mark.usefixtures("db_session")
-    def when_the_booking_does_not_exists(self, app):
-        # Given
-        pro = users_factories.ProFactory()
-        offerer = create_offerer()
-        user_offerer = create_user_offerer(pro, offerer)
-        venue = create_venue(offerer)
-        offer = create_offer_with_event_product(venue)
-        stock = create_stock(offer=offer)
-        beneficiary = users_factories.BeneficiaryGrant18Factory()
-        booking = create_booking(user=beneficiary, stock=stock, venue=venue)
-        repository.save(user_offerer, booking)
-
-        ApiKeyFactory(offerer=offerer)
-
-        # When
-        response = TestClient(app.test_client()).patch(
-            "/v2/bookings/cancel/token/FAKETOKEN",
-            headers={"Authorization": f"Bearer {DEFAULT_CLEAR_API_KEY}"},
-        )
-
-        # Then
+    def when_the_booking_does_not_exists(self, client):
+        user = users_factories.ProFactory()
+        url = "/v2/bookings/cancel/token/FAKETOKEN"
+        response = client.with_basic_auth(user.email).patch(url)
         assert response.status_code == 404
         assert response.json["global"] == ["Cette contremarque n'a pas été trouvée"]
-        assert push_testing.requests == []
 
 
 class Returns410Test:
     @pytest.mark.usefixtures("db_session")
-    def test_cancel_a_booking_already_cancelled(self, app):
+    def test_cancel_a_booking_already_cancelled(self, client):
         # Given
-        pro_user = users_factories.ProFactory(email="Mr Books@example.net", publicName="Mr Books")
-        offerer = create_offerer(siren="793875030")
-        user_offerer = create_user_offerer(pro_user, offerer)
-        venue = create_venue(offerer)
-        book_offer = create_offer_with_thing_product(venue)
-        stock = create_stock(offer=book_offer)
-
-        user = users_factories.BeneficiaryGrant18Factory()
-        booking = create_booking(user=user, stock=stock, is_cancelled=True, venue=venue)
-
-        repository.save(booking, user_offerer)
-        ApiKeyFactory(offerer=offerer)
+        booking = bookings_factories.CancelledBookingFactory()
+        pro_user = offers_factories.UserOffererFactory(offerer=booking.offerer).user
 
         # When
-        response = TestClient(app.test_client()).patch(
-            "/v2/bookings/cancel/token/{}".format(booking.token),
-            headers={"Authorization": "Bearer " + DEFAULT_CLEAR_API_KEY},
-        )
+        url = f"/v2/bookings/cancel/token/{booking.token}"
+        response = client.with_basic_auth(pro_user.email).patch(url)
 
         # Then
         assert response.status_code == 410
         assert response.json["global"] == ["Cette contremarque a déjà été annulée"]
-        assert push_testing.requests == []

--- a/tests/routes/serialization/reimbursement_csv_test.py
+++ b/tests/routes/serialization/reimbursement_csv_test.py
@@ -31,9 +31,7 @@ class ReimbursementDetailsTest:
         )
         payments_factories.PaymentStatusFactory(payment=payment, status=TransactionStatus.SENT)
 
-        payments_info = find_all_offerer_payments(
-            payment.booking.stock.offer.venue.managingOfferer.id, reimbursement_period
-        )
+        payments_info = find_all_offerer_payments(payment.booking.offerer.id, reimbursement_period)
 
         # when
         raw_csv = ReimbursementDetails(payments_info[0]).as_csv_row()
@@ -66,9 +64,7 @@ class ReimbursementDetailsTest:
         )
         payments_factories.PaymentStatusFactory(payment=payment, status=TransactionStatus.SENT)
 
-        payments_info = find_all_offerer_payments(
-            payment.booking.stock.offer.venue.managingOfferer.id, reimbursement_period
-        )
+        payments_info = find_all_offerer_payments(payment.booking.offererId, reimbursement_period)
 
         # when
         raw_csv = ReimbursementDetails(payments_info[0]).as_csv_row()


### PR DESCRIPTION
**Commits à relire séparément.**

À la base, je voulais "juste" utiliser `Booking.venueId` et `Booking.offererId`... mais certains tests échouaient car ils utilisent `pcapi.model_creators.generic_creators.create_booking()`. Je les ai mis à jour pour utiliser `BookingFactory`.

Si j'ai le courage vendredi prochain, je supprimerai les autres usages de ce `create_booking()` dans les tests. Mais ce sera dans une autre pull request. À chaque PR suffit sa peine ! :)