### PR TITLE
(PC-10071) FIX: remove isPermanent filter

### DIFF
--- a/src/pcapi/admin/custom_views/venue_view.py
+++ b/src/pcapi/admin/custom_views/venue_view.py
@@ -114,7 +114,7 @@ class VenueView(BaseAdminView):
         )
 
         super().update_model(new_venue_form, venue)
-        search.async_index_venues([venue])
+        search.async_index_venue_ids([venue.id])
 
         if has_siret_changed and old_siret:
             update_offer_and_stock_id_at_providers(venue, old_siret)

--- a/src/pcapi/core/offerers/api.py
+++ b/src/pcapi/core/offerers/api.py
@@ -72,7 +72,7 @@ def update_venue(venue: Venue, contact_data: venues_serialize.VenueContactModel 
     venue.fill_venue_type_code_from_label()
 
     repository.save(venue)
-    search.async_index_venues([venue])
+    search.async_index_venue_ids([venue.id])
 
     indexing_modifications_fields = set(modifications.keys()) & set(VENUE_ALGOLIA_INDEXED_FIELDS)
     if indexing_modifications_fields or contact_data:
@@ -113,7 +113,7 @@ def create_venue(venue_data: PostVenueBodyModel) -> Venue:
 
     repository.save(venue)
 
-    search.async_index_venues([venue])
+    search.async_index_venue_ids([venue.id])
     return venue
 
 

--- a/src/pcapi/core/search/__init__.py
+++ b/src/pcapi/core/search/__init__.py
@@ -43,9 +43,9 @@ def async_index_offer_ids(offer_ids: Iterable[int]) -> None:
             )
 
 
-def async_index_venues(venues: Iterable[Venue]) -> None:
+def async_index_venue_ids(venue_ids: Iterable[int]) -> None:
     """Ask for an asynchronous reindexation of the given list of
-    permanent ``Venue``.
+    permanent ``Venue`` ids.
 
     This function returns quickly. The "real" reindexation will be
     done later through a cron job.
@@ -53,7 +53,6 @@ def async_index_venues(venues: Iterable[Venue]) -> None:
     backends = _get_backends()
     for backend in backends:
         try:
-            venue_ids = [venue.id for venue in venues if venue.isPermanent]
             backend.enqueue_venue_ids(venue_ids)
         except Exception:  # pylint: disable=broad-except
             if settings.IS_RUNNING_TESTS:

--- a/tests/admin/custom_views/venue_view_test.py
+++ b/tests/admin/custom_views/venue_view_test.py
@@ -144,9 +144,9 @@ class VenueViewTest:
     @clean_database
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
-    @patch("pcapi.core.search.async_index_venues")
+    @patch("pcapi.core.search.async_index_venue_ids")
     def test_update_venue_reindex_venue_only(
-        self, mocked_async_index_venues, mocked_async_index_offers_of_venue_ids, mocked_validate_csrf_token, app
+        self, mocked_async_index_venue_ids, mocked_async_index_offers_of_venue_ids, mocked_validate_csrf_token, app
     ):
         AdminFactory(email="user@example.com")
         venue = VenueFactory(isPermanent=False)
@@ -171,7 +171,7 @@ class VenueViewTest:
         venue = Venue.query.get(venue.id)
         assert venue.isPermanent
 
-        mocked_async_index_venues.assert_called_once_with([venue])
+        mocked_async_index_venue_ids.assert_called_once_with([venue.id])
         mocked_async_index_offers_of_venue_ids.assert_not_called()
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10071


## But de la pull request

FIX : lors de l'ajout d'un lieu à la file d'attente d'indexation, on continuait de filtrer et de ne garder que les lieus permanents. Le problème est que ce filtrage a été déplacé au moment de l'indexation afin de désindexer les lieux qui ne sont pas/plus permanents.

Ce qui signifie qu'un lieu qui passe de permanent a non permanent n'était pas ajoute à la file d'attente, et donc pas désindexé.