### PR TITLE
(PC-10989) Flask Admin: Add bulk reactivate button for beneficiary users

### DIFF
--- a/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -131,6 +131,7 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
         "isEmailValidated",
         FilterByDepositTypeEqual(column=None, name="Type du portefeuille"),
         FilterByDepositTypeNotEqual(column=None, name="Type du portefeuille"),
+        "isActive",
     ]
 
     @property

--- a/src/pcapi/admin/custom_views/mixins/suspension_mixin.py
+++ b/src/pcapi/admin/custom_views/mixins/suspension_mixin.py
@@ -3,6 +3,7 @@ from flask import redirect
 from flask import request
 from flask import url_for
 from flask_admin import expose
+from flask_admin.actions import action
 from flask_admin.form import SecureForm
 from flask_login import current_user
 from markupsafe import Markup
@@ -65,6 +66,15 @@ class SuspensionMixin:
     @property
     def user_list_url(self):
         return url_for(".index_view")
+
+    @action("unsuspend_selection", "Réactiver la sélection")
+    def action_bulk_edit(self, ids):
+        if not _allow_suspension_and_unsuspension(current_user):
+            return Forbidden()
+
+        users_api.bulk_unsuspend_account(ids, current_user)
+        flash("Les comptes utilisateurs ont été réactivés. Leur mot de passe a été réinitialisé.")
+        return redirect(self.user_list_url)
 
     @expose("suspend", methods=["GET", "POST"])
     def suspend_user_view(self):

--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -484,6 +484,21 @@ def unsuspend_account(user: User, actor: User) -> None:
     )
 
 
+def bulk_unsuspend_account(user_ids: list[int], actor: User) -> None:
+    User.query.filter(User.id.in_(user_ids)).update(
+        values={"isActive": True, "suspensionReason": ""}, synchronize_session=False
+    )
+    db.session.commit()
+
+    logger.info(
+        "Some accounts have been reactivated",
+        extra={
+            "actor": actor.id,
+            "users": user_ids,
+        },
+    )
+
+
 def send_user_emails_for_email_change(user: User, new_email: str) -> None:
     user_with_new_email = find_user_by_email(new_email)
     if user_with_new_email:

--- a/tests/core/users/test_api.py
+++ b/tests/core/users/test_api.py
@@ -317,13 +317,25 @@ class SuspendAccountTest:
 
 class UnsuspendAccountTest:
     def test_unsuspend_account(self):
-        user = users_factories.UserFactory(isActive=False)
+        user = users_factories.UserFactory(isActive=False, suspensionReason="User not cool")
         actor = users_factories.AdminFactory()
 
         users_api.unsuspend_account(user, actor)
 
         assert not user.suspensionReason
         assert user.isActive
+
+    def test_bulk_unsuspend_account(self):
+        user1 = users_factories.UserFactory(isActive=False, suspensionReason="User not cool")
+        user2 = users_factories.UserFactory(isActive=False, suspensionReason="User not cool")
+        user3 = users_factories.UserFactory(isActive=False, suspensionReason="User not cool")
+        actor = users_factories.AdminFactory()
+
+        users_api.bulk_unsuspend_account([user1.id, user2.id, user3.id], actor)
+
+        for user in [user1, user2, user3]:
+            assert not user.suspensionReason
+            assert user.isActive
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Lien vers Jira: https://passculture.atlassian.net/browse/PC-10989

## But de la pull request

Permettre aux admin de réactiver en masse des comptes utilisateurs (Plutôt que de passer par un ticket shérif)

##  Implémentation

Ajouter un bouton dans Flask-Admin
​
##  Informations supplémentaires

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
![Screenshot from 2021-09-23 10-48-56](https://user-images.githubusercontent.com/14235661/134478987-92ad05cc-edc8-4efe-993b-15b8dd6090bc.png)


