### PR TITLE
[PC-10713] When a user is unsubscribed in Sendinblue, it is synchronized in the database

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ gql[requests]
 gspread==3.6.0
 gunicorn==20.0.4
 inflect==4.1.0
+ipaddress
 isbnlib==3.10.3
 isort==5.6.4
 itsdangerous==1.1.0
@@ -38,6 +39,7 @@ mypy==0.812
 nltk==3.5
 notion-client==0.4.0
 pgcli==2.2.0
+phonenumberslite==8.12.23
 Pillow>=8.1.1
 pydantic[email]==1.8.2
 PyJWT[crypto]==2.1.0
@@ -67,11 +69,10 @@ sib-api-v3-sdk
 simplejson==3.17.2
 spectree==0.3.15
 SQLAlchemy==1.3.*
+tabulate==0.8.9
 # FIXME (xordoquy, 2021-08-16): current apscheduler version (3.6.3)
 # does not work with tzlocal 3+.
 tzlocal<3.0.0
 Werkzeug==1.0.1
 wheel==0.35.1
 WTForms-SQLAlchemy
-phonenumberslite==8.12.23
-tabulate==0.8.9

--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -28,6 +28,7 @@ from pcapi import settings
 from pcapi.core.logging import get_or_set_correlation_id
 from pcapi.core.logging import install_logging
 from pcapi.models.db import db
+from pcapi.serialization.spec_tree import ExtendedSpecTree
 from pcapi.serialization.utils import before_handler
 from pcapi.utils.health_checker import read_version_from_file
 from pcapi.utils.json_encoder import EnumJSONEncoder
@@ -184,3 +185,7 @@ app.url_map.strict_slashes = False
 
 with app.app_context():
     app.redis_client = redis.from_url(url=settings.REDIS_URL, decode_responses=True)
+
+
+api = ExtendedSpecTree("flask", MODE="strict", before=before_handler, PATH="/", version=1)
+api.register(public_api)

--- a/src/pcapi/routes/external/__init__.py
+++ b/src/pcapi/routes/external/__init__.py
@@ -4,3 +4,4 @@ from flask import Flask
 def install_routes(app: Flask) -> None:
     # pylint: disable=unused-import
     from . import bank_informations
+    from . import unsubscribe_users

--- a/src/pcapi/routes/external/unsubscribe_users.py
+++ b/src/pcapi/routes/external/unsubscribe_users.py
@@ -1,0 +1,46 @@
+import ipaddress
+
+from flask import request
+
+from pcapi import settings
+from pcapi.flask_app import api
+from pcapi.flask_app import public_api
+from pcapi.models.api_errors import ApiErrors
+from pcapi.repository import repository
+from pcapi.repository.user_queries import find_user_by_email
+from pcapi.serialization.decorator import spectree_serialize
+
+
+SENDINBLUE_IP_RANGE = ipaddress.IPv4Network("185.107.232.0/24")
+
+
+@public_api.route("/webhooks/sendinblue/unsubscribe", methods=["POST"])
+@spectree_serialize(
+    on_success_status=204,
+    api=api,
+)  # type: ignore
+def unsubscribe_user():
+    source_ip = ipaddress.IPv4Address(request.headers.get("X-Forwarded-For", "0.0.0.0"))
+    if source_ip not in SENDINBLUE_IP_RANGE and settings.IS_DEV is False:
+        raise ApiErrors(
+            {"IP": "Source IP address is not whitelisted"},
+            status_code=401,
+        )
+
+    user_email = request.json.get("email")
+    if not user_email:
+        raise ApiErrors(
+            {"email": "Email missing in request payload"},
+            status_code=400,
+        )
+
+    user_to_unsubscribe = find_user_by_email(user_email)
+    if user_to_unsubscribe is None:
+        raise ApiErrors({"User": "user not found for email %s" % user_email}, status_code=400)
+
+    user_to_unsubscribe.notificationSubscriptions = (
+        {**user_to_unsubscribe.notificationSubscriptions, "marketing_email": False}
+        if user_to_unsubscribe.notificationSubscriptions is not None
+        else {"marketing_email": False}
+    )
+    repository.save(user_to_unsubscribe)

--- a/tests/routes/external/unsubscribe_user_test.py
+++ b/tests/routes/external/unsubscribe_user_test.py
@@ -1,0 +1,71 @@
+import pytest
+
+from pcapi.core.testing import override_settings
+from pcapi.core.users.factories import UserFactory
+from pcapi.flask_app import db
+
+from tests.conftest import TestClient
+
+
+@pytest.mark.usefixtures("db_session")
+class UnsubscribeUserTest:
+    def test_unsubscribe_user(self, app):
+        # Given
+        existing_user = UserFactory(email="lucy.ellingson@kennet.ca")
+        headers = {"origin": "http://localhost:3000", "X-Forwarded-For": "185.107.232.1"}
+        data = {"email": "lucy.ellingson@kennet.ca"}
+        assert existing_user.notificationSubscriptions["marketing_email"]
+
+        # When
+        response = TestClient(app.test_client()).post("/webhooks/sendinblue/unsubscribe", json=data, headers=headers)
+
+        # Then
+        assert response.status_code == 204
+        db.session.refresh(existing_user)
+        assert not existing_user.notificationSubscriptions["marketing_email"]
+
+    def test_unsubscribe_user_from_forbidden_ip(self, app):
+        # Given
+        existing_user = UserFactory(email="lucy.ellingson@kennet.ca")
+        assert existing_user.notificationSubscriptions["marketing_email"]
+
+        headers = {"origin": "http://localhost:3000", "X-Forwarded-For": "127.0.0.1"}
+        data = {"email": "lucy.ellingson@kennet.ca"}
+
+        # When
+        with override_settings(IS_DEV=False):
+            response = TestClient(app.test_client()).post(
+                "/webhooks/sendinblue/unsubscribe", json=data, headers=headers
+            )
+
+        # Then
+        assert response.status_code == 401
+        db.session.refresh(existing_user)
+        assert existing_user.notificationSubscriptions["marketing_email"]
+
+    def test_unsubscribe_user_bad_request(self, app):
+        # Given
+        existing_user = UserFactory(email="lucy.ellingson@kennet.ca")
+        assert existing_user.notificationSubscriptions["marketing_email"]
+
+        headers = {"origin": "http://localhost:3000", "X-Forwarded-For": "185.107.232.1"}
+        data = {}
+
+        # When
+        response = TestClient(app.test_client()).post("/webhooks/sendinblue/unsubscribe", json=data, headers=headers)
+
+        # Then
+        assert response.status_code == 400
+        db.session.refresh(existing_user)
+        assert existing_user.notificationSubscriptions["marketing_email"]
+
+    def test_unsubscribe_user_does_not_exist(self, app):
+        # Given
+        headers = {"origin": "http://localhost:3000", "X-Forwarded-For": "185.107.232.1"}
+        data = {"email": "lucy.ellingson@kennet.ca"}
+
+        # When
+        response = TestClient(app.test_client()).post("/webhooks/sendinblue/unsubscribe", json=data, headers=headers)
+
+        # Then
+        assert response.status_code == 400


### PR DESCRIPTION
## But de la pull request
Ajout d'une route pour que le webhook de sendinblue puisse mettre à jour les données en base chez nous

##  Implémentation

- Ajouts de la route
- Authentification par whitelist 
​
##  Informations supplémentaires

- Le workflow est ici: https://automation.sendinblue.com/scenarios/2
- Doc Sendinblue pour la whitelist: https://developers.sendinblue.com/docs/how-to-use-webhooks#securing-your-webhooks
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)