### PR TITLE
(PC-fix) fix: get ids, not objects

### DIFF
--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_search_objects.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_search_objects.py
@@ -1,7 +1,5 @@
 import logging
 
-from sqlalchemy import orm
-
 from pcapi import settings
 from pcapi.core import search
 from pcapi.models import Offer
@@ -14,10 +12,10 @@ logger = logging.getLogger(__name__)
 def create_industrial_search_indexed_objects() -> None:
     if settings.ALGOLIA_TRIGGER_INDEXATION:
         logger.info("create_industrial_algolia_objects")
-        offer_ids = Offer.query.options(orm.load_only(Offer.id)).all()
+        offer_ids = [offer_id for offer_id, in Offer.query.with_entities(Offer.id)]
         search.unindex_all_offers()
         search.reindex_offer_ids(offer_ids)
 
-        venue_ids = Venue.query.options(orm.load_only(Venue.id)).all()
+        venue_ids = [venue_id for venue_id, in Venue.query.with_entities(Venue.id)]
         search.unindex_all_venues()
         search.reindex_venue_ids(venue_ids)


### PR DESCRIPTION
## But de la pull request

Fix : récupérer les ids des objets, pas les objets eux-mêmes.
