### PR TITLE
(PC-10577) : exclude the user from duplicate searches

### DIFF
--- a/src/pcapi/repository/user_queries.py
+++ b/src/pcapi/repository/user_queries.py
@@ -1,5 +1,6 @@
 from datetime import MINYEAR
 from datetime import datetime
+from typing import Optional
 
 from sqlalchemy import Column
 from sqlalchemy import func
@@ -51,15 +52,23 @@ def find_pro_users_by_email_provider(email_provider: str) -> list[User]:
     )
 
 
-def find_beneficiary_by_civility(first_name: str, last_name: str, date_of_birth: datetime) -> list[User]:
+def beneficiary_by_civility_query(
+    first_name: str, last_name: str, date_of_birth: datetime, exclude_email: Optional[str] = None
+) -> Query:
     civility_predicate = (
         (matching(User.firstName, first_name))
         & (matching(User.lastName, last_name))
         & (User.dateOfBirth == date_of_birth)
         & (User.isBeneficiary == True)
     )
+    if exclude_email:
+        civility_predicate = civility_predicate & (User.email != exclude_email)
 
-    return User.query.filter(civility_predicate).all()
+    return User.query.filter(civility_predicate)
+
+
+def find_beneficiary_by_civility(first_name: str, last_name: str, date_of_birth: datetime) -> list[User]:
+    return beneficiary_by_civility_query(first_name=first_name, last_name=last_name, date_of_birth=date_of_birth).all()
 
 
 def find_by_validation_token(token: str) -> User:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10577


## But de la pull request

Il arrive qu'un utilisateur soit marqué comme dupliqué de lui-même.
Le but de cette PR est donc d'ignorer l'email donné lorsque l'on recherche des utilisateurs en doublons.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
