### PR TITLE
(PC-10999) send cancellation mail for all users

### DIFF
--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -171,7 +171,7 @@ def _cancel_bookings_from_stock(stock: Stock, reason: BookingCancellationReasons
     Cancel multiple bookings and update the users' credit information on Batch.
     Note that this will not reindex the stock.offer in Algolia
     """
-    deleted_bookings = []
+    deleted_bookings: list[Booking] = []
     with transaction():
         stock = offers_repository.get_and_lock_stock(stock_id=stock.id)
         for booking in stock.bookings:
@@ -186,7 +186,8 @@ def _cancel_bookings_from_stock(stock: Stock, reason: BookingCancellationReasons
         repository.save(*deleted_bookings)
 
     for booking in deleted_bookings:
-        update_external_user(booking.user)
+        if booking.individualBooking is not None:
+            update_external_user(booking.individualBooking.user)
 
     return deleted_bookings
 

--- a/src/pcapi/core/bookings/models.py
+++ b/src/pcapi/core/bookings/models.py
@@ -270,6 +270,36 @@ class Booking(PcObject, Model):
     def isConfirmed(cls):  # pylint: disable=no-self-argument
         return and_(cls.cancellationLimitDate.isnot(None), cls.cancellationLimitDate <= datetime.utcnow())
 
+    @property
+    def firstName(self) -> Optional[str]:
+        if self.individualBooking is not None:
+            return self.individualBooking.user.firstName
+
+        if self.educationalBooking is not None:
+            return self.educationalBooking.educationalRedactor.firstName
+
+        return None
+
+    @property
+    def lastName(self) -> Optional[str]:
+        if self.individualBooking is not None:
+            return self.individualBooking.user.lastName
+
+        if self.educationalBooking is not None:
+            return self.educationalBooking.educationalRedactor.lastName
+
+        return None
+
+    @property
+    def email(self) -> Optional[str]:
+        if self.individualBooking is not None:
+            return self.individualBooking.user.email
+
+        if self.educationalBooking is not None:
+            return self.educationalBooking.educationalRedactor.email
+
+        return None
+
 
 # FIXME (dbaty, 2020-02-08): once `Deposit.expirationDate` has been
 # populated after the deployment of v122, make the column NOT NULLable

--- a/src/pcapi/core/bookings/models.py
+++ b/src/pcapi/core/bookings/models.py
@@ -129,7 +129,7 @@ class Booking(PcObject, Model):
         unique=True,
         index=True,
     )
-    educationalBooking = relationship(
+    educationalBooking: Optional[EducationalBooking] = relationship(
         EducationalBooking,
         back_populates="booking",
         uselist=False,
@@ -142,7 +142,7 @@ class Booking(PcObject, Model):
         unique=True,
         index=True,
     )
-    individualBooking = relationship(
+    individualBooking: Optional[IndividualBooking] = relationship(
         IndividualBooking,
         back_populates="booking",
         uselist=False,

--- a/src/pcapi/core/bookings/models.py
+++ b/src/pcapi/core/bookings/models.py
@@ -57,7 +57,13 @@ class IndividualBooking(Model):
     id = Column(BigInteger, primary_key=True, autoincrement=True)
 
     userId = Column(BigInteger, ForeignKey("user.id"), index=True, nullable=False)
-    user = relationship("User", foreign_keys=[userId], backref="userIndividualBookings")
+    user = relationship(
+        "User",
+        foreign_keys=[userId],
+        backref="userIndividualBookings",
+        lazy="joined",
+        innerjoin=True,
+    )
 
     booking = relationship(
         "Booking",

--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -472,7 +472,7 @@ def delete_stock(stock: Stock) -> None:
     if cancelled_bookings:
         for booking in cancelled_bookings:
             try:
-                user_emails.send_warning_to_beneficiary_after_pro_booking_cancellation(booking)
+                user_emails.send_warning_to_user_after_pro_booking_cancellation(booking)
             except mailing.MailServiceException as exc:
                 logger.exception(
                     "Could not notify beneficiary about deletion of stock",

--- a/src/pcapi/domain/user_emails.py
+++ b/src/pcapi/domain/user_emails.py
@@ -32,9 +32,6 @@ from pcapi.emails.beneficiary_soon_to_be_expired_bookings import (
     build_soon_to_be_expired_bookings_recap_email_data_for_beneficiary,
 )
 from pcapi.emails.beneficiary_soon_to_be_expired_bookings import filter_books_bookings
-from pcapi.emails.beneficiary_warning_after_pro_booking_cancellation import (
-    retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation,
-)
 from pcapi.emails.new_offer_validation import retrieve_data_for_offer_approval_email
 from pcapi.emails.new_offer_validation import retrieve_data_for_offer_rejection_email
 from pcapi.emails.new_offerer_validated_withdrawal_terms import (
@@ -54,6 +51,9 @@ from pcapi.emails.user_notification_after_stock_update import (
 )
 from pcapi.emails.user_reset_password import retrieve_data_for_reset_password_native_app_email
 from pcapi.emails.user_reset_password import retrieve_data_for_reset_password_user_email
+from pcapi.emails.user_warning_after_pro_booking_cancellation import (
+    retrieve_data_to_warn_user_after_pro_booking_cancellation,
+)
 from pcapi.models import Offer
 from pcapi.models.feature import FeatureToggle
 from pcapi.repository.offerer_queries import find_new_offerer_user_email
@@ -101,8 +101,8 @@ def send_offerer_driven_cancellation_email_to_offerer(booking: Booking) -> None:
         mails.send(recipients=[offerer_booking_email], data=email)
 
 
-def send_warning_to_beneficiary_after_pro_booking_cancellation(booking: Booking) -> None:
-    data = retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation(booking)
+def send_warning_to_user_after_pro_booking_cancellation(booking: Booking) -> None:
+    data = retrieve_data_to_warn_user_after_pro_booking_cancellation(booking)
     mails.send(recipients=[booking.user.email], data=data)
 
 
@@ -139,7 +139,7 @@ def send_booking_cancellation_emails_to_user_and_offerer(
         send_beneficiary_booking_cancellation_email(booking)
         send_user_driven_cancellation_email_to_offerer(booking)
     if reason == BookingCancellationReasons.OFFERER:
-        send_warning_to_beneficiary_after_pro_booking_cancellation(booking)
+        send_warning_to_user_after_pro_booking_cancellation(booking)
         send_offerer_driven_cancellation_email_to_offerer(booking)
     if reason == BookingCancellationReasons.FRAUD:
         send_user_driven_cancellation_email_to_offerer(booking)

--- a/src/pcapi/emails/offerer_bookings_recap_after_deleting_stock.py
+++ b/src/pcapi/emails/offerer_bookings_recap_after_deleting_stock.py
@@ -35,8 +35,6 @@ def retrieve_offerer_bookings_recap_email_data_after_offerer_cancellation(bookin
 
 def _extract_users_information_from_bookings_list(bookings: list[Booking]) -> list[dict]:
     users_keys = ("firstName", "lastName", "email", "countermark")
-    users_properties = [
-        [booking.user.firstName, booking.user.lastName, booking.user.email, booking.token] for booking in bookings
-    ]
+    users_properties = [[booking.firstName, booking.lastName, booking.email, booking.token] for booking in bookings]
 
     return [dict(zip(users_keys, user_property)) for user_property in users_properties]

--- a/src/pcapi/emails/user_warning_after_pro_booking_cancellation.py
+++ b/src/pcapi/emails/user_warning_after_pro_booking_cancellation.py
@@ -23,10 +23,7 @@ def retrieve_data_to_warn_user_after_pro_booking_cancellation(booking: Booking) 
     offerer_name = offer.venue.managingOfferer.name
     offer_name = offer.name
     offer_price = str(booking.total_amount)
-    if booking.individualBooking is not None:
-        user_first_name = booking.individualBooking.user.firstName
-    if booking.educationalBooking is not None:
-        user_first_name = booking.educationalBooking.educationalRedactor.firstName
+    user_first_name = booking.firstName
     venue_name = offer.venue.publicName if offer.venue.publicName else offer.venue.name
     template_id = 1116690 if booking.individualBooking is not None else 3192295
 

--- a/src/pcapi/emails/user_warning_after_pro_booking_cancellation.py
+++ b/src/pcapi/emails/user_warning_after_pro_booking_cancellation.py
@@ -7,7 +7,7 @@ from pcapi.utils.mailing import format_booking_hours_for_email
 from pcapi.utils.mailing import get_event_datetime
 
 
-def retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation(booking: Booking) -> dict:
+def retrieve_data_to_warn_user_after_pro_booking_cancellation(booking: Booking) -> dict:
     stock = booking.stock
     offer = stock.offer
     event_date = ""
@@ -25,7 +25,7 @@ def retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation(booking: Bo
     offerer_name = offer.venue.managingOfferer.name
     offer_name = offer.name
     offer_price = str(booking.total_amount)
-    user_first_name = booking.user.firstName
+    user_first_name = booking.individualBooking.user.firstName
     venue_name = offer.venue.publicName if offer.venue.publicName else offer.venue.name
     can_book_again = int(booking.user.deposit.expirationDate > datetime.datetime.now())
 

--- a/src/pcapi/emails/user_warning_after_pro_booking_cancellation.py
+++ b/src/pcapi/emails/user_warning_after_pro_booking_cancellation.py
@@ -1,5 +1,3 @@
-import datetime
-
 from babel.dates import format_date
 
 from pcapi.models import Booking
@@ -25,12 +23,15 @@ def retrieve_data_to_warn_user_after_pro_booking_cancellation(booking: Booking) 
     offerer_name = offer.venue.managingOfferer.name
     offer_name = offer.name
     offer_price = str(booking.total_amount)
-    user_first_name = booking.individualBooking.user.firstName
+    if booking.individualBooking is not None:
+        user_first_name = booking.individualBooking.user.firstName
+    if booking.educationalBooking is not None:
+        user_first_name = booking.educationalBooking.educationalRedactor.firstName
     venue_name = offer.venue.publicName if offer.venue.publicName else offer.venue.name
-    can_book_again = int(booking.user.deposit.expirationDate > datetime.datetime.now())
+    template_id = 1116690 if booking.individualBooking is not None else 3192295
 
     return {
-        "MJ-TemplateID": 1116690,
+        "MJ-TemplateID": template_id,
         "MJ-TemplateLanguage": True,
         "Vars": {
             "event_date": event_date,
@@ -43,7 +44,6 @@ def retrieve_data_to_warn_user_after_pro_booking_cancellation(booking: Booking) 
             "offer_price": offer_price,
             "offerer_name": offerer_name,
             "user_first_name": user_first_name,
-            "can_book_again": can_book_again,
             "venue_name": venue_name,
         },
     }

--- a/src/pcapi/emails/user_warning_after_pro_booking_cancellation.py
+++ b/src/pcapi/emails/user_warning_after_pro_booking_cancellation.py
@@ -24,6 +24,7 @@ def retrieve_data_to_warn_user_after_pro_booking_cancellation(booking: Booking) 
     offer_name = offer.name
     offer_price = str(booking.total_amount)
     user_first_name = booking.firstName
+    user_last_name = booking.lastName
     venue_name = offer.venue.publicName if offer.venue.publicName else offer.venue.name
     template_id = 1116690 if booking.individualBooking is not None else 3192295
 
@@ -41,6 +42,7 @@ def retrieve_data_to_warn_user_after_pro_booking_cancellation(booking: Booking) 
             "offer_price": offer_price,
             "offerer_name": offerer_name,
             "user_first_name": user_first_name,
+            "user_last_name": user_last_name,
             "venue_name": venue_name,
         },
     }

--- a/tests/admin/custom_views/offer_view_test.py
+++ b/tests/admin/custom_views/offer_view_test.py
@@ -599,7 +599,7 @@ class OfferViewTest:
         with freeze_time("2020-11-17 15:00:00") as frozen_time:
             offer = offers_factories.OfferFactory(validation=OfferValidationStatus.APPROVED, isActive=True)
             stock = offers_factories.StockFactory(offer=offer, price=10)
-            unused_booking = booking_factories.BookingFactory(stock=stock)
+            unused_booking = booking_factories.IndividualBookingFactory(stock=stock)
             used_booking = booking_factories.UsedBookingFactory(stock=stock)
             frozen_time.move_to("2020-12-20 15:00:00")
             data = dict(validation=OfferValidationStatus.REJECTED.value)

--- a/tests/core/bookings/test_api.py
+++ b/tests/core/bookings/test_api.py
@@ -520,8 +520,8 @@ class CancelByOffererTest:
 
     def test_cancel_all_bookings_from_stock(self, app):
         stock = offers_factories.StockFactory(dnBookedQuantity=1)
-        booking_1 = factories.BookingFactory(stock=stock)
-        booking_2 = factories.BookingFactory(stock=stock)
+        booking_1 = factories.IndividualBookingFactory(stock=stock)
+        booking_2 = factories.IndividualBookingFactory(stock=stock)
         used_booking = factories.UsedBookingFactory(stock=stock)
         cancelled_booking = factories.CancelledBookingFactory(stock=stock)
 

--- a/tests/core/offers/test_api.py
+++ b/tests/core/offers/test_api.py
@@ -541,7 +541,7 @@ class DeleteStockTest:
     @mock.patch("pcapi.domain.user_emails.send_warning_to_user_after_pro_booking_cancellation")
     def test_delete_stock_cancel_bookings_and_send_emails(self, mocked_send_to_beneficiaries, mocked_send_to_offerer):
         stock = factories.EventStockFactory()
-        booking1 = bookings_factories.BookingFactory(stock=stock)
+        booking1 = bookings_factories.IndividualBookingFactory(stock=stock)
         booking2 = bookings_factories.CancelledBookingFactory(stock=stock)
         booking3 = bookings_factories.UsedBookingFactory(stock=stock)
 

--- a/tests/core/offers/test_api.py
+++ b/tests/core/offers/test_api.py
@@ -538,7 +538,7 @@ class DeleteStockTest:
         mocked_async_index_offer_ids.assert_called_once_with([stock.offerId])
 
     @mock.patch("pcapi.domain.user_emails.send_offerer_bookings_recap_email_after_offerer_cancellation")
-    @mock.patch("pcapi.domain.user_emails.send_warning_to_beneficiary_after_pro_booking_cancellation")
+    @mock.patch("pcapi.domain.user_emails.send_warning_to_user_after_pro_booking_cancellation")
     def test_delete_stock_cancel_bookings_and_send_emails(self, mocked_send_to_beneficiaries, mocked_send_to_offerer):
         stock = factories.EventStockFactory()
         booking1 = bookings_factories.BookingFactory(stock=stock)

--- a/tests/domain/user_emails_test.py
+++ b/tests/domain/user_emails_test.py
@@ -149,6 +149,7 @@ class SendWarningToBeneficiaryAfterProBookingCancellationTest:
                 "offer_price": "10.00",
                 "offerer_name": booking.offerer.name,
                 "user_first_name": "Jeanne",
+                "user_last_name": "Doux",
                 "venue_name": booking.venue.name,
                 "env": "-development",
             },

--- a/tests/domain/user_emails_test.py
+++ b/tests/domain/user_emails_test.py
@@ -36,7 +36,7 @@ from pcapi.domain.user_emails import send_reset_password_email_to_pro
 from pcapi.domain.user_emails import send_reset_password_email_to_user
 from pcapi.domain.user_emails import send_soon_to_be_expired_individual_bookings_recap_email_to_beneficiary
 from pcapi.domain.user_emails import send_user_driven_cancellation_email_to_offerer
-from pcapi.domain.user_emails import send_warning_to_beneficiary_after_pro_booking_cancellation
+from pcapi.domain.user_emails import send_warning_to_user_after_pro_booking_cancellation
 from pcapi.domain.user_emails import send_withdrawal_terms_to_newly_validated_offerer
 from pcapi.model_creators.generic_creators import create_booking
 from pcapi.model_creators.generic_creators import create_offerer
@@ -129,7 +129,7 @@ class SendWarningToBeneficiaryAfterProBookingCancellationTest:
         booking = BookingFactory(user__email="user@example.com", user__firstName="Jeanne")
 
         # When
-        send_warning_to_beneficiary_after_pro_booking_cancellation(booking)
+        send_warning_to_user_after_pro_booking_cancellation(booking)
 
         # Then
         assert mails_testing.outbox[0].sent_data == {

--- a/tests/domain/user_emails_test.py
+++ b/tests/domain/user_emails_test.py
@@ -7,6 +7,7 @@ from dateutil.relativedelta import relativedelta
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import IndividualBookingFactory
 from pcapi.core.categories import subcategories
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.offers.factories import OfferFactory
@@ -126,7 +127,7 @@ class SendBeneficiaryUserDrivenCancellationEmailToOffererTest:
 class SendWarningToBeneficiaryAfterProBookingCancellationTest:
     def test_should_sends_email_to_beneficiary_when_pro_cancels_booking(self):
         # Given
-        booking = BookingFactory(user__email="user@example.com", user__firstName="Jeanne")
+        booking = IndividualBookingFactory(user__email="user@example.com", user__firstName="Jeanne")
 
         # When
         send_warning_to_user_after_pro_booking_cancellation(booking)
@@ -148,7 +149,6 @@ class SendWarningToBeneficiaryAfterProBookingCancellationTest:
                 "offer_price": "10.00",
                 "offerer_name": booking.offerer.name,
                 "user_first_name": "Jeanne",
-                "can_book_again": True,
                 "venue_name": booking.venue.name,
                 "env": "-development",
             },

--- a/tests/emails/user_warning_after_pro_booking_cancellation_test.py
+++ b/tests/emails/user_warning_after_pro_booking_cancellation_test.py
@@ -17,7 +17,11 @@ class RetrieveDataToWarnUserAfterProBookingCancellationTest:
         stock = offers_factories.EventStockFactory(
             beginningDatetime=datetime(2019, 7, 20, 12, 0, 0, tzinfo=timezone.utc)
         )
-        booking = bookings_factories.IndividualBookingFactory(stock=stock, individualBooking__user__firstName="Georges")
+        booking = bookings_factories.IndividualBookingFactory(
+            stock=stock,
+            individualBooking__user__firstName="Georges",
+            individualBooking__user__lastName="Moustiquos",
+        )
 
         # When
         mailjet_data = retrieve_data_to_warn_user_after_pro_booking_cancellation(booking)
@@ -37,6 +41,7 @@ class RetrieveDataToWarnUserAfterProBookingCancellationTest:
                 "offer_price": "10.00",
                 "offerer_name": booking.offerer.name,
                 "user_first_name": "Georges",
+                "user_last_name": "Moustiquos",
                 "venue_name": booking.venue.name,
             },
         }
@@ -49,6 +54,7 @@ class RetrieveDataToWarnUserAfterProBookingCancellationTest:
         booking = bookings_factories.EducationalBookingFactory(
             stock=stock,
             educationalBooking__educationalRedactor__firstName="Georgio",
+            educationalBooking__educationalRedactor__lastName="Di georgio",
         )
 
         # When
@@ -69,6 +75,7 @@ class RetrieveDataToWarnUserAfterProBookingCancellationTest:
                 "offer_price": "10.00",
                 "offerer_name": booking.offerer.name,
                 "user_first_name": "Georgio",
+                "user_last_name": "Di georgio",
                 "venue_name": booking.venue.name,
             },
         }
@@ -76,7 +83,11 @@ class RetrieveDataToWarnUserAfterProBookingCancellationTest:
     def test_should_return_thing_data_when_booking_is_on_a_thing(self):
         # Given
         stock = offers_factories.ThingStockFactory()
-        booking = bookings_factories.IndividualBookingFactory(stock=stock, individualBooking__user__firstName="Georges")
+        booking = bookings_factories.IndividualBookingFactory(
+            stock=stock,
+            individualBooking__user__firstName="Georges",
+            individualBooking__user__lastName="Doux",
+        )
 
         # When
         mailjet_data = retrieve_data_to_warn_user_after_pro_booking_cancellation(booking)
@@ -96,6 +107,7 @@ class RetrieveDataToWarnUserAfterProBookingCancellationTest:
                 "offer_price": "10.00",
                 "offerer_name": booking.offerer.name,
                 "user_first_name": "Georges",
+                "user_last_name": "Doux",
                 "venue_name": booking.venue.name,
             },
         }
@@ -103,7 +115,11 @@ class RetrieveDataToWarnUserAfterProBookingCancellationTest:
     def test_should_return_thing_data_when_booking_is_on_an_online_offer(self):
         # Given
         stock = offers_factories.ThingStockFactory(offer__product=offers_factories.DigitalProductFactory())
-        booking = bookings_factories.IndividualBookingFactory(stock=stock, individualBooking__user__firstName="Georges")
+        booking = bookings_factories.IndividualBookingFactory(
+            stock=stock,
+            individualBooking__user__firstName="Georges",
+            individualBooking__user__lastName="Georges",
+        )
 
         # When
         mailjet_data = retrieve_data_to_warn_user_after_pro_booking_cancellation(booking)
@@ -123,6 +139,7 @@ class RetrieveDataToWarnUserAfterProBookingCancellationTest:
                 "offer_price": "10.00",
                 "offerer_name": booking.offerer.name,
                 "user_first_name": "Georges",
+                "user_last_name": "Georges",
                 "venue_name": booking.venue.name,
             },
         }

--- a/tests/emails/user_warning_after_pro_booking_cancellation_test.py
+++ b/tests/emails/user_warning_after_pro_booking_cancellation_test.py
@@ -27,7 +27,6 @@ class RetrieveDataToWarnUserAfterProBookingCancellationTest:
             "MJ-TemplateID": 1116690,
             "MJ-TemplateLanguage": True,
             "Vars": {
-                "can_book_again": 1,
                 "event_date": "samedi 20 juillet 2019",
                 "event_hour": "14h",
                 "is_event": 1,
@@ -38,6 +37,38 @@ class RetrieveDataToWarnUserAfterProBookingCancellationTest:
                 "offer_price": "10.00",
                 "offerer_name": booking.offerer.name,
                 "user_first_name": "Georges",
+                "venue_name": booking.venue.name,
+            },
+        }
+
+    def test_should_return_redactor_first_name_when_booking_is_educational(self):
+        # Given
+        stock = offers_factories.EventStockFactory(
+            beginningDatetime=datetime(2019, 7, 20, 12, 0, 0, tzinfo=timezone.utc)
+        )
+        booking = bookings_factories.EducationalBookingFactory(
+            stock=stock,
+            educationalBooking__educationalRedactor__firstName="Georgio",
+        )
+
+        # When
+        mailjet_data = retrieve_data_to_warn_user_after_pro_booking_cancellation(booking)
+
+        # Then
+        assert mailjet_data == {
+            "MJ-TemplateID": 3192295,
+            "MJ-TemplateLanguage": True,
+            "Vars": {
+                "event_date": "samedi 20 juillet 2019",
+                "event_hour": "14h",
+                "is_event": 1,
+                "is_free_offer": 0,
+                "is_online": 0,
+                "is_thing": 0,
+                "offer_name": booking.stock.offer.name,
+                "offer_price": "10.00",
+                "offerer_name": booking.offerer.name,
+                "user_first_name": "Georgio",
                 "venue_name": booking.venue.name,
             },
         }
@@ -55,7 +86,6 @@ class RetrieveDataToWarnUserAfterProBookingCancellationTest:
             "MJ-TemplateID": 1116690,
             "MJ-TemplateLanguage": True,
             "Vars": {
-                "can_book_again": 1,
                 "event_date": "",
                 "event_hour": "",
                 "is_event": 0,
@@ -83,7 +113,6 @@ class RetrieveDataToWarnUserAfterProBookingCancellationTest:
             "MJ-TemplateID": 1116690,
             "MJ-TemplateLanguage": True,
             "Vars": {
-                "can_book_again": 1,
                 "event_date": "",
                 "event_hour": "",
                 "is_event": 0,

--- a/tests/emails/user_warning_after_pro_booking_cancellation_test.py
+++ b/tests/emails/user_warning_after_pro_booking_cancellation_test.py
@@ -5,22 +5,22 @@ import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.offers.factories as offers_factories
-from pcapi.emails.beneficiary_warning_after_pro_booking_cancellation import (
-    retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation,
+from pcapi.emails.user_warning_after_pro_booking_cancellation import (
+    retrieve_data_to_warn_user_after_pro_booking_cancellation,
 )
 
 
 @pytest.mark.usefixtures("db_session")
-class RetrieveDataToWarnBeneficiaryAfterProBookingCancellationTest:
+class RetrieveDataToWarnUserAfterProBookingCancellationTest:
     def test_should_return_event_data_when_booking_is_on_an_event(self):
         # Given
         stock = offers_factories.EventStockFactory(
             beginningDatetime=datetime(2019, 7, 20, 12, 0, 0, tzinfo=timezone.utc)
         )
-        booking = bookings_factories.BookingFactory(stock=stock)
+        booking = bookings_factories.IndividualBookingFactory(stock=stock, individualBooking__user__firstName="Georges")
 
         # When
-        mailjet_data = retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation(booking)
+        mailjet_data = retrieve_data_to_warn_user_after_pro_booking_cancellation(booking)
 
         # Then
         assert mailjet_data == {
@@ -37,7 +37,7 @@ class RetrieveDataToWarnBeneficiaryAfterProBookingCancellationTest:
                 "offer_name": booking.stock.offer.name,
                 "offer_price": "10.00",
                 "offerer_name": booking.offerer.name,
-                "user_first_name": "Jeanne",
+                "user_first_name": "Georges",
                 "venue_name": booking.venue.name,
             },
         }
@@ -45,10 +45,10 @@ class RetrieveDataToWarnBeneficiaryAfterProBookingCancellationTest:
     def test_should_return_thing_data_when_booking_is_on_a_thing(self):
         # Given
         stock = offers_factories.ThingStockFactory()
-        booking = bookings_factories.BookingFactory(stock=stock)
+        booking = bookings_factories.IndividualBookingFactory(stock=stock, individualBooking__user__firstName="Georges")
 
         # When
-        mailjet_data = retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation(booking)
+        mailjet_data = retrieve_data_to_warn_user_after_pro_booking_cancellation(booking)
 
         # Then
         assert mailjet_data == {
@@ -65,7 +65,7 @@ class RetrieveDataToWarnBeneficiaryAfterProBookingCancellationTest:
                 "offer_name": booking.stock.offer.name,
                 "offer_price": "10.00",
                 "offerer_name": booking.offerer.name,
-                "user_first_name": "Jeanne",
+                "user_first_name": "Georges",
                 "venue_name": booking.venue.name,
             },
         }
@@ -73,10 +73,10 @@ class RetrieveDataToWarnBeneficiaryAfterProBookingCancellationTest:
     def test_should_return_thing_data_when_booking_is_on_an_online_offer(self):
         # Given
         stock = offers_factories.ThingStockFactory(offer__product=offers_factories.DigitalProductFactory())
-        booking = bookings_factories.BookingFactory(stock=stock)
+        booking = bookings_factories.IndividualBookingFactory(stock=stock, individualBooking__user__firstName="Georges")
 
         # When
-        mailjet_data = retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation(booking)
+        mailjet_data = retrieve_data_to_warn_user_after_pro_booking_cancellation(booking)
 
         # Then
         assert mailjet_data == {
@@ -93,17 +93,20 @@ class RetrieveDataToWarnBeneficiaryAfterProBookingCancellationTest:
                 "offer_name": booking.stock.offer.name,
                 "offer_price": "10.00",
                 "offerer_name": booking.offerer.name,
-                "user_first_name": "Jeanne",
+                "user_first_name": "Georges",
                 "venue_name": booking.venue.name,
             },
         }
 
     def test_should_not_display_the_price_when_booking_is_on_a_free_offer(self):
         # Given
-        booking = bookings_factories.BookingFactory(stock__price=0)
+        booking = bookings_factories.IndividualBookingFactory(
+            stock__price=0,
+            individualBooking__user__firstName="Georges",
+        )
 
         # When
-        mailjet_data = retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation(booking)
+        mailjet_data = retrieve_data_to_warn_user_after_pro_booking_cancellation(booking)
 
         # Then
         assert mailjet_data["Vars"]["is_free_offer"] == 1
@@ -111,10 +114,14 @@ class RetrieveDataToWarnBeneficiaryAfterProBookingCancellationTest:
 
     def test_should_display_the_price_multiplied_by_quantity_when_it_is_a_duo_offer(self):
         # Given
-        booking = bookings_factories.BookingFactory(amount=10, quantity=2)
+        booking = bookings_factories.IndividualBookingFactory(
+            amount=10,
+            quantity=2,
+            individualBooking__user__firstName="Georges",
+        )
 
         # When
-        mailjet_data = retrieve_data_to_warn_beneficiary_after_pro_booking_cancellation(booking)
+        mailjet_data = retrieve_data_to_warn_user_after_pro_booking_cancellation(booking)
 
         # Then
         assert mailjet_data["Vars"]["is_free_offer"] == 0

--- a/tests/routes/pro/delete_stock_test.py
+++ b/tests/routes/pro/delete_stock_test.py
@@ -1,4 +1,4 @@
-from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import IndividualBookingFactory
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import OfferValidationStatus
@@ -18,7 +18,7 @@ class Returns200Test:
             offerer=offer.venue.managingOfferer,
         )
         stock = offers_factories.StockFactory(offer=offer)
-        booking = BookingFactory(stock=stock)
+        booking = IndividualBookingFactory(stock=stock)
 
         # when
         client = TestClient(app.test_client()).with_session_auth("pro@example.com")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10999


## But de la pull request

- Envoi d'un email au rédacteur de projet en cas de suppression du stock de la part de l'acteur culturel
- Correction du bug 500 suite à la tentative d'envoi d'une notif batch à l'utilisateur.

##  Implémentation

- Ajout de propriétés qui permettent de récupérer firstName, lastName et email sur le booking indépendamment du type de réservation (Educational ou Individual)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
