### PR TITLE
(PC-10813): Hide beneficiary in Support View for jouve operator

### DIFF
--- a/src/pcapi/admin/custom_views/support_view.py
+++ b/src/pcapi/admin/custom_views/support_view.py
@@ -151,7 +151,9 @@ class BeneficiaryView(base_configuration.BaseAdminView):
     def get_query(self):
         filters = users_models.User.beneficiaryFraudChecks.any() | users_models.User.beneficiaryFraudResult.has()
         if flask_login.current_user.has_jouve_role:
-            filters = users_models.User.beneficiaryFraudChecks.any(type=fraud_models.FraudCheckType.JOUVE)
+            filters = users_models.User.has_beneficiary_role.is_(False) & users_models.User.beneficiaryFraudChecks.any(
+                type=fraud_models.FraudCheckType.JOUVE
+            )
 
         query = users_models.User.query.filter(filters).options(
             sqlalchemy.orm.joinedload(users_models.User.beneficiaryFraudChecks),


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10813


## But de la pull request

Masquer les utilisateurs beneficiaires de la liste affichée aux opérateurs jouves dans l'onglet "Support" dans Flask Admin

##  Implémentation

La requete d'affichage est modifiée lorsqu'on sait que la personne identifiée sur Flask Admin est un opérateur jouve:
- on filtre les utilisateurs qui n'ont pas de vérification JOUVE
- on filtre les utilisateurs déjà bénéficiaires

##  Informations supplémentaires

N/A.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)