### PR TITLE
payment: Fix performance issue in get_venues_to_reimburse

### DIFF
--- a/src/pcapi/scripts/payment/batch_steps.py
+++ b/src/pcapi/scripts/payment/batch_steps.py
@@ -58,6 +58,7 @@ def get_venues_to_reimburse(cutoff_date: datetime) -> Iterable[tuple[id, str]]:
         .outerjoin(Payment, Booking.id == Payment.bookingId)
         .filter(Payment.id.is_(None))
         .with_entities(Booking.venueId)
+        .distinct()
     )
     return (
         Venue.query


### PR DESCRIPTION
A previous commit (2c27ac2d3b6feba4ecb28) introduced a subquery, but I
forgot to use `DISTINCT` (although I am pretty sure that I tested the
query with it). The query plan is very different without it and the
query takes 15 minutes, versus less than 10 seconds with `DISTINCT`.

With `DISTINCT`:

    Nested Loop  (cost=540069.28..540077.31 rows=1 width=40) (actual time=3354.615..3557.732 rows=3249 loops=1)
       ->  Unique  (cost=540068.99..540069.00 rows=1 width=8) (actual time=3354.582..3551.094 rows=3249 loops=1)
             ->  Sort  (cost=540068.99..540068.99 rows=1 width=8) (actual time=3354.580..3503.019 rows=535060 loops=1)
                   Sort Key: booking."venueId"
                   Sort Method: external merge  Disk: 9480kB
                   ->  Gather  (cost=231296.37..540068.98 rows=1 width=8) (actual time=2516.415..3277.991 rows=535060 loops=1)
                         Workers Planned: 2
                         Workers Launched: 2
                         ->  Parallel Hash Left Join  (cost=230296.37..539068.88 rows=1 width=8) (actual time=2508.462..3176.347 rows=178353 loops=3)
                             [...]

Without `DISTINCT`:

    Nested Loop Semi Join  (cost=231296.37..541289.08 rows=1 width=40) (actual time=5333.245..2221844.666 rows=3249 loops=1)
       Join Filter: (venue.id = booking."venueId")
       Rows Removed by Join Filter: 11728632592
       ->  Seq Scan on venue  (cost=0.00..861.84 rows=23884 width=50) (actual time=0.010..128.008 rows=24802 loops=1)
       ->  Materialize  (cost=231296.37..540068.98 rows=1 width=8) (actual time=0.107..45.297 rows=472891 loops=24802)
             ->  Gather  (cost=231296.37..540068.98 rows=1 width=8) (actual time=2581.460..3223.310 rows=535060 loops=1)
                   Workers Planned: 2
                   Workers Launched: 2
                   ->  Parallel Hash Left Join  (cost=230296.37..539068.88 rows=1 width=8) (actual time=2574.233..3261.745 rows=178353 loops=3)
                             [...]