### PR TITLE
(PC-10591) index permanent venues only

### DIFF
--- a/src/pcapi/admin/custom_views/venue_view.py
+++ b/src/pcapi/admin/custom_views/venue_view.py
@@ -119,7 +119,7 @@ class VenueView(BaseAdminView):
             update_offer_and_stock_id_at_providers(venue, old_siret)
 
         if has_indexed_attribute_changed:
-            search.async_index_venue_ids([venue.id])
+            search.async_index_venues([venue])
             search.async_index_offers_of_venue_ids([venue.id])
 
         return True

--- a/src/pcapi/core/offerers/api.py
+++ b/src/pcapi/core/offerers/api.py
@@ -73,7 +73,7 @@ def update_venue(venue: Venue, contact_data: venues_serialize.VenueContactModel 
     indexing_modifications_fields = set(modifications.keys()) & set(VENUE_ALGOLIA_INDEXED_FIELDS)
 
     if indexing_modifications_fields or contact_data:
-        search.async_index_venue_ids([venue.id])
+        search.async_index_venues([venue])
         search.async_index_offers_of_venue_ids([venue.id])
 
     return venue
@@ -107,7 +107,7 @@ def create_venue(venue_data: PostVenueBodyModel) -> Venue:
 
     repository.save(venue)
 
-    search.async_index_venue_ids([venue.id])
+    search.async_index_venues([venue])
     return venue
 
 

--- a/src/pcapi/core/search/__init__.py
+++ b/src/pcapi/core/search/__init__.py
@@ -43,9 +43,9 @@ def async_index_offer_ids(offer_ids: Iterable[int]) -> None:
             )
 
 
-def async_index_venue_ids(venue_ids: Iterable[int]) -> None:
+def async_index_venues(venues: Iterable[Venue]) -> None:
     """Ask for an asynchronous reindexation of the given list of
-    ``Venue.id``.
+    ``Venue``.
 
     This function returns quickly. The "real" reindexation will be
     done later through a cron job.
@@ -53,6 +53,7 @@ def async_index_venue_ids(venue_ids: Iterable[int]) -> None:
     backends = _get_backends()
     for backend in backends:
         try:
+            venue_ids = [venue.id for venue in venues if venue.isPermanent]
             backend.enqueue_venue_ids(venue_ids)
         except Exception:  # pylint: disable=broad-except
             if settings.IS_RUNNING_TESTS:

--- a/tests/core/search/test_api.py
+++ b/tests/core/search/test_api.py
@@ -33,6 +33,17 @@ def test_async_index_offers_of_venue_ids(app):
     assert app.redis_client.smembers("search:appsearch:venue-ids-for-offers-to-index") == {b"1", b"2"}
 
 
+def test_async_index_venues(app):
+    permanent_venue = offers_factories.VenueFactory(isPermanent=True)
+    other_venue = offers_factories.VenueFactory(isPermanent=False)
+
+    search.async_index_venues([permanent_venue, other_venue])
+
+    enqueued_ids = app.redis_client.smembers("search:appsearch:venue-ids-new-to-index")
+    enqueued_ids = {int(venue_id) for venue_id in enqueued_ids}
+    assert enqueued_ids == {permanent_venue.id}
+
+
 @override_settings(REDIS_VENUE_IDS_CHUNK_SIZE=1)
 def test_index_offers_of_venues_in_queue(app):
     bookable_offer = make_bookable_offer()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10591


## But de la pull request

Filtrer les lieux indexés : ne prendre en compte que ceux qui sont permanents.

##  Implémentation

Je n'ai pas touché à la signature de la méthode pour maintenir une cohérence entre les différentes fonctions `async_xyz` d'indexation : ça aurait été plus simple de passer des `Venue` au lieu de leurs identifiants.

##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)

