### PR TITLE
(PC-11055) Make firstName, lastName and civility optional for educational redactors

### DIFF
--- a/alembic_version_conflict_detection.txt
+++ b/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-5129a4e3aabb (head)
+418152da3d41 (head)

--- a/src/pcapi/alembic/versions/20211006_418152da3d41_make_some_redactor_fields_optional.py
+++ b/src/pcapi/alembic/versions/20211006_418152da3d41_make_some_redactor_fields_optional.py
@@ -1,0 +1,23 @@
+"""make_some_redactor_fields_optional
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "418152da3d41"
+down_revision = "5129a4e3aabb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("educational_redactor", "civility", existing_type=sa.VARCHAR(length=20), nullable=True)
+    op.alter_column("educational_redactor", "firstName", existing_type=sa.VARCHAR(length=128), nullable=True)
+    op.alter_column("educational_redactor", "lastName", existing_type=sa.VARCHAR(length=128), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("educational_redactor", "lastName", existing_type=sa.VARCHAR(length=128), nullable=False)
+    op.alter_column("educational_redactor", "firstName", existing_type=sa.VARCHAR(length=128), nullable=False)
+    op.alter_column("educational_redactor", "civility", existing_type=sa.VARCHAR(length=20), nullable=False)

--- a/src/pcapi/core/educational/models.py
+++ b/src/pcapi/core/educational/models.py
@@ -91,11 +91,11 @@ class EducationalRedactor(Model):
 
     email: str = Column(String(120), nullable=False, unique=True, index=True)
 
-    firstName: str = Column(String(128), nullable=False)
+    firstName: str = Column(String(128), nullable=True)
 
-    lastName: str = Column(String(128), nullable=False)
+    lastName: str = Column(String(128), nullable=True)
 
-    civility: str = Column(String(20), nullable=False)
+    civility: str = Column(String(20), nullable=True)
 
     educationalBookings = relationship(
         "EducationalBooking",

--- a/src/pcapi/routes/adage_iframe/serialization/adage_authentication.py
+++ b/src/pcapi/routes/adage_iframe/serialization/adage_authentication.py
@@ -32,9 +32,9 @@ class AuthenticatedResponse(BaseModel):
 
 
 class RedactorInformation(BaseModel):
-    civility: str
-    lastname: str
-    firstname: str
+    civility: Optional[str]
+    lastname: Optional[str]
+    firstname: Optional[str]
     email: str
     uai: str
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11055


## But de la pull request

Rendre optionnel certains champs des educational redactor pour permettre à des profils sans info de préréserver des offres EAC
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
