### PR TITLE
(PC-10685) Ensure to process valid applications once

### DIFF
--- a/src/pcapi/scripts/beneficiary/remote_import.py
+++ b/src/pcapi/scripts/beneficiary/remote_import.py
@@ -20,6 +20,7 @@ from pcapi.core.users.models import User
 from pcapi.domain import user_emails
 from pcapi.domain.beneficiary_pre_subscription.validator import get_beneficiary_duplicates
 from pcapi.domain.demarches_simplifiees import get_closed_application_ids_for_demarche_simplifiee
+from pcapi.domain.demarches_simplifiees import get_existing_applications_id
 from pcapi.domain.user_activation import create_beneficiary_from_application
 from pcapi.models import ApiErrors
 from pcapi.models import ImportStatus
@@ -57,12 +58,15 @@ def run(procedure_id: int, use_graphql_api: bool = False) -> None:
         procedure_id,
     )
 
+    existing_applications_ids = get_existing_applications_id(procedure_id)
     if use_graphql_api:
         client = DMSGraphQLClient()
         for application_details in client.get_applications_with_details(
             procedure_id, GraphQLApplicationStates.accepted
         ):
             application_id = application_details["number"]
+            if application_id in existing_applications_ids:
+                continue
             process_application(
                 procedure_id,
                 application_id,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10685


## But de la pull request

Il s'agit d'éviter de repasser sur les dossiers DMS que nous avons déjà traité,
ce qui provoque des envois d'emails non voulus


##  Implémentation

On réutilise une fonction disponible pour récupérer les bénéficiaires déjà importés.

##  Informations supplémentaires
N/A
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)