### PR TITLE
(PC-10957) : Add inapp message when Jouve's application is rejected

### DIFF
--- a/src/pcapi/admin/custom_views/support_view.py
+++ b/src/pcapi/admin/custom_views/support_view.py
@@ -16,6 +16,7 @@ from pcapi.admin import base_configuration
 from pcapi.connectors.beneficiaries import jouve_backend
 import pcapi.core.fraud.api as fraud_api
 import pcapi.core.fraud.models as fraud_models
+from pcapi.core.subscription import messages as subscription_messages
 import pcapi.core.subscription.models as subscription_models
 import pcapi.core.users.api as users_api
 import pcapi.core.users.models as users_models
@@ -241,6 +242,8 @@ class BeneficiaryView(base_configuration.BaseAdminView):
             review.reason += " ; Redirigé vers DMS"
             user_emails.send_document_verification_error_email(user.email, "unread-document")
             flask.flash(f"L'utilisateur {user.firstName} {user.lastName} à été redirigé vers DMS")
+        elif review.review == fraud_models.FraudReviewStatus.KO.value:
+            subscription_messages.on_fraud_review_ko(user)
         db.session.add(review)
         db.session.commit()
 

--- a/src/pcapi/core/subscription/messages.py
+++ b/src/pcapi/core/subscription/messages.py
@@ -14,3 +14,12 @@ def create_message_jouve_manual_review(user: users_models.User, application_id: 
         popOverIcon=models.PopOverIcon.CLOCK,
     )
     repository.save(message)
+
+
+def on_fraud_review_ko(user: users_models.User) -> None:
+    message = models.SubscriptionMessage(
+        user=user,
+        userMessage="Ton dossier a été rejeté. Tu n'es pas éligible au pass culture.",
+        popOverIcon=models.PopOverIcon.INFO,
+    )
+    repository.save(message)

--- a/tests/admin/custom_views/support_view_test.py
+++ b/tests/admin/custom_views/support_view_test.py
@@ -6,6 +6,7 @@ from pcapi import settings
 import pcapi.core.fraud.factories as fraud_factories
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.mails.testing as mails_testing
+from pcapi.core.subscription import models as subscription_models
 from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 import pcapi.core.users.factories as users_factories
@@ -235,6 +236,11 @@ class BeneficiaryValidationViewTest:
         assert review.author == admin
         assert review.review == fraud_models.FraudReviewStatus.KO
         assert user.isBeneficiary is False
+
+        assert subscription_models.SubscriptionMessage.query.count() == 1
+        message = subscription_models.SubscriptionMessage.query.first()
+        assert message.popOverIcon == subscription_models.PopOverIcon.INFO
+        assert message.userMessage == "Ton dossier a été rejeté. Tu n'es pas éligible au pass culture."
 
     def test_return_to_dms(self, client):
         user = users_factories.UserFactory(isBeneficiary=False)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10957


## But de la pull request

Ajout d'un message inapp quand un dossier Jouve est rejeté manuellement

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
