### PR TITLE
App Search (tests) : TestingBackend hérite maintenant de AppSearchBackend

### DIFF
--- a/src/pcapi/core/search/backends/testing.py
+++ b/src/pcapi/core/search/backends/testing.py
@@ -2,23 +2,26 @@ from flask import current_app
 
 from pcapi.core.search import testing
 
-from .algolia import AlgoliaBackend
+from .appsearch import AppSearchBackend
 
 
 class FakeClient:
-    def save_objects(self, objects):
-        for obj in objects:
-            testing.search_store[obj["objectID"]] = obj
+    def __init__(self, key):
+        self.key = key
 
-    def delete_objects(self, object_ids):
-        for object_id in object_ids:
-            testing.search_store.pop(object_id, None)
+    def create_or_update_documents(self, documents):
+        for document in documents:
+            testing.search_store[self.key][document["id"]] = document
 
-    def clear_objects(self):
-        testing.search_store = {}
+    def delete_documents(self, document_ids):
+        for document_id in document_ids:
+            testing.search_store[self.key].pop(document_id, None)
+
+    def delete_all_documents(self):
+        testing.search_store[self.key] = {}
 
 
-class TestingBackend(AlgoliaBackend):
+class TestingBackend(AppSearchBackend):
     """A backend to be used by automated tests.
 
     We subclass a real-looking backend to be as close as possible to
@@ -27,5 +30,6 @@ class TestingBackend(AlgoliaBackend):
     """
 
     def __init__(self):  # pylint: disable=super-init-not-called
-        self.algolia_client = FakeClient()
+        self.offers_engine = FakeClient("offers")
+        self.venues_engine = FakeClient("venues")
         self.redis_client = current_app.redis_client

--- a/src/pcapi/core/search/testing.py
+++ b/src/pcapi/core/search/testing.py
@@ -1,6 +1,9 @@
-search_store = {}
+search_store = None
 
 
 def reset_search_store():
     global search_store  # pylint: disable=global-statement
-    search_store = {}
+    search_store = {"offers": {}, "venues": {}}
+
+
+reset_search_store()

--- a/tests/core/search/test_api.py
+++ b/tests/core/search/test_api.py
@@ -25,12 +25,12 @@ def fail(*args, **kwargs):
 
 def test_async_index_offer_ids(app):
     search.async_index_offer_ids({1, 2})
-    assert set(app.redis_client.lrange("offer_ids", 0, 5)) == {b"1", b"2"}
+    assert app.redis_client.smembers("search:appsearch:offer-ids-to-index") == {b"1", b"2"}
 
 
 def test_async_index_offers_of_venue_ids(app):
     search.async_index_offers_of_venue_ids({1, 2})
-    assert set(app.redis_client.lrange("venue_ids_for_offers", 0, 5)) == {b"1", b"2"}
+    assert app.redis_client.smembers("search:appsearch:venue-ids-for-offers-to-index") == {b"1", b"2"}
 
 
 @override_settings(REDIS_VENUE_IDS_CHUNK_SIZE=1)
@@ -39,132 +39,130 @@ def test_index_offers_of_venues_in_queue(app):
     venue1 = bookable_offer.venue
     unbookable_offer = make_unbookable_offer()
     venue2 = unbookable_offer.venue
-    app.redis_client.lpush("venue_ids_for_offers", venue1.id, venue2.id)
+    queue = "search:appsearch:venue-ids-for-offers-to-index"
+    app.redis_client.sadd(queue, venue1.id, venue2.id)
 
     # `index_offers_of_venues_in_queue` pops 1 venue from the queue
     # (REDIS_VENUE_IDS_FOR_OFFERS_TO_INDEX).
     search.index_offers_of_venues_in_queue()
-    assert app.redis_client.lrange("venue_ids_for_offers", 0, 5) == [str(venue1.id).encode()]
+    assert app.redis_client.scard(queue) == 1
 
     search.index_offers_of_venues_in_queue()
-    assert app.redis_client.llen("venue_ids_for_offers") == 0
+    assert app.redis_client.scard(queue) == 0
 
-    assert bookable_offer.id in search_testing.search_store
-    assert unbookable_offer.id not in search_testing.search_store
+    assert bookable_offer.id in search_testing.search_store["offers"]
+    assert unbookable_offer.id not in search_testing.search_store["offers"]
 
 
 @override_settings(REDIS_VENUE_IDS_CHUNK_SIZE=1)
 def test_index_venues_in_queue(app):
     venue1 = offers_factories.VenueFactory()
     venue2 = offers_factories.VenueFactory()
-    app.redis_client.lpush("venue_ids_new", venue1.id, venue2.id)
+    queue = "search:appsearch:venue-ids-new-to-index"
+    app.redis_client.sadd(queue, venue1.id, venue2.id)
 
     # `index_venues_in_queue` pops 1 venue from the queue (REDIS_VENUE_IDS_CHUNK_SIZE).
     search.index_venues_in_queue()
-    assert app.redis_client.lrange("venue_ids_new", 0, 5) == [str(venue1.id).encode()]
+    assert app.redis_client.scard(queue) == 1
 
     search.index_venues_in_queue()
-    assert app.redis_client.llen("venue_ids_new") == 0
+    assert app.redis_client.scard(queue) == 0
 
 
 class ReindexOfferIdsTest:
     def test_index_new_offer(self):
         offer = make_bookable_offer()
-        assert search_testing.search_store == {}
+        assert search_testing.search_store["offers"] == {}
         search.reindex_offer_ids([offer.id])
-        assert offer.id in search_testing.search_store
+        assert offer.id in search_testing.search_store["offers"]
 
     def test_unindex_unbookable_offer(self, app):
         offer = make_unbookable_offer()
-        app.redis_client.hset("indexed_offers", offer.id, "")
-        search_testing.search_store[offer.id] = "dummy"
+        search_testing.search_store["offers"][offer.id] = "dummy"
         search.reindex_offer_ids([offer.id])
-        assert search_testing.search_store == {}
+        assert search_testing.search_store["offers"] == {}
 
-    def test_unindex_unbookable_offer_not_in_cache(self):
-        offer = make_unbookable_offer()
-        search_testing.search_store[offer.id] = "dummy"
-        search.reindex_offer_ids([offer.id])
-        assert offer.id in search_testing.search_store  # still there, not unindexed
-
-    @mock.patch("pcapi.core.search.backends.testing.FakeClient.save_objects", fail)
-    def test_handle_indexation_error(self):
+    @mock.patch("pcapi.core.search.backends.testing.FakeClient.create_or_update_documents", fail)
+    def test_handle_indexation_error(self, app):
         offer = make_bookable_offer()
-        assert search_testing.search_store == {}
+        assert search_testing.search_store["offers"] == {}
         with override_settings(IS_RUNNING_TESTS=False):  # as on prod: don't catch errors
             search.reindex_offer_ids([offer.id])
-        assert offer.id not in search_testing.search_store
-        backend = search._get_backends()[0]
-        assert backend.pop_offer_ids_from_queue(5, from_error_queue=True) == {offer.id}
+        assert offer.id not in search_testing.search_store["offers"]
+        assert app.redis_client.smembers("search:appsearch:offer-ids-in-error-to-index") == {str(offer.id).encode()}
 
-    @mock.patch("pcapi.core.search.backends.testing.FakeClient.delete_objects", fail)
+    @mock.patch("pcapi.core.search.backends.testing.FakeClient.delete_documents", fail)
     def test_handle_unindexation_error(self, app):
         offer = make_unbookable_offer()
-        app.redis_client.hset("indexed_offers", offer.id, "")
-        search_testing.search_store[offer.id] = "dummy"
+        search_testing.search_store["offers"][offer.id] = "dummy"
         with override_settings(IS_RUNNING_TESTS=False):  # as on prod: don't catch errors
             search.reindex_offer_ids([offer.id])
-        assert offer.id in search_testing.search_store
-        backend = search._get_backends()[0]
-        assert backend.pop_offer_ids_from_queue(5, from_error_queue=True) == {offer.id}
+        assert offer.id in search_testing.search_store["offers"]
+        assert app.redis_client.smembers("search:appsearch:offer-ids-in-error-to-index") == {str(offer.id).encode()}
 
 
 @override_settings(REDIS_OFFER_IDS_CHUNK_SIZE=3)
 @mock.patch("pcapi.core.search._reindex_offer_ids")
 class IndexOffersInQueueTest:
     def test_cron_behaviour(self, mocked_reindex_offer_ids, app):
-        # Put 8 items in the queue, in that order: 1..8
-        app.redis_client.lpush("offer_ids", *reversed(range(1, 9)))
+        items = set(range(1, 9))  # 8 items: 1..8
+        app.redis_client.sadd("search:appsearch:offer-ids-to-index", *items)
 
         search.index_offers_in_queue()
 
-        # First run pops and indexes 1, 2, 3. Second run pops and
-        # indexes 4, 5, 6. And stops because there are less than
-        # REDIS_OFFER_IDS_CHUNK_SIZE items left in the queue.
-        # fmt: off
-        assert mocked_reindex_offer_ids.mock_calls == [
-            mock.call(mock.ANY, {1, 2, 3}),
-            mock.call(mock.ANY, {4, 5, 6})
-        ]
-        # fmt: on
-        assert app.redis_client.lrange("offer_ids", 0, 5) == [b"7", b"8"]
+        # First run pops and indexes 3 items. Second run pops and
+        # indexes another set of 3 items. And stops because there are
+        # less than REDIS_OFFER_IDS_CHUNK_SIZE items left in the
+        # queue.
+        calls = mocked_reindex_offer_ids.mock_calls
+        assert len(calls) == 2
+
+        assert calls[0].args[1].issubset(items)
+        assert len(calls[0].args[1]) == 3
+
+        assert calls[1].args[1].issubset(items)
+        assert len(calls[1].args[1]) == 3
+
+        assert app.redis_client.scard("search:appsearch:offer-ids-to-index") == 2
 
     def test_command_behaviour(self, mocked_reindex_offer_ids, app):
         # Put 8 items in the queue, in that order: 1..8
-        app.redis_client.lpush("offer_ids", *reversed(range(1, 9)))
+        items = set(range(1, 9))  # 8 items: 1..8
+        app.redis_client.sadd("search:appsearch:offer-ids-to-index", *items)
 
         search.index_offers_in_queue(stop_only_when_empty=True)
 
         # First run pops and indexes 1, 2, 3. Second run pops and
         # indexes 4, 5, 6. Third run pops 7, 8 and stops because the
         # queue is empty.
-        assert mocked_reindex_offer_ids.mock_calls == [
-            mock.call(mock.ANY, {1, 2, 3}),
-            mock.call(mock.ANY, {4, 5, 6}),
-            mock.call(mock.ANY, {7, 8}),
-        ]
-        assert app.redis_client.llen("offer_ids") == 0
+        calls = mocked_reindex_offer_ids.mock_calls
+        assert len(calls) == 3
+
+        assert calls[0].args[1].issubset(items)
+        assert len(calls[0].args[1]) == 3
+
+        assert calls[1].args[1].issubset(items)
+        assert len(calls[1].args[1]) == 3
+
+        assert calls[2].args[1].issubset(items)
+        assert len(calls[2].args[1]) == 2
+
+        assert app.redis_client.llen("search:appsearch:offer-ids-to-index") == 0
 
 
-def test_unindex_offer_ids(app):
-    search_testing.search_store[1] = "dummy"
-    search_testing.search_store[2] = "dummy"
-    app.redis_client.hset("indexed_offers", "1", "")
-    app.redis_client.hset("indexed_offers", "2", "")
+def test_unindex_offer_ids():
+    search_testing.search_store["offers"][1] = "dummy"
+    search_testing.search_store["offers"][2] = "dummy"
 
     search.unindex_offer_ids([1, 2])
 
-    assert app.redis_client.hkeys("indexed_offers") == []
-    assert search_testing.search_store == {}
+    assert search_testing.search_store["offers"] == {}
 
 
-def test_unindex_all_offers(app):
-    search_testing.search_store[1] = "dummy"
-    search_testing.search_store[2] = "dummy"
-    app.redis_client.hset("indexed_offers", "1", "")
-    app.redis_client.hset("indexed_offers", "2", "")
+def test_unindex_all_offers():
+    search_testing.search_store["offers"][1] = "dummy"
+    search_testing.search_store["offers"][2] = "dummy"
 
     search.unindex_all_offers()
 
-    assert app.redis_client.hkeys("indexed_offers") == []
-    assert search_testing.search_store == {}
+    assert search_testing.search_store["offers"] == {}

--- a/tests/core/search/test_integration.py
+++ b/tests/core/search/test_integration.py
@@ -14,31 +14,31 @@ def test_offer_indexation_on_booking_cycle(app):
     beneficiary = users_factories.BeneficiaryGrant18Factory()
     stock = offers_factories.StockFactory(quantity=1)
     offer = stock.offer
-    assert search_testing.search_store == {}
+    assert search_testing.search_store["offers"] == {}
 
     search.async_index_offer_ids([offer.id])
-    assert search_testing.search_store == {}
+    assert search_testing.search_store["offers"] == {}
 
     search.index_offers_in_queue()
-    assert offer.id in search_testing.search_store
+    assert offer.id in search_testing.search_store["offers"]
 
     booking = bookings_api.book_offer(beneficiary, stock.id, quantity=1)
     search.index_offers_in_queue()
-    assert offer.id not in search_testing.search_store
+    assert offer.id not in search_testing.search_store["offers"]
 
     bookings_api.cancel_booking_by_beneficiary(beneficiary, booking)
     search.index_offers_in_queue()
-    assert offer.id in search_testing.search_store
+    assert offer.id in search_testing.search_store["offers"]
 
 
 def test_offer_indexation_on_venue_cycle(app):
     stock = offers_factories.StockFactory(quantity=1)
     offer = stock.offer
     venue = offer.venue
-    assert search_testing.search_store == {}
+    assert search_testing.search_store["offers"] == {}
 
     search.async_index_offers_of_venue_ids([venue.id])
-    assert search_testing.search_store == {}
+    assert search_testing.search_store["offers"] == {}
 
     search.index_offers_of_venues_in_queue()
-    assert offer.id in search_testing.search_store
+    assert offer.id in search_testing.search_store["offers"]


### PR DESCRIPTION
J'ai supprimé un mock de Redis au passage, commits à relire séparément.