### PR TITLE
(PC-10991) : BENEFICIARY_INFORMATION step is for client > v1.160

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -805,7 +805,7 @@ def get_next_beneficiary_validation_step(user: User) -> Optional[BeneficiaryVali
     if not user.is_phone_validated and FeatureToggle.ENABLE_PHONE_VALIDATION.is_active():
         return BeneficiaryValidationStep.PHONE_VALIDATION
     if not user.hasCompletedIdCheck:
-        if is_client_older("1.155.0") or not user.extraData.get("is_identity_document_uploaded"):
+        if is_client_older("1.160.0") or not user.extraData.get("is_identity_document_uploaded"):
             return BeneficiaryValidationStep.ID_CHECK
         return BeneficiaryValidationStep.BENEFICIARY_INFORMATION
 

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -299,7 +299,7 @@ class AccountTest:
         assert me_response.json["hasCompletedIdCheck"]
 
     @pytest.mark.parametrize(
-        "client_version,extra_step", [("1.154.9", "id-check"), ("1.155.0", "beneficiary-information")]
+        "client_version,extra_step", [("1.154.9", "id-check"), ("1.160.0", "beneficiary-information")]
     )
     @freeze_time("2021-06-01")
     def test_next_beneficiary_validation_step(self, client_version, extra_step, app):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10991

## But de la pull request

retarder l'ajout de l'étape `BENEFICIARY_INFORMATION` après la version v1.160 de l'app native.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
