### PR TITLE
(PC-8434) index subcategory id instead of label

### DIFF
--- a/src/pcapi/core/search/backends/algolia.py
+++ b/src/pcapi/core/search/backends/algolia.py
@@ -234,7 +234,6 @@ class AlgoliaBackend(base.SearchBackend):
         object_to_index = {
             "objectID": offer.id,
             "offer": {
-                "subcategoryLabel": offer.subcategory.app_label,
                 "author": author,
                 "category": offer.offer_category_name_for_app,
                 "rankingWeight": offer.rankingWeight,
@@ -264,6 +263,7 @@ class AlgoliaBackend(base.SearchBackend):
                 "speaker": speaker,
                 "stageDirector": stage_director,
                 "stocksDateCreated": sorted(stocks_date_created),
+                "subcategoryId": offer.subcategory.id,
                 # PC-8526: Warning: we should not store the full url of the image but only the path.
                 # Currrently we store `OBJECT_STORAGE_URL/path`, but we should store `path` and build the
                 # full url in the frontend.

--- a/src/pcapi/core/search/backends/appsearch.py
+++ b/src/pcapi/core/search/backends/appsearch.py
@@ -34,7 +34,6 @@ DOCUMENTS_PER_REQUEST_LIMIT = 100
 OFFERS_ENGINE_NAME = "offers"
 
 OFFERS_SCHEMA = {
-    "subcategory_label": "text",
     "artist": "text",
     "category": "text",
     "date_created": "date",
@@ -54,6 +53,7 @@ OFFERS_SCHEMA = {
     "ranking_weight": "number",
     "search_group_name": "text",
     "stocks_date_created": "date",
+    "subcategory_id": "text",
     "tags": "text",
     "times": "number",
     "thumb_url": "text",
@@ -69,7 +69,7 @@ OFFERS_FIELD_WEIGHTS = {
     "category": 0,
     "label": 0,
     "search_group_name": 0,
-    "subcategory_label": 0,
+    "subcategory_id": 0,
     "tags": 0,
     "thumb_url": 0,
     "venue_department_code": 0,
@@ -367,7 +367,6 @@ class AppSearchBackend(base.SearchBackend):
         venue = offer.venue
         return omit_empty_values(
             {
-                "subcategory_label": offer.subcategory.app_label,
                 "artist": artist.strip() or None,
                 "category": offer.offer_category_name_for_app,
                 "date_created": offer.dateCreated,  # used only to rank results
@@ -386,6 +385,7 @@ class AppSearchBackend(base.SearchBackend):
                 "ranking_weight": offer.rankingWeight or 0,
                 "search_group_name": offer.subcategory.search_group_name,
                 "stocks_date_created": [stock.dateCreated for stock in stocks],
+                "subcategory_id": offer.subcategory.id,
                 "tags": [criterion.name for criterion in offer.criteria],
                 "times": times,
                 "thumb_url": url_path(offer.thumbUrl),

--- a/tests/core/search/test_serialize_algolia.py
+++ b/tests/core/search/test_serialize_algolia.py
@@ -95,7 +95,6 @@ class BuildObjectTest:
         assert result == {
             "objectID": 3,
             "offer": {
-                "subcategoryLabel": "Autre type d'événement musical",
                 "author": None,
                 "category": "MUSIQUE",
                 "dateCreated": 1577872800.0,
@@ -125,6 +124,7 @@ class BuildObjectTest:
                 "speaker": None,
                 "stageDirector": None,
                 "stocksDateCreated": [1606820400.0, 1607166000.0, 1607673600.0],
+                "subcategoryId": subcategories.EVENEMENT_MUSIQUE.id,
                 "thumbUrl": f"http://localhost/storage/thumbs/products/{humanized_product_id}",
                 "tags": [],
                 "times": [32400],
@@ -461,7 +461,6 @@ class BuildObjectTest:
         assert result == {
             "objectID": 3,
             "offer": {
-                "subcategoryLabel": "Autre type d'événement musical",
                 "author": None,
                 "category": "MUSIQUE",
                 "dateCreated": 1577872800.0,
@@ -491,6 +490,7 @@ class BuildObjectTest:
                 "speaker": None,
                 "stageDirector": None,
                 "stocksDateCreated": [1607166000.0],
+                "subcategoryId": subcategories.EVENEMENT_MUSIQUE.id,
                 "thumbUrl": f"http://localhost/storage/thumbs/products/{humanized_product_id}",
                 "tags": ["Mon tag associé"],
                 "times": [32400],
@@ -556,7 +556,6 @@ class BuildObjectTest:
         assert result == {
             "objectID": 3,
             "offer": {
-                "subcategoryLabel": "Autre type d'événement musical",
                 "author": None,
                 "category": "MUSIQUE",
                 "dateCreated": 1577872800.0,
@@ -586,6 +585,7 @@ class BuildObjectTest:
                 "speaker": None,
                 "stageDirector": None,
                 "stocksDateCreated": [1607166000.0],
+                "subcategoryId": subcategories.EVENEMENT_MUSIQUE.id,
                 "thumbUrl": f"http://localhost/storage/thumbs/products/{humanized_product_id}",
                 "tags": {"Mon tag associé", "Iron Man mon super héros"},
                 "times": [32400],

--- a/tests/core/search/test_serialize_appsearch.py
+++ b/tests/core/search/test_serialize_appsearch.py
@@ -38,7 +38,6 @@ def test_serialize_offer():
     stock = offers_factories.StockFactory(offer=offer, price=10)
     serialized = appsearch.AppSearchBackend().serialize_offer(offer)
     assert serialized == {
-        "subcategory_label": "Livre",
         "artist": "Author Performer Speaker Stage Director",
         "category": "LIVRE",
         "date_created": offer.dateCreated,
@@ -56,6 +55,7 @@ def test_serialize_offer():
         "ranking_weight": 2,
         "search_group_name": subcategories.SearchGroups.LIVRE.name,
         "stocks_date_created": [stock.dateCreated],
+        "subcategory_id": subcategories.LIVRE_PAPIER.id,
         "offerer_name": "Les Librairies Associées",
         "venue_id": 127,
         "venue_department_code": "75",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-8434


## But de la pull request

Changement de champs indexés sur Algolia/AppSearch: indexation de l'id de la sous-catégorie au lieu du label.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
