### PR TITLE
(PC-10687) Add libraries in dockerfile for xmlsec1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9.7-slim
 
 ENV PYTHONUNBUFFERED 1
 WORKDIR /usr/local/bin
-RUN apt update && apt-get -y install build-essential libpq-dev
+RUN apt update && apt-get -y install build-essential libpq-dev libffi-dev xmlsec1 libxmlsec1-openssl
 COPY ./requirements.txt ./
 RUN pip install -r ./requirements.txt
 RUN python -m nltk.downloader punkt stopwords


### PR DESCRIPTION
xmlsec1 will be used by PySAML2

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10687

Les dépendances ajoutées proviennent de ces instructions : https://github.com/abarto/flask-pysaml2-example#debianubuntu