### PR TITLE
FIX : CORS on api_pro_v2 blueprint

### DIFF
--- a/src/pcapi/routes/pro/blueprints.py
+++ b/src/pcapi/routes/pro/blueprints.py
@@ -1,11 +1,12 @@
 from flask import Blueprint
+from flask_cors import CORS
 
 from pcapi.serialization.spec_tree import ExtendedSpecTree
 from pcapi.serialization.utils import before_handler
 
 
 pro_api_v2 = Blueprint("pro_api_v2", __name__)
-
+CORS(pro_api_v2, resources={r"/*": {"origins": "*"}}, supports_credentials=True)
 
 API_KEY_AUTH = "ApiKeyAuth"
 


### PR DESCRIPTION
- On est passé récemment du blueprint `public_api` à `pro_api_v2` sans configurer les CORS
- `pro_api_v2` doit être public