### PR TITLE
(PC-11048/11049) add educonnect + id check underage feature toggle

### DIFF
--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -65,6 +65,7 @@ class FeatureToggle(enum.Enum):
     ENABLE_NATIVE_EAC_INDIVIDUAL = "Active l'EAC individuel sur l'app native"
     ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS = "Active le nouveau délai de rétractation pour les livres"
     ENABLE_DMS_GRAPHQL_API = "Utilise l'API GraphQL de DMS"
+    ENABLE_EDUCONNECT_AUTHENTICATION = "Active l'authentification via educonnect sur l'app native"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -109,6 +110,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL,
     FeatureToggle.ENABLE_NEW_AUTO_EXPIRY_DELAY_BOOKS_BOOKINGS,
     FeatureToggle.ENABLE_DMS_GRAPHQL_API,
+    FeatureToggle.ENABLE_EDUCONNECT_AUTHENTICATION,
 )
 
 

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -32,7 +32,10 @@ class FeatureToggle(enum.Enum):
     API_SIRENE_AVAILABLE = "Active les fonctionnalitées liées à l'API Sirene"
     WEBAPP_HOMEPAGE = "Permettre l affichage de la nouvelle page d accueil de la webapp"
     APPLY_BOOKING_LIMITS_V2 = "Permettre l affichage des nouvelles règles de génération de portefeuille des jeunes"
-    ALLOW_IDCHECK_REGISTRATION = "Autoriser les utilisateurs à suivre le parcours d inscription ID Check"
+    ALLOW_IDCHECK_REGISTRATION = "Autoriser les utilisateurs de 18 ans à suivre le parcours d inscription ID Check"
+    ALLOW_IDCHECK_UNDERAGE_REGISTRATION = (
+        "Autoriser les utilisateurs de moins de 15 à 17 ans à suivre le parcours d inscription ID Check"
+    )
     WHOLE_FRANCE_OPENING = "Ouvre le service à la France entière"
     ENABLE_NATIVE_APP_RECAPTCHA = "Active le reCaptacha sur l'API native"
     OFFER_VALIDATION_MOCK_COMPUTATION = "Active le calcul automatique de validation d'offre depuis le nom de l'offre"
@@ -94,6 +97,7 @@ class Feature(PcObject, Model, DeactivableMixin):
 
 
 FEATURES_DISABLED_BY_DEFAULT = (
+    FeatureToggle.ALLOW_IDCHECK_UNDERAGE_REGISTRATION,
     FeatureToggle.FORCE_PHONE_VALIDATION,
     FeatureToggle.ENABLE_NEW_VENUE_PAGES,
     FeatureToggle.ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11048


## But de la pull request

Ajout de 2 FF:
- activer/désactiver l'authentification via educonnect sur l'app native
- activer/désactiver l'accès à idcheck pour les utilisateurs de 15 à 17 ans
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
