### PR TITLE
(PC-10985) circleci: don't fail nightly workflow if coveralls fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ jobs:
                   RUN_ENV=tests venv/bin/pytest tests --durations=10  --cov --cov-report html
                   --junitxml=test-results/junit.xml
 
-                  venv/bin/coveralls
+                  venv/bin/coveralls || echo "Encountered an error while running coveralls"
 
       - unless:
           condition: << parameters.is_nightly_build >>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10985


## But de la pull request

Ne pas échouer le build nightly quand l'upload à Coveralls échoue

##  Implémentation

- édition du fichier de conf CircleCI
​
##  Informations supplémentaires

N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
