### PR TITLE
(PC-11183) Set educonnect student_level field as optional

### DIFF
--- a/src/pcapi/core/users/external/educonnect/api.py
+++ b/src/pcapi/core/users/external/educonnect/api.py
@@ -99,12 +99,22 @@ def get_educonnect_user(saml_response: str) -> models.EduconnectUser:
             educonnect_id=educonnect_identity[_get_field_oid("57")][0],
             first_name=educonnect_identity["givenName"][0],
             last_name=educonnect_identity["sn"][0],
+            logout_url=educonnect_identity[_get_field_oid("5")][0],
             saml_request_id=saml_request_id,
-            student_level=educonnect_identity[_get_field_oid("73")][0],
+            student_level=educonnect_identity.get(_get_field_oid("73"), [None])[0],
         )
+    except KeyError as exception:
+        logger.error(
+            "Key error raised when parsing educonnect saml response: %s",
+            repr(exception),
+            extra={"saml_request_id": saml_request_id},
+        )
+        raise exceptions.ParsingError()
     except Exception as exception:
         logger.error(
-            "Error when parsing educonnect saml response %s", exception, extra={"saml_request_id": saml_request_id}
+            "Error when parsing educonnect saml response: %s",
+            repr(exception),
+            extra={"saml_request_id": saml_request_id},
         )
         raise exceptions.ParsingError()
 

--- a/src/pcapi/core/users/external/educonnect/models.py
+++ b/src/pcapi/core/users/external/educonnect/models.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import datetime
+from typing import Optional
 
 
 @dataclass
@@ -9,5 +10,6 @@ class EduconnectUser:
     educonnect_id: str
     first_name: str
     last_name: str
+    logout_url: str
     saml_request_id: str
-    student_level: str
+    student_level: Optional[str]

--- a/src/pcapi/routes/saml/educonnect.py
+++ b/src/pcapi/routes/saml/educonnect.py
@@ -44,6 +44,7 @@ def on_educonnect_authentication_response() -> None:
             "educonnect_id": educonnect_user.educonnect_id,
             "first_name": educonnect_user.first_name,
             "last_name": educonnect_user.last_name,
+            "logout_url": educonnect_user.logout_url,
             "saml_request_id": educonnect_user.saml_request_id,
             "student_level": educonnect_user.student_level,
         },

--- a/tests/routes/saml/educonnect_test.py
+++ b/tests/routes/saml/educonnect_test.py
@@ -27,6 +27,7 @@ def test_on_educonnect_authentication_response(mock_get_educonnect_saml_client, 
         "urn:oid:1.3.6.1.4.1.20326.10.999.1.57": [
             "e6759833fb379e0340322889f2a367a5a5150f1533f80dfe963d21e43e33f7164b76cc802766cdd33c6645e1abfd1875"
         ],
+        "urn:oid:1.3.6.1.4.1.20326.10.999.1.5": ["https://educonnect.education.gouv.fr/Logout"],
         "urn:oid:1.3.6.1.4.1.20326.10.999.1.67": ["2006-08-18"],
         "urn:oid:1.3.6.1.4.1.20326.10.999.1.73": ["2212"],
         "urn:oid:1.3.6.1.4.1.20326.10.999.1.6": ["2021-10-08 11:51:33.437"],
@@ -43,6 +44,7 @@ def test_on_educonnect_authentication_response(mock_get_educonnect_saml_client, 
         "educonnect_id": "e6759833fb379e0340322889f2a367a5a5150f1533f80dfe963d21e43e33f7164b76cc802766cdd33c6645e1abfd1875",
         "first_name": "Max",
         "last_name": "SENS",
+        "logout_url": "https://educonnect.education.gouv.fr/Logout",
         "saml_request_id": "id-XXMmsDBrJGm1N0761",
         "student_level": "2212",
     }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11183


## But de la pull request

Le champ `FrEduCtEleveNiveau` n'est en fait pas présent dans la requête :( 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
