### PR TITLE
(PC-10854) : fix rate limit test against json request

### DIFF
--- a/src/pcapi/routes/error_handlers/generic_error_handlers.py
+++ b/src/pcapi/routes/error_handlers/generic_error_handlers.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Union
 
@@ -106,8 +107,11 @@ def ratelimit_handler(error: Exception) -> tuple[dict, int]:
     from pcapi.utils.login_manager import get_request_authorization
 
     identifier = None
-    if request.json and "identifier" in request.json:
-        identifier = request.json["identifier"]
+    try:
+        if request.is_json and "identifier" in request.json:
+            identifier = request.json["identifier"]
+    except json.JSONDecodeError:
+        pass
     auth = get_request_authorization()
     if auth and auth.username:
         identifier = auth.username


### PR DESCRIPTION
1. use `request.is_json` to check the request's content type
instead of guessing it from the body
2. catch JSON exception. Might be because the body is malformatted
on purpose.

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10854

## But de la pull request

Corriger une exception lorsque le rate limit est atteint avec une requête JSON mal formatée

##  Implémentation

N/A
​
##  Informations supplémentaires

N/A​

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
