### PR TITLE
(PC-10386): Confirmation beneficiary email new book expiration delay

### DIFF
--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -148,7 +148,7 @@ class BookOfferTest:
         email_data1 = mails_testing.outbox[0].sent_data
         assert email_data1["MJ-TemplateID"] == 2843165  # to offerer
         email_data2 = mails_testing.outbox[1].sent_data
-        assert email_data2["MJ-TemplateID"] == 2996790  # to beneficiary
+        assert email_data2["MJ-TemplateID"] == 3094927  # to beneficiary
 
     def test_booked_categories_are_sent_to_batch_backend(self, app):
         offer1 = offers_factories.OfferFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10386


## But de la pull request

Ajout d'un nouveau template mailjet de confirmation de réservation envoyé aux **bénéficiares** avec un paramètre additionnel expiration_delay pour gérer le cas du nouveau délai de retrait des livres.

##  Implémentation

Ajout de l'id du nouveau template et l'utiliser dans le cas ou le FF ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS est activé.
Ajout du nouveau paramètre expiration_delay.
Ajout d'une classe de test pour le comportement FF désactivé qui sera supprimé une fois le FF activé.
Ajout d'une classe de test pour le comportement FF activé.

​
##  Informations supplémentaires
N/A
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
