### PR TITLE
(PC-10926) : adapt handle_expired_bookings cron to educational bookings

### DIFF
--- a/src/pcapi/core/bookings/factories.py
+++ b/src/pcapi/core/bookings/factories.py
@@ -3,6 +3,7 @@ import datetime
 import factory
 
 from pcapi.core.educational.factories import EducationalBookingFactory as EducationalBookingSubFactory
+from pcapi.core.educational.factories import PendingEducationalBookingFactory as PendingEducationalBookingSubFactory
 from pcapi.core.educational.factories import UsedEducationalBookingFactory as UsedEducationalBookingSubFactory
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.testing import BaseFactory
@@ -81,6 +82,14 @@ class UsedEducationalBookingFactory(BookingFactory):
     status = models.BookingStatus.USED
     isUsed = True
     dateUsed = factory.LazyFunction(datetime.datetime.now)
+    userId = None
+    user = None
+
+
+class PendingEducationalBookingFactory(BookingFactory):
+    educationalBooking = factory.SubFactory(PendingEducationalBookingSubFactory)
+    stock = factory.SubFactory(offers_factories.EducationalEventStockFactory)
+    status = models.BookingStatus.PENDING
     userId = None
     user = None
 

--- a/src/pcapi/core/educational/factories.py
+++ b/src/pcapi/core/educational/factories.py
@@ -81,3 +81,8 @@ class EducationalBookingFactory(BaseFactory):
 
 class UsedEducationalBookingFactory(EducationalBookingFactory):
     status = EducationalBookingStatus.USED_BY_INSTITUTE
+
+
+class PendingEducationalBookingFactory(EducationalBookingFactory):
+    status = None
+    confirmationLimitDate = datetime.datetime.utcnow() + datetime.timedelta(days=15)

--- a/tests/core/bookings/test_repository.py
+++ b/tests/core/bookings/test_repository.py
@@ -1597,28 +1597,22 @@ class FindExpiringBookingsTest:
             book_offer = offers_factories.OfferFactory(subcategoryId=subcategories.LIVRE_PAPIER.id)
             movie_offer = offers_factories.OfferFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
 
-            book_booking_before_new_delay = bookings_factories.BookingFactory(
-                stock__offer=book_offer, dateCreated=datetime.utcnow()
+            movie_booking = bookings_factories.IndividualBookingFactory(
+                stock__offer=movie_offer, dateCreated=datetime.utcnow()
             )
-            movie_booking = bookings_factories.BookingFactory(stock__offer=movie_offer, dateCreated=datetime.utcnow())
-
-            print("book_booking_before_new_delay.dateCreated", book_booking_before_new_delay.dateCreated)
 
             frozen_time.move_to("2021-08-06 15:00:00")
-            book_booking_new_expiry_delay = bookings_factories.BookingFactory(
+            book_booking_new_expiry_delay = bookings_factories.IndividualBookingFactory(
                 stock__offer=book_offer, dateCreated=datetime.utcnow()
             )
-            bookings_factories.BookingFactory(stock__offer=movie_offer, dateCreated=datetime.utcnow())
-
-            bookings = booking_repository.find_expiring_bookings().all()
-            assert bookings == []
+            bookings_factories.IndividualBookingFactory(stock__offer=movie_offer, dateCreated=datetime.utcnow())
 
             frozen_time.move_to("2021-08-17 17:00:00")
 
-            bookings = booking_repository.find_expiring_bookings().all()
-            assert bookings == [book_booking_new_expiry_delay]
+            bookings = booking_repository.find_expiring_individual_bookings_query().all()
+            assert bookings == [book_booking_new_expiry_delay.individualBooking]
 
             frozen_time.move_to("2021-09-01 17:00:00")
 
-            bookings = booking_repository.find_expiring_bookings().all()
-            assert set(bookings) == {book_booking_new_expiry_delay, movie_booking, book_booking_before_new_delay}
+            bookings = booking_repository.find_expiring_individual_bookings_query().all()
+            assert set(bookings) == {book_booking_new_expiry_delay.individualBooking, movie_booking.individualBooking}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10926


## But de la pull request

- Adapter le cron handle_expired_bookings aux réservations éducationnelles. Les règles d'expiration sont différentes (cf ticket)

##  Implémentation

- décomposition en deux fonctions `handle_expired_individual_bookings` et `handle_expired_educaitonal_bookings`
- Factorisation de la partie `update` dans une fonction commune `cancelled_expired_bookings` prenant une query différente en pramètre (en fonction du type de booking)
​
##  Informations supplémentaires

- Creation d'une factory `PendingEducationalBookingFactory`
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
