### PR TITLE
(PC-10071) FIX: always re/un-index venue on update

### DIFF
--- a/src/pcapi/admin/custom_views/venue_view.py
+++ b/src/pcapi/admin/custom_views/venue_view.py
@@ -114,12 +114,12 @@ class VenueView(BaseAdminView):
         )
 
         super().update_model(new_venue_form, venue)
+        search.async_index_venues([venue])
 
         if has_siret_changed and old_siret:
             update_offer_and_stock_id_at_providers(venue, old_siret)
 
         if has_indexed_attribute_changed:
-            search.async_index_venues([venue])
             search.async_index_offers_of_venue_ids([venue.id])
 
         return True

--- a/src/pcapi/core/offerers/api.py
+++ b/src/pcapi/core/offerers/api.py
@@ -72,11 +72,10 @@ def update_venue(venue: Venue, contact_data: venues_serialize.VenueContactModel 
     venue.fill_venue_type_code_from_label()
 
     repository.save(venue)
+    search.async_index_venues([venue])
 
     indexing_modifications_fields = set(modifications.keys()) & set(VENUE_ALGOLIA_INDEXED_FIELDS)
-
     if indexing_modifications_fields or contact_data:
-        search.async_index_venues([venue])
         search.async_index_offers_of_venue_ids([venue.id])
 
     return venue


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10071


## But de la pull request

Deux problèmes existent : 

1. un lieu n'est pas systématiquement réindexé lors d'une mise à jour (PRO / FA) ;
2. lorsqu'un lieu passe de permanent à non permanent, il n'est pas désindexé.

Cette PR vise à les régler.
