### PR TITLE
fix(pcapi-cron) PC-10939 : Bump memory limit from 1Gi to 1536mi (temp…

### DIFF
--- a/helm/pcapi/values.production.yaml
+++ b/helm/pcapi/values.production.yaml
@@ -272,7 +272,7 @@ crons:
   resources:
     limits:
       cpu: 500m
-      memory: 1Gi
+      memory: 1536Mi
     requests:
       cpu: 300m
       memory: 768Mi


### PR DESCRIPTION
Temporary fix 