### PR TITLE
(PC-10636) : add extra step for beneficiary only for newer clients

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -797,12 +797,14 @@ def check_sms_sending_is_allowed(user: User) -> None:
 
 
 def get_next_beneficiary_validation_step(user: User) -> Optional[BeneficiaryValidationStep]:
+    from pcapi.routes.native.utils import is_client_older
+
     if user.isBeneficiary or not user.is_eligible:
         return None
     if not user.is_phone_validated and FeatureToggle.ENABLE_PHONE_VALIDATION.is_active():
         return BeneficiaryValidationStep.PHONE_VALIDATION
     if not user.hasCompletedIdCheck:
-        if not user.extraData.get("is_identity_document_uploaded"):
+        if is_client_older("1.155.0") or not user.extraData.get("is_identity_document_uploaded"):
             return BeneficiaryValidationStep.ID_CHECK
         return BeneficiaryValidationStep.BENEFICIARY_INFORMATION
 

--- a/src/pcapi/routes/native/utils.py
+++ b/src/pcapi/routes/native/utils.py
@@ -15,6 +15,19 @@ def convert_to_cent(amount: Optional[Decimal]) -> Optional[int]:
     return int(amount * 100)
 
 
+def is_client_older(version: str) -> bool:
+    version = semver.VersionInfo.parse(version)
+    client_version_header = flask.request.headers.get("app-version", None)
+    if not client_version_header:
+        return False
+    try:
+        client_version = semver.VersionInfo.parse(client_version_header)
+    except ValueError:
+        return True
+
+    return client_version < version
+
+
 def check_client_version() -> None:
     client_version_header = flask.request.headers.get("app-version", None)
     sentry_sdk.set_tag("client.version", client_version_header)


### PR DESCRIPTION
The addition of the extra steps indeed causes issues for native
applications that are nonnt able to understand the step and
redirects to the home.
This is an issue if the user uploaded its ID card but didn't
validate the general conditions in which case the user is locked
out of the beneficiary process.
The workaround is to act as usual for older native app and only
return the new extra step for newer versions.

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10636


## But de la pull request

Ne pas casser le parcours pour devenir bénéficiaire sur les "vieilles" version de l'application mobile.

##  Implémentation

N/A
​
##  Informations supplémentaires

N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
