### PR TITLE
(PC-10715) : cron exceptions are caught by Sentry

### DIFF
--- a/src/pcapi/scheduled_tasks/utils.py
+++ b/src/pcapi/scheduled_tasks/utils.py
@@ -5,7 +5,8 @@ import sentry_sdk
 
 def sentry_listener(event: cron_events.JobExecutionEvent) -> None:
     if event.exception:
-        sentry_sdk.capture_exception(event.exception)
+        exc_info = type(event.exception), event.exception, event.exception.__traceback__
+        sentry_sdk.capture_exception(exc_info)
 
 
 def activate_sentry(scheduler: base_schedulers.BaseScheduler) -> None:


### PR DESCRIPTION
Somehow, either apscheduler or sentry documentation has an issue
with what is expected to be captured leading to a mmissing
exception.
This can be fixed by explicitly building the exc_info when
calling Sentry.