### PR TITLE
(PC-10836): save lastProviderId for offers and stocks imported with pc stocks api

### DIFF
--- a/src/pcapi/workers/synchronize_stocks_job.py
+++ b/src/pcapi/workers/synchronize_stocks_job.py
@@ -2,17 +2,22 @@ import logging
 
 from pcapi.core.offerers.repository import find_venue_by_id
 from pcapi.core.providers import api
+from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.workers import worker
 from pcapi.workers.decorators import job
 
+
+PASS_CULTURE_STOCKS_PROVIDER_NAME = "PCAPIStocks"
 
 logger = logging.getLogger(__name__)
 
 
 @job(worker.low_queue)
 def synchronize_stocks_job(stock_details, venue_id: str) -> None:
+    pc_provider = get_provider_by_local_class(PASS_CULTURE_STOCKS_PROVIDER_NAME)
+
     venue = find_venue_by_id(venue_id)
-    operations = api.synchronize_stocks(stock_details, venue)
+    operations = api.synchronize_stocks(stock_details, venue, provider_id=pc_provider.id)
     logger.info(
         "Processed stocks synchronization",
         extra={

--- a/tests/routes/pro/post_venue_stocks_test.py
+++ b/tests/routes/pro/post_venue_stocks_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from pcapi.core.offerers.factories import ApiKeyFactory
 from pcapi.core.offerers.factories import DEFAULT_CLEAR_API_KEY
+from pcapi.core.offerers.factories import ProviderFactory
 import pcapi.core.offers.factories as offers_factories
 
 from tests.conftest import TestClient
@@ -15,6 +16,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 @patch("pcapi.core.providers.api.synchronize_stocks")
 def test_accepts_request(mock_synchronize_stocks, app):
+    api_stocks_provider = ProviderFactory(name="Pass Culture API Stocks", localClass="PCAPIStocks")
     offerer = offers_factories.OffererFactory(siren=123456789)
     venue = offers_factories.VenueFactory(managingOfferer=offerer, id=3)
     ApiKeyFactory(offerer=offerer)
@@ -48,6 +50,7 @@ def test_accepts_request(mock_synchronize_stocks, app):
             },
         ],
         venue,
+        provider_id=api_stocks_provider.id,
     )
 
 
@@ -57,6 +60,7 @@ def test_accepts_request(mock_synchronize_stocks, app):
 )
 @patch("pcapi.core.providers.api.synchronize_stocks")
 def test_accepts_request_with_price(mock_synchronize_stocks, price, expected_price, app):
+    api_stocks_provider = ProviderFactory(name="Pass Culture API Stocks", localClass="PCAPIStocks")
     offerer = offers_factories.OffererFactory(siren=123456789)
     venue = offers_factories.VenueFactory(managingOfferer=offerer, id=3)
     ApiKeyFactory(offerer=offerer)
@@ -82,6 +86,7 @@ def test_accepts_request_with_price(mock_synchronize_stocks, price, expected_pri
             }
         ],
         venue,
+        provider_id=api_stocks_provider.id,
     )
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10836


## But de la pull request
Taguer les offres importées via l'API Stocks en type "offres importées" 

##  Implémentation
- Ajout d'un nouveau `Provider` pass Culture API Stocks.
- Utiliser ce nouveau provider comme lastProvider pour les offres importées via l'API Stocks.

​
##  Informations supplémentaires


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
