### PR TITLE
(PC-11014) Add a new BeneficiaryImportStatus if one already exist

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -369,11 +369,19 @@ def attach_beneficiary_import_details(
     beneficiary_pre_subscription: BeneficiaryPreSubscription,
     status: ImportStatus = ImportStatus.CREATED,
 ) -> None:
-    beneficiary_import = BeneficiaryImport()
+    beneficiary_import = BeneficiaryImport.query.filter_by(
+        applicationId=beneficiary_pre_subscription.application_id,
+        sourceId=beneficiary_pre_subscription.source_id,
+        source=beneficiary_pre_subscription.source,
+        beneficiary=beneficiary,
+    ).one_or_none()
+    if not beneficiary_import:
+        beneficiary_import = BeneficiaryImport()
 
-    beneficiary_import.applicationId = beneficiary_pre_subscription.application_id
-    beneficiary_import.sourceId = beneficiary_pre_subscription.source_id
-    beneficiary_import.source = beneficiary_pre_subscription.source
+        beneficiary_import.applicationId = beneficiary_pre_subscription.application_id
+        beneficiary_import.sourceId = beneficiary_pre_subscription.source_id
+        beneficiary_import.source = beneficiary_pre_subscription.source
+        beneficiary_import.beneficiary = beneficiary
 
     beneficiary_import.setStatus(status=status)
     beneficiary_import.beneficiary = beneficiary


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11014

## But de la pull request

Creer un nouveau BeneficiaryImportStatus si il existe deja un BeneficiaryImportStatus pour cet
utilisateur, afin de logguer les changemnts sur le parcours d'inscription en tant que beneficiaire.

Lorsqu'un operateur modifie le N° de CNI Sur F.A. on rencontre un PB avec la contrainte d'unicité
puisqu'on recree un BeneficiaryImport au lieu d'ajouter un nouveau BeneficiaryImportStatus.

##  Implémentation
 N/A.
##  Informations supplémentaires
 N/A.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)