### PR TITLE
(PC-10789) venue: set venue type code on create/update

### DIFF
--- a/src/pcapi/core/offerers/api.py
+++ b/src/pcapi/core/offerers/api.py
@@ -68,6 +68,9 @@ def update_venue(venue: Venue, contact_data: venues_serialize.VenueContactModel 
     if contact_data:
         upsert_venue_contact(venue, contact_data)
 
+    # TODO: Remove this step when a new stable venue type system is setup
+    venue.fill_venue_type_code_from_label()
+
     repository.save(venue)
 
     indexing_modifications_fields = set(modifications.keys()) & set(VENUE_ALGOLIA_INDEXED_FIELDS)
@@ -104,6 +107,9 @@ def create_venue(venue_data: PostVenueBodyModel) -> Venue:
 
     if venue_data.contact:
         upsert_venue_contact(venue, venue_data.contact)
+
+    # TODO: Remove this step when a new stable venue type system is setup
+    venue.fill_venue_type_code_from_label()
 
     repository.save(venue)
 

--- a/src/pcapi/core/offerers/models.py
+++ b/src/pcapi/core/offerers/models.py
@@ -83,24 +83,40 @@ CONSTRAINT_CHECK_HAS_SIRET_XOR_HAS_COMMENT_XOR_IS_VIRTUAL = """
 
 
 class VenueTypeCode(enum.Enum):
-    VISUAL_ARTS = "VISUAL_ARTS"
-    CULTURAL_CENTRE = "CULTURAL_CENTRE"
-    ARTISTIC_COURSE = "ARTISTIC_COURSE"
-    SCIENTIFIC_CULTURE = "SCIENTIFIC_CULTURE"
-    FESTIVAL = "FESTIVAL"
-    GAMES = "GAMES"
-    BOOKSTORE = "BOOKSTORE"
-    LIBRARY = "LIBRARY"
-    MUSEUM = "MUSEUM"
-    RECORD_STORE = "RECORD_STORE"
-    MUSICAL_INSTRUMENT_STORE = "MUSICAL_INSTRUMENT_STORE"
-    CONCERT_HALL = "CONCERT_HALL"
-    DIGITAL = "DIGITAL"
-    PATRIMONY_TOURISM = "PATRIMONY_TOURISM"
-    MOVIE = "MOVIE"
-    PERFORMING_ARTS = "PERFORMING_ARTS"
-    CREATIVE_ARTS_STORE = "CREATIVE_ARTS_STORE"
-    OTHER = "OTHER"
+    VISUAL_ARTS = "Arts visuels, arts plastiques et galeries"
+    CULTURAL_CENTRE = "Centre culturel"
+    ARTISTIC_COURSE = "Cours et pratique artistiques"
+    SCIENTIFIC_CULTURE = "Culture scientifique"
+    FESTIVAL = "Festival"
+    GAMES = "Jeux / Jeux vidéos"
+    BOOKSTORE = "Librairie"
+    LIBRARY = "Bibliothèque ou médiathèque"
+    MUSEUM = "Musée"
+    RECORD_STORE = "Musique - Disquaire"
+    MUSICAL_INSTRUMENT_STORE = "Musique - Magasin d’instruments"
+    CONCERT_HALL = "Musique - Salle de concerts"
+    DIGITAL = "Offre numérique"
+    PATRIMONY_TOURISM = "Patrimoine et tourisme"
+    MOVIE = "Cinéma - Salle de projections"
+    PERFORMING_ARTS = "Spectacle vivant"
+    CREATIVE_ARTS_STORE = "Magasin arts créatifs"
+    OTHER = "Autre"
+
+    @classmethod
+    def __get_validators__(cls):
+        cls.lookup = {v: k.name for v, k in cls.__members__.items()}
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        try:
+            return cls.lookup[v]
+        except KeyError:
+            raise ValueError(f"{v}: invalide")
+
+    @classmethod
+    def from_label(cls, label: str) -> "VenueTypeCode":
+        return {code.value: code.name for code in cls}[label]
 
 
 class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, NeedsValidationMixin):
@@ -246,6 +262,11 @@ class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, Ne
         if field not in type(self).__table__.columns:
             raise ValueError(f"Unknown field {field} for model {type(self)}")
         return getattr(self, field) != value
+
+    def fill_venue_type_code_from_label(self) -> None:
+        if not self.venueType:
+            return
+        self.venueTypeCode = VenueTypeCode.from_label(self.venueType.label)
 
 
 class VenueLabel(PcObject, Model):

--- a/src/pcapi/core/offers/factories.py
+++ b/src/pcapi/core/offers/factories.py
@@ -55,7 +55,7 @@ class VenueFactory(BaseFactory):
     publicName = factory.SelfAttribute("name")
     siret = factory.LazyAttributeSequence(lambda o, n: f"{o.managingOfferer.siren}{n:05}")
     isVirtual = False
-    venueTypeCode = offerers_models.VenueTypeCode.OTHER.value
+    venueTypeCode = offerers_models.VenueTypeCode.OTHER
     description = factory.Faker("text", max_nb_chars=64)
 
     contact = factory.RelatedFactory("pcapi.core.offerers.factories.VenueContactFactory", factory_related_name="venue")

--- a/src/pcapi/routes/native/v1/offerers.py
+++ b/src/pcapi/routes/native/v1/offerers.py
@@ -14,4 +14,25 @@ def get_venue(venue_id: int) -> serializers.VenueResponse:
     if not venue.isPermanent:
         abort(404)
 
-    return serializers.VenueResponse.from_orm(venue)
+    return serializers.VenueResponse(
+        id=venue.id,
+        name=venue.name,
+        latitude=venue.latitude,
+        longitude=venue.longitude,
+        city=venue.city,
+        publicName=venue.publicName,
+        isVirtual=venue.isVirtual,
+        isPermanent=venue.isPermanent,
+        withdrawalDetails=venue.withdrawalDetails,
+        address=venue.address,
+        postalCode=venue.postalCode,
+        venueTypeCode=venue.venueTypeCode.name,
+        description=venue.description,
+        contact=venue.contact,
+        accessibility={
+            "audioDisability": venue.audioDisabilityCompliant,
+            "mentalDisability": venue.mentalDisabilityCompliant,
+            "motorDisability": venue.motorDisabilityCompliant,
+            "visualDisability": venue.visualDisabilityCompliant,
+        },
+    )

--- a/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -35,14 +35,3 @@ class VenueResponse(BaseModel):
     description: typing.Optional[venues_serialize.VenueDescription]  # type: ignore
     contact: typing.Optional[venues_serialize.VenueContactModel]
     accessibility: VenueAccessibilityModel
-
-    @classmethod
-    def from_orm(cls, venue: offerers_models.Venue) -> "VenueResponse":
-        venue.accessibility = {
-            "audioDisability": venue.audioDisabilityCompliant,
-            "mentalDisability": venue.mentalDisabilityCompliant,
-            "motorDisability": venue.motorDisabilityCompliant,
-            "visualDisability": venue.visualDisabilityCompliant,
-        }
-
-        return super().from_orm(venue)

--- a/src/pcapi/scripts/update_venue_type_codes.py
+++ b/src/pcapi/scripts/update_venue_type_codes.py
@@ -11,6 +11,7 @@ import logging
 
 from sqlalchemy import exc
 
+from pcapi.core.offerers.models import VenueTypeCode
 from pcapi.models import db
 
 
@@ -39,26 +40,7 @@ def _update_venues_with_label(code: str, label: str) -> set[int]:
 
 def update_venues_codes() -> set[int]:
     logger.info("update venues codes: start")
-    codes_labels = [
-        ("VISUAL_ARTS", "Arts visuels, arts plastiques et galeries"),
-        ("CULTURAL_CENTRE", "Centre culturel"),
-        ("ARTISTIC_COURSE", "Cours et pratique artistiques"),
-        ("SCIENTIFIC_CULTURE", "Culture scientifique"),
-        ("FESTIVAL", "Festival"),
-        ("GAMES", "Jeux / Jeux vidéos"),
-        ("BOOKSTORE", "Librairie"),
-        ("LIBRARY", "Bibliothèque ou médiathèque"),
-        ("MUSEUM", "Musée"),
-        ("RECORD_STORE", "Musique - Disquaire"),
-        ("MUSICAL_INSTRUMENT_STORE", "Musique - Magasin d’instruments"),
-        ("CONCERT_HALL", "Musique - Salle de concerts"),
-        ("DIGITAL", "Offre numérique"),
-        ("PATRIMONY_TOURISM", "Patrimoine et tourisme"),
-        ("MOVIE", "Cinéma - Salle de projections"),
-        ("PERFORMING_ARTS", "Spectacle vivant"),
-        ("CREATIVE_ARTS_STORE", "Magasin arts créatifs"),
-        ("OTHER", "Autre"),
-    ]
+    codes_labels = [(code.name, code.value) for code in VenueTypeCode]
 
     updated_ids = set()
     for code, label in codes_labels:

--- a/tests/routes/native/v1/offerers_test.py
+++ b/tests/routes/native/v1/offerers_test.py
@@ -25,7 +25,7 @@ class VenuesTest:
             "withdrawalDetails": venue.withdrawalDetails,
             "address": venue.address,
             "postalCode": venue.postalCode,
-            "venueTypeCode": venue.venueTypeCode.value,
+            "venueTypeCode": venue.venueTypeCode.name,
             "description": venue.description,
             "contact": {
                 "email": venue.contact.email,

--- a/tests/routes/webapp/get_booking_by_id_test.py
+++ b/tests/routes/webapp/get_booking_by_id_test.py
@@ -171,7 +171,7 @@ class Returns200Test:
                         "venueLabelId": None,
                         "venueTypeId": None,
                         "visualDisabilityCompliant": None,
-                        "venueTypeCode": "OTHER",
+                        "venueTypeCode": offer.venue.venueTypeCode.value,
                         "withdrawalDetails": None,
                     },
                     "venueId": humanize(offer.venue.id),

--- a/tests/scripts/update_venue_type_codes_test.py
+++ b/tests/scripts/update_venue_type_codes_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from pcapi.core.offerers.factories import VenueTypeFactory
 from pcapi.core.offerers.models import Venue
+from pcapi.core.offerers.models import VenueTypeCode
 from pcapi.core.offers.factories import VenueFactory
 from pcapi.scripts.update_venue_type_codes import update_venues_codes
 
@@ -19,7 +20,7 @@ def test_update_venue_codes(app):
 
     update_venues_codes()
 
-    assert Venue.query.get(bookstore.id).venueTypeCode.value == "BOOKSTORE"
-    assert Venue.query.get(museum.id).venueTypeCode.value == "MUSEUM"
-    assert Venue.query.get(digital.id).venueTypeCode.value == "DIGITAL"
-    assert Venue.query.get(undefined.id).venueTypeCode.value == "OTHER"
+    assert Venue.query.get(bookstore.id).venueTypeCode == VenueTypeCode.BOOKSTORE
+    assert Venue.query.get(museum.id).venueTypeCode == VenueTypeCode.MUSEUM
+    assert Venue.query.get(digital.id).venueTypeCode == VenueTypeCode.DIGITAL
+    assert Venue.query.get(undefined.id).venueTypeCode == VenueTypeCode.OTHER


### PR DESCRIPTION
**Contexte**

(fait suite à https://github.com/pass-culture/pass-culture-api/pull/3149 , branche sans ticket)

[Cette PR](https://github.com/pass-culture/pass-culture-api/pull/2956) a ajouté une nouvelle colonne à la table venue : `venueTypeCode`. Elle vise à remplacer `venueTypeId` (et la table `venue_type`).

Pour rappel : avec les nouveautés côté lieux, on avait besoin d'une logique d'enum qui permettait de lister explicitement tous les types de lieux avec des codes stables. Le fonctionnement avec la table `venue_type` (qui ne comportait qu'un label) ne permettait pas cela.

**Besoin**

La précédente PR a ajouté la colonne et un script qui permet de remplir la colonne `venuTypeCode` de tous les lieux en se basant sur le label du `venue_type` associé.

Le but de cette PR est de s'assurer que `venuTypeCode` sera toujours correctement renseigné avant de passer à l'étape suivante : supprimer venueTypeId et la table `venue_type`. Cette étape intermédiaire évite d'avoir à effectuer un gros changement d'un coup (sachant qu'elles impliquent des modifications côté front PRO).