### PR TITLE
(PC-fix) openapi: fix venue type code

### DIFF
--- a/src/pcapi/core/offerers/models.py
+++ b/src/pcapi/core/offerers/models.py
@@ -81,27 +81,29 @@ CONSTRAINT_CHECK_HAS_SIRET_XOR_HAS_COMMENT_XOR_IS_VIRTUAL = """
     OR (siret IS NOT NULL AND "isVirtual" IS FALSE)
 """
 
+VENUE_TYPE_CODE_MAPPING = {
+    "VISUAL_ARTS": "Arts visuels, arts plastiques et galeries",
+    "CULTURAL_CENTRE": "Centre culturel",
+    "ARTISTIC_COURSE": "Cours et pratique artistiques",
+    "SCIENTIFIC_CULTURE": "Culture scientifique",
+    "FESTIVAL": "Festival",
+    "GAMES": "Jeux / Jeux vidéos",
+    "BOOKSTORE": "Librairie",
+    "LIBRARY": "Bibliothèque ou médiathèque",
+    "MUSEUM": "Musée",
+    "RECORD_STORE": "Musique - Disquaire",
+    "MUSICAL_INSTRUMENT_STORE": "Musique - Magasin d’instruments",
+    "CONCERT_HALL": "Musique - Salle de concerts",
+    "DIGITAL": "Offre numérique",
+    "PATRIMONY_TOURISM": "Patrimoine et tourisme",
+    "MOVIE": "Cinéma - Salle de projections",
+    "PERFORMING_ARTS": "Spectacle vivant",
+    "CREATIVE_ARTS_STORE": "Magasin arts créatifs",
+    "OTHER": "Autre",
+}
 
-class VenueTypeCode(enum.Enum):
-    VISUAL_ARTS = "Arts visuels, arts plastiques et galeries"
-    CULTURAL_CENTRE = "Centre culturel"
-    ARTISTIC_COURSE = "Cours et pratique artistiques"
-    SCIENTIFIC_CULTURE = "Culture scientifique"
-    FESTIVAL = "Festival"
-    GAMES = "Jeux / Jeux vidéos"
-    BOOKSTORE = "Librairie"
-    LIBRARY = "Bibliothèque ou médiathèque"
-    MUSEUM = "Musée"
-    RECORD_STORE = "Musique - Disquaire"
-    MUSICAL_INSTRUMENT_STORE = "Musique - Magasin d’instruments"
-    CONCERT_HALL = "Musique - Salle de concerts"
-    DIGITAL = "Offre numérique"
-    PATRIMONY_TOURISM = "Patrimoine et tourisme"
-    MOVIE = "Cinéma - Salle de projections"
-    PERFORMING_ARTS = "Spectacle vivant"
-    CREATIVE_ARTS_STORE = "Magasin arts créatifs"
-    OTHER = "Autre"
 
+class BaseVenueTypeCode(enum.Enum):
     @classmethod
     def __get_validators__(cls):
         cls.lookup = {v: k.name for v, k in cls.__members__.items()}
@@ -115,8 +117,15 @@ class VenueTypeCode(enum.Enum):
             raise ValueError(f"{v}: invalide")
 
     @classmethod
-    def from_label(cls, label: str) -> "VenueTypeCode":
+    def from_label(cls, label: str) -> "BaseVenueTypeCode":
         return {code.value: code.name for code in cls}[label]
+
+
+VenueTypeCode = enum.Enum("VenueTypeCode", VENUE_TYPE_CODE_MAPPING, type=BaseVenueTypeCode)
+VenueTypeCodeKey = enum.Enum(
+    "VenueTypeCodeKey",
+    {name: name for name, _ in VENUE_TYPE_CODE_MAPPING.items()},
+)
 
 
 class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, NeedsValidationMixin):

--- a/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -2,7 +2,6 @@ import typing
 
 from pcapi.core.offerers import models as offerers_models
 from pcapi.routes.serialization import venues_serialize
-from pcapi.serialization.utils import to_camel
 
 from . import BaseModel
 
@@ -15,11 +14,6 @@ class VenueAccessibilityModel(BaseModel):
 
 
 class VenueResponse(BaseModel):
-    class Config:
-        orm_mode = True
-        alias_generator = to_camel
-        allow_population_by_field_name = True
-
     id: int
     name: str
     latitude: typing.Optional[float]
@@ -31,7 +25,7 @@ class VenueResponse(BaseModel):
     withdrawalDetails: typing.Optional[str]
     address: typing.Optional[str]
     postalCode: typing.Optional[str]
-    venueTypeCode: typing.Optional[offerers_models.VenueTypeCode]
+    venueTypeCode: typing.Optional[offerers_models.VenueTypeCodeKey]
     description: typing.Optional[venues_serialize.VenueDescription]  # type: ignore
     contact: typing.Optional[venues_serialize.VenueContactModel]
     accessibility: VenueAccessibilityModel


### PR DESCRIPTION
## But de la pull request

Faire en sorte que l'enum VenueTypeCode dans openapi.json contienne les codes et non les labels.

Avec quelques petites modifications, on était arrivé à faire en sorte que SQLA et Pydantic gèrent venue.venueTypeCode en utilisant le nom (code) et jamais la valeur (label) de l'enum. Mais ça coince côté spectree lors de la génération du fichier openapi.json : c'est la valeur de l'enum qui est utilisée et je n'ai pas trouvé de moyen de changer ce comportement.

Donc cette PR propose de créer deux enums pour répondre à ce problème. C'est étrange, ce n'est pas idéal (pour ne pas dire pas très élégant), mais... ça fonctionne.

Si quelqu'un a une meilleure idée, je suis preneur.