### PR TITLE
(PC-10609) search: Configure "boosts" on App Search

### DIFF
--- a/src/pcapi/scripts/setup_app_search.py
+++ b/src/pcapi/scripts/setup_app_search.py
@@ -36,6 +36,11 @@ def setup_engine(engine):
             return
     print(f"{engine.engine_name}: Synonyms have been set.")
 
+    response = engine.set_search_settings()
+    if hasattr(response, "ok") and not _check_errors(response):
+        return
+    print(f"{engine.engine_name}: Search settings have been set.")
+
 
 def setup_offers_engine():
     backend = appsearch.AppSearchBackend()


### PR DESCRIPTION
Use the value of `Offer.rankingWeight` as a boost on App Search.