### PR TITLE
(PC-10773) circleci: fix venv cache generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,12 @@
 version: 2.1
 orbs:
   slack: circleci/slack@4.2
-
+  
+parameters:
+  venv_cache_key:
+    type: string
+    default: 'deps1-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Branch }}-{{ checksum "requirements.txt" }}'
+      
 slack-fail-post-step: &slack-fail-post-step
   post-steps:
     - slack/notify:
@@ -206,7 +211,7 @@ jobs:
             equal: [ "master", << pipeline.git.branch >> ]
           steps:
             - restore_cache:
-                key: deps1-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Branch }}-{{ checksum "requirements.txt" }}
+                key: << pipeline.parameters.venv_cache_key >>
       - run:
           name: Install requirements
           command: |
@@ -218,7 +223,7 @@ jobs:
             equal: [ "master", << pipeline.git.branch >> ]
           steps:
             - save_cache:
-                key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+                key: << pipeline.parameters.venv_cache_key >>
                 paths:
                   - "venv"
       - run:
@@ -278,7 +283,7 @@ jobs:
             equal: [ "master", << pipeline.git.branch >> ]
           steps:
             - restore_cache:
-                key: deps1-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Branch }}-{{ checksum "requirements.txt" }}
+                key: << pipeline.parameters.venv_cache_key >>
       - run:
           name: Install requirements
           command: |
@@ -290,7 +295,7 @@ jobs:
             equal: [ "master", << pipeline.git.branch >> ]
           steps:
             - save_cache:
-                key: deps1-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Branch }}-{{ checksum "requirements.txt" }}
+                key: << pipeline.parameters.venv_cache_key >>
                 paths:
                   - "venv"
       - run:


### PR DESCRIPTION
## But de la pull request

Corriger la configuration CircleCI de génération de cache dans les jobs de tests/quality

##  Implémentation

- Ajout d'un hash de la version de python utilisée
- Factorisation dans un `parameter` pour éviter de futurs oublis
​
Informations supplémentaires

- On peut consulter les [pipelines](https://app.circleci.com/pipelines/github/pass-culture/pass-culture-api?branch=PC-10773-fix-circleci-cache-generation) de cette branche pour vérifier le bon fonctionnement de ce changement:
  - Le cache est généré dans ce [job](https://app.circleci.com/pipelines/github/pass-culture/pass-culture-api/10783/workflows/1ad7b319-c0c0-4cb3-9d70-01b725b9dcb8/jobs/29458/parallel-runs/0/steps/0-104)
  - Le cache est restauré dans les jobs suivants, par exemple [celui-ci](https://app.circleci.com/pipelines/github/pass-culture/pass-culture-api/10783/workflows/7e10fcae-6705-49c9-83ab-afe4541c6c0e/jobs/29468/parallel-runs/0/steps/0-102)  
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
