### PR TITLE
(PC-11055): make adage jwt fields optional for auth but required for actions

### DIFF
--- a/src/pcapi/core/educational/api.py
+++ b/src/pcapi/core/educational/api.py
@@ -22,6 +22,7 @@ from pcapi.models import db
 from pcapi.repository import repository
 from pcapi.repository import transaction
 from pcapi.routes.adage_iframe.serialization.adage_authentication import AuthenticatedInformation
+from pcapi.routes.adage_iframe.serialization.adage_authentication import RedactorInformation
 from pcapi.utils.mailing import build_pc_pro_offer_link
 from pcapi.utils.mailing import format_booking_date_for_email
 from pcapi.utils.mailing import format_booking_hours_for_email
@@ -43,7 +44,7 @@ def _create_redactor(redactor_informations: AuthenticatedInformation) -> Educati
     return redactor
 
 
-def book_educational_offer(redactor_informations: AuthenticatedInformation, stock_id: int) -> EducationalBooking:
+def book_educational_offer(redactor_informations: RedactorInformation, stock_id: int) -> EducationalBooking:
     redactor = educational_repository.find_redactor_by_email(redactor_informations.email)
     if not redactor:
         redactor = _create_redactor(redactor_informations)

--- a/src/pcapi/core/educational/exceptions.py
+++ b/src/pcapi/core/educational/exceptions.py
@@ -7,7 +7,7 @@ class EducationalInstitutionUnknown(ClientError):
 
 
 class StockNotBookable(ClientError):
-    def __init__(self, stock_id) -> None:
+    def __init__(self, stock_id: int) -> None:
         super().__init__("stock", f"Le stock {stock_id} n'est pas réservable")
 
 
@@ -19,12 +19,12 @@ class EducationalYearNotFound(ClientError):
 
 
 class OfferIsNotEducational(ClientError):
-    def __init__(self, offer_id) -> None:
+    def __init__(self, offer_id: int) -> None:
         super().__init__("offer", f"L'offre {offer_id} n'est pas une offre éducationnelle")
 
 
 class OfferIsNotEvent(ClientError):
-    def __init__(self, offer_id) -> None:
+    def __init__(self, offer_id: int) -> None:
         super().__init__("offer", f"L'offre {offer_id} n'est pas une offre évènementielle")
 
 
@@ -61,4 +61,8 @@ class EducationalBookingIsRefused(Exception):
 
 
 class BookingIsCancelled(Exception):
+    pass
+
+
+class MissingRequiredRedactorInformation(Exception):
     pass

--- a/src/pcapi/routes/adage_iframe/bookings.py
+++ b/src/pcapi/routes/adage_iframe/bookings.py
@@ -4,10 +4,14 @@ from pcapi.connectors.api_adage import AdageException
 from pcapi.connectors.api_adage import InstitutionalProjectRedactorNotFoundException
 from pcapi.core.educational import api as educational_api
 from pcapi.core.educational import exceptions
+from pcapi.core.educational.exceptions import MissingRequiredRedactorInformation
 from pcapi.core.offers import exceptions as offers_exceptions
 from pcapi.models.api_errors import ApiErrors
 from pcapi.routes.adage_iframe import blueprint
 from pcapi.routes.adage_iframe.security import adage_jwt_required
+from pcapi.routes.adage_iframe.serialization.adage_authentication import (
+    get_redactor_information_from_adage_authentication,
+)
 from pcapi.routes.adage_iframe.serialization.adage_authentication import AuthenticatedInformation
 from pcapi.routes.adage_iframe.serialization.educational_booking import BookEducationalOfferRequest
 from pcapi.routes.adage_iframe.serialization.educational_booking import BookEducationalOfferResponse
@@ -18,20 +22,15 @@ logger = logging.getLogger(__name__)
 
 
 @blueprint.adage_iframe.route("/bookings", methods=["POST"])
-@spectree_serialize(api=blueprint.api, response_model=BookEducationalOfferResponse, on_error_statuses=[400])
+@spectree_serialize(api=blueprint.api, response_model=BookEducationalOfferResponse, on_error_statuses=[400, 403])
 @adage_jwt_required
 def book_educational_offer(
-    authenticated_information: AuthenticatedInformation, body: BookEducationalOfferRequest
+    body: BookEducationalOfferRequest,
+    authenticated_information: AuthenticatedInformation,
 ) -> BookEducationalOfferResponse:
-    if authenticated_information.uai is None:
-        raise ApiErrors(
-            {"global": "Vous devez sélectionner un établissement scolaire pour pouvoir effectuer une pré-réservation"},
-            status_code=400,
-        )
-
     try:
         booking = educational_api.book_educational_offer(
-            redactor_informations=authenticated_information,
+            redactor_informations=get_redactor_information_from_adage_authentication(authenticated_information),
             stock_id=body.stockId,
         )
     except AdageException as exception:
@@ -47,6 +46,19 @@ def book_educational_offer(
             {"global": "La récupération des informations du rédacteur de projet via Adage a échoué"},
             status_code=500,
         )
+
+    except MissingRequiredRedactorInformation:
+        logger.info(
+            "Could not book offer: missing information in adage jwt",
+            extra={"authenticated_information": authenticated_information.dict()},
+        )
+        raise ApiErrors(
+            {
+                "authorization": "Des informations sur le rédacteur de projet, et nécessaires à la préréservation, sont manquantes"
+            },
+            status_code=403,
+        )
+
     except InstitutionalProjectRedactorNotFoundException:
         logger.info(
             "Could not book offer: redactor does not exist in Adage",

--- a/src/pcapi/routes/adage_iframe/serialization/adage_authentication.py
+++ b/src/pcapi/routes/adage_iframe/serialization/adage_authentication.py
@@ -1,7 +1,14 @@
 import enum
+import logging
 from typing import Optional
 
 from pydantic import BaseModel
+from pydantic import ValidationError
+
+from pcapi.core.educational.exceptions import MissingRequiredRedactorInformation
+
+
+logger = logging.getLogger(__name__)
 
 
 class AdageFrontRoles(enum.Enum):
@@ -10,9 +17,9 @@ class AdageFrontRoles(enum.Enum):
 
 
 class AuthenticatedInformation(BaseModel):
-    civility: str
-    lastname: str
-    firstname: str
+    civility: Optional[str]
+    lastname: Optional[str]
+    firstname: Optional[str]
     email: str
     uai: Optional[str]
 
@@ -22,3 +29,21 @@ class AuthenticatedResponse(BaseModel):
 
     class Config:
         use_enum_values = True
+
+
+class RedactorInformation(BaseModel):
+    civility: str
+    lastname: str
+    firstname: str
+    email: str
+    uai: str
+
+
+def get_redactor_information_from_adage_authentication(
+    authenticated_information: AuthenticatedInformation,
+) -> RedactorInformation:
+    try:
+        redactor_information: RedactorInformation = RedactorInformation(**authenticated_information.dict())
+    except ValidationError:
+        raise MissingRequiredRedactorInformation()
+    return redactor_information

--- a/tests/routes/adage_iframe/get_authenticate_test.py
+++ b/tests/routes/adage_iframe/get_authenticate_test.py
@@ -9,9 +9,6 @@ from tests.routes.adage_iframe.utils_create_test_token import create_adage_jwt_f
 
 class Returns200Test:
     valid_user = {
-        "civilite": "Mme.",
-        "nom": "LAPROF",
-        "prenom": "Sabine",
         "mail": "sabine.laprof@example.com",
         "uai": "EAU123",
     }


### PR DESCRIPTION

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11055


## But de la pull request

- Rendre les champs autre qu'email optionnel pour l'authentification via jwt
- Rendre ces champs obligatoires pour l'action de préréservation (pas d'autres actions pour le moment)

##  Implémentation

- Rendre les champs optionnels dans le modèle Pydantic `AuthenticatedInformation`
- Nouveau modèle Pydantic `RedactorInformation` avec les même champs mais obligatoires
- Construction du second modèle à partir du premier dans la route `book_educational_offer`
​
##  Informations supplémentaires

- Utilisation des fixtures pytest pour réduire le code identique à l'initialisation des tests
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
