### PR TITLE
(PC-10807) Add external cloud task

### DIFF
--- a/src/pcapi/core/users/external/batch.py
+++ b/src/pcapi/core/users/external/batch.py
@@ -3,8 +3,7 @@ import logging
 from typing import Optional
 
 from pcapi.core.users.external.models import UserAttributes
-from pcapi.tasks.batch_tasks import UpdateBatchAttributesRequest
-from pcapi.tasks.batch_tasks import update_user_attributes_task
+from pcapi.notifications import push as batch_push
 
 
 logger = logging.getLogger(__name__)
@@ -18,7 +17,7 @@ def update_user_attributes(user_id: int, user_attributes: UserAttributes):
         return
 
     formatted_attributes = format_user_attributes(user_attributes)
-    update_user_attributes_task.delay(UpdateBatchAttributesRequest(user_id=user_id, attributes=formatted_attributes))
+    batch_push.update_user_attributes(user_id=user_id, attribute_values=formatted_attributes)
 
 
 def format_user_attributes(user_attributes: UserAttributes) -> dict:

--- a/src/pcapi/notifications/push/__init__.py
+++ b/src/pcapi/notifications/push/__init__.py
@@ -1,4 +1,5 @@
 from pcapi import settings
+from pcapi.notifications.push.backends.batch import BatchBackend
 from pcapi.notifications.push.backends.batch import UserUpdateData
 from pcapi.notifications.push.transactional_notifications import TransactionalNotificationData
 from pcapi.utils.module_loading import import_string
@@ -7,6 +8,14 @@ from pcapi.utils.module_loading import import_string
 def update_user_attributes(user_id: int, attribute_values: dict) -> None:
     backend = import_string(settings.PUSH_NOTIFICATION_BACKEND)
     backend().update_user_attributes(user_id, attribute_values)
+
+
+def update_user_attributes_with_legacy_internal_task(user_id: int, attribute_values: dict) -> None:
+    backend = import_string(settings.PUSH_NOTIFICATION_BACKEND)
+    if backend == BatchBackend:
+        backend().update_user_attributes_with_legacy_internal_task(user_id, attribute_values)
+    else:
+        update_user_attributes(user_id, attribute_values)
 
 
 def update_users_attributes(users_data: list[UserUpdateData]) -> None:

--- a/src/pcapi/tasks/__init__.py
+++ b/src/pcapi/tasks/__init__.py
@@ -4,4 +4,5 @@ from flask import Flask
 def install_handlers(app: Flask) -> None:
     # pylint: disable=unused-import
     from . import account
+    from . import batch_tasks
     from . import sendinblue_tasks

--- a/src/pcapi/tasks/batch_tasks.py
+++ b/src/pcapi/tasks/batch_tasks.py
@@ -1,9 +1,11 @@
+# TODO: remove this file when batch is called directly by cloudtask and remaining enqueued tasks have been leased
+
 import logging
 
 from pydantic import BaseModel
 
 from pcapi import settings
-from pcapi.notifications.push import update_user_attributes
+from pcapi.notifications.push import update_user_attributes_with_legacy_internal_task
 from pcapi.tasks.decorator import task
 
 
@@ -19,4 +21,4 @@ class UpdateBatchAttributesRequest(BaseModel):
 
 @task(BATCH_CUSTOM_DATA_QUEUE_NAME, "/batch/update_user_attributes")
 def update_user_attributes_task(payload: UpdateBatchAttributesRequest) -> None:
-    update_user_attributes(payload.user_id, payload.attributes)
+    update_user_attributes_with_legacy_internal_task(payload.user_id, payload.attributes)

--- a/src/pcapi/tasks/cloud_task.py
+++ b/src/pcapi/tasks/cloud_task.py
@@ -1,5 +1,7 @@
+from dataclasses import dataclass
 import json
 import logging
+from typing import Optional
 
 from google.api_core import retry
 from google.api_core.exceptions import AlreadyExists
@@ -22,21 +24,19 @@ def get_client():
     return get_client.client
 
 
-def enqueue_task(queue, url, payload):
+@dataclass
+class CloudTaskHttpRequest:
+    http_method: tasks_v2.HttpMethod
+    url: str
+    headers: Optional[dict] = None
+    body: Optional[bytes] = None
 
+
+def enqueue_task(queue: str, http_request: CloudTaskHttpRequest):
     client = get_client()
     parent = client.queue_path(settings.GCP_PROJECT, settings.GCP_REGION_CLOUD_TASK, queue)
 
-    body = json.dumps(payload).encode()
-
-    task_request = {
-        "http_request": {
-            "http_method": tasks_v2.HttpMethod.POST,
-            "url": url,
-            "headers": {"Content-type": "application/json", AUTHORIZATION_HEADER_KEY: AUTHORIZATION_HEADER_VALUE},
-            "body": body,
-        },
-    }
+    task_request = {"http_request": http_request}
 
     try:
         response = client.create_task(
@@ -49,6 +49,19 @@ def enqueue_task(queue, url, payload):
             ),
         )
     except AlreadyExists:
-        logger.info("Task on queue %s url %s already retried", queue, url)
+        logger.info("Task on queue %s url %s already retried", queue, http_request.url)
+        return None
+
     task_id = response.name.split("/")[-1]
     return task_id
+
+
+def enqueue_internal_task(queue, url, payload):
+    http_request = CloudTaskHttpRequest(
+        http_method=tasks_v2.HttpMethod.POST,
+        url=url,
+        headers={"Content-type": "application/json", AUTHORIZATION_HEADER_KEY: AUTHORIZATION_HEADER_VALUE},
+        body=json.dumps(payload).encode(),
+    )
+
+    return enqueue_task(queue, http_request)

--- a/src/pcapi/tasks/decorator.py
+++ b/src/pcapi/tasks/decorator.py
@@ -77,7 +77,7 @@ def _enqueue_task(queue, path, payload):
         _call_task_handler(queue, url, payload)
         return None
 
-    return cloud_task.enqueue_task(queue, url, payload)
+    return cloud_task.enqueue_internal_task(queue, url, payload)
 
 
 def _call_task_handler(queue, url, payload):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 from functools import wraps
 from pathlib import Path
 from pprint import pprint
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from alembic import command
 from alembic.config import Config
@@ -169,6 +171,17 @@ def assert_num_queries():
 @pytest.fixture(name="client")
 def client_fixture(app: Flask):
     return TestClient(app.test_client())
+
+
+@pytest.fixture(name="cloud_task_client")
+def cloud_task_client_fixture():
+    """
+    Mock for google.cloud.tasks_v2.CloudTasksClient
+    """
+    with patch("pcapi.tasks.cloud_task.get_client") as mock_get_client:
+        cloud_task_client_mock = MagicMock()
+        mock_get_client.return_value = cloud_task_client_mock
+        yield cloud_task_client_mock
 
 
 class TestClient:

--- a/tests/notifications/push/backends/batch_test.py
+++ b/tests/notifications/push/backends/batch_test.py
@@ -1,20 +1,40 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from google.cloud import tasks_v2
 import requests_mock
 
+from pcapi.core.testing import override_settings
 from pcapi.notifications.push.backends.batch import BatchBackend
 from pcapi.notifications.push.transactional_notifications import TransactionalNotificationData
 from pcapi.notifications.push.transactional_notifications import TransactionalNotificationMessage
 
 
 class BatchPushNotificationClientTest:
-    def test_update_user_attributes(self):
-        with requests_mock.Mocker() as mock:
-            android_post = mock.post("https://api.example.com/1.0/fake_android_api_key/data/users/1")
-            ios_post = mock.post("https://api.example.com/1.0/fake_ios_api_key/data/users/1")
+    @override_settings(BATCH_SECRET_API_KEY="coucou-la-cle")
+    @patch("pcapi.tasks.cloud_task.get_client")
+    def test_update_user_attributes(self, mock_get_client):
+        client_mock = MagicMock()
+        mock_get_client.return_value = client_mock
+        BatchBackend().update_user_attributes(1, {"attri": "but"})
 
-            BatchBackend().update_user_attributes(1, {"attri": "but"})
+        assert client_mock.create_task.call_count == 2
 
-            assert ios_post.last_request.json() == {"overwrite": False, "values": {"attri": "but"}}
-            assert android_post.last_request.json() == {"overwrite": False, "values": {"attri": "but"}}
+        ((_, ios_call_args), (_, android_call_args)) = client_mock.create_task.call_args_list
+
+        assert ios_call_args["request"]["task"]["http_request"] == {
+            "body": b'{"overwrite": false, "values": {"attri": "but"}}',
+            "headers": {"Content-Type": "application/json", "X-Authorization": "coucou-la-cle"},
+            "http_method": tasks_v2.HttpMethod.POST,
+            "url": "https://api.example.com/1.0/fake_android_api_key/data/users/1",
+        }
+
+        assert android_call_args["request"]["task"]["http_request"] == {
+            "body": b'{"overwrite": false, "values": {"attri": "but"}}',
+            "headers": {"Content-Type": "application/json", "X-Authorization": "coucou-la-cle"},
+            "http_method": tasks_v2.HttpMethod.POST,
+            "url": "https://api.example.com/1.0/fake_ios_api_key/data/users/1",
+        }
 
     def test_send_transactional_notification(self):
         with requests_mock.Mocker() as mock:

--- a/tests/notifications/push/backends/batch_test.py
+++ b/tests/notifications/push/backends/batch_test.py
@@ -1,6 +1,3 @@
-from unittest.mock import MagicMock
-from unittest.mock import patch
-
 from google.cloud import tasks_v2
 import requests_mock
 
@@ -12,15 +9,12 @@ from pcapi.notifications.push.transactional_notifications import TransactionalNo
 
 class BatchPushNotificationClientTest:
     @override_settings(BATCH_SECRET_API_KEY="coucou-la-cle")
-    @patch("pcapi.tasks.cloud_task.get_client")
-    def test_update_user_attributes(self, mock_get_client):
-        client_mock = MagicMock()
-        mock_get_client.return_value = client_mock
+    def test_update_user_attributes(self, cloud_task_client):
         BatchBackend().update_user_attributes(1, {"attri": "but"})
 
-        assert client_mock.create_task.call_count == 2
+        assert cloud_task_client.create_task.call_count == 2
 
-        ((_, ios_call_args), (_, android_call_args)) = client_mock.create_task.call_args_list
+        ((_, ios_call_args), (_, android_call_args)) = cloud_task_client.create_task.call_args_list
 
         assert ios_call_args["request"]["task"]["http_request"] == {
             "body": b'{"overwrite": false, "values": {"attri": "but"}}',

--- a/tests/tasks/batch_tasks_test.py
+++ b/tests/tasks/batch_tasks_test.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+
+import pytest
+
+from pcapi import settings
+from pcapi.core.testing import override_settings
+from pcapi.tasks.cloud_task import AUTHORIZATION_HEADER_KEY
+from pcapi.tasks.cloud_task import AUTHORIZATION_HEADER_VALUE
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+@override_settings(PUSH_NOTIFICATION_BACKEND="pcapi.notifications.push.backends.batch.BatchBackend")
+@patch("pcapi.notifications.push.backends.batch.requests")
+def test_legacy_batch_task(request_mock, client):
+    response = client.post(
+        f"{settings.API_URL}/cloud-tasks/batch/update_user_attributes",
+        json={"user_id": 123, "attributes": {"TEXTE_À": True}},
+        headers={AUTHORIZATION_HEADER_KEY: AUTHORIZATION_HEADER_VALUE},
+    )
+    assert response.status_code == 204
+
+    ((android_url, android_call_args), (ios_url, ios_call_args)) = request_mock.post.call_args_list
+
+    assert android_url == ("https://api.example.com/1.0/fake_android_api_key/data/users/123",)
+    assert android_call_args["json"] == {"overwrite": False, "values": {"TEXTE_À": True}}
+
+    assert ios_url == ("https://api.example.com/1.0/fake_ios_api_key/data/users/123",)
+    assert ios_call_args["json"] == {"overwrite": False, "values": {"TEXTE_À": True}}

--- a/tests/tasks/decorator_test.py
+++ b/tests/tasks/decorator_test.py
@@ -72,15 +72,18 @@ class CloudTaskDecoratorTest:
     @patch("pcapi.tasks.cloud_task.AUTHORIZATION_HEADER_VALUE", "Bearer secret-token")
     @override_settings(IS_RUNNING_TESTS=False)
     @override_settings(IS_DEV=False)
-    @patch("pcapi.tasks.cloud_task.tasks_v2.CloudTasksClient")
+    @patch("pcapi.tasks.cloud_task.get_client")
     def test_calling_google_cloud_task_client(self, mock_tasks_client):
         inner_task = MagicMock()
         test_task = generate_task(inner_task)
         payload = {"chouquette_price": 12}
 
+        client_mock = MagicMock()
+        mock_tasks_client.return_value = client_mock
+
         test_task.delay(payload)
 
-        mock_tasks_client().create_task.assert_called_once()
+        client_mock.create_task.assert_called_once()
 
         _, call_args = mock_tasks_client().create_task.call_args
 

--- a/tests/tasks/decorator_test.py
+++ b/tests/tasks/decorator_test.py
@@ -72,20 +72,16 @@ class CloudTaskDecoratorTest:
     @patch("pcapi.tasks.cloud_task.AUTHORIZATION_HEADER_VALUE", "Bearer secret-token")
     @override_settings(IS_RUNNING_TESTS=False)
     @override_settings(IS_DEV=False)
-    @patch("pcapi.tasks.cloud_task.get_client")
-    def test_calling_google_cloud_task_client(self, mock_tasks_client):
+    def test_calling_google_cloud_task_client(self, cloud_task_client):
         inner_task = MagicMock()
         test_task = generate_task(inner_task)
         payload = {"chouquette_price": 12}
 
-        client_mock = MagicMock()
-        mock_tasks_client.return_value = client_mock
-
         test_task.delay(payload)
 
-        client_mock.create_task.assert_called_once()
+        cloud_task_client.create_task.assert_called_once()
 
-        _, call_args = mock_tasks_client().create_task.call_args
+        _, call_args = cloud_task_client.create_task.call_args
 
         assert call_args["request"]["task"]["http_request"] == {
             "body": b'{"chouquette_price": 12}',

--- a/tests/tasks/decorator_test.py
+++ b/tests/tasks/decorator_test.py
@@ -51,7 +51,7 @@ class CloudTaskDecoratorTest:
 
     @patch("pcapi.tasks.cloud_task.AUTHORIZATION_HEADER_VALUE", "Bearer secret-token")
     @override_settings(IS_RUNNING_TESTS=False)
-    @patch("pcapi.tasks.decorator.requests.post")
+    @patch("pcapi.tasks.cloud_task.requests.post")
     def test_calling_task_in_dev(self, requests_post):
         inner_task = MagicMock()
         test_task = generate_task(inner_task)


### PR DESCRIPTION
## But de la pull request

Previous behaviour was: api -> CloudTask -> api -> Batch API ;
Now we have: api -> CloudTask -> BatchAPI so that we put less load on our api. 
We need to conserve the '/batch/update_user_attributes' endpoint until the next release so that the queue with former 'internal call' is leased"

##  Implémentation

Ajout d'une logique "
- enqueue_task_internal -> pour les taches qui passent par notre api, tel que l'upload de piece d'identité jouve
- enque_task -> le point d'entrée pour appeler CloudTask
​
- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
