### PR TITLE
(PC-8558): Fix create venue provider quantity bug

### DIFF
--- a/src/pcapi/routes/pro/venue_providers.py
+++ b/src/pcapi/routes/pro/venue_providers.py
@@ -46,7 +46,10 @@ def create_venue_provider(body: PostVenueProviderBody) -> VenueProviderResponse:
             dehumanize_id(body.providerId),
             dehumanize_id(body.venueId),
             VenueProviderCreationPayload(
-                isDuo=body.isDuo, price=body.price, venueIdAtOfferProvider=body.venueIdAtOfferProvider
+                isDuo=body.isDuo,
+                price=body.price,
+                quantity=body.quantity,
+                venueIdAtOfferProvider=body.venueIdAtOfferProvider,
             ),
         )
     except exceptions.VenueSiretNotRegistered as exc:

--- a/tests/routes/pro/post_venue_provider_test.py
+++ b/tests/routes/pro/post_venue_provider_test.py
@@ -88,7 +88,7 @@ class Returns201Test:
             "providerId": humanize(provider.id),
             "venueId": humanize(venue.id),
             "price": "9.99",
-            "available": 50,
+            "quantity": 50,
             "isDuo": True,
         }
 
@@ -99,7 +99,9 @@ class Returns201Test:
 
         # Then
         assert response.status_code == 201
+        assert response.json["isDuo"]
         assert response.json["price"] == 9.99
+        assert response.json["quantity"] == 50
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.workers.venue_provider_job.venue_provider_job.delay")


### PR DESCRIPTION
Ajout de l'attribut `quantity` à la création de venue provider oublié lors d'une précédente refacto.