### PR TITLE
(PC-11016): subcategories: don't select livestreams

### DIFF
--- a/src/pcapi/core/categories/subcategories.py
+++ b/src/pcapi/core/categories/subcategories.py
@@ -782,6 +782,7 @@ LIVESTREAM_MUSIQUE = Subcategory(
     is_digital_deposit=True,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    is_selectable=False,
 )
 ABO_CONCERT = Subcategory(
     id="ABO_CONCERT",
@@ -1046,6 +1047,7 @@ LIVESTREAM_EVENEMENT = Subcategory(
     is_digital_deposit=True,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    is_selectable=False,
 )
 FESTIVAL_SPECTACLE = Subcategory(
     id="FESTIVAL_SPECTACLE",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11016


## But de la pull request

Ne plus rendre selectionnable les catégories livestream_musical et livestream_evenement

##  Implémentation

passer is_selectable à false
​
##  Informations supplémentaires

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
