### PR TITLE
(PC-10896) Update sendinblue lastVisitDate only after one day

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -891,10 +891,18 @@ def fraud_manager(user: User, phone_number: str) -> typing.Generator:
         raise
 
 
-def update_user_last_connection_date(user):
-    user.lastConnectionDate = datetime.now()
-    repository.save(user)
-    update_external_user(user, update_batch=False)
+def update_last_connection_date(user):
+    previous_connection_date = user.lastConnectionDate
+    last_connection_date = datetime.utcnow()
+
+    if not previous_connection_date or last_connection_date - previous_connection_date > timedelta(minutes=15):
+        user.lastConnectionDate = last_connection_date
+        repository.save(user)
+
+        if not previous_connection_date or (
+            last_connection_date.date() - previous_connection_date.date() >= timedelta(days=1)
+        ):
+            update_external_user(user, update_batch=False)
 
 
 def create_user_access_token(user: User) -> str:

--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -14,6 +14,7 @@ from typing import Tuple
 from typing import Union
 
 from flask import current_app as app
+from flask_jwt_extended import create_access_token
 from google.cloud.storage.blob import Blob
 from jwt import DecodeError
 from jwt import ExpiredSignatureError
@@ -888,3 +889,13 @@ def fraud_manager(user: User, phone_number: str) -> typing.Generator:
     except exceptions.PhoneValidationAttemptsLimitReached as error:
         fraud_api.handle_phone_validation_attempts_limit_reached(user, error.attempts)
         raise
+
+
+def update_user_last_connection_date(user):
+    user.lastConnectionDate = datetime.now()
+    repository.save(user)
+    update_external_user(user, update_batch=False)
+
+
+def create_user_access_token(user: User) -> str:
+    return create_access_token(identity=user.email, additional_claims={"user_claims": {"user_id": user.id}})

--- a/src/pcapi/routes/native/v1/authentication.py
+++ b/src/pcapi/routes/native/v1/authentication.py
@@ -45,7 +45,7 @@ def signin(body: authentication.SigninRequest) -> authentication.SigninResponse:
     except users_exceptions.CredentialsException as exc:
         raise ApiErrors({"general": ["Identifiant ou Mot de passe incorrect"]}) from exc
 
-    users_api.update_user_last_connection_date(user)
+    users_api.update_last_connection_date(user)
     return authentication.SigninResponse(
         access_token=users_api.create_user_access_token(user),
         refresh_token=create_refresh_token(identity=user.email),
@@ -60,7 +60,7 @@ def refresh() -> authentication.RefreshResponse:
     user = find_user_by_email(email)
     if not user:
         raise ApiErrors({"email": "unknown"}, status_code=401)
-    users_api.update_user_last_connection_date(user)
+    users_api.update_last_connection_date(user)
     return authentication.RefreshResponse(access_token=users_api.create_user_access_token(user))
 
 

--- a/tests/routes/native/v1/authentication_test.py
+++ b/tests/routes/native/v1/authentication_test.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from flask_jwt_extended import decode_token
 from flask_jwt_extended.utils import create_access_token
+from flask_jwt_extended.utils import create_refresh_token
 from freezegun import freeze_time
 import pytest
 
@@ -360,15 +361,10 @@ def test_refresh_token_route_updates_user_last_connection_date(client):
         email=data["identifier"], password=data["password"], lastConnectionDate=datetime(1990, 1, 1)
     )
 
-    # Get the refresh token
-    response = client.post("/native/v1/signin", json=data)
-    assert response.status_code == 200
-    assert response.json["refreshToken"]
-    refresh_token = response.json["refreshToken"]
-    sendinblue_testing.reset_sendinblue_requests()
+    refresh_token = create_refresh_token(identity=user.email)
 
     client.auth_header = {"Authorization": f"Bearer {refresh_token}"}
-    refresh_response = client.post("/native/v1/refresh_access_token", json={})
+    refresh_response = client.post("/native/v1/refresh_access_token")
     assert refresh_response.status_code == 200
 
     assert user.lastConnectionDate == datetime(2020, 3, 15)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10896


## But de la pull request

(Ajout de fonctionnalités, Problèmes résolus, etc)

##  Implémentation

The app native frontend calls the `refresh_access_token` route three times d'affilée (which is to be fixed in frontend side). So as an optimization we don't want to update the value too often. Moreover, Sendinblue only keeps the date and not the datetime, so wait at least one day of differnece before updating​

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
