### PR TITLE
(PC-8434) change typing of route /subcategories to use enums

### DIFF
--- a/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/src/pcapi/routes/native/v1/serialization/offers.py
@@ -298,7 +298,7 @@ class SubcategoryResponseModel(BaseModel):
 
 
 class SearchGroupResponseModel(BaseModel):
-    name: str
+    name: subcategories.SearchGroupNameEnum
     value: Optional[str]
 
     class Config:
@@ -308,7 +308,7 @@ class SearchGroupResponseModel(BaseModel):
 
 
 class HomepageLabelResponseModel(BaseModel):
-    name: str
+    name: HomepageLabelNameEnum
     value: Optional[str]
 
     class Config:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-8434


## But de la pull request

Utilisation de l'enum pour les clefs de la route /subcategories.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket