### PR TITLE
(PC-10852) Support des n° de CNI portugaise, nettoyage des espaces inutiles

### DIFF
--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -149,7 +149,7 @@ def _validate_id_piece_number_format_fraud_item(id_piece_number):
         return models.FraudItem(
             status=models.FraudStatus.SUSPICIOUS, detail="Le numéro de la pièce d'identité est vide"
         )
-    if not re.fullmatch(r"^\w{9,10}|\w{12}$", id_piece_number):
+    if not re.fullmatch(r"^[\w]{8,12}|[\s\w]{14}$", id_piece_number):
         return models.FraudItem(
             status=models.FraudStatus.SUSPICIOUS, detail="Le format du numéro de la pièce d'identité n'est pas valide"
         )

--- a/src/pcapi/scripts/beneficiary/remote_import.py
+++ b/src/pcapi/scripts/beneficiary/remote_import.py
@@ -238,6 +238,7 @@ def parse_beneficiary_information(application_detail: dict, procedure_id: int) -
         if label == "Quelle est votre adresse de résidence":
             information["address"] = value
         if label == "Quel est le numéro de la pièce que vous venez de saisir ?":
+            value = value.strip()
             if not fraud_api._validate_id_piece_number_format_fraud_item(value):
                 parsing_errors["id_piece_number"] = value
             else:
@@ -283,6 +284,7 @@ def parse_beneficiary_information_graphql(application_detail: dict, procedure_id
         if label == "Quelle est votre adresse de résidence":
             information["address"] = value
         if label == "Quel est le numéro de la pièce que vous venez de saisir ?":
+            value = value.strip()
             if not fraud_api._validate_id_piece_number_format_fraud_item(value):
                 parsing_errors["id_piece_number"] = value
             else:

--- a/tests/core/fraud/test_api.py
+++ b/tests/core/fraud/test_api.py
@@ -145,6 +145,7 @@ class JouveFraudCheckTest:
         [
             "321070751234",
             "090435303687",
+            "00000000 0 ZU4",  # portugal format
         ],
     )
     def test_jouve_id_piece_number_valid_format(self, id_piece_number):

--- a/tests/scripts/beneficiary/remote_import_test.py
+++ b/tests/scripts/beneficiary/remote_import_test.py
@@ -525,6 +525,19 @@ class ParseBeneficiaryInformationTest:
             assert information.application_id == 123
             assert information.procedure_id == 201201
 
+        @pytest.mark.parametrize("possible_value", ["0123456789", " 0123456789", "0123456789 ", " 0123456789 "])
+        def test_beneficiary_information_id_piece_number_with_spaces(self, possible_value):
+            application_detail = make_new_beneficiary_application_details(1, "closed", id_piece_number=possible_value)
+            information = remote_import.parse_beneficiary_information(application_detail, procedure_id=123123)
+            assert information.id_piece_number == "0123456789"
+
+        @pytest.mark.parametrize("possible_value", ["0123456789", " 0123456789", "0123456789 ", " 0123456789 "])
+        def test_beneficiary_information_id_piece_number_with_spaces_graphql(self, possible_value):
+            application_detail = make_graphql_application(1, "closed", id_piece_number=possible_value)
+            information = remote_import.parse_beneficiary_information_graphql(application_detail, procedure_id=123123)
+
+            assert information.id_piece_number == "0123456789"
+
     class ParsingErrorsTest:
         def test_beneficiary_information_postalcode_error(self):
             application_detail = make_new_beneficiary_application_details(1, "closed", postal_code="Strasbourg")
@@ -540,19 +553,6 @@ class ParseBeneficiaryInformationTest:
                 remote_import.parse_beneficiary_information(application_detail, procedure_id=123123)
 
             assert exc_info.value.errors["id_piece_number"] == possible_value
-
-        @pytest.mark.parametrize("possible_value", ["0123456789", " 0123456789", "0123456789 ", " 0123456789 "])
-        def test_beneficiary_information_id_piece_number_with_spaces(self, possible_value):
-            application_detail = make_new_beneficiary_application_details(1, "closed", id_piece_number=possible_value)
-            information = remote_import.parse_beneficiary_information(application_detail, procedure_id=123123)
-            assert information.id_piece_number == "0123456789"
-
-        @pytest.mark.parametrize("possible_value", ["0123456789", " 0123456789", "0123456789 ", " 0123456789 "])
-        def test_beneficiary_information_id_piece_number_with_spaces_graphql(self, possible_value):
-            application_detail = make_graphql_application(1, "closed", id_piece_number=possible_value)
-            information = remote_import.parse_beneficiary_information_graphql(application_detail, procedure_id=123123)
-
-            assert information.id_piece_number == "0123456789"
 
 
 @pytest.mark.usefixtures("db_session")

--- a/tests/scripts/beneficiary/remote_import_test.py
+++ b/tests/scripts/beneficiary/remote_import_test.py
@@ -541,6 +541,19 @@ class ParseBeneficiaryInformationTest:
 
             assert exc_info.value.errors["id_piece_number"] == possible_value
 
+        @pytest.mark.parametrize("possible_value", ["0123456789", " 0123456789", "0123456789 ", " 0123456789 "])
+        def test_beneficiary_information_id_piece_number_with_spaces(self, possible_value):
+            application_detail = make_new_beneficiary_application_details(1, "closed", id_piece_number=possible_value)
+            information = remote_import.parse_beneficiary_information(application_detail, procedure_id=123123)
+            assert information.id_piece_number == "0123456789"
+
+        @pytest.mark.parametrize("possible_value", ["0123456789", " 0123456789", "0123456789 ", " 0123456789 "])
+        def test_beneficiary_information_id_piece_number_with_spaces_graphql(self, possible_value):
+            application_detail = make_graphql_application(1, "closed", id_piece_number=possible_value)
+            information = remote_import.parse_beneficiary_information_graphql(application_detail, procedure_id=123123)
+
+            assert information.id_piece_number == "0123456789"
+
 
 @pytest.mark.usefixtures("db_session")
 class RunIntegrationTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10852


## But de la pull request

Dans certains cas, l'utilisateur entre un n° de pièce d'identité avec des espaces dans le champs
du formulaire DMS (ca m'est arrivé ..)

De plus, le n° de CNI portugaise est constitué du NIF, d'espaces, e d'un numero aléatoire


##  Implémentation

Modificiation de la regex, et ajouts de cas de tests

​
##  Informations supplémentaires
N/A

​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)