### PR TITLE
(PC-10382): Add new auto expiry delay books bookings

### DIFF
--- a/src/pcapi/core/bookings/conf.py
+++ b/src/pcapi/core/bookings/conf.py
@@ -12,12 +12,13 @@ BOOKINGS_AUTO_EXPIRY_DELAY = datetime.timedelta(days=30)
 BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY = datetime.timedelta(days=10)
 # TODO(yacine) This date is used to avoid cancellation of bookings created before this date after
 #  Should be removed 20 days after activation of the new auto expiry delay
-ACTIVATION_NEW_BOOKING_AUTO_EXPIRY_DELAY_DATE = (
+BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY_START_DATE = (
     datetime.date.today() - datetime.timedelta(days=10)
     if (settings.IS_TESTING or settings.IS_DEV)
     else datetime.date(2021, 9, 22)
 )
 BOOKINGS_EXPIRY_NOTIFICATION_DELAY = datetime.timedelta(days=7)
+BOOKS_BOOKINGS_EXPIRY_NOTIFICATION_DELAY = datetime.timedelta(days=5)
 AUTO_USE_AFTER_EVENT_TIME_DELAY = datetime.timedelta(hours=48)
 
 

--- a/src/pcapi/core/bookings/conf.py
+++ b/src/pcapi/core/bookings/conf.py
@@ -1,6 +1,7 @@
 import datetime
 from decimal import Decimal
 
+from pcapi import settings
 from pcapi.models.feature import FeatureToggle
 from pcapi.models.offer_type import ThingType
 
@@ -8,6 +9,14 @@ from pcapi.models.offer_type import ThingType
 CONFIRM_BOOKING_AFTER_CREATION_DELAY = datetime.timedelta(hours=48)
 CONFIRM_BOOKING_BEFORE_EVENT_DELAY = datetime.timedelta(hours=48)
 BOOKINGS_AUTO_EXPIRY_DELAY = datetime.timedelta(days=30)
+BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY = datetime.timedelta(days=10)
+# TODO(yacine) This date is used to avoid cancellation of bookings created before this date after
+#  Should be removed 20 days after activation of the new auto expiry delay
+ACTIVATION_NEW_BOOKING_AUTO_EXPIRY_DELAY_DATE = (
+    datetime.date.today() - datetime.timedelta(days=10)
+    if (settings.IS_TESTING or settings.IS_DEV)
+    else datetime.date(2021, 9, 22)
+)
 BOOKINGS_EXPIRY_NOTIFICATION_DELAY = datetime.timedelta(days=7)
 AUTO_USE_AFTER_EVENT_TIME_DELAY = datetime.timedelta(hours=48)
 

--- a/src/pcapi/core/bookings/models.py
+++ b/src/pcapi/core/bookings/models.py
@@ -18,9 +18,9 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
 
-from pcapi.core.bookings.conf import ACTIVATION_NEW_BOOKING_AUTO_EXPIRY_DELAY_DATE
 from pcapi.core.bookings.conf import BOOKINGS_AUTO_EXPIRY_DELAY
 from pcapi.core.bookings.conf import BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY
+from pcapi.core.bookings.conf import BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY_START_DATE
 from pcapi.core.bookings.exceptions import BookingHasAlreadyBeenUsed
 from pcapi.core.bookings.exceptions import BookingIsAlreadyCancelled
 from pcapi.core.bookings.exceptions import BookingIsAlreadyUsed
@@ -184,7 +184,7 @@ class Booking(PcObject, Model):
         if (
             self.stock.offer.subcategoryId == subcategories.LIVRE_PAPIER.id
             and FeatureToggle.ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS
-            and self.dateCreated > ACTIVATION_NEW_BOOKING_AUTO_EXPIRY_DELAY_DATE
+            and self.dateCreated > BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY_START_DATE
         ):
             return self.dateCreated + BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY
         return self.dateCreated + BOOKINGS_AUTO_EXPIRY_DELAY

--- a/tests/scripts/booking/handle_expired_bookings_test.py
+++ b/tests/scripts/booking/handle_expired_bookings_test.py
@@ -21,7 +21,7 @@ from pcapi.scripts.booking import handle_expired_bookings
 class CancelExpiredBookingsTest:
     @override_features(ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS=True)
     @patch(
-        "pcapi.core.bookings.repository.ACTIVATION_NEW_BOOKING_AUTO_EXPIRY_DELAY_DATE",
+        "pcapi.core.bookings.repository.BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY_START_DATE",
         date.today() - timedelta(days=20),
     )
     def should_cancel_old_thing_that_can_expire_booking(self, app) -> None:


### PR DESCRIPTION
**Objectif :** Réduction du délai de retrait pour les livres (subcategory:`LIVRE_PAPIER`) à 10 jours, et envoi de notification à J-5.

** Implémentation :**
-  Ajout du cas des livres à la requête `find_expiring_bookings` avec le nouveau délai d'annulation automatique.
- Ajout du cas des livres à la requête `find_soon_to_be_expiring_booking_ordered_by_user` avec le nouveau délai d'envoi de notification.
- ajout de `ACTIVATION_NEW_BOOKING_AUTO_EXPIRY_DELAY_DATE` pour empêcher la rétroactivité sur les réservation faite avant le passage au nouveau délai de retrait.
- Modification des tests.
- Ajout des commentaires pour le nettoyage 20 jours après l'activation du nouveau délai de retrait.