### PR TITLE
(PC-10389): New mailjet template to notify beneficiary when expired bookings

### DIFF
--- a/src/pcapi/domain/user_emails.py
+++ b/src/pcapi/domain/user_emails.py
@@ -145,9 +145,31 @@ def send_booking_cancellation_emails_to_user_and_offerer(
         send_user_driven_cancellation_email_to_offerer(booking)
 
 
-def send_expired_bookings_recap_email_to_beneficiary(beneficiary: User, bookings: list[Booking]) -> None:
-    data = build_expired_bookings_recap_email_data_for_beneficiary(beneficiary, bookings)
+# TODO(yacine) this function will be removed after removing FF ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS
+def legacy_send_expired_bookings_recap_email_to_beneficiary(beneficiary: User, bookings: list[Booking]) -> None:
+    data = build_expired_bookings_recap_email_data_for_beneficiary(
+        beneficiary, bookings, BOOKINGS_AUTO_EXPIRY_DELAY.days
+    )
     mails.send(recipients=[beneficiary.email], data=data)
+
+
+def send_expired_bookings_recap_email_to_beneficiary(beneficiary: User, bookings: list[Booking]) -> None:
+    if not FeatureToggle.ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS.is_active():
+        legacy_send_expired_bookings_recap_email_to_beneficiary(beneficiary, bookings)
+    else:
+        books_bookings, other_bookings = filter_books_bookings(bookings)
+
+        if books_bookings:
+            books_bookings_data = build_expired_bookings_recap_email_data_for_beneficiary(
+                beneficiary, bookings, BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY.days
+            )
+            mails.send(recipients=[beneficiary.email], data=books_bookings_data)
+
+        if other_bookings:
+            other_bookings_data = build_expired_bookings_recap_email_data_for_beneficiary(
+                beneficiary, bookings, BOOKINGS_AUTO_EXPIRY_DELAY.days
+            )
+            mails.send(recipients=[beneficiary.email], data=other_bookings_data)
 
 
 def send_expired_individual_bookings_recap_email_to_offerer(offerer: Offerer, bookings: list[Booking]) -> None:

--- a/src/pcapi/emails/beneficiary_expired_bookings.py
+++ b/src/pcapi/emails/beneficiary_expired_bookings.py
@@ -1,14 +1,27 @@
 from pcapi.core.users.models import User
 from pcapi.models import Booking
+from pcapi.models.feature import FeatureToggle
 
 
-def build_expired_bookings_recap_email_data_for_beneficiary(beneficiary: User, bookings: list[Booking]) -> dict:
+OLD_MAILJET_TEMPLATE_ID = 1951103
+NEW_MAILJET_TEMPLATE_ID = 3095107
+
+
+def build_expired_bookings_recap_email_data_for_beneficiary(
+    beneficiary: User, bookings: list[Booking], withdrawal_period: int
+) -> dict:
+    mj_template_id = (
+        NEW_MAILJET_TEMPLATE_ID
+        if FeatureToggle.ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS.is_active()
+        else OLD_MAILJET_TEMPLATE_ID
+    )
     return {
-        "Mj-TemplateID": 1951103,
+        "Mj-TemplateID": mj_template_id,
         "Mj-TemplateLanguage": True,
         "Vars": {
             "user_firstName": beneficiary.firstName,
             "bookings": _extract_bookings_information_from_bookings_list(bookings),
+            "withdrawal_period": withdrawal_period,
         },
     }
 

--- a/tests/emails/beneficiary_expired_bookings_test.py
+++ b/tests/emails/beneficiary_expired_bookings_test.py
@@ -7,12 +7,13 @@ from pcapi.core.bookings.factories import CancelledBookingFactory
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import ProductFactory
+from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
 from pcapi.emails.beneficiary_expired_bookings import build_expired_bookings_recap_email_data_for_beneficiary
 
 
 @pytest.mark.usefixtures("db_session")
-def test_should_send_email_to_offerer_when_expired_bookings_cancelled():
+def test_should_send_email_to_beneficiary_when_expired_bookings_cancelled():
     now = datetime.utcnow()
     amnesiac_user = users_factories.UserFactory(email="dory@example.com", firstName="Dory")
     long_ago = now - timedelta(days=31)
@@ -37,8 +38,7 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled():
     )
 
     email_data = build_expired_bookings_recap_email_data_for_beneficiary(
-        amnesiac_user,
-        [expired_today_dvd_booking, expired_today_cd_booking],
+        amnesiac_user, [expired_today_dvd_booking, expired_today_cd_booking], 30
     )
 
     assert email_data == {
@@ -50,5 +50,50 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled():
                 {"offer_name": "Memento", "venue_name": "Mnémosyne"},
                 {"offer_name": "Random Access Memories", "venue_name": "Virgin Megastore"},
             ],
+            "withdrawal_period": 30,
+        },
+    }
+
+
+@override_features(ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS=True)
+@pytest.mark.usefixtures("db_session")
+def test_should_send_email_to_beneficiary_when_expired_bookings_cancelled_with_new_auto_expiry_delay_ff_enabled():
+    now = datetime.utcnow()
+    amnesiac_user = users_factories.UserFactory(email="dory@example.com", firstName="Dory")
+    long_ago = now - timedelta(days=31)
+    dvd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
+    expired_today_dvd_booking = CancelledBookingFactory(
+        stock__offer__product=dvd,
+        stock__offer__name="Memento",
+        stock__offer__venue__name="Mnémosyne",
+        dateCreated=long_ago,
+        cancellationReason=BookingCancellationReasons.EXPIRED,
+        user=amnesiac_user,
+    )
+
+    cd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id)
+    expired_today_cd_booking = CancelledBookingFactory(
+        stock__offer__product=cd,
+        stock__offer__name="Random Access Memories",
+        stock__offer__venue__name="Virgin Megastore",
+        dateCreated=long_ago,
+        cancellationReason=BookingCancellationReasons.EXPIRED,
+        user=amnesiac_user,
+    )
+
+    email_data = build_expired_bookings_recap_email_data_for_beneficiary(
+        amnesiac_user, [expired_today_dvd_booking, expired_today_cd_booking], 30
+    )
+
+    assert email_data == {
+        "Mj-TemplateID": 3095107,
+        "Mj-TemplateLanguage": True,
+        "Vars": {
+            "user_firstName": "Dory",
+            "bookings": [
+                {"offer_name": "Memento", "venue_name": "Mnémosyne"},
+                {"offer_name": "Random Access Memories", "venue_name": "Virgin Megastore"},
+            ],
+            "withdrawal_period": 30,
         },
     }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10389

## But de la pull request

Ajout d'un nouveau template mailjet de notification d'annulation automatique de réservation aux bénéficiaires avec un paramètre additionnel `withdrawal_period` pour gérer le cas du nouveau délai de retrait des livres.

##  Implémentation

- Ajout de l'id du nouveau template et l'utiliser dans le cas ou le FF ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS est activé.
- Ajout du nouveau paramètre `withdrawal_period`.
- Ajout d'une classe de test pour le comportement FF désactivé qui sera supprimé une fois le FF activé.
- Ajout d'une classe de test pour le comportement FF activé.​

##  Informations supplémentaires

N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
