### PR TITLE
(PC-10384): Fix books bookings auto expiry delay start date bug

### DIFF
--- a/src/pcapi/core/bookings/conf.py
+++ b/src/pcapi/core/bookings/conf.py
@@ -16,9 +16,9 @@ BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY = datetime.timedelta(days=10)
 # TODO(yacine) This date is used to avoid cancellation of bookings created before this date after
 #  Should be removed 20 days after activation of the new auto expiry delay
 BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY_START_DATE = (
-    datetime.date.today() - datetime.timedelta(days=11)
+    datetime.datetime.today() - datetime.timedelta(days=11)
     if (settings.IS_TESTING or settings.IS_DEV)
-    else datetime.date(2021, 9, 22)
+    else datetime.datetime(2021, 9, 22)
 )
 BOOKINGS_EXPIRY_NOTIFICATION_DELAY = datetime.timedelta(days=7)
 BOOKS_BOOKINGS_EXPIRY_NOTIFICATION_DELAY = datetime.timedelta(days=5)

--- a/tests/core/bookings/test_models.py
+++ b/tests/core/bookings/test_models.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from datetime import timedelta
 from decimal import Decimal
+from unittest.mock import patch
 
+from freezegun import freeze_time
 import pytest
 
 from pcapi.core.bookings import factories
@@ -9,6 +11,7 @@ from pcapi.core.bookings import models
 from pcapi.core.bookings.models import Booking
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import MediationFactory
+from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
 from pcapi.models import ApiErrors
 from pcapi.models import db
@@ -183,3 +186,89 @@ class BookingIsConfirmedSqlQueryTest:
         query_result = Booking.query.filter(Booking.isConfirmed.is_(False)).all()
 
         assert len(query_result) == 1
+
+
+@pytest.mark.usefixtures("db_session")
+class BookingExpirationDateLegacyRulesTest:
+    @patch("pcapi.core.bookings.models.BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY_START_DATE", datetime(2021, 8, 3))
+    @override_features(ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS=False)
+    def test_booking_expiration_date_before_start_new_rules_start_date(self):
+        with freeze_time("2021-08-01 15:00:00"):
+            book_booking = factories.BookingFactory(
+                dateCreated=datetime.utcnow(), stock__offer__product__subcategoryId=subcategories.LIVRE_PAPIER.id
+            )
+            dvd_booking = factories.BookingFactory(
+                dateCreated=datetime.utcnow(),
+                stock__offer__product__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
+            )
+            digital_book_booking = factories.BookingFactory(
+                dateCreated=datetime.utcnow(),
+                stock__offer__product__subcategoryId=subcategories.LIVRE_NUMERIQUE.id,
+            )
+
+            assert book_booking.expirationDate == datetime(2021, 8, 31, 15, 0, 0)
+            assert dvd_booking.expirationDate == datetime(2021, 8, 31, 15, 0, 0)
+            assert not digital_book_booking.expirationDate
+
+    @patch("pcapi.core.bookings.models.BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY_START_DATE", datetime(2021, 8, 3))
+    @override_features(ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS=False)
+    def test_booking_expiration_date_after_new_rules_start_date(self):
+        with freeze_time("2021-08-05 15:00:00"):
+            book_booking = factories.BookingFactory(
+                dateCreated=datetime.utcnow(), stock__offer__product__subcategoryId=subcategories.LIVRE_PAPIER.id
+            )
+            dvd_booking = factories.BookingFactory(
+                dateCreated=datetime.utcnow(),
+                stock__offer__product__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
+            )
+            digital_book_booking = factories.BookingFactory(
+                dateCreated=datetime.utcnow(),
+                stock__offer__product__subcategoryId=subcategories.LIVRE_NUMERIQUE.id,
+            )
+
+            assert book_booking.expirationDate == datetime(2021, 9, 4, 15, 0, 0)
+            assert dvd_booking.expirationDate == datetime(2021, 9, 4, 15, 0, 0)
+            assert not digital_book_booking.expirationDate
+
+
+@pytest.mark.usefixtures("db_session")
+class BookingExpirationDateNewRulesTest:
+    @patch("pcapi.core.bookings.models.BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY_START_DATE", datetime(2021, 8, 3))
+    @override_features(ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS=True)
+    def test_booking_expiration_date_before_start_new_rules_start_date(self):
+        with freeze_time("2021-08-01 15:00:00"):
+            book_booking = factories.BookingFactory(
+                dateCreated=datetime.utcnow(), stock__offer__product__subcategoryId=subcategories.LIVRE_PAPIER.id
+            )
+            dvd_booking = factories.BookingFactory(
+                dateCreated=datetime.utcnow(),
+                stock__offer__product__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
+            )
+            digital_book_booking = factories.BookingFactory(
+                dateCreated=datetime.utcnow(),
+                stock__offer__product__subcategoryId=subcategories.LIVRE_NUMERIQUE.id,
+            )
+
+            assert book_booking.expirationDate == datetime(2021, 8, 31, 15, 0, 0)
+            assert dvd_booking.expirationDate == datetime(2021, 8, 31, 15, 0, 0)
+            assert not digital_book_booking.expirationDate
+
+    @patch("pcapi.core.bookings.models.BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY_START_DATE", datetime(2021, 8, 3))
+    @override_features(ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS=True)
+    def test_booking_expiration_date_after_new_rules_start_date(self):
+        with freeze_time("2021-08-05 15:00:00"):
+            book_booking = factories.BookingFactory(
+                dateCreated=datetime.utcnow(), stock__offer__product__subcategoryId=subcategories.LIVRE_PAPIER.id
+            )
+            dvd_booking = factories.BookingFactory(
+                dateCreated=datetime.utcnow(),
+                stock__offer__product__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
+            )
+            digital_book_booking = factories.BookingFactory(
+                dateCreated=datetime.utcnow(),
+                stock__offer__product__subcategoryId=subcategories.LIVRE_NUMERIQUE.id,
+            )
+
+            assert book_booking.expirationDate == datetime(2021, 8, 15, 15, 0, 0)
+            assert dvd_booking.expirationDate == datetime(2021, 9, 4, 15, 0, 0)
+            assert not digital_book_booking.expirationDate


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10384


## But de la pull request

Résolution du problème `can't compare datetime.datetime to datetime.date` pour la property `expirationDate`

##  Implémentation

- Remplacer `date()` par `datetime()` pour la constante `BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY_START_DATE`
​
##  Informations supplémentaires
N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
