### PR TITLE
(PC-fix) Fix: .is_active() to check if FF is active

### DIFF
--- a/src/pcapi/core/bookings/models.py
+++ b/src/pcapi/core/bookings/models.py
@@ -191,7 +191,7 @@ class Booking(PcObject, Model):
             return None
         if (
             self.stock.offer.subcategoryId == subcategories.LIVRE_PAPIER.id
-            and FeatureToggle.ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS
+            and FeatureToggle.ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS.is_active()
             and self.dateCreated > BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY_START_DATE
         ):
             return self.dateCreated + BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY


### PR DESCRIPTION
## But de la pull request

Bug : appeler .is_active() pour vérifier qu'un FF est actif.

EDIT : problème identifié par @victorenaud 