### PR TITLE
(PC-10590) : offer reported as type OTHER are emailed to support

### DIFF
--- a/src/pcapi/domain/offer_report_emails.py
+++ b/src/pcapi/domain/offer_report_emails.py
@@ -1,10 +1,14 @@
 from pcapi import settings
 from pcapi.core import mails
 from pcapi.core.offers.models import Offer
+from pcapi.core.offers.models import Reason
 from pcapi.core.users.models import User
 from pcapi.emails.offer_report import build_offer_report_data
 
 
 def send_report_notification(user: User, offer: Offer, reason: str, custom_reason: str) -> bool:
     data = build_offer_report_data(user, offer, reason, custom_reason)
-    return mails.send(recipients=[settings.REPORT_OFFER_EMAIL_ADDRESS], data=data)
+    recipients = [settings.REPORT_OFFER_EMAIL_ADDRESS]
+    if reason == Reason.OTHER.value:
+        recipients = [settings.SUPPORT_EMAIL_ADDRESS]
+    return mails.send(recipients=recipients, data=data)

--- a/tests/domain/offer_report_email_test.py
+++ b/tests/domain/offer_report_email_test.py
@@ -1,0 +1,37 @@
+import pytest
+
+from pcapi import settings
+import pcapi.core.mails.testing as mails_testing
+from pcapi.core.offers.factories import OfferFactory
+from pcapi.core.offers.models import Reason
+from pcapi.core.users.factories import BeneficiaryFactory
+from pcapi.domain.offer_report_emails import send_report_notification
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class OfferReportEmailTest:
+    def test_report_other(self):
+        # Given
+        user = BeneficiaryFactory()
+        offer = OfferFactory()
+        reason = Reason.OTHER.value
+
+        # When
+        send_report_notification(user, offer, reason, "blabla")
+
+        # Then
+        assert mails_testing.outbox[0].sent_data["To"] == settings.SUPPORT_EMAIL_ADDRESS
+
+    def test_report_inappropriate(self):
+        # Given
+        user = BeneficiaryFactory()
+        offer = OfferFactory()
+        reason = Reason.INAPPROPRIATE.value
+
+        # When
+        send_report_notification(user, offer, reason, "blabla")
+
+        # Then
+        assert mails_testing.outbox[0].sent_data["To"] == settings.REPORT_OFFER_EMAIL_ADDRESS

--- a/tests/routes/native/v1/offers_test.py
+++ b/tests/routes/native/v1/offers_test.py
@@ -375,7 +375,7 @@ class ReportOfferTest:
         assert len(mails_testing.outbox) == 1
 
         email = mails_testing.outbox[0]
-        assert email.sent_data["To"] == "report_offer@example.com"
+        assert email.sent_data["To"] == "support@example.com"
         assert email.sent_data["Vars"]["user_id"] == user.id
         assert email.sent_data["Vars"]["offer_id"] == offer.id
         assert "saynul" in email.sent_data["Vars"]["reason"]


### PR DESCRIPTION
Reported offer emails are now sent to support if the report is
categorized as "OTHER" otherwise reports are sent to the
offer report dedicated mail.