### PR TITLE
(PC-10773) circleci: add pyenv version prefix to venv cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ jobs:
             equal: [ "master", << pipeline.git.branch >> ]
           steps:
             - restore_cache:
-                key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+                key: deps1-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - run:
           name: Install requirements
           command: |
@@ -278,7 +278,7 @@ jobs:
             equal: [ "master", << pipeline.git.branch >> ]
           steps:
             - restore_cache:
-                key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+                key: deps1-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - run:
           name: Install requirements
           command: |
@@ -290,7 +290,7 @@ jobs:
             equal: [ "master", << pipeline.git.branch >> ]
           steps:
             - save_cache:
-                key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+                key: deps1-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Branch }}-{{ checksum "requirements.txt" }}
                 paths:
                   - "venv"
       - run:


### PR DESCRIPTION
##  Objectif

Invalider le cache du venv de CircleCI en cas de changement de version de Python 

##  Implémentation

- ajout d'un hash de la version de Python utilisée

##  Informations supplémentaires

Inspiré de https://github.com/CircleCI-Public/python-orb/commit/b757a4f5d1b6a6df168b1f815774fe3d7ece48e0

Tests:

1. créer une branche à partir de 5a64879433feeae4dfa16bf54ed64629a8871cb1 (python 3.9.4)
    -> succès
2. rebaser sur master 39a1dc930566af45a1f166f8455981c30207f51a (python 3.9.7)
    -> échec `Error: [Errno 2] No such file or directory: '/home/circleci/pass-culture-api-ci/venv/bin/python3'`
3. butiner le commit de cette PR
    -> succès

On retrouvera ici ces essais: https://app.circleci.com/pipelines/github/pass-culture/pass-culture-api?branch=fseguin%2Ftest-new-cache