### PR TITLE
(PC-11011): Add subscriptionMessage field to /me endpoint

### DIFF
--- a/src/pcapi/routes/native/v1/serialization/account.py
+++ b/src/pcapi/routes/native/v1/serialization/account.py
@@ -1,5 +1,4 @@
 import datetime
-from datetime import date
 from enum import Enum
 from typing import Optional
 from uuid import UUID
@@ -44,7 +43,7 @@ class ActivityEnum(str, Enum):
 class AccountRequest(BaseModel):
     email: str
     password: str
-    birthdate: date
+    birthdate: datetime.date
     marketing_email_subscription: Optional[bool] = False
     token: str
     postal_code: Optional[str] = None
@@ -113,6 +112,28 @@ class DomainsCredit(BaseModel):
         orm_mode = True
 
 
+class CallToActionIcon(Enum):
+    info = "info"
+    warning = "warning"
+
+
+class PopOverIcon(Enum):
+    email = "Email"
+
+
+class CallToActionMessage(BaseModel):
+    callToActionTitle: str
+    callToActionLink: str
+    callToActionIcon: CallToActionIcon
+
+
+class SubscriptionMessage(BaseModel):
+    userMessage: str
+    callToAction: CallToActionMessage
+    popOverIcon: PopOverIcon
+    updatedAt: datetime.datetime
+
+
 class UserProfileResponse(BaseModel):
     id: int
     booked_offers: dict[str, int]
@@ -129,6 +150,7 @@ class UserProfileResponse(BaseModel):
     lastName: Optional[str]
     next_beneficiary_validation_step: Optional[BeneficiaryValidationStep]
     subscriptions: NotificationSubscriptions  # if we send user.notification_subscriptions, pydantic will take the column and not the property
+    subscriptionMessage: Optional[SubscriptionMessage]
     isBeneficiary: bool
     roles: list[UserRole]
     phoneNumber: Optional[str]

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -137,6 +137,7 @@ class AccountTest:
             "pseudo": "jdo",
             "showEligibleCard": False,
             "subscriptions": {"marketingPush": True, "marketingEmail": True},
+            "subscriptionMessage": None,
         }
         EXPECTED_DATA.update(USER_DATA)
 
@@ -187,6 +188,7 @@ class AccountTest:
             "pseudo": "jdo",
             "showEligibleCard": False,
             "subscriptions": {"marketingPush": True, "marketingEmail": True},
+            "subscriptionMessage": None,
         }
         EXPECTED_DATA.update(USER_DATA)
 
@@ -237,6 +239,7 @@ class AccountTest:
             "pseudo": "jdo",
             "showEligibleCard": False,
             "subscriptions": {"marketingPush": True, "marketingEmail": True},
+            "subscriptionMessage": None,
         }
         EXPECTED_DATA.update(USER_DATA)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11011


## But de la pull request

Ajouter un champs dans la requete à /me pour que le front sache afficher à l'utilisateur
des informations complémentaires sur l'état de son parcours de validation de bénéficiaire

##  Implémentation

Simple ajout d'un champs avec un type complet pour definir le type du message à envoyer à l'utilisateur:
- CTA (lien, message du bouton etc)
- enum pour typer les messages

##  Informations supplémentaires

N/A

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)