### PR TITLE
(PC-10071) FIX: add getter for Venue.venueTypeCode

### DIFF
--- a/src/pcapi/core/offerers/models.py
+++ b/src/pcapi/core/offerers/models.py
@@ -118,6 +118,10 @@ class VenueTypeCode(enum.Enum):
     def from_label(cls, label: str) -> "VenueTypeCode":
         return {code.value: code.name for code in cls}[label]
 
+    @classmethod
+    def get_default(cls) -> "VenueTypeCode":
+        return cls.OTHER
+
 
 class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, NeedsValidationMixin):
     __tablename__ = "venue"
@@ -174,7 +178,9 @@ class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, Ne
 
     venueType = relationship("VenueType", foreign_keys=[venueTypeId])
 
-    venueTypeCode = Column(sa.Enum(VenueTypeCode, create_constraint=False), nullable=True, default=VenueTypeCode.OTHER)
+    venueTypeCode = Column(
+        sa.Enum(VenueTypeCode, create_constraint=False), nullable=True, default=VenueTypeCode.get_default()
+    )
 
     venueLabelId = Column(Integer, ForeignKey("venue_label.id"), nullable=True)
 
@@ -269,6 +275,11 @@ class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, Ne
         if not self.venueType:
             return
         self.venueTypeCode = VenueTypeCode.from_label(self.venueType.label)
+
+    def get_venue_type_code(self) -> VenueTypeCode:
+        if not self.venueTypeCode:
+            self.venueTypeCode = VenueTypeCode.get_default()
+        return self.venueTypeCode
 
 
 class VenueLabel(PcObject, Model):

--- a/src/pcapi/core/search/backends/appsearch.py
+++ b/src/pcapi/core/search/backends/appsearch.py
@@ -406,7 +406,7 @@ class AppSearchBackend(base.SearchBackend):
                 "id": venue.id,
                 "name": venue.publicName or venue.name,
                 "offerer_name": venue.managingOfferer.name,
-                "venue_type": venue.venueTypeCode.name,
+                "venue_type": venue.get_venue_type_code().name,
                 "position": position(venue),
                 "description": venue.description,
                 "audio_disability": to_app_search_bool(venue.audioDisabilityCompliant),

--- a/src/pcapi/routes/native/v1/offerers.py
+++ b/src/pcapi/routes/native/v1/offerers.py
@@ -26,7 +26,7 @@ def get_venue(venue_id: int) -> serializers.VenueResponse:
         withdrawalDetails=venue.withdrawalDetails,
         address=venue.address,
         postalCode=venue.postalCode,
-        venueTypeCode=venue.venueTypeCode.name,
+        venueTypeCode=venue.get_venue_type_code().name,
         description=venue.description,
         contact=venue.contact,
         accessibility={

--- a/tests/core/search/test_serialize_appsearch.py
+++ b/tests/core/search/test_serialize_appsearch.py
@@ -245,7 +245,7 @@ def test_serialize_venue():
         "id": venue.id,
         "name": venue.name,
         "offerer_name": venue.managingOfferer.name,
-        "venue_type": venue.venueTypeCode.name,
+        "venue_type": venue.get_venue_type_code().name,
         "position": f"{venue.latitude},{venue.longitude}",
         "description": venue.description,
         "email": "some@email.com",

--- a/tests/routes/native/v1/offerers_test.py
+++ b/tests/routes/native/v1/offerers_test.py
@@ -25,7 +25,7 @@ class VenuesTest:
             "withdrawalDetails": venue.withdrawalDetails,
             "address": venue.address,
             "postalCode": venue.postalCode,
-            "venueTypeCode": venue.venueTypeCode.name,
+            "venueTypeCode": venue.get_venue_type_code().name,
             "description": venue.description,
             "contact": {
                 "email": venue.contact.email,

--- a/tests/routes/webapp/get_booking_by_id_test.py
+++ b/tests/routes/webapp/get_booking_by_id_test.py
@@ -171,7 +171,7 @@ class Returns200Test:
                         "venueLabelId": None,
                         "venueTypeId": None,
                         "visualDisabilityCompliant": None,
-                        "venueTypeCode": offer.venue.venueTypeCode.value,
+                        "venueTypeCode": offer.venue.get_venue_type_code().value,
                         "withdrawalDetails": None,
                     },
                     "venueId": humanize(offer.venue.id),


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10071


## But de la pull request

FIX : à certains endroits du code, on accède à l'attribut `name` d'un `VenueTypeCode` via `Venue.venueTypeCode` de Venue ce qui créé des erreurs puisque `venueTypeCode` peut être `NULL` en base de données.

Note : default de SQLA ne définit que la valeur par défaut lors de l'insertion ou de la mise à jour.