### PR TITLE
(PC-11148) compute underage deposit expiration date

### DIFF
--- a/src/pcapi/core/bookings/conf.py
+++ b/src/pcapi/core/bookings/conf.py
@@ -29,12 +29,8 @@ def _get_hours_from_timedelta(td: datetime.timedelta) -> float:
     return td.total_seconds() / 3600
 
 
-def _compute_next_birthday_date(birth_date: datetime.datetime) -> datetime.datetime:
-    if birth_date.replace(year=datetime.date.today().year) > datetime.datetime.now():
-        next_birthday = birth_date.replace(year=datetime.date.today().year)
-    else:
-        next_birthday = birth_date.replace(year=datetime.date.today().year + 1)
-    return next_birthday
+def _compute_eighteenth_birthday(birth_date: datetime.datetime) -> datetime.datetime:
+    return birth_date + relativedelta(years=18)
 
 
 BOOKING_CONFIRMATION_ERROR_CLAUSES = {
@@ -80,7 +76,7 @@ class Grant15LimitConfiguration(BaseLimitConfiguration):
     PHYSICAL_CAP = None
 
     def compute_expiration_date(self, birth_date: datetime.datetime) -> datetime.datetime:
-        return _compute_next_birthday_date(birth_date)
+        return _compute_eighteenth_birthday(birth_date)
 
 
 class Grant16LimitConfiguration(BaseLimitConfiguration):
@@ -89,7 +85,7 @@ class Grant16LimitConfiguration(BaseLimitConfiguration):
     PHYSICAL_CAP = None
 
     def compute_expiration_date(self, birth_date: datetime.datetime) -> datetime.datetime:
-        return _compute_next_birthday_date(birth_date)
+        return _compute_eighteenth_birthday(birth_date)
 
 
 class Grant17LimitConfiguration(BaseLimitConfiguration):
@@ -98,7 +94,7 @@ class Grant17LimitConfiguration(BaseLimitConfiguration):
     PHYSICAL_CAP = None
 
     def compute_expiration_date(self, birth_date: datetime.datetime) -> datetime.datetime:
-        return _compute_next_birthday_date(birth_date)
+        return _compute_eighteenth_birthday(birth_date)
 
 
 class Grant18LimitConfigurationV1(BaseLimitConfiguration):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11148


## But de la pull request

Fixer la date d'expiration du crédit des bénéficiaires 15-17 à la veille de leurs 18 ans.

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
