### PR TITLE
(PC-10863) Fix update_booking_used cron by improving log_cron method

### DIFF
--- a/src/pcapi/core/bookings/api.py
+++ b/src/pcapi/core/bookings/api.py
@@ -427,10 +427,12 @@ def auto_mark_as_used_after_event() -> None:
     n_individual_updated = individual_bookings.update(
         {"isUsed": True, "status": BookingStatus.USED, "dateUsed": now}, synchronize_session=False
     )
+    db.session.commit()
 
     n_educational_updated = educational_bookings.update(
         {"isUsed": True, "status": BookingStatus.USED, "dateUsed": now}, synchronize_session=False
     )
+    db.session.commit()
 
     logger.info(
         "Automatically marked bookings as used after event",

--- a/src/pcapi/scheduled_tasks/CONTRIBUTING.md
+++ b/src/pcapi/scheduled_tasks/CONTRIBUTING.md
@@ -33,11 +33,11 @@ def synchronize_titelive_stocks(app):
 ```
 
 
-Un autre décorateur `@log_cron` permet de logguer l'exécution des crons sous un format standard afin de profiter des outils de monitoring.
+Un autre décorateur `@log_cron_with_transaction` permet de logguer l'exécution des crons sous un format standard afin de profiter des outils de monitoring.
 
 Exemple :
 ```python
-@log_cron
+@log_cron_with_transaction
 def synchronize_titelive_stocks(app):
     titelive_stocks_provider_id = get_provider_by_local_class(TITELIVE_STOCKS_PROVIDER_NAME).id
     update_venues_for_specific_provider(titelive_stocks_provider_id)
@@ -68,7 +68,7 @@ def synchronize_titelive_stocks(app):
 
 Exemple :
 ```python
-@log_cron
+@log_cron_with_transaction
 @cron_context
 @cron_require_feature(FeatureToggle.SYNCHRONIZE_TITELIVE)
 def synchronize_titelive_stocks(app):
@@ -80,7 +80,7 @@ def synchronize_titelive_stocks(app):
 
 Exemple :
 ```python
-@log_cron
+@log_cron_with_transaction
 @cron_require_feature(FeatureToggle.SYNCHRONIZE_TITELIVE)
 @cron_context
 def synchronize_titelive_stocks(app):

--- a/src/pcapi/scheduled_tasks/algolia_clock.py
+++ b/src/pcapi/scheduled_tasks/algolia_clock.py
@@ -7,7 +7,7 @@ from pcapi.core.logging import install_logging
 import pcapi.core.offers.api as offers_api
 from pcapi.scheduled_tasks import utils
 from pcapi.scheduled_tasks.decorators import cron_context
-from pcapi.scheduled_tasks.decorators import log_cron
+from pcapi.scheduled_tasks.decorators import log_cron_with_transaction
 
 
 install_logging()
@@ -15,37 +15,37 @@ install_logging()
 
 # FIXME (dbaty, 2021-06-16): rename the file and the cron (and the
 # name of the pod).
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def index_offers_in_algolia_by_offer(app):
     search.index_offers_in_queue()
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def index_offers_in_algolia_by_venue(app):
     search.index_offers_of_venues_in_queue()
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def delete_expired_offers_in_algolia(app):
     offers_api.unindex_expired_offers()
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def index_offers_in_error_in_algolia_by_offer(app):
     search.index_offers_in_queue(from_error_queue=True)
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def index_venues(app):
     search.index_venues_in_queue()
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def index_venues_in_error(app):
     search.index_venues_in_queue(from_error_queue=True)

--- a/src/pcapi/scheduled_tasks/clock.py
+++ b/src/pcapi/scheduled_tasks/clock.py
@@ -31,7 +31,7 @@ from pcapi.repository.user_queries import find_most_recent_beneficiary_creation_
 from pcapi.scheduled_tasks import utils
 from pcapi.scheduled_tasks.decorators import cron_context
 from pcapi.scheduled_tasks.decorators import cron_require_feature
-from pcapi.scheduled_tasks.decorators import log_cron
+from pcapi.scheduled_tasks.decorators import log_cron_with_transaction
 from pcapi.scripts.beneficiary import remote_import, remote_tag_has_completed
 from pcapi.scripts.booking.handle_expired_bookings import handle_expired_bookings
 from pcapi.scripts.booking.notify_soon_to_be_expired_bookings import notify_soon_to_be_expired_individual_bookings
@@ -43,14 +43,14 @@ install_logging()
 logger = logging.getLogger(__name__)
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 @cron_require_feature(FeatureToggle.UPDATE_BOOKING_USED)
 def update_booking_used(app: Flask) -> None:
     bookings_api.auto_mark_as_used_after_event()
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 @cron_require_feature(FeatureToggle.SYNCHRONIZE_ALLOCINE)
 def synchronize_allocine_stocks(app: Flask) -> None:
@@ -58,7 +58,7 @@ def synchronize_allocine_stocks(app: Flask) -> None:
     synchronize_venue_providers_for_provider(allocine_stocks_provider_id)
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def synchronize_provider_api(app: Flask) -> None:
     provider_api_stocks.synchronize_stocks()
@@ -66,7 +66,7 @@ def synchronize_provider_api(app: Flask) -> None:
 
 # FIXME (asaunier, 2021-05-25): This clock must be removed once every application from procedure
 #  defined in DMS_NEW_ENROLLMENT_PROCEDURE_ID has been treated
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def pc_remote_import_beneficiaries(app: Flask) -> None:
     procedure_id = settings.DMS_NEW_ENROLLMENT_PROCEDURE_ID
@@ -79,7 +79,7 @@ def pc_remote_import_beneficiaries(app: Flask) -> None:
 
 # FIXME (xordoquy, 2021-06-16): This clock must be removed once every application from procedure
 #  defined in 44623 has been treated
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def pc_remote_import_beneficiaries_from_old_dms(app: Flask) -> None:
     if not settings.IS_PROD:
@@ -92,7 +92,7 @@ def pc_remote_import_beneficiaries_from_old_dms(app: Flask) -> None:
     remote_tag_has_completed.run(import_from_date, procedure_id)
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def pc_import_beneficiaries_from_dms_v3(app: Flask) -> None:
     procedure_id = settings.DMS_ENROLLMENT_PROCEDURE_ID_AFTER_GENERAL_OPENING
@@ -103,7 +103,7 @@ def pc_import_beneficiaries_from_dms_v3(app: Flask) -> None:
     remote_tag_has_completed.run(import_from_date, procedure_id)
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def pc_import_beneficiaries_from_dms_v4(app: Flask) -> None:
     for procedure_name, procedure_id in (
@@ -120,19 +120,19 @@ def pc_import_beneficiaries_from_dms_v4(app: Flask) -> None:
         remote_tag_has_completed.run(import_from_date, procedure_id)
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def pc_handle_expired_bookings(app: Flask) -> None:
     handle_expired_bookings()
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def pc_notify_soon_to_be_expired_individual_bookings(app: Flask) -> None:
     notify_soon_to_be_expired_individual_bookings()
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def pc_notify_newly_eligible_users(app: Flask) -> None:
     if not settings.IS_PROD and not settings.IS_TESTING:
@@ -142,14 +142,14 @@ def pc_notify_newly_eligible_users(app: Flask) -> None:
         send_newly_eligible_user_email(user)
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def pc_clean_expired_tokens(app: Flask) -> None:
     users_api.delete_expired_tokens()
     db.session.commit()
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def pc_check_stock_quantity_consistency(app: Flask) -> None:
     inconsistent_stocks = check_stock_consistency()
@@ -157,7 +157,7 @@ def pc_check_stock_quantity_consistency(app: Flask) -> None:
         logger.error("Found inconsistent stocks: %s", ", ".join([str(stock_id) for stock_id in inconsistent_stocks]))
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def pc_send_tomorrow_events_notifications(app: Flask) -> None:
     stock_ids = find_tomorrow_event_stock_ids()
@@ -165,13 +165,13 @@ def pc_send_tomorrow_events_notifications(app: Flask) -> None:
         send_tomorrow_stock_notification.delay(stock_id)
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def pc_clean_past_draft_offers(app: Flask) -> None:
     delete_past_draft_offers()
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 def pc_send_withdrawal_terms_to_offerers_validated_yesterday(app: Flask) -> None:
     yesterday = date.today() - timedelta(days=1)

--- a/src/pcapi/scheduled_tasks/titelive_clock.py
+++ b/src/pcapi/scheduled_tasks/titelive_clock.py
@@ -12,27 +12,27 @@ from pcapi.models.feature import FeatureToggle
 from pcapi.scheduled_tasks import utils
 from pcapi.scheduled_tasks.decorators import cron_context
 from pcapi.scheduled_tasks.decorators import cron_require_feature
-from pcapi.scheduled_tasks.decorators import log_cron
+from pcapi.scheduled_tasks.decorators import log_cron_with_transaction
 
 
 install_logging()
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 @cron_require_feature(FeatureToggle.SYNCHRONIZE_TITELIVE_PRODUCTS)
 def synchronize_titelive_things(app):
     synchronize_data_for_provider("TiteLiveThings")
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 @cron_require_feature(FeatureToggle.SYNCHRONIZE_TITELIVE_PRODUCTS_DESCRIPTION)
 def synchronize_titelive_thing_descriptions(app):
     synchronize_data_for_provider("TiteLiveThingDescriptions")
 
 
-@log_cron
+@log_cron_with_transaction
 @cron_context
 @cron_require_feature(FeatureToggle.SYNCHRONIZE_TITELIVE_PRODUCTS_THUMBS)
 def synchronize_titelive_thing_thumbs(app):

--- a/tests/scheduled_tasks/decorators_test.py
+++ b/tests/scheduled_tasks/decorators_test.py
@@ -8,7 +8,7 @@ from pcapi.core.testing import override_features
 from pcapi.models.feature import FeatureToggle
 from pcapi.scheduled_tasks.decorators import cron_context
 from pcapi.scheduled_tasks.decorators import cron_require_feature
-from pcapi.scheduled_tasks.decorators import log_cron
+from pcapi.scheduled_tasks.decorators import log_cron_with_transaction
 from pcapi.scheduled_tasks.logger import CronStatus
 
 
@@ -67,7 +67,7 @@ class LogCronTest:
     @patch("pcapi.scheduled_tasks.decorators.build_cron_log_message")
     def test_should_call_logger_with_builded_message(self, mock_cron_log_builder, mock_logger_info, mock_time):
         # Given
-        @log_cron
+        @log_cron_with_transaction
         def decorated_function(*args):
             return "expected result"
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10863


## But de la pull request

Corriger le problème du cron `update_booking_used` qui ne fonctionne plus depuis 3 mois.
Éviter que le problème se reproduise sur d'autres cron

##  Implémentation

- Wrap de la méthode appelée au moment d'exécuter les crons pour permettre de remettre la base de données dans un état correct
​
##  Informations supplémentaires

- Correction des logs qui n'affichaient rien en cas d'exception sur le cron pour prévenir de la date d'arrêt
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
