### PR TITLE
(PC-10874) : add tags to sentry to be able to filter per source

### DIFF
--- a/src/pcapi/app.py
+++ b/src/pcapi/app.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from sentry_sdk import set_tag
 from werkzeug.middleware.profiler import ProfilerMiddleware
 
 from pcapi import settings
@@ -58,4 +59,5 @@ if __name__ == "__main__":
             debugpy.wait_for_client()
             print("🎉 Code debugger attached, enjoy debugging 🎉", flush=True)
 
+    set_tag("pcapi.app_type", "app")
     app.run(host="0.0.0.0", port=port, debug=True, use_reloader=True)

--- a/src/pcapi/scheduled_tasks/algolia_clock.py
+++ b/src/pcapi/scheduled_tasks/algolia_clock.py
@@ -1,4 +1,5 @@
 from apscheduler.schedulers.blocking import BlockingScheduler
+from sentry_sdk import set_tag
 
 from pcapi import settings
 from pcapi.core import search
@@ -41,6 +42,7 @@ def index_offers_in_error_in_algolia_by_offer(app):
 def main():
     from pcapi.flask_app import app
 
+    set_tag("pcapi.app_type", "algolia_clock")
     scheduler = BlockingScheduler()
 
     utils.activate_sentry(scheduler)

--- a/src/pcapi/scheduled_tasks/clock.py
+++ b/src/pcapi/scheduled_tasks/clock.py
@@ -7,6 +7,7 @@ import logging
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 from flask import Flask
+from sentry_sdk import set_tag
 
 # FIXME (xordoquy, 2021-03-01): this is to prevent circular imports when importing pcapi.core.users.api
 import pcapi.models  # pylint: disable=unused-import
@@ -165,6 +166,7 @@ def pc_send_withdrawal_terms_to_offerers_validated_yesterday(app: Flask) -> None
 def main() -> None:
     from pcapi.flask_app import app
 
+    set_tag("pcapi.app_type", "clock")
     scheduler = BlockingScheduler()
     utils.activate_sentry(scheduler)
 

--- a/src/pcapi/scheduled_tasks/titelive_clock.py
+++ b/src/pcapi/scheduled_tasks/titelive_clock.py
@@ -2,6 +2,7 @@
     isort:skip_file
 """
 from apscheduler.schedulers.blocking import BlockingScheduler
+from sentry_sdk import set_tag
 
 # FIXME (asaunier, 2021-04-20): this is to prevent circular imports
 import pcapi.models  # pylint: disable=unused-import
@@ -41,6 +42,7 @@ def synchronize_titelive_thing_thumbs(app):
 def main():
     from pcapi.flask_app import app
 
+    set_tag("pcapi.app_type", "titelive_clock")
     scheduler = BlockingScheduler()
     utils.activate_sentry(scheduler)
 

--- a/src/pcapi/workers/worker.py
+++ b/src/pcapi/workers/worker.py
@@ -70,6 +70,7 @@ def log_database_connection_status() -> None:
 
 
 if __name__ == "__main__":
+    sentry_sdk.set_tag("pcapi.app_type", "worker")
     listen = sys.argv[1:] or ["default"]
     logger.info("Worker: listening to queues %s", listen)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10874

## But de la pull request

Ajout de tags dans Sentry afin de pouvoir filtrer les événements par source (web, cron, worker).

##  Implémentation

Voir https://docs.sentry.io/platforms/python/enriching-events/tags/
​
##  Informations supplémentaires

N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
