### PR TITLE
(PC-10851) send mail on educational booking

### DIFF
--- a/src/pcapi/core/bookings/models.py
+++ b/src/pcapi/core/bookings/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from decimal import Decimal
 import enum
 from typing import Optional
 
@@ -199,7 +200,7 @@ class Booking(PcObject, Model):
         return self.dateCreated + BOOKINGS_AUTO_EXPIRY_DELAY
 
     @property
-    def total_amount(self) -> float:
+    def total_amount(self) -> Decimal:
         return self.amount * self.quantity
 
     # FIXME: many functions here are only used when serializing

--- a/src/pcapi/core/educational/api.py
+++ b/src/pcapi/core/educational/api.py
@@ -237,7 +237,7 @@ def _build_prebooking_mail_data(booking: bookings_models.Booking) -> dict:
             "date": format_booking_date_for_email(booking),
             "heure": format_booking_hours_for_email(booking),
             "quantity": booking.quantity,
-            "prix": str(booking.total_amount) if booking.total_amount > 0 else "Gratuit",
+            "prix": str(booking.amount) if booking.amount > 0 else "Gratuit",
             "user_firstName": educational_booking.educationalRedactor.firstName,
             "user_lastName": educational_booking.educationalRedactor.lastName,
             "user_email": educational_booking.educationalRedactor.email,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10851


## But de la pull request

Permettre l'envoi de mail à la confirmation d'une pré-réservation

##  Implémentation

- Utilisation de mailjet
​
##  Informations supplémentaires

- Exemples : Réparation des infos envoyées dans le mail de pré-résa
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
