### PR TITLE
(PC-8443):replace offer price by booking price when counter confirm

### DIFF
--- a/src/pcapi/routes/serialization/bookings_serialize.py
+++ b/src/pcapi/routes/serialization/bookings_serialize.py
@@ -75,7 +75,7 @@ def get_booking_response(booking: Booking) -> GetBookingResponse:
         offerName=booking.stock.offer.product.name,
         offerType=BookingOfferType.EVENEMENT if booking.stock.offer.isEvent else BookingOfferType.EVENEMENT,
         phoneNumber=(booking.user.phoneNumber if booking.stock.offer.product.type == str(EventType.ACTIVATION) else ""),
-        price=booking.stock.price,
+        price=booking.amount,
         quantity=booking.quantity,
         theater=extra_data.get("theater", ""),
         userName=f"{booking.educationalBooking.educationalRedactor.firstName} {booking.educationalBooking.educationalRedactor.lastName}"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-8443


## But de la pull request
En tant qu’acteur culturel
J'aimerais qu’au moment de rentrer une contremarque dans l’onglet Guichet, ça soit le prix de réservation qui s’affiche et non pas le prix de l’offre

##  Implémentation

remplacement du prix - booking.stock.price (prix de l'offre qui peut être mis à jour à n'importe quel moment) par booking.amount (prix enregistré au moment du booking)
​
## Checklist :

- [x ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x ] Branche : pc-XXX-whatever-describe-the-branch
    - [x ] PR : (PC-XXX) Description rapide de l' US
    - [x ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
