### PR TITLE
Dockerfile: fix build

### DIFF
--- a/Dockerfile.gcp
+++ b/Dockerfile.gcp
@@ -35,7 +35,7 @@ RUN apt-get update && \
 RUN apt update && \
 		apt install -y wget gnupg2 && \
 		wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-		echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+		echo "deb http://apt.postgresql.org/pub/repos/apt/ `. /etc/os-release && echo $VERSION_CODENAME`-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
 		apt update && apt -y install postgresql-client-12 && \
 		apt clean
 


### PR DESCRIPTION
lsb-release is not included in Bullseye