### PR TITLE
(PC-11082): Correction de la lectures des champs DMS procédure v4

### DIFF
--- a/src/pcapi/scripts/beneficiary/remote_import.py
+++ b/src/pcapi/scripts/beneficiary/remote_import.py
@@ -269,13 +269,18 @@ def parse_beneficiary_information_graphql(application_detail: dict, procedure_id
 
         if "Veuillez indiquer votre département" in label:
             information["department"] = re.search("^[0-9]{2,3}|[2BbAa]{2}", value).group(0)
-        if label == "Quelle est votre date de naissance":
+        if label in ("Quelle est votre date de naissance", "Quelle est ta date de naissance ?"):
             information["birth_date"] = date_parser.parse(value, FrenchParserInfo())
-        if label == "Quel est votre numéro de téléphone":
+        if label in (
+            "Quel est votre numéro de téléphone",
+            "Quel est ton numéro de téléphone ?",
+        ):
             information["phone"] = value.replace(" ", "")
         if label in (
             "Quel est le code postal de votre commune de résidence ?",
             "Quel est le code postal de votre commune de résidence ? (ex : 25370)",
+            "Quel est le code postal de ta commune de résidence ? (ex : 25370)",
+            "Quel est le code postal de ta commune de résidence ?",
         ):
             space_free = str(value).strip().replace(" ", "")
             try:
@@ -283,11 +288,18 @@ def parse_beneficiary_information_graphql(application_detail: dict, procedure_id
             except Exception:  # pylint: disable=broad-except
                 parsing_errors["postal_code"] = value
 
-        if label == "Veuillez indiquer votre statut":
+        if label in ("Veuillez indiquer votre statut", "Merci d'indiquer ton statut", "Merci d' indiquer ton statut"):
             information["activity"] = value
-        if label == "Quelle est votre adresse de résidence":
+        if label in (
+            "Quelle est votre adresse de résidence",
+            "Quelle est ton adresse de résidence",
+            "Quelle est ton adresse de résidence ?",
+        ):
             information["address"] = value
-        if label == "Quel est le numéro de la pièce que vous venez de saisir ?":
+        if label in (
+            "Quel est le numéro de la pièce que vous venez de saisir ?",
+            "Quel est le numéro de la pièce que tu viens de saisir ?",
+        ):
             value = value.strip()
             if not fraud_api.validate_id_piece_number_format_fraud_item(value):
                 parsing_errors["id_piece_number"] = value

--- a/tests/scripts/beneficiary/fixture.py
+++ b/tests/scripts/beneficiary/fixture.py
@@ -445,7 +445,7 @@ def make_new_application():
                 {
                     "id": "Q2hhbXAtMTg3Mzc0Mw==",
                     "type": "text",
-                    "label": "Quel est le numéro de la pièce que vous venez de saisir ?",
+                    "label": "Quel est le numéro de la pièce que tu viens de saisir ?",
                     "description": "Indiquez ici le numéro de la pièce que vous avez envoyé (généralement située en haut à droite du recto). \nLe format ressemble à cela : \n- Ancienne carte d'identité : 880692310285\n- Nouvelle carte d'identité : F9GFAL123\n- Passeport : 21GT764978",
                     "required": True,
                     "options": None,
@@ -454,7 +454,7 @@ def make_new_application():
                 {
                     "id": "Q2hhbXAtNTgyMjE5",
                     "type": "phone",
-                    "label": "Quel est votre numéro de téléphone",
+                    "label": "Quel est ton numéro de téléphone ?",
                     "description": "",
                     "required": True,
                     "options": None,
@@ -463,7 +463,7 @@ def make_new_application():
                 {
                     "id": "Q2hhbXAtNTgyMjIx",
                     "type": "integer_number",
-                    "label": "Quel est le code postal de votre commune de résidence ? (ex : 25370)",
+                    "label": "Quel est le code postal de ta commune de résidence ? (ex : 25370)",
                     "description": "Renseigner le code postal à 5 chiffres\nExemple: 92110",
                     "required": True,
                     "options": None,
@@ -472,7 +472,7 @@ def make_new_application():
                 {
                     "id": "Q2hhbXAtNTgyMjIz",
                     "type": "address",
-                    "label": "Quelle est votre adresse de résidence",
+                    "label": "Quelle est ton adresse de résidence",
                     "description": None,
                     "required": True,
                     "options": None,
@@ -481,7 +481,7 @@ def make_new_application():
                 {
                     "id": "Q2hhbXAtNzE4MDk0",
                     "type": "drop_down_list",
-                    "label": "Veuillez indiquer votre statut",
+                    "label": "Merci d'indiquer ton statut",
                     "description": "",
                     "required": True,
                     "options": [
@@ -580,18 +580,18 @@ def make_new_application():
             },
             {
                 "id": "Q2hhbXAtMTg3Mzc0Mw==",
-                "label": "Quel est le numéro de la pièce que vous venez de saisir ?",
+                "label": "Quel est le numéro de la pièce que tu viens de saisir ?",
                 "stringValue": "F9GFAL123",
             },
-            {"id": "Q2hhbXAtNTgyMjE5", "label": "Quel est votre numéro de téléphone", "stringValue": "06 01 01 01 01"},
+            {"id": "Q2hhbXAtNTgyMjE5", "label": "Quel est ton numéro de téléphone ?", "stringValue": "06 01 01 01 01"},
             {
                 "id": "Q2hhbXAtNTgyMjIx",
-                "label": "Quel est le code postal de votre commune de résidence ? (ex : 25370)",
+                "label": "Quel est le code postal de ta commune de résidence ? (ex : 25370)",
                 "stringValue": "92700",
             },
             {
                 "id": "Q2hhbXAtNTgyMjIz",
-                "label": "Quelle est votre adresse de résidence",
+                "label": "Quelle est ton adresse de résidence",
                 "stringValue": "32 rue des sapins gris 21350 l'îsle à dent",
             },
             {"id": "Q2hhbXAtNzE4MDk0", "label": "Veuillez indiquer votre statut", "stringValue": "Employé"},


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11082


## But de la pull request

Corriger les données lues dans la procédure v4 : entre le moment ou nous l'avons implémenté et ou la procédure à été mise en production, les labels sur lesquels nous nous basons ont changés.

Nous pourrions utiliser des ID de champs, mais chaque procédure a ses propres IDs, tout comme les procédures dupliquées pour avoir des versions production, testing, staging des formulaires, ce qui augmente le nombre d'erreurs possibles.

##  Implémentation
N/A.​
##  Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)