### PR TITLE
(PC-11013) Sets CTA Fields as nullable on SubscriptionMessage

### DIFF
--- a/alembic_version_conflict_detection.txt
+++ b/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-418152da3d41 (head)
+e788c9f3cd3b (head)

--- a/src/pcapi/alembic/versions/20211007_e788c9f3cd3b_subscriptionmesage_set_nullable_cta_.py
+++ b/src/pcapi/alembic/versions/20211007_e788c9f3cd3b_subscriptionmesage_set_nullable_cta_.py
@@ -1,0 +1,23 @@
+"""SubscriptionMesage : set nullable CTA columns
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e788c9f3cd3b"
+down_revision = "418152da3d41"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("beneficiary_subscription_message", "callToActionIcon", existing_type=sa.TEXT(), nullable=True)
+    op.alter_column("beneficiary_subscription_message", "callToActionLink", existing_type=sa.TEXT(), nullable=True)
+    op.alter_column("beneficiary_subscription_message", "callToActionTitle", existing_type=sa.TEXT(), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("beneficiary_subscription_message", "callToActionTitle", existing_type=sa.TEXT(), nullable=False)
+    op.alter_column("beneficiary_subscription_message", "callToActionLink", existing_type=sa.TEXT(), nullable=False)
+    op.alter_column("beneficiary_subscription_message", "callToActionIcon", existing_type=sa.TEXT(), nullable=False)

--- a/src/pcapi/core/subscription/models.py
+++ b/src/pcapi/core/subscription/models.py
@@ -89,10 +89,10 @@ class SubscriptionMessage(PcObject, Model):
 
     userMessage = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
 
-    callToActionTitle = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
+    callToActionTitle = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
 
-    callToActionLink = sqlalchemy.Column(sqlalchemy.Text, nullable=False)
+    callToActionLink = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
 
-    callToActionIcon = sqlalchemy.Column(sqlalchemy.Enum(CallToActionIcon, create_constraint=False), nullable=False)
+    callToActionIcon = sqlalchemy.Column(sqlalchemy.Enum(CallToActionIcon, create_constraint=False), nullable=True)
 
     popOverIcon = sqlalchemy.Column(sqlalchemy.Enum(PopOverIcon, create_constraint=False), nullable=False)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11013


## But de la pull request

Correction suite à relectures : le CTA est optionnel sur certains cas d'interface
Du coup, les champs en base doivent être optionnels

##  Implémentation

N/A.
##  Informations supplémentaires

N/A.
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)