### PR TITLE
(PC-10993) don't fail build-container if requirements change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,22 +299,15 @@ jobs:
             # By using only cache prefix, we load the most recent checksum
             - pass-culture-api-requirements-checksum-
       - run:
-          name: Check if the requirements have changed
-          command: md5sum --status -c requirements.md5;
-      - run:
-          name: Build docker image when requirements have changed
-          command: docker build -t passcultureapp/api-flask:latest .
-          when: on_fail
-      - run:
-          name: Push docker image
+          name: Build and push docker image if the requirements have changed
           command: |
+            md5sum --status -c requirements.md5 ||
+            docker build -t passcultureapp/api-flask:latest .
             docker login -u passcultureapp -p $DOCKERHUB_PASSWORD
             docker push passcultureapp/api-flask:latest
-          when: on_fail
       - run:
           name: Generate requirements print
           command: md5sum ./requirements.txt > requirements.md5
-          when: on_fail
       - save_cache:
           key: pass-culture-api-requirements-checksum-{{ .Revision }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,7 +312,6 @@ jobs:
           key: pass-culture-api-requirements-checksum-{{ .Revision }}
           paths:
             - requirements.md5
-          when: on_fail
 
   build-and-push-image:
     executor: gcp-sdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,66 +14,6 @@ slack-fail-post-step: &slack-fail-post-step
         channel: shérif
         template: basic_fail_1
 
-slack-send-deployment-notification: &slack-send-deployment-notification
-  - slack/notify:
-      event: pass
-      channel: alertes-deploiement
-      custom: |
-        {
-          "blocks": [
-            {
-              "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": "${CIRCLE_SHA1} has been successfully deployed to testing :muscle:"
-              }
-            },
-            {
-              "type": "actions",
-              "elements": [
-                {
-                  "type": "button",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "View job",
-                    "emoji": true
-                  },
-                  "url": "$CIRCLE_BUILD_URL"
-                }
-              ]
-            }
-          ]
-        }
-  - slack/notify:
-      event: fail
-      channel: alertes-deploiement
-      custom: |
-        {
-          "blocks": [
-            {
-              "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": "${CIRCLE_SHA1} this deployment has failed :pleurs:"
-              }
-            },
-            {
-              "type": "actions",
-              "elements": [
-                {
-                  "type": "button",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "View job",
-                    "emoji": true
-                  },
-                  "url": "$CIRCLE_BUILD_URL"
-                }
-              ]
-            }
-          ]
-        }
-
 ###################
 #  EXECUTORS
 ###################
@@ -363,7 +303,6 @@ jobs:
           kubernetes_namespace: testing
           helm_values_file: ./helm/pcapi/values.testing.yaml
           app_version: ${CIRCLE_SHA1}
-      - <<: *slack-send-deployment-notification
 
   functional-tests-webapp:
     machine:
@@ -538,6 +477,7 @@ workflows:
             - GCP
             - GCP_EHP
             - Slack
+          <<: *slack-fail-post-step
       - restart-pcapi:
           requires:
             - deploy-pcapi


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10993


## But de la pull request

Ne pas marquer le job build-container si les requirements ont changé

##  Implémentation

- Modification de la syntaxe de la config.yml pour CircleCI
​
##  Informations supplémentaires

Bonus: ne plus envoyer de notifications sur les succès de déploiements en testing, et utiliser le template `basic_fail_1` fourni par l'[orb](https://github.com/CircleCI-Public/slack-orb/wiki#templates)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
