### PR TITLE
(PC-11057): model offer: use subcategory in is_offline_only property

### DIFF
--- a/src/pcapi/core/offers/factories.py
+++ b/src/pcapi/core/offers/factories.py
@@ -103,6 +103,7 @@ class ThingProductFactory(ProductFactory):
 
 
 class DigitalProductFactory(ThingProductFactory):
+    subcategoryId = subcategories.VOD.id
     name = factory.Sequence("Digital product {}".format)
     url = factory.Sequence("http://example.com/product/{}".format)
     isNational = True

--- a/src/pcapi/core/offers/models.py
+++ b/src/pcapi/core/offers/models.py
@@ -34,6 +34,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 
 import pcapi.core.bookings.conf as bookings_conf
+from pcapi.core.categories import subcategories
 from pcapi.core.categories.subcategories import ALL_SUBCATEGORIES_DICT
 from pcapi.core.categories.subcategories import Subcategory
 from pcapi.models.db import Model
@@ -528,19 +529,7 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin, ProvidableMixin):
 
     @property
     def is_offline_only(self) -> bool:
-        offline_thing = [
-            thing_type
-            for thing_type in ThingType
-            if self._is_same_type(thing_type) and self._is_offline_type_only(thing_type)
-        ]
-
-        return len(list(offline_thing)) == 1
-
-    def _is_same_type(self, thing_type) -> bool:
-        return str(thing_type) == self.type
-
-    def _is_offline_type_only(self, thing_type):
-        return thing_type.value["offlineOnly"]
+        return self.subcategory.online_offline_platform == subcategories.OnlineOfflinePlatformChoices.OFFLINE.value
 
     def get_label_from_type_string(self):
         matching_type_thing = next(filter(lambda thing_type: str(thing_type) == self.type, ThingType))


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11057


## But de la pull request

Pouvoir créer une offre de sous-categorie "Abonnement plateforme musicale"

##  Implémentation

- la propriété is_offline_only du model Offer utilise maintenant des sous-catégories

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
