### PR TITLE
(PC) venue: set venue type code on create/update

### DIFF
--- a/src/pcapi/core/offerers/api.py
+++ b/src/pcapi/core/offerers/api.py
@@ -65,6 +65,9 @@ def update_venue(venue: Venue, **attrs: typing.Any) -> Venue:
     validation.check_venue_edition(modifications, venue)
     venue.populate_from_dict(modifications)
 
+    # TODO: Remove this step when a new stable venue type system is setup
+    venue.fill_venue_type_code_from_label()
+
     repository.save(venue)
 
     indexing_modifications_fields = set(modifications.keys()) & set(VENUE_ALGOLIA_INDEXED_FIELDS)
@@ -97,6 +100,9 @@ def create_venue(venue_data: PostVenueBodyModel) -> Venue:
     data = venue_data.dict(by_alias=True)
     venue = Venue()
     venue.populate_from_dict(data)
+
+    # TODO: Remove this step when a new stable venue type system is setup
+    venue.fill_venue_type_code_from_label()
 
     repository.save(venue)
 

--- a/src/pcapi/core/offerers/models.py
+++ b/src/pcapi/core/offerers/models.py
@@ -102,6 +102,33 @@ class VenueTypeCode(enum.Enum):
     CREATIVE_ARTS_STORE = "CREATIVE_ARTS_STORE"
     OTHER = "OTHER"
 
+    @classmethod
+    def from_label(cls, label: str) -> "VenueTypeCode":
+        return cls.codes_from_labels()[label]
+
+    @classmethod
+    def codes_from_labels(cls) -> dict[str, "VenueTypeCode"]:
+        return {
+            "Arts visuels, arts plastiques et galeries": cls.VISUAL_ARTS,
+            "Centre culturel": cls.CULTURAL_CENTRE,
+            "Cours et pratique artistiques": cls.ARTISTIC_COURSE,
+            "Culture scientifique": cls.SCIENTIFIC_CULTURE,
+            "Festival": cls.FESTIVAL,
+            "Jeux / Jeux vidéos": cls.GAMES,
+            "Librairie": cls.BOOKSTORE,
+            "Bibliothèque ou médiathèque": cls.LIBRARY,
+            "Musée": cls.MUSEUM,
+            "Musique - Disquaire": cls.RECORD_STORE,
+            "Musique - Magasin d’instruments": cls.MUSICAL_INSTRUMENT_STORE,
+            "Musique - Salle de concerts": cls.CONCERT_HALL,
+            "Offre numérique": cls.DIGITAL,
+            "Patrimoine et tourisme": cls.PATRIMONY_TOURISM,
+            "Cinéma - Salle de projections": cls.MOVIE,
+            "Spectacle vivant": cls.PERFORMING_ARTS,
+            "Magasin arts créatifs": cls.CREATIVE_ARTS_STORE,
+            "Autre": cls.OTHER,
+        }
+
 
 class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, NeedsValidationMixin):
     __tablename__ = "venue"
@@ -246,6 +273,11 @@ class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, Ne
         if field not in type(self).__table__.columns:
             raise ValueError(f"Unknown field {field} for model {type(self)}")
         return getattr(self, field) != value
+
+    def fill_venue_type_code_from_label(self) -> None:
+        if not self.venueType:
+            return
+        self.VenueTypeCode = VenueTypeCode.from_label(self.venueType.label)
 
 
 class VenueLabel(PcObject, Model):

--- a/src/pcapi/core/offerers/models.py
+++ b/src/pcapi/core/offerers/models.py
@@ -83,51 +83,28 @@ CONSTRAINT_CHECK_HAS_SIRET_XOR_HAS_COMMENT_XOR_IS_VIRTUAL = """
 
 
 class VenueTypeCode(enum.Enum):
-    VISUAL_ARTS = "VISUAL_ARTS"
-    CULTURAL_CENTRE = "CULTURAL_CENTRE"
-    ARTISTIC_COURSE = "ARTISTIC_COURSE"
-    SCIENTIFIC_CULTURE = "SCIENTIFIC_CULTURE"
-    FESTIVAL = "FESTIVAL"
-    GAMES = "GAMES"
-    BOOKSTORE = "BOOKSTORE"
-    LIBRARY = "LIBRARY"
-    MUSEUM = "MUSEUM"
-    RECORD_STORE = "RECORD_STORE"
-    MUSICAL_INSTRUMENT_STORE = "MUSICAL_INSTRUMENT_STORE"
-    CONCERT_HALL = "CONCERT_HALL"
-    DIGITAL = "DIGITAL"
-    PATRIMONY_TOURISM = "PATRIMONY_TOURISM"
-    MOVIE = "MOVIE"
-    PERFORMING_ARTS = "PERFORMING_ARTS"
-    CREATIVE_ARTS_STORE = "CREATIVE_ARTS_STORE"
-    OTHER = "OTHER"
+    VISUAL_ARTS = "Arts visuels, arts plastiques et galeries"
+    CULTURAL_CENTRE = "Centre culturel"
+    ARTISTIC_COURSE = "Cours et pratique artistiques"
+    SCIENTIFIC_CULTURE = "Culture scientifique"
+    FESTIVAL = "Festival"
+    GAMES = "Jeux / Jeux vidéos"
+    BOOKSTORE = "Librairie"
+    LIBRARY = "Bibliothèque ou médiathèque"
+    MUSEUM = "Musée"
+    RECORD_STORE = "Musique - Disquaire"
+    MUSICAL_INSTRUMENT_STORE = "Musique - Magasin d’instruments"
+    CONCERT_HALL = "Musique - Salle de concerts"
+    DIGITAL = "Offre numérique"
+    PATRIMONY_TOURISM = "Patrimoine et tourisme"
+    MOVIE = "Cinéma - Salle de projections"
+    PERFORMING_ARTS = "Spectacle vivant"
+    CREATIVE_ARTS_STORE = "Magasin arts créatifs"
+    OTHER = "Autre"
 
     @classmethod
     def from_label(cls, label: str) -> "VenueTypeCode":
-        return cls.codes_from_labels()[label]
-
-    @classmethod
-    def codes_from_labels(cls) -> dict[str, "VenueTypeCode"]:
-        return {
-            "Arts visuels, arts plastiques et galeries": cls.VISUAL_ARTS,
-            "Centre culturel": cls.CULTURAL_CENTRE,
-            "Cours et pratique artistiques": cls.ARTISTIC_COURSE,
-            "Culture scientifique": cls.SCIENTIFIC_CULTURE,
-            "Festival": cls.FESTIVAL,
-            "Jeux / Jeux vidéos": cls.GAMES,
-            "Librairie": cls.BOOKSTORE,
-            "Bibliothèque ou médiathèque": cls.LIBRARY,
-            "Musée": cls.MUSEUM,
-            "Musique - Disquaire": cls.RECORD_STORE,
-            "Musique - Magasin d’instruments": cls.MUSICAL_INSTRUMENT_STORE,
-            "Musique - Salle de concerts": cls.CONCERT_HALL,
-            "Offre numérique": cls.DIGITAL,
-            "Patrimoine et tourisme": cls.PATRIMONY_TOURISM,
-            "Cinéma - Salle de projections": cls.MOVIE,
-            "Spectacle vivant": cls.PERFORMING_ARTS,
-            "Magasin arts créatifs": cls.CREATIVE_ARTS_STORE,
-            "Autre": cls.OTHER,
-        }
+        return {item.value: item for item in cls}[label]
 
 
 class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, NeedsValidationMixin):

--- a/src/pcapi/core/offerers/models.py
+++ b/src/pcapi/core/offerers/models.py
@@ -254,7 +254,7 @@ class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, Ne
     def fill_venue_type_code_from_label(self) -> None:
         if not self.venueType:
             return
-        self.VenueTypeCode = VenueTypeCode.from_label(self.venueType.label)
+        self.venueTypeCode = VenueTypeCode.from_label(self.venueType.label)
 
 
 class VenueLabel(PcObject, Model):

--- a/src/pcapi/scripts/update_venue_type_codes.py
+++ b/src/pcapi/scripts/update_venue_type_codes.py
@@ -11,6 +11,7 @@ import logging
 
 from sqlalchemy import exc
 
+from pcapi.core.offerers.models import VenueTypeCode
 from pcapi.models import db
 
 
@@ -39,26 +40,7 @@ def _update_venues_with_label(code: str, label: str) -> set[int]:
 
 def update_venues_codes() -> set[int]:
     logger.info("update venues codes: start")
-    codes_labels = [
-        ("VISUAL_ARTS", "Arts visuels, arts plastiques et galeries"),
-        ("CULTURAL_CENTRE", "Centre culturel"),
-        ("ARTISTIC_COURSE", "Cours et pratique artistiques"),
-        ("SCIENTIFIC_CULTURE", "Culture scientifique"),
-        ("FESTIVAL", "Festival"),
-        ("GAMES", "Jeux / Jeux vidéos"),
-        ("BOOKSTORE", "Librairie"),
-        ("LIBRARY", "Bibliothèque ou médiathèque"),
-        ("MUSEUM", "Musée"),
-        ("RECORD_STORE", "Musique - Disquaire"),
-        ("MUSICAL_INSTRUMENT_STORE", "Musique - Magasin d’instruments"),
-        ("CONCERT_HALL", "Musique - Salle de concerts"),
-        ("DIGITAL", "Offre numérique"),
-        ("PATRIMONY_TOURISM", "Patrimoine et tourisme"),
-        ("MOVIE", "Cinéma - Salle de projections"),
-        ("PERFORMING_ARTS", "Spectacle vivant"),
-        ("CREATIVE_ARTS_STORE", "Magasin arts créatifs"),
-        ("OTHER", "Autre"),
-    ]
+    codes_labels = [(code.name, label) for label, code in VenueTypeCode.codes_from_labels().items()]
 
     updated_ids = set()
     for code, label in codes_labels:


### PR DESCRIPTION
**Contexte**

[Cette PR](https://github.com/pass-culture/pass-culture-api/pull/2956) a ajouté une nouvelle colonne à la table venue : `venueTypeCode`. Elle vise à remplacer `venueTypeId` (et la table `venue_type`).

Pour rappel : avec les nouveautés côté lieux, on avait besoin d'une logique d'enum qui permettait de lister explicitement tous les types de lieux avec des codes stables. Le fonctionnement avec la table `venue_type` (qui ne comportait qu'un label) ne permettait pas cela.

**Besoin**

La précédente PR a ajouté la colonne et un script qui permet de remplir la colonne `venuTypeCode` de tous les lieux en se basant sur le label du `venue_type` associé.

Le but de cette PR est de s'assurer que `venuTypeCode` sera toujours correctement renseigné avant de passer à l'étape suivante : supprimer venueTypeId et la table `venue_type`. Cette étape intermédiaire évite d'avoir à effectuer un gros changement d'un coup (sachant qu'elles impliquent des modifications côté front PRO).