### PR TITLE
(PC-10993) circleci: fix multiline syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,10 +241,11 @@ jobs:
       - run:
           name: Build and push docker image if the requirements have changed
           command: |
-            md5sum --status -c requirements.md5 ||
-            docker build -t passcultureapp/api-flask:latest .
-            docker login -u passcultureapp -p $DOCKERHUB_PASSWORD
+            md5sum --status -c requirements.md5 || (
+            docker build -t passcultureapp/api-flask:latest .;
+            docker login -u passcultureapp -p $DOCKERHUB_PASSWORD;
             docker push passcultureapp/api-flask:latest
+            )
       - run:
           name: Generate requirements print
           command: md5sum ./requirements.txt > requirements.md5


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10993


## But de la pull request

Corriger la syntaxe de la config.yml de CircleCI

##  Implémentation

- mieux écrire du bash
​
##  Informations supplémentaires

@dzen m'avait prévenu !

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
