### PR TITLE
(PC-10400): New mailjet template to notify offerer of expired bookings with variable withdrawal period

### DIFF
--- a/src/pcapi/domain/user_emails.py
+++ b/src/pcapi/domain/user_emails.py
@@ -172,11 +172,33 @@ def send_expired_bookings_recap_email_to_beneficiary(beneficiary: User, bookings
             mails.send(recipients=[beneficiary.email], data=other_bookings_data)
 
 
-def send_expired_individual_bookings_recap_email_to_offerer(offerer: Offerer, bookings: list[Booking]) -> None:
+# TODO(yacine) this function will be removed after removing FF ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS
+def legacy_send_expired_individual_bookings_recap_email_to_offerer(offerer: Offerer, bookings: list[Booking]) -> None:
     offerer_booking_email = bookings[0].stock.offer.bookingEmail
     if offerer_booking_email:
-        data = build_expired_bookings_recap_email_data_for_offerer(offerer, bookings)
+        data = build_expired_bookings_recap_email_data_for_offerer(offerer, bookings, BOOKINGS_AUTO_EXPIRY_DELAY.days)
         mails.send(recipients=[offerer_booking_email], data=data)
+
+
+def send_expired_individual_bookings_recap_email_to_offerer(offerer: Offerer, bookings: list[Booking]) -> None:
+    if not FeatureToggle.ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS.is_active():
+        legacy_send_expired_individual_bookings_recap_email_to_offerer(offerer, bookings)
+    else:
+        offerer_booking_email = bookings[0].stock.offer.bookingEmail
+        if offerer_booking_email:
+            books_bookings, other_bookings = filter_books_bookings(bookings)
+
+            if books_bookings:
+                books_bookings_data = build_expired_bookings_recap_email_data_for_offerer(
+                    offerer, books_bookings, BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY.days
+                )
+                mails.send(recipients=[offerer_booking_email], data=books_bookings_data)
+
+            if other_bookings:
+                other_bookings_data = build_expired_bookings_recap_email_data_for_offerer(
+                    offerer, other_bookings, BOOKINGS_AUTO_EXPIRY_DELAY.days
+                )
+                mails.send(recipients=[offerer_booking_email], data=other_bookings_data)
 
 
 def send_pro_user_validation_email(user: User) -> None:

--- a/src/pcapi/emails/offerer_expired_bookings.py
+++ b/src/pcapi/emails/offerer_expired_bookings.py
@@ -1,16 +1,29 @@
 from pcapi.core.offerers.models import Offerer
 from pcapi.domain.postal_code.postal_code import PostalCode
 from pcapi.models import Booking
+from pcapi.models.feature import FeatureToggle
 from pcapi.utils.mailing import build_pc_pro_offer_link
 
 
-def build_expired_bookings_recap_email_data_for_offerer(offerer: Offerer, bookings: list[Booking]) -> dict:
+OLD_MAILJET_TEMPLATE_ID = 1952508
+NEW_MAILJET_TEMPLATE_ID = 3095184
+
+
+def build_expired_bookings_recap_email_data_for_offerer(
+    offerer: Offerer, bookings: list[Booking], withdrawal_period
+) -> dict:
+    mj_template_id = (
+        NEW_MAILJET_TEMPLATE_ID
+        if FeatureToggle.ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS.is_active()
+        else OLD_MAILJET_TEMPLATE_ID
+    )
     return {
-        "Mj-TemplateID": 1952508,
+        "Mj-TemplateID": mj_template_id,
         "Mj-TemplateLanguage": True,
         "Vars": {
             "bookings": _extract_bookings_information_from_bookings_list(bookings),
             "department": PostalCode(offerer.postalCode).get_departement_code(),
+            "withdrawal_period": withdrawal_period,
         },
     }
 

--- a/tests/emails/offerer_expired_bookings_test.py
+++ b/tests/emails/offerer_expired_bookings_test.py
@@ -4,15 +4,18 @@ from unittest.mock import patch
 
 import pytest
 
+from pcapi.core.bookings.conf import BOOKINGS_AUTO_EXPIRY_DELAY
 from pcapi.core.bookings.factories import CancelledBookingFactory
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import OffererFactory
 from pcapi.core.offers.factories import ProductFactory
+from pcapi.core.testing import override_features
 from pcapi.emails.offerer_expired_bookings import build_expired_bookings_recap_email_data_for_offerer
 
 
 @pytest.mark.usefixtures("db_session")
+@override_features(ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS=False)
 @patch(
     "pcapi.emails.offerer_expired_bookings.build_pc_pro_offer_link",
     return_value="http://pc_pro.com/offer_link",
@@ -46,8 +49,7 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled(self, app)
     )
 
     email_data = build_expired_bookings_recap_email_data_for_offerer(
-        offerer,
-        [expired_today_dvd_booking, expired_today_cd_booking],
+        offerer, [expired_today_dvd_booking, expired_today_cd_booking], BOOKINGS_AUTO_EXPIRY_DELAY.days
     )
 
     assert email_data == {
@@ -73,5 +75,72 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled(self, app)
                 },
             ],
             "department": "75",
+            "withdrawal_period": 30,
+        },
+    }
+
+
+@pytest.mark.usefixtures("db_session")
+@override_features(ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS=True)
+@patch(
+    "pcapi.emails.offerer_expired_bookings.build_pc_pro_offer_link",
+    return_value="http://pc_pro.com/offer_link",
+)
+def test_should_send_email_to_offerer_when_expired_bookings_cancelled_with_new_auto_expiry_delay_ff_enabled(self, app):
+    now = datetime.utcnow()
+    offerer = OffererFactory()
+    long_ago = now - timedelta(days=31)
+    dvd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
+    expired_today_dvd_booking = CancelledBookingFactory(
+        user__publicName="Dory",
+        user__email="dory@example.com",
+        stock__offer__product=dvd,
+        stock__offer__name="Memento",
+        stock__offer__venue__name="Mnémosyne",
+        stock__offer__venue__managingOfferer=offerer,
+        dateCreated=long_ago,
+        cancellationReason=BookingCancellationReasons.EXPIRED,
+    )
+
+    cd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id)
+    expired_today_cd_booking = CancelledBookingFactory(
+        user__publicName="Dorian",
+        user__email="dorian@example.com",
+        stock__offer__product=cd,
+        stock__offer__name="Random Access Memories",
+        stock__offer__venue__name="Virgin Megastore",
+        stock__offer__venue__managingOfferer=offerer,
+        dateCreated=long_ago,
+        cancellationReason=BookingCancellationReasons.EXPIRED,
+    )
+
+    email_data = build_expired_bookings_recap_email_data_for_offerer(
+        offerer, [expired_today_dvd_booking, expired_today_cd_booking], BOOKINGS_AUTO_EXPIRY_DELAY.days
+    )
+
+    assert email_data == {
+        "Mj-TemplateID": 3095184,
+        "Mj-TemplateLanguage": True,
+        "Vars": {
+            "bookings": [
+                {
+                    "offer_name": "Memento",
+                    "venue_name": "Mnémosyne",
+                    "price": "10.00",
+                    "user_name": "Dory",
+                    "user_email": "dory@example.com",
+                    "pcpro_offer_link": "http://pc_pro.com/offer_link",
+                },
+                {
+                    "offer_name": "Random Access Memories",
+                    "venue_name": "Virgin Megastore",
+                    "price": "10.00",
+                    "user_name": "Dorian",
+                    "user_email": "dorian@example.com",
+                    "pcpro_offer_link": "http://pc_pro.com/offer_link",
+                },
+            ],
+            "department": "75",
+            "withdrawal_period": 30,
         },
     }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10400


## But de la pull request

Ajout d'un nouveau template mailjet de notification d'annulation automatique de réservation aux offerers au bout de X jours avec un paramètre additionnel `withdrawal_period` pour gérer le cas du nouveau délai de retrait des livres.

##  Implémentation

- Ajout de l'id du nouveau template et l'utiliser dans le cas ou le FF ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS est activé.
- Ajout du nouveau paramètre `withdrawal_period`.
- Ajout d'une classe de test pour le comportement FF désactivé qui sera supprimé une fois le FF activé.
- Ajout d'une classe de test pour le comportement FF activé.
​
##  Informations supplémentaires
N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
