### PR TITLE
(PC-10806) Install feature flags in app init

### DIFF
--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -1,4 +1,5 @@
 import enum
+import logging
 
 from alembic import op
 import flask
@@ -10,6 +11,9 @@ from sqlalchemy.sql import text
 from pcapi.models.db import Model
 from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.pc_object import PcObject
+
+
+logger = logging.getLogger(__name__)
 
 
 class FeatureToggle(enum.Enum):
@@ -127,3 +131,23 @@ def remove_feature_from_database(feature: FeatureToggle) -> None:
     """
     statement = text("DELETE FROM feature WHERE name = :name").bindparams(name=feature.name)
     op.execute(statement)
+
+
+def install_feature_flags() -> None:
+    installed_flag_names = {f[0] for f in Feature.query.with_entity(Feature.name).all()}
+    defined_flag_name = {f.name for f in list(FeatureToggle)}
+
+    to_install_flags = defined_flag_name - installed_flag_names
+    to_remove_flags = installed_flag_names - defined_flag_name
+
+    new_flags = []
+    for flag in to_install_flags:
+        new_flags.append(
+            Feature(name=FeatureToggle[flag].name, description=FeatureToggle[flag].value),
+            initial_value=FeatureToggle[flag] not in FEATURES_DISABLED_BY_DEFAULT,
+        )
+
+    if to_remove_flags:
+        logger.warning(
+            "The following feature flags are present in database but not present in code: %s", to_remove_flags
+        )


### PR DESCRIPTION
Feature présents en db mais pas présent dans le code :
```
'SYNCHRONIZE_ALGOLIA',
'USE_NEW_BATCH_INDEX_OFFERS_BEHAVIOUR',
'RECOMMENDATIONS_WITH_GEOLOCATION',
'SYNCHRONIZE_LIBRAIRES',
'PARALLEL_SYNCHRONIZATION_OF_VENUE_PROVIDER',
'SAVE_SEEN_OFFERS',
'ENABLE_WHOLE_VENUE_PROVIDER_ALGOLIA_INDEXATION',
'FNAC_SYNCHRONIZATION_V2',
'UPDATE_DISCOVERY_VIEW',
'SYNCHRONIZE_TITELIVE',
'SEARCH_ALGOLIA',
'SYNCHRONIZE_VENUE_PROVIDER_IN_WORKER',
'FULL_OFFERS_SEARCH_WITH_OFFERER_AND_VENUE',
'CLEAN_DISCOVERY_VIEW'
```