### PR TITLE
(PC-10816) FIX : dateUsed was not set when uncancelling and setting as used a booking

### DIFF
--- a/src/pcapi/core/bookings/models.py
+++ b/src/pcapi/core/bookings/models.py
@@ -178,6 +178,7 @@ class Booking(PcObject, Model):
         self.cancellationReason = None
         self.status = BookingStatus.USED
         self.isUsed = True
+        self.dateUsed = datetime.utcnow()
 
     def mark_as_confirmed(self) -> None:
         self.status = BookingStatus.CONFIRMED

--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -571,12 +571,14 @@ class MarkAsUsedTest:
         assert booking.status is BookingStatus.USED
         assert len(push_testing.requests) == 1
 
+    @freeze_time("2021-09-08")
     def test_mark_as_used_with_uncancel(self):
         booking = factories.CancelledBookingFactory()
         api.mark_as_used_with_uncancelling(booking)
         assert booking.isUsed
         assert not booking.isCancelled
         assert booking.status is BookingStatus.USED
+        assert booking.dateUsed == datetime.utcnow()
         assert not booking.cancellationReason
 
     def test_mark_as_used_when_stock_starts_soon(self):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10816


## But de la pull request

Correction d'un bug : présence de réservation avec le statut `USED` mais sans `dateUsed`
Ce bug intervient dans le cas particulier où l'on 'dés-annule' une réservation pour contrer une tentative de fraude.
Initialement nous ne voulions pas écraser la `dateUsed` initiale lors de la dés-annulation, mais celle-ci n'est jamais renseignée. En effet, comme la réservation a été annulée, elle n'a jamais pu être validée.

##  Implémentation

Fixer la `dateUsed` à `now()` dans la fonction `mark_booking_as_used_with_uncancelling`
Ajout d'une assertion dans le test `mark_as_used_with_uncancelling` de bookings.api
​
##  Informations supplémentaires

N/A

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
