### PR TITLE
(PC-9745) Make venue public_name optional in find_by_siret response

### DIFF
--- a/src/pcapi/routes/adage_iframe/serialization/venues.py
+++ b/src/pcapi/routes/adage_iframe/serialization/venues.py
@@ -1,9 +1,11 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 
 class VenueResponse(BaseModel):
     id: int
-    publicName: str
+    publicName: Optional[str]
     name: str
 
     class Config:

--- a/tests/routes/adage_iframe/get_venue_by_siret_test.py
+++ b/tests/routes/adage_iframe/get_venue_by_siret_test.py
@@ -21,9 +21,9 @@ class Returns200Test:
             uai=None,
         )
 
-    def test_return_venue_of_given_siret(self, app):
+    def test_return_venue_with_publicName_of_given_siret(self, app):
         # Given
-        requested_venue = offerers_factories.VenueFactory()
+        requested_venue = offerers_factories.VenueFactory(publicName="Un petit surnom")
         offerers_factories.VenueFactory()
         valid_encoded_token = self._create_adage_valid_token()
 
@@ -39,6 +39,26 @@ class Returns200Test:
             "id": requested_venue.id,
             "name": requested_venue.name,
             "publicName": requested_venue.publicName,
+        }
+
+    def test_return_venue_without_publicName_of_given_siret(self, app):
+        # Given
+        requested_venue = offerers_factories.VenueFactory(publicName=None)
+        offerers_factories.VenueFactory()
+        valid_encoded_token = self._create_adage_valid_token()
+
+        test_client = TestClient(app.test_client())
+        test_client.auth_header = {"Authorization": f"Bearer {valid_encoded_token}"}
+
+        # When
+        response = test_client.get(f"/adage-iframe/venues/{requested_venue.siret}")
+
+        # Then
+        assert response.status_code == 200
+        assert response.json == {
+            "id": requested_venue.id,
+            "name": requested_venue.name,
+            "publicName": None,
         }
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-9745


## But de la pull request

L'attribut `public_name` d'un venue est optionnel dans le modèle. Nous voulons quand même renvoyer un Venue au front adage, même si le public_name n'existe pas.

##  Implémentation

- Rendre le champ publicName optionnel dans le modèle de serialisation `VenueResponse`
​
##  Informations supplémentaires

N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
