### PR TITLE
(PC-fix) remove dangerous '%' for LIKE query

### DIFF
--- a/src/pcapi/repository/user_queries.py
+++ b/src/pcapi/repository/user_queries.py
@@ -32,7 +32,7 @@ def find_user_by_email(email: str) -> User:
 
 
 def find_beneficiary_users_by_email_provider(email_provider: str) -> list[User]:
-    formatted_email_provider = f"%@%{email_provider}"
+    formatted_email_provider = f"%@{email_provider}"
     return (
         User.query.filter_by(isBeneficiary=True, isActive=True)
         .filter(func.lower(User.email).like(func.lower(formatted_email_provider)))
@@ -41,7 +41,7 @@ def find_beneficiary_users_by_email_provider(email_provider: str) -> list[User]:
 
 
 def find_pro_users_by_email_provider(email_provider: str) -> list[User]:
-    formatted_email_provider = f"%@%{email_provider}"
+    formatted_email_provider = f"%@{email_provider}"
     return (
         User.query.filter_by(isBeneficiary=False, isActive=True)
         .join(UserOfferer)

--- a/tests/scripts/suspend_suspected_fraudulent_beneficiary_users_test.py
+++ b/tests/scripts/suspend_suspected_fraudulent_beneficiary_users_test.py
@@ -87,7 +87,10 @@ class SuspendFraudulentBeneficiaryUsersByEmailProvidersTest:
         # Then
         assert not beneficiary_fraudulent_user.isActive
         assert not beneficiary_fraudulent_user_with_uppercase_domain.isActive
-        assert not beneficiary_fraudulent_user_with_subdomain.isActive
+
+        # Do not handle sub-domains
+        assert beneficiary_fraudulent_user_with_subdomain.isActive
+
         assert non_beneficiary_fraudulent_user.isActive
 
     @pytest.mark.usefixtures("db_session")

--- a/tests/scripts/suspend_suspected_fraudulent_pro_users_test.py
+++ b/tests/scripts/suspend_suspected_fraudulent_pro_users_test.py
@@ -55,7 +55,9 @@ def test_only_suspend_pro_users_in_given_emails_providers_list():
 
     # Then
     assert not pro_fraudulent_user_with_uppercase_domain.isActive
-    assert not pro_fraudulent_user_with_subdomain.isActive
+
+    # Do not handle sub-domains
+    assert pro_fraudulent_user_with_subdomain.isActive
     assert beneficiary_fraudulent_user.isActive
 
 


### PR DESCRIPTION
## But de la pull request

Effectuer une requête plus stricte lorsqu'il s'agit de retrouver des utilisateurs en fonction des noms de domaine de leurs adresses email. Tel que le LIKE est construit, on risque d'avoir de très mauvaises surprises. Il semble que le but était de gérer les sous-domaines, mais on devrait trouver un moyen de le faire sans prendre de risques.