### PR TITLE
Pc 10144 use User from individual booking and not from booking

### DIFF
--- a/src/pcapi/admin/custom_views/booking_view.py
+++ b/src/pcapi/admin/custom_views/booking_view.py
@@ -12,6 +12,7 @@ from wtforms import validators
 from pcapi.admin.base_configuration import BaseCustomAdminView
 import pcapi.core.bookings.api as bookings_api
 from pcapi.core.bookings.models import Booking
+from pcapi.core.bookings.models import IndividualBooking
 from pcapi.core.offers.models import Stock
 from pcapi.domain.client_exceptions import ClientError
 from pcapi.models.api_errors import ApiErrors
@@ -49,7 +50,7 @@ class BookingView(BaseCustomAdminView):
                 token = search_form.token.data.strip().upper()
                 booking = (
                     Booking.query.filter_by(token=token)
-                    .options(joinedload(Booking.user))
+                    .options(joinedload(Booking.individualBooking).joinedload(IndividualBooking.user))
                     .options(joinedload(Booking.stock).joinedload(Stock.offer))
                     .one_or_none()
                 )
@@ -61,7 +62,7 @@ class BookingView(BaseCustomAdminView):
                     cancel_form = CancelForm(booking_id=booking.id)
         elif "id" in request.args:
             booking = (
-                Booking.query.options(joinedload(Booking.user))
+                Booking.query.options(joinedload(Booking.individualBooking).joinedload(IndividualBooking.user))
                 .options(joinedload(Booking.stock).joinedload(Stock.offer))
                 .get(request.args["id"])
             )

--- a/src/pcapi/core/bookings/factories.py
+++ b/src/pcapi/core/bookings/factories.py
@@ -1,7 +1,6 @@
 import datetime
 
 import factory
-from factory.declarations import LazyAttribute
 
 from pcapi.core.educational.factories import EducationalBookingFactory as EducationalBookingSubFactory
 from pcapi.core.educational.factories import PendingEducationalBookingFactory as PendingEducationalBookingSubFactory
@@ -23,7 +22,7 @@ class BookingFactory(BaseFactory):
     quantity = 1
     stock = factory.SubFactory(offers_factories.StockFactory)
     token = factory.LazyFunction(random_token)
-    user = factory.SubFactory(users_factories.BeneficiaryGrant18Factory)
+    user = None
     amount = factory.SelfAttribute("stock.price")
     status = models.BookingStatus.CONFIRMED
 
@@ -115,14 +114,14 @@ class IndividualBookingSubFactory(BaseFactory):
 
 class IndividualBookingFactory(BookingFactory):
     individualBooking = factory.SubFactory(IndividualBookingSubFactory)
-    user = LazyAttribute(lambda booking: booking.individualBooking.user)
+    user = None
 
 
 class CancelledIndividualBookingFactory(CancelledBookingFactory):
     individualBooking = factory.SubFactory(IndividualBookingSubFactory)
-    user = LazyAttribute(lambda booking: booking.individualBooking.user)
+    user = None
 
 
 class UsedIndividualBookingFactory(UsedBookingFactory):
     individualBooking = factory.SubFactory(IndividualBookingSubFactory)
-    user = LazyAttribute(lambda booking: booking.individualBooking.user)
+    user = None

--- a/src/pcapi/core/bookings/models.py
+++ b/src/pcapi/core/bookings/models.py
@@ -224,9 +224,7 @@ class Booking(PcObject, Model):
 
         token = self.activationCode.code if self.activationCode else self.token
 
-        return (
-            url.replace("{token}", token).replace("{offerId}", humanize(offer.id)).replace("{email}", self.user.email)
-        )
+        return url.replace("{token}", token).replace("{offerId}", humanize(offer.id)).replace("{email}", self.email)
 
     @staticmethod
     def restize_internal_error(ie: Exception) -> list[str]:
@@ -288,6 +286,16 @@ class Booking(PcObject, Model):
 
         if self.educationalBooking is not None:
             return self.educationalBooking.educationalRedactor.lastName
+
+        return None
+
+    @property
+    def publicName(self) -> Optional[str]:
+        if self.individualBooking is not None:
+            return self.individualBooking.user.publicName
+
+        if self.educationalBooking is not None:
+            return f"{self.educationalBooking.educationalRedactor.firstName} {self.educationalBooking.educationalRedactor.lastName}"
 
         return None
 

--- a/src/pcapi/core/offers/api.py
+++ b/src/pcapi/core/offers/api.py
@@ -448,7 +448,7 @@ def upsert_stocks(
 
     for stock in edited_stocks:
         previous_beginning = edited_stocks_previous_beginnings[stock.id]
-        if stock.beginningDatetime != previous_beginning:
+        if stock.beginningDatetime != previous_beginning and not stock.offer.isEducational:
             _notify_beneficiaries_upon_stock_edit(stock)
     search.async_index_offer_ids([offer.id])
 

--- a/src/pcapi/core/users/repository.py
+++ b/src/pcapi/core/users/repository.py
@@ -7,6 +7,8 @@ from dateutil.relativedelta import relativedelta
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.query import Query
 
+from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.bookings.models import IndividualBooking
 from pcapi.domain.beneficiary_pre_subscription.validator import _is_postal_code_eligible
 from pcapi.domain.favorite.favorite import FavoriteDomain
 from pcapi.infrastructure.repository.favorite import favorite_domain_converter
@@ -144,8 +146,9 @@ def find_favorites_domain_by_beneficiary(beneficiary_identifier: int) -> list[Fa
         Offer.query.filter(Offer.id.in_(offer_ids))
         .join(Stock)
         .join(Booking)
-        .filter(Booking.userId == beneficiary_identifier)
-        .filter(Booking.isCancelled == False)
+        .join(IndividualBooking)
+        .filter(IndividualBooking.userId == beneficiary_identifier)
+        .filter(Booking.status != BookingStatus.CANCELLED)
         .with_entities(
             Booking.id.label("booking_id"),
             Booking.quantity,

--- a/src/pcapi/emails/beneficiary_booking_cancellation.py
+++ b/src/pcapi/emails/beneficiary_booking_cancellation.py
@@ -1,15 +1,15 @@
 import datetime
 
-from pcapi.models import Booking
+from pcapi.core.bookings.models import IndividualBooking
 from pcapi.utils.date import get_date_formatted_for_email
 from pcapi.utils.date import get_time_formatted_for_email
 from pcapi.utils.date import utc_datetime_to_department_timezone
 from pcapi.utils.human_ids import humanize
 
 
-def make_beneficiary_booking_cancellation_email_data(booking: Booking) -> dict:
-    stock = booking.stock
-    beneficiary = booking.user
+def make_beneficiary_booking_cancellation_email_data(individual_booking: IndividualBooking) -> dict:
+    stock = individual_booking.booking.stock
+    beneficiary = individual_booking.user
     offer = stock.offer
     event_date = ""
     event_hour = ""
@@ -17,7 +17,7 @@ def make_beneficiary_booking_cancellation_email_data(booking: Booking) -> dict:
     is_event = int(offer.isEvent)
     offer_id = humanize(offer.id)
     offer_name = offer.name
-    price = str(booking.total_amount)
+    price = str(individual_booking.booking.total_amount)
     is_free_offer = 1 if stock.price == 0 else 0
     can_book_again = int(beneficiary.deposit.expirationDate > datetime.datetime.now())
 

--- a/src/pcapi/emails/beneficiary_booking_confirmation.py
+++ b/src/pcapi/emails/beneficiary_booking_confirmation.py
@@ -1,6 +1,6 @@
 from pcapi.core.bookings.constants import BOOKINGS_AUTO_EXPIRY_DELAY
 from pcapi.core.bookings.constants import BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY
-from pcapi.core.bookings.models import Booking
+from pcapi.core.bookings.models import IndividualBooking
 from pcapi.core.categories import subcategories
 from pcapi.utils.date import get_date_formatted_for_email
 from pcapi.utils.date import get_time_formatted_for_email
@@ -8,17 +8,17 @@ from pcapi.utils.date import utc_datetime_to_department_timezone
 from pcapi.utils.human_ids import humanize
 
 
-def retrieve_data_for_beneficiary_booking_confirmation_email(booking: Booking) -> dict:
-    stock = booking.stock
+def retrieve_data_for_beneficiary_booking_confirmation_email(individual_booking: IndividualBooking) -> dict:
+    stock = individual_booking.booking.stock
     offer = stock.offer
     venue = offer.venue
-    beneficiary = booking.user
+    beneficiary = individual_booking.user
 
     is_digital_offer = offer.isDigital
     is_physical_offer = not offer.isEvent and not is_digital_offer
     is_event = offer.isEvent
 
-    if is_digital_offer and booking.activationCode:
+    if is_digital_offer and individual_booking.booking.activationCode:
         can_expire = 0
     else:
         can_expire = int(offer.subcategory.can_expire)
@@ -31,7 +31,7 @@ def retrieve_data_for_beneficiary_booking_confirmation_email(booking: Booking) -
             expiration_delay = BOOKINGS_AUTO_EXPIRY_DELAY.days
 
     department_code = venue.departementCode if not is_digital_offer else beneficiary.departementCode
-    booking_date_in_tz = utc_datetime_to_department_timezone(booking.dateCreated, department_code)
+    booking_date_in_tz = utc_datetime_to_department_timezone(individual_booking.booking.dateCreated, department_code)
 
     beneficiary_first_name = beneficiary.firstName
     formatted_booking_date = get_date_formatted_for_email(booking_date_in_tz)
@@ -41,7 +41,7 @@ def retrieve_data_for_beneficiary_booking_confirmation_email(booking: Booking) -
     offerer_name = venue.managingOfferer.name
     formatted_event_beginning_time = ""
     formatted_event_beginning_date = ""
-    stock_price = f"{booking.total_amount} €" if stock.price > 0 else "Gratuit"
+    stock_price = f"{individual_booking.booking.total_amount} €" if stock.price > 0 else "Gratuit"
     venue_name = venue.publicName if venue.publicName else venue.name
     venue_address = venue.address or ""
     venue_postal_code = venue.postalCode or ""
@@ -49,8 +49,8 @@ def retrieve_data_for_beneficiary_booking_confirmation_email(booking: Booking) -
     is_event_or_physical_offer_stringified_boolean = 1 if is_event or is_physical_offer else 0
     is_physical_offer_stringified_boolean = 1 if is_physical_offer else 0
     is_event_stringified_boolean = 1 if is_event else 0
-    is_single_event_stringified_boolean = 1 if is_event and booking.quantity == 1 else 0
-    is_duo_event_stringified_boolean = 1 if is_event and booking.quantity == 2 else 0
+    is_single_event_stringified_boolean = 1 if is_event and individual_booking.booking.quantity == 1 else 0
+    is_duo_event_stringified_boolean = 1 if is_event and individual_booking.booking.quantity == 2 else 0
     offer_id = humanize(offer.id)
     mediation_id = humanize(offer.activeMediation.id) if offer.activeMediation else "vide"
     if is_event:
@@ -59,16 +59,26 @@ def retrieve_data_for_beneficiary_booking_confirmation_email(booking: Booking) -
         formatted_event_beginning_date = get_date_formatted_for_email(event_beginning_date_in_tz)
 
     is_digital_booking_with_activation_code_and_no_expiration_date = (
-        1 if is_digital_offer and booking.activationCode and not booking.activationCode.expirationDate else 0
+        1
+        if is_digital_offer
+        and individual_booking.booking.activationCode
+        and not individual_booking.booking.activationCode.expirationDate
+        else 0
     )
 
     code_expiration_date = (
-        get_date_formatted_for_email(booking.activationCode.expirationDate)
-        if is_digital_offer and booking.activationCode and booking.activationCode.expirationDate
+        get_date_formatted_for_email(individual_booking.booking.activationCode.expirationDate)
+        if is_digital_offer
+        and individual_booking.booking.activationCode
+        and individual_booking.booking.activationCode.expirationDate
         else ""
     )
 
-    booking_token = booking.activationCode.code if booking.activationCode else booking.token
+    booking_token = (
+        individual_booking.booking.activationCode.code
+        if individual_booking.booking.activationCode
+        else individual_booking.booking.token
+    )
     has_offer_url = 1 if is_digital_offer else 0
     return {
         "MJ-TemplateID": 3094927,
@@ -99,7 +109,7 @@ def retrieve_data_for_beneficiary_booking_confirmation_email(booking: Booking) -
             "can_expire": can_expire,
             "expiration_delay": expiration_delay,
             "has_offer_url": has_offer_url,
-            "digital_offer_url": booking.completedUrl or "",
+            "digital_offer_url": individual_booking.booking.completedUrl or "",
             "offer_withdrawal_details": offer.withdrawalDetails or "",
         },
     }

--- a/src/pcapi/emails/offerer_booking_recap.py
+++ b/src/pcapi/emails/offerer_booking_recap.py
@@ -1,6 +1,6 @@
 from pcapi.core.bookings.constants import BOOKINGS_AUTO_EXPIRY_DELAY
 from pcapi.core.bookings.constants import BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY
-from pcapi.core.bookings.models import Booking
+from pcapi.core.bookings.models import IndividualBooking
 from pcapi.core.categories import subcategories
 from pcapi.models.feature import FeatureToggle
 from pcapi.utils.mailing import build_pc_pro_offer_link
@@ -8,17 +8,18 @@ from pcapi.utils.mailing import format_booking_date_for_email
 from pcapi.utils.mailing import format_booking_hours_for_email
 
 
-def retrieve_data_for_offerer_booking_recap_email(booking: Booking) -> dict:
+def retrieve_data_for_offerer_booking_recap_email(individual_booking: IndividualBooking) -> dict:
+    booking = individual_booking.booking
     offer = booking.stock.offer
     venue = offer.venue
     venue_name = venue.publicName if venue.publicName else venue.name
     offer_name = offer.name
     price = "Gratuit" if booking.stock.price == 0 else f"{booking.stock.price} €"
     quantity = booking.quantity
-    user_email = booking.user.email
-    user_firstname = booking.user.firstName
-    user_lastname = booking.user.lastName
-    user_phoneNumber = booking.user.phoneNumber or ""
+    user_email = individual_booking.user.email
+    user_firstname = individual_booking.user.firstName
+    user_lastname = individual_booking.user.lastName
+    user_phoneNumber = individual_booking.user.phoneNumber or ""
     departement_code = venue.departementCode or "numérique"
     is_event = int(offer.isEvent)
 

--- a/src/pcapi/emails/offerer_expired_bookings.py
+++ b/src/pcapi/emails/offerer_expired_bookings.py
@@ -28,8 +28,8 @@ def _extract_bookings_information_from_bookings_list(bookings: list[Booking]) ->
                 "offer_name": offer.name,
                 "venue_name": offer.venue.publicName if offer.venue.publicName else offer.venue.name,
                 "price": str(stock.price) if stock.price > 0 else "gratuit",
-                "user_name": booking.user.publicName,
-                "user_email": booking.user.email,
+                "user_name": booking.publicName,
+                "user_email": booking.email,
                 "pcpro_offer_link": build_pc_pro_offer_link(offer),
             }
         )

--- a/src/pcapi/emails/user_notification_after_stock_update.py
+++ b/src/pcapi/emails/user_notification_after_stock_update.py
@@ -9,7 +9,7 @@ def retrieve_data_to_warn_user_after_stock_update_affecting_booking(booking: Boo
     stock = booking.stock
     offer = stock.offer
     offer_name = offer.name
-    user_first_name = booking.user.firstName
+    user_first_name = booking.firstName
     venue_name = offer.venue.publicName if offer.venue.publicName else offer.venue.name
     is_event = int(offer.isEvent)
     event_date = ""

--- a/src/pcapi/infrastructure/repository/beneficiary_bookings/beneficiary_bookings_sql_repository.py
+++ b/src/pcapi/infrastructure/repository/beneficiary_bookings/beneficiary_bookings_sql_repository.py
@@ -1,3 +1,4 @@
+from pcapi.core.bookings.models import IndividualBooking
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.models import Mediation
 from pcapi.core.users.models import User
@@ -106,13 +107,14 @@ def _get_stocks_information(offers_ids: list[int]) -> list[object]:
 def _get_bookings_information(beneficiary_id: int) -> list[Booking]:
     offer_activation_subcategories = [subcategories.ACTIVATION_EVENT.id, subcategories.ACTIVATION_THING.id]
     return (
-        Booking.query.join(User, User.id == Booking.userId)
+        Booking.query.join(IndividualBooking)
+        .join(User, User.id == IndividualBooking.userId)
         .join(Stock, Stock.id == Booking.stockId)
         .join(Offer)
         .join(Product, Offer.productId == Product.id)
         .join(Venue, Venue.id == Offer.venueId)
         .outerjoin(ActivationCode, ActivationCode.bookingId == Booking.id)
-        .filter(Booking.userId == beneficiary_id)
+        .filter(IndividualBooking.userId == beneficiary_id)
         .filter(Offer.subcategoryId.notin_(offer_activation_subcategories))
         .distinct(Booking.stockId)
         .order_by(Booking.stockId, Booking.isCancelled, Booking.dateCreated.desc())
@@ -128,8 +130,8 @@ def _get_bookings_information(beneficiary_id: int) -> list[Booking]:
             Booking.quantity,
             Booking.stockId,
             Booking.token,
-            Booking.userId,
             Booking.displayAsEnded,
+            IndividualBooking.userId,
             Offer.id.label("offerId"),
             Offer.name,
             Offer.subcategoryId,

--- a/src/pcapi/model_creators/generic_creators.py
+++ b/src/pcapi/model_creators/generic_creators.py
@@ -6,6 +6,7 @@ from typing import Union
 
 from pcapi.core.bookings import api as bookings_api
 from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.bookings.models import IndividualBooking
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offers.models import Mediation
 from pcapi.core.providers.models import AllocineVenueProvider
@@ -101,7 +102,6 @@ def create_booking(
     if not stock.offer:
         stock.offer = create_offer_with_thing_product(venue)
 
-    booking.user = user
     booking.amount = amount if amount is not None else stock.price
     booking.dateCreated = date_created
     booking.dateUsed = date_used
@@ -114,10 +114,14 @@ def create_booking(
     booking.offerer = offerer
     booking.venue = venue
     booking.token = token if token is not None else random_token()
-    booking.userId = user.id
     booking.cancellationLimitDate = bookings_api.compute_cancellation_limit_date(stock.beginningDatetime, date_created)
 
-    return booking
+    individual_booking = IndividualBooking()
+    individual_booking.user = user
+    individual_booking.userId = user.id
+    individual_booking.booking = booking
+
+    return individual_booking.booking
 
 
 def create_favorite(idx: int = None, mediation: Mediation = None, offer: Offer = None, user: User = None) -> Favorite:

--- a/src/pcapi/notifications/push/transactional_notifications.py
+++ b/src/pcapi/notifications/push/transactional_notifications.py
@@ -42,7 +42,7 @@ def get_bookings_cancellation_notification_data(booking_ids: list[int]) -> Optio
     )
     return TransactionalNotificationData(
         group_id=GroupId.CANCEL_BOOKING.value,
-        user_ids=[booking.userId for booking in bookings],
+        user_ids=[booking.individualBooking.userId for booking in bookings],
         message=TransactionalNotificationMessage(
             title=f"{cancelled_object.capitalize()} annulée",
             body=f"""Ta {cancelled_object} "{bookings[0].stock.offer.name}" a été annulée par l'offreur.""",
@@ -63,7 +63,7 @@ def get_tomorrow_stock_notification_data(stock_id: int) -> Optional[Transactiona
 
     return TransactionalNotificationData(
         group_id=GroupId.TOMORROW_STOCK.value,
-        user_ids=[booking.userId for booking in individual_bookings],
+        user_ids=[individual_booking.userId for individual_booking in individual_bookings],
         message=TransactionalNotificationMessage(
             title=f"{stock.offer.name}, c'est demain !",
             body="Retrouve les détails de la réservation sur l’application pass Culture",

--- a/src/pcapi/repository/reimbursement_queries.py
+++ b/src/pcapi/repository/reimbursement_queries.py
@@ -8,6 +8,7 @@ from sqlalchemy import subquery
 from sqlalchemy.orm import aliased
 
 from pcapi.core.bookings.models import Booking
+from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.bookings.models import EducationalBooking
 from pcapi.core.bookings.models import IndividualBooking
 from pcapi.core.educational.models import EducationalRedactor
@@ -43,6 +44,7 @@ def find_all_offerers_payments(
             payment_date.between(*reimbursement_period, symmetric=True),
             Booking.offererId.in_(offerer_ids),
             Booking.isUsed,
+            Booking.status == BookingStatus.USED,
             (Booking.venueId == venue_id) if venue_id else (Booking.venueId is not None),
         )
         .join(Offerer)

--- a/src/pcapi/routes/pro/bookings.py
+++ b/src/pcapi/routes/pro/bookings.py
@@ -9,7 +9,6 @@ import pcapi.core.bookings.api as bookings_api
 from pcapi.core.bookings.models import Booking
 import pcapi.core.bookings.repository as booking_repository
 import pcapi.core.bookings.validation as bookings_validation
-from pcapi.core.categories import subcategories
 from pcapi.routes.apis import private_api
 from pcapi.routes.apis import public_api
 from pcapi.routes.serialization import serialize
@@ -45,6 +44,8 @@ BASE_CODE_DESCRIPTIONS = {
 }
 
 # @debt api-migration
+# TODO (gvanneste, 2021-10-19) : retravailler cette fonction, notamment check_user_is_logged_in_or_email_is_provided
+# À brûler : juste checker si le user a droit de récupérer les bookings
 @public_api.route("/bookings/token/<token>", methods=["GET"])
 def get_booking_by_token(token: str) -> tuple[str, int]:
     email: Optional[str] = request.args.get("email", None)
@@ -278,14 +279,11 @@ def _create_response_to_get_booking_by_token(booking: Booking) -> dict:
     response = {
         "bookingId": humanize(booking.id),
         "date": date,
-        "email": booking.user.email,
+        "email": booking.email,
         "isUsed": booking.isUsed,
         "offerName": offer_name,
-        "userName": booking.user.publicName,
-        "venueDepartmentCode": venue_departement_code,
+        "userName": booking.publicName,
+        "venueDepartementCode": venue_departement_code,
     }
-
-    if offer.subcategoryId in subcategories.ACTIVATION_SUBCATEGORIES:
-        response.update({"phoneNumber": booking.user.phoneNumber, "dateOfBirth": serialize(booking.user.dateOfBirth)})
 
     return response

--- a/src/pcapi/routes/serialization/bookings_serialize.py
+++ b/src/pcapi/routes/serialization/bookings_serialize.py
@@ -57,38 +57,26 @@ def get_booking_response(booking: Booking) -> GetBookingResponse:
         formula = BookingFormula.VOID
 
     extra_data = booking.stock.offer.extraData or {}
-    is_educational_booking = booking.educationalBookingId is not None
 
     return GetBookingResponse(
         bookingId=humanize(booking.id),
-        dateOfBirth=(
-            format_into_utc_date(booking.user.dateOfBirth)
-            if not is_educational_booking
-            and booking.stock.offer.subcategoryId in subcategories.ACTIVATION_SUBCATEGORIES
-            else ""
-        ),
+        dateOfBirth="",
         datetime=(format_into_utc_date(booking.stock.beginningDatetime) if booking.stock.beginningDatetime else ""),
         ean13=(
             extra_data.get("isbn", "") if booking.stock.offer.subcategoryId in subcategories.BOOK_WITH_ISBN else None
         ),
-        email=booking.educationalBooking.educationalRedactor.email if is_educational_booking else booking.user.email,
+        email=booking.email,
         formula=formula,
         isUsed=booking.isUsed,
         offerId=booking.stock.offer.id,
         publicOfferId=humanize(booking.stock.offer.id),
         offerName=booking.stock.offer.product.name,
         offerType=BookingOfferType.EVENEMENT if booking.stock.offer.isEvent else BookingOfferType.EVENEMENT,
-        phoneNumber=(
-            booking.user.phoneNumber
-            if booking.stock.offer.subcategoryId in subcategories.ACTIVATION_SUBCATEGORIES
-            else ""
-        ),
+        phoneNumber="",
         price=booking.amount,
         quantity=booking.quantity,
         theater=extra_data.get("theater", ""),
-        userName=f"{booking.educationalBooking.educationalRedactor.firstName} {booking.educationalBooking.educationalRedactor.lastName}"
-        if is_educational_booking
-        else booking.user.publicName,
+        userName=booking.publicName,
         venueAddress=booking.venue.address,
         venueDepartmentCode=booking.venue.departementCode,
         venueName=booking.venue.name,

--- a/src/pcapi/routes/webapp/bookings.py
+++ b/src/pcapi/routes/webapp/bookings.py
@@ -4,6 +4,7 @@ from flask import abort
 from flask import jsonify
 from flask_login import current_user
 from flask_login import login_required
+from sqlalchemy.orm import joinedload
 
 import pcapi.core.bookings.api as bookings_api
 from pcapi.core.bookings.models import Booking
@@ -34,7 +35,10 @@ def get_bookings() -> Any:
 @private_api.route("/bookings/<booking_id>", methods=["GET"])
 @login_required
 def get_booking(booking_id: int) -> Any:
-    booking = Booking.query.filter_by(id=dehumanize(booking_id)).first_or_404()
+    booking = (
+        Booking.query.filter_by(id=dehumanize(booking_id)).options(joinedload(Booking.individualBooking)).first_or_404()
+    )
+    booking.userId = booking.individualBooking.userId
 
     return jsonify(as_dict(booking, includes=WEBAPP_GET_BOOKING_INCLUDES)), 200
 

--- a/src/pcapi/templates/admin/booking.html
+++ b/src/pcapi/templates/admin/booking.html
@@ -5,50 +5,50 @@
 <h2>Réservations</h2>
 
 <form action="" method="POST">
-  {{ forms.display_form(search_form, "Rechercher la réservation") }}
+    {{ forms.display_form(search_form, "Rechercher la réservation") }}
 </form>
 
 {% if booking %}
-  <hr>
-  <p>
-    <div><b>Code :</b> {{ booking.token }}</div>
-    <div><b>Bénéficiaire :</b> {{ booking.user.email }} ({{ booking.user.id }})</div>
-    <div><b>Offre :</b> {{ booking.stock.offer.name }}</div>
-    <div><b>Date d'annulation :</b>
-      {% if booking.isCancelled %}
-        {% if booking.cancellationDate %}
-            {{ booking.cancellationDate.strftime('%d/%m/%Y %H:%M') }}
-        {% else %}
-            inconnue
-        {% endif %}
-      {% else %}
-        non annulée
-      {% endif %}
-    </div>
-  </p>
+<hr>
+<p>
+<div><b>Code :</b> {{ booking.token }}</div>
+<div><b>Bénéficiaire :</b> {{ booking.email }} ({{ booking.individualBooking.user.id }})</div>
+<div><b>Offre :</b> {{ booking.stock.offer.name }}</div>
+<div><b>Date d'annulation :</b>
+    {% if booking.isCancelled %}
+    {% if booking.cancellationDate %}
+    {{ booking.cancellationDate.strftime('%d/%m/%Y %H:%M') }}
+    {% else %}
+    inconnue
+    {% endif %}
+    {% else %}
+    non annulée
+    {% endif %}
+</div>
+</p>
 
-  {% if mark_as_used_form %}
-    <p>
-      Si cette réservation a été annulée par erreur (ou
-      frauduleusement) alors qu'elle a en fait été utilisée, il est
-      possible de la marquer comme utilisée.
-    </p>
-    <form action={{ url_for(".uncancel_and_mark_as_used", booking_id=booking.id) }} method="POST">
-      {{ forms.display_form(mark_as_used_form) }}
-      <input class="btn btn-danger" type="submit" value="Marquer comme utilisée">
-    </form>
-  {% endif %}
+{% if mark_as_used_form %}
+<p>
+    Si cette réservation a été annulée par erreur (ou
+    frauduleusement) alors qu'elle a en fait été utilisée, il est
+    possible de la marquer comme utilisée.
+</p>
+<form action={{ url_for(".uncancel_and_mark_as_used", booking_id=booking.id) }} method="POST">
+    {{ forms.display_form(mark_as_used_form) }}
+    <input class="btn btn-danger" type="submit" value="Marquer comme utilisée">
+</form>
+{% endif %}
 
-  {% if cancel_form %}
-    <p>
-      Annuler cette réservation manuellement.
-      <br>
-    </p>
-    <form action={{ url_for(".cancel", booking_id=booking.id) }} method="POST">
-      {{ forms.display_form(cancel_form) }}
-      <input class="btn btn-danger" type="submit" value="Marquer comme annulée">
-    </form>
-  {% endif %}
+{% if cancel_form %}
+<p>
+    Annuler cette réservation manuellement.
+    <br>
+</p>
+<form action={{ url_for(".cancel", booking_id=booking.id) }} method="POST">
+    {{ forms.display_form(cancel_form) }}
+    <input class="btn btn-danger" type="submit" value="Marquer comme annulée">
+</form>
+{% endif %}
 
 {% endif %} {# if booking #}
 

--- a/src/pcapi/templates/mails/offerer_recap_email_after_offerer_cancellation.html
+++ b/src/pcapi/templates/mails/offerer_recap_email_after_offerer_cancellation.html
@@ -1,55 +1,61 @@
 <html>
-    <body>
-        <p id="mail-greeting">Cher partenaire pass Culture,</p>
-        <p id="action">
-            Vous venez d'annuler la réservation de {{ user_name }} ({{ user_email }})
-        </p>
-            <p id="recap">
-                Voici le récapitulatif
-                {% if is_final %}
-                    final des réservations :
-                {% else %}
-                    des réservations à ce jour :
-                {% endif %}
-                <br/> (total {{ number_of_bookings }}) pour {{ stock_name }}
-                {% if stock_date_time %}
-                    <br/> le {{ stock_date_time }},
-                {% endif %}
-                {% if venue.isVirtual %}
-                    <br/> Offre numérique proposée par {{ venue.name }}.
-                {% else %}
-                    <br/> proposé par {{ venue.name }} (Adresse : {{ venue.address }}, {{ venue.postalCode }} {{ venue.city }}).
-                {% endif %}
-            </p>
-            {% if stock_bookings %}
-                <table id="recap-table">
-                    <tr>
-                        <th>Prénom</th>
-                        <th>Nom</th>
-                        <th>Email</th>
-                        {% if booking_is_on_event %}
-                            <th>Code réservation</th>
-                        {% endif %}
-                    </tr>
-                    {% for booking in stock_bookings %}
-                        <tr>
-                            <td>{{ booking.user.firstName }}</td>
-                            <td>{{ booking.user.lastName }}</td>
-                            <td>{{ booking.user.email }}</td>
-                            {% if booking_is_on_event %}
-                                <td>{{ booking.token }}</td>
-                            {% endif %}
-                        </tr>
-                    {% endfor %}
-                </table>
-            {% else %}
-                <p id="no-recap">Aucune réservation</p>
-            {% endif %}
-        <p id="unsubscribe-option">
-            Vous recevez ce message parce que votre adresse e-mail est renseignée comme adresse de contact sur votre offre.
-            <br> Si vous souhaitez modifier l’adresse de contact cliquez ici : <a id="change-email" href="mailto:support@passculture.app?subject=Changer%20l%27adresse%20e-mail%20de%20notification%20des%20r%C3%A9servations">être notifié des réservations à une autre adresse e-mail</a>.
-            <br> Si vous ne souhaitez plus recevoir de notifications de réservations par e-mail, cliquez ici : <a id="remove-email" href="mailto:support@passculture.app?subject=Ne%20plus%20recevoir%20les%20notifications%20de%20r%C3%A9servations">ne plus recevoir les notifications de réservations</a>.
-        </p>
-    </body>
-</html>
 
+<body>
+    <p id="mail-greeting">Cher partenaire pass Culture,</p>
+    <p id="action">
+        Vous venez d'annuler la réservation de {{ user_name }} ({{ user_email }})
+    </p>
+    <p id="recap">
+        Voici le récapitulatif
+        {% if is_final %}
+        final des réservations :
+        {% else %}
+        des réservations à ce jour :
+        {% endif %}
+        <br /> (total {{ number_of_bookings }}) pour {{ stock_name }}
+        {% if stock_date_time %}
+        <br /> le {{ stock_date_time }},
+        {% endif %}
+        {% if venue.isVirtual %}
+        <br /> Offre numérique proposée par {{ venue.name }}.
+        {% else %}
+        <br /> proposé par {{ venue.name }} (Adresse : {{ venue.address }}, {{ venue.postalCode }} {{ venue.city }}).
+        {% endif %}
+    </p>
+    {% if stock_bookings %}
+    <table id="recap-table">
+        <tr>
+            <th>Prénom</th>
+            <th>Nom</th>
+            <th>Email</th>
+            {% if booking_is_on_event %}
+            <th>Code réservation</th>
+            {% endif %}
+        </tr>
+        {% for booking in stock_bookings %}
+        <tr>
+            <td>{{ booking.firstName }}</td>
+            <td>{{ booking.lastName }}</td>
+            <td>{{ booking.email }}</td>
+            {% if booking_is_on_event %}
+            <td>{{ booking.token }}</td>
+            {% endif %}
+        </tr>
+        {% endfor %}
+    </table>
+    {% else %}
+    <p id="no-recap">Aucune réservation</p>
+    {% endif %}
+    <p id="unsubscribe-option">
+        Vous recevez ce message parce que votre adresse e-mail est renseignée comme adresse de contact sur votre offre.
+        <br> Si vous souhaitez modifier l’adresse de contact cliquez ici : <a id="change-email"
+            href="mailto:support@passculture.app?subject=Changer%20l%27adresse%20e-mail%20de%20notification%20des%20r%C3%A9servations">être
+            notifié des réservations à une autre adresse e-mail</a>.
+        <br> Si vous ne souhaitez plus recevoir de notifications de réservations par e-mail, cliquez ici : <a
+            id="remove-email"
+            href="mailto:support@passculture.app?subject=Ne%20plus%20recevoir%20les%20notifications%20de%20r%C3%A9servations">ne
+            plus recevoir les notifications de réservations</a>.
+    </p>
+</body>
+
+</html>

--- a/src/pcapi/utils/mailing.py
+++ b/src/pcapi/utils/mailing.py
@@ -49,9 +49,7 @@ def build_pc_webapp_reset_password_link(token_value: str) -> str:
 
 def extract_users_information_from_bookings(bookings: list[Booking]) -> list[dict]:
     users_keys = ("firstName", "lastName", "email", "contremarque")
-    users_properties = [
-        [booking.user.firstName, booking.user.lastName, booking.user.email, booking.token] for booking in bookings
-    ]
+    users_properties = [[booking.firstName, booking.lastName, booking.email, booking.token] for booking in bookings]
 
     return [dict(zip(users_keys, user_property)) for user_property in users_properties]
 
@@ -106,8 +104,8 @@ def make_validation_email_object(
 def make_offerer_driven_cancellation_email_for_offerer(booking: Booking) -> dict:
     stock_name = booking.stock.offer.name
     venue = booking.venue
-    user_name = booking.user.publicName
-    user_email = booking.user.email
+    user_name = booking.publicName
+    user_email = booking.email
     email_subject = "Confirmation de votre annulation de réservation pour {}, proposé par {}".format(
         stock_name, venue.name
     )

--- a/tests/admin/custom_views/beneficiary_user_view_test.py
+++ b/tests/admin/custom_views/beneficiary_user_view_test.py
@@ -194,8 +194,8 @@ class BeneficiaryUserViewTest:
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_suspend_beneficiary(self, mocked_validate_csrf_token, app):
         admin = users_factories.AdminFactory(email="admin15@example.com")
-        booking = bookings_factories.BookingFactory()
-        beneficiary = booking.user
+        booking = bookings_factories.IndividualBookingFactory()
+        beneficiary = booking.individualBooking.user
 
         client = TestClient(app.test_client()).with_session_auth(admin.email)
         url = f"/pc/back-office/beneficiary_users/suspend?user_id={beneficiary.id}"

--- a/tests/admin/custom_views/suspend_fraudulent_users_by_ids_test.py
+++ b/tests/admin/custom_views/suspend_fraudulent_users_by_ids_test.py
@@ -2,8 +2,7 @@ import io
 
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
-from pcapi.core.bookings.factories import UsedBookingFactory
+from pcapi.core.bookings import factories as booking_factories
 from pcapi.core.users.factories import AdminFactory
 from pcapi.core.users.factories import BeneficiaryGrant18Factory
 
@@ -14,8 +13,8 @@ class SuspendFraudulentUsersByIdsTest:
         admin_user = AdminFactory()
         fraudulent_user_1 = BeneficiaryGrant18Factory(id=5)
         fraudulent_user_2 = BeneficiaryGrant18Factory(id=16)
-        BookingFactory(user=fraudulent_user_1)
-        UsedBookingFactory(user=fraudulent_user_2)
+        booking_factories.IndividualBookingFactory(individualBooking__user=fraudulent_user_1)
+        booking_factories.UsedIndividualBookingFactory(individualBooking__user=fraudulent_user_2)
         user_ids_csv = (io.BytesIO(b"user_id\n5\n16"), "user_ids.csv")
         files = {"user_ids_csv": user_ids_csv}
         headers = {"content-type": "multipart/form-data"}

--- a/tests/core/bookings/test_models.py
+++ b/tests/core/bookings/test_models.py
@@ -50,9 +50,9 @@ def test_save_cancellation_date_postgresql_function():
 
 
 def test_booking_completed_url_gets_normalized():
-    booking = factories.BookingFactory(
+    booking = factories.IndividualBookingFactory(
         token="ABCDEF",
-        user__email="1@example.com",
+        individualBooking__user__email="1@example.com",
         stock__offer__url="example.com?token={token}&email={email}",
     )
     assert booking.completedUrl == "http://example.com?token=ABCDEF&email=1@example.com"

--- a/tests/core/offers/test_api.py
+++ b/tests/core/offers/test_api.py
@@ -181,7 +181,9 @@ class UpsertStocksTest:
         event_reported_in_10_days = now + timedelta(days=10)
         offer = factories.EventOfferFactory()
         existing_stock = factories.StockFactory(offer=offer, beginningDatetime=event_in_4_days)
-        booking = bookings_factories.UsedBookingFactory(stock=existing_stock, dateCreated=booking_made_3_days_ago)
+        booking = bookings_factories.UsedIndividualBookingFactory(
+            stock=existing_stock, dateCreated=booking_made_3_days_ago
+        )
         edited_stock_data = StockEditionBodyModel(
             id=existing_stock.id,
             beginningDatetime=event_reported_in_10_days,
@@ -207,7 +209,7 @@ class UpsertStocksTest:
         event_reported_in_less_48_hours = now + timedelta(days=1)
         offer = factories.EventOfferFactory()
         existing_stock = factories.StockFactory(offer=offer, beginningDatetime=event_in_3_days)
-        booking = bookings_factories.UsedBookingFactory(
+        booking = bookings_factories.UsedIndividualBookingFactory(
             stock=existing_stock, dateCreated=now, dateUsed=date_used_in_48_hours
         )
         edited_stock_data = StockEditionBodyModel(
@@ -654,8 +656,8 @@ class DeleteStockTest:
     def test_delete_stock_cancel_bookings_and_send_emails(self, mocked_send_to_beneficiaries, mocked_send_to_offerer):
         stock = factories.EventStockFactory()
         booking1 = bookings_factories.IndividualBookingFactory(stock=stock)
-        booking2 = bookings_factories.CancelledBookingFactory(stock=stock)
-        booking3 = bookings_factories.UsedBookingFactory(stock=stock)
+        booking2 = bookings_factories.CancelledIndividualBookingFactory(stock=stock)
+        booking3 = bookings_factories.UsedIndividualBookingFactory(stock=stock)
 
         api.delete_stock(stock)
 
@@ -679,7 +681,7 @@ class DeleteStockTest:
 
         assert push_testing.requests[-1] == {
             "group_id": "Cancel_booking",
-            "user_ids": [booking1.userId],
+            "user_ids": [booking1.individualBooking.userId],
             "message": {
                 "body": f"""Ta réservation "{stock.offer.name}" a été annulée par l'offreur.""",
                 "title": "Réservation annulée",

--- a/tests/core/users/external/external_users_test.py
+++ b/tests/core/users/external/external_users_test.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 import pytest
 
 from pcapi.core.bookings.factories import IndividualBookingFactory
+from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.offers.factories import OfferFactory
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import testing as sendinblue_testing
@@ -65,7 +66,9 @@ def test_get_user_attributes():
     b2 = IndividualBookingFactory(
         individualBooking__user=user, amount=10, dateUsed=datetime(2021, 5, 6), stock__offer=offer
     )
-    IndividualBookingFactory(individualBooking__user=user, amount=100, isCancelled=True)  # should be ignored
+    IndividualBookingFactory(
+        individualBooking__user=user, amount=100, status=BookingStatus.CANCELLED
+    )  # should be ignored
 
     last_date_created = max(booking.dateCreated for booking in [b1, b2])
 

--- a/tests/core/users/test_api.py
+++ b/tests/core/users/test_api.py
@@ -269,12 +269,12 @@ class SuspendAccountTest:
 
     def test_suspend_beneficiary(self):
         user = users_factories.BeneficiaryGrant18Factory()
-        cancellable_booking = bookings_factories.BookingFactory(user=user)
+        cancellable_booking = bookings_factories.IndividualBookingFactory(individualBooking__user=user)
         yesterday = datetime.now() - timedelta(days=1)
-        confirmed_booking = bookings_factories.BookingFactory(
-            user=user, cancellation_limit_date=yesterday, status=BookingStatus.CONFIRMED
+        confirmed_booking = bookings_factories.IndividualBookingFactory(
+            individualBooking__user=user, cancellation_limit_date=yesterday, status=BookingStatus.CONFIRMED
         )
-        used_booking = bookings_factories.UsedBookingFactory(user=user)
+        used_booking = bookings_factories.UsedIndividualBookingFactory(individualBooking__user=user)
         actor = users_factories.AdminFactory()
 
         users_api.suspend_account(user, users_constants.SuspensionReason.FRAUD, actor)
@@ -288,7 +288,7 @@ class SuspendAccountTest:
         assert used_booking.status is BookingStatus.USED
 
     def test_suspend_pro(self):
-        booking = bookings_factories.BookingFactory()
+        booking = bookings_factories.IndividualBookingFactory()
         pro = offers_factories.UserOffererFactory(offerer=booking.offerer).user
         actor = users_factories.AdminFactory()
 
@@ -299,7 +299,7 @@ class SuspendAccountTest:
         assert booking.status is BookingStatus.CANCELLED
 
     def test_suspend_pro_with_other_offerer_users(self):
-        booking = bookings_factories.BookingFactory()
+        booking = bookings_factories.IndividualBookingFactory()
         pro = offers_factories.UserOffererFactory(offerer=booking.offerer).user
         offers_factories.UserOffererFactory(offerer=booking.offerer)
         actor = users_factories.AdminFactory()

--- a/tests/core/users/test_repository.py
+++ b/tests/core/users/test_repository.py
@@ -134,7 +134,7 @@ class FindByBeneficiaryTest:
         venue = offers_factories.VenueFactory()
         offer = offers_factories.ThingOfferFactory(venue=venue)
         stock = offers_factories.StockFactory(offer=offer, price=0)
-        booking = bookings_factories.BookingFactory(stock=stock, user=beneficiary)
+        booking = bookings_factories.IndividualBookingFactory(stock=stock, individualBooking__user=beneficiary)
         mediation = offers_factories.MediationFactory(offer=offer)
         favorite = users_factories.FavoriteFactory(mediation=mediation, offer=offer, user=beneficiary)
 

--- a/tests/domain/payments_test.py
+++ b/tests/domain/payments_test.py
@@ -40,7 +40,7 @@ from pcapi.utils.human_ids import humanize
 class CreatePaymentForBookingTest:
     def test_basics(self):
         offerer = offers_factories.OffererFactory(name="offerer", siren="123456")
-        booking = bookings_factories.BookingFactory(stock__offer__venue__managingOfferer=offerer)
+        booking = bookings_factories.IndividualBookingFactory(stock__offer__venue__managingOfferer=offerer)
         reimbursement = BookingReimbursement(booking, PhysicalOffersReimbursement(), Decimal(10))
         batch_date = datetime.utcnow()
 
@@ -60,7 +60,7 @@ class CreatePaymentForBookingTest:
         assert payment.recipientSiren == "123456"
 
     def test_use_iban_and_bic_from_venue(self):
-        booking = bookings_factories.BookingFactory()
+        booking = bookings_factories.IndividualBookingFactory()
         offers_factories.BankInformationFactory(venue=booking.venue, iban="iban1", bic="bic1")
         offers_factories.BankInformationFactory(offerer=booking.offerer, iban="iban2", bic="bic2")
         reimbursement = BookingReimbursement(booking, PhysicalOffersReimbursement(), Decimal(10))
@@ -72,7 +72,7 @@ class CreatePaymentForBookingTest:
         assert payment.bic == "BIC1"
 
     def test_use_iban_and_bic_from_offerer(self):
-        booking = bookings_factories.BookingFactory()
+        booking = bookings_factories.IndividualBookingFactory()
         offers_factories.BankInformationFactory(offerer=booking.offerer, iban="iban", bic="bic")
         reimbursement = BookingReimbursement(booking, PhysicalOffersReimbursement(), Decimal(10))
         batch_date = datetime.utcnow()
@@ -83,7 +83,7 @@ class CreatePaymentForBookingTest:
         assert payment.bic == "BIC"
 
     def test_with_custom_reimbursement_rule(self):
-        booking = bookings_factories.BookingFactory()
+        booking = bookings_factories.IndividualBookingFactory()
         rule = payments_factories.CustomReimbursementRuleFactory(offer=booking.stock.offer, amount=2)
         reimbursement = BookingReimbursement(booking, rule, Decimal(2))
         batch_date = datetime.utcnow()
@@ -231,7 +231,7 @@ class CreatePaymentDetailsTest:
     @pytest.mark.usefixtures("db_session")
     def test_contains_info_on_booking(self):
         # given
-        booking = bookings_factories.BookingFactory(
+        booking = bookings_factories.IndividualBookingFactory(
             dateCreated=datetime(2018, 2, 5),
             dateUsed=datetime(2018, 2, 19),
         )

--- a/tests/emails/beneficiary_booking_cancellation_test.py
+++ b/tests/emails/beneficiary_booking_cancellation_test.py
@@ -15,8 +15,8 @@ from pcapi.emails.beneficiary_booking_cancellation import make_beneficiary_booki
 class MakeBeneficiaryBookingCancellationEmailDataTest:
     def test_should_return_thing_data_when_booking_is_a_thing(self):
         # Given
-        booking = factories.CancelledBookingFactory(
-            user=BeneficiaryGrant18Factory(email="fabien@example.com", firstName="Fabien"),
+        booking = factories.CancelledIndividualBookingFactory(
+            individualBooking__user=BeneficiaryGrant18Factory(email="fabien@example.com", firstName="Fabien"),
             stock=ThingStockFactory(
                 price=10.2,
                 beginningDatetime=datetime.now() - timedelta(days=1),
@@ -26,7 +26,7 @@ class MakeBeneficiaryBookingCancellationEmailDataTest:
         )
 
         # When
-        email_data = make_beneficiary_booking_cancellation_email_data(booking)
+        email_data = make_beneficiary_booking_cancellation_email_data(booking.individualBooking)
 
         # Then
         assert email_data == {
@@ -48,8 +48,8 @@ class MakeBeneficiaryBookingCancellationEmailDataTest:
     @freeze_time("2019-11-26 18:29:20.891028")
     def test_should_return_event_data_when_booking_is_an_event(self):
         # Given
-        booking = factories.CancelledBookingFactory(
-            user=BeneficiaryGrant18Factory(email="fabien@example.com", firstName="Fabien"),
+        booking = factories.CancelledIndividualBookingFactory(
+            individualBooking__user=BeneficiaryGrant18Factory(email="fabien@example.com", firstName="Fabien"),
             stock=EventStockFactory(
                 price=10.2,
                 beginningDatetime=datetime.utcnow(),
@@ -59,7 +59,7 @@ class MakeBeneficiaryBookingCancellationEmailDataTest:
         )
 
         # When
-        email_data = make_beneficiary_booking_cancellation_email_data(booking)
+        email_data = make_beneficiary_booking_cancellation_email_data(booking.individualBooking)
 
         # Then
         assert email_data == {
@@ -80,20 +80,20 @@ class MakeBeneficiaryBookingCancellationEmailDataTest:
 
     def test_should_return_is_free_offer_when_offer_price_equals_to_zero(self):
         # Given
-        booking = factories.CancelledBookingFactory(stock__price=0)
+        booking = factories.CancelledIndividualBookingFactory(stock__price=0)
 
         # When
-        email_data = make_beneficiary_booking_cancellation_email_data(booking)
+        email_data = make_beneficiary_booking_cancellation_email_data(booking.individualBooking)
 
         # Then
         assert email_data["Vars"]["is_free_offer"] == 1
 
     def test_should_return_the_price_multiplied_by_quantity_when_it_is_a_duo_offer(self):
         # Given
-        booking = factories.CancelledBookingFactory(quantity=2, stock__price=10)
+        booking = factories.CancelledIndividualBookingFactory(quantity=2, stock__price=10)
 
         # When
-        email_data = make_beneficiary_booking_cancellation_email_data(booking)
+        email_data = make_beneficiary_booking_cancellation_email_data(booking.individualBooking)
 
         # Then
         assert email_data["Vars"]["offer_price"] == "20.00"

--- a/tests/emails/offerer_booking_recap_test.py
+++ b/tests/emails/offerer_booking_recap_test.py
@@ -16,9 +16,9 @@ def make_booking(**kwargs):
     attributes = dict(
         dateCreated=datetime(2019, 10, 3, 13, 24, 6, tzinfo=timezone.utc),
         token="ABC123",
-        user__firstName="John",
-        user__lastName="Doe",
-        user__email="john@example.com",
+        individualBooking__user__firstName="John",
+        individualBooking__user__lastName="Doe",
+        individualBooking__user__email="john@example.com",
         stock__beginningDatetime=datetime(2019, 11, 6, 14, 59, 5, tzinfo=timezone.utc),
         stock__price=10,
         stock__offer__name="Super événement",
@@ -31,7 +31,7 @@ def make_booking(**kwargs):
         stock__offer__venue__managingOfferer__name="Théâtre du coin",
     )
     attributes.update(kwargs)
-    return bookings_factories.BookingFactory(**attributes)
+    return bookings_factories.IndividualBookingFactory(**attributes)
 
 
 def get_expected_base_email_data(booking, **overrides):
@@ -74,7 +74,7 @@ class OffererBookingRecapTest:
     def test_with_event(self):
         booking = make_booking()
 
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         expected = get_expected_base_email_data(booking)
         assert email_data == expected
@@ -88,7 +88,7 @@ class OffererBookingRecapTest:
             stock__offer__product__subcategoryId=subcategories.LIVRE_PAPIER.id,
         )
 
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         expected = get_expected_base_email_data(
             booking,
@@ -119,7 +119,7 @@ class OffererBookingRecapTest:
             stock__offer__venue__siret=None,
         )
 
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         expected = get_expected_base_email_data(
             booking,
@@ -148,7 +148,7 @@ class OffererBookingRecapTest:
             stock__offer__venue__siret=None,
         )
 
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         expected = get_expected_base_email_data(
             booking,
@@ -176,7 +176,7 @@ class OffererBookingRecapTest:
         )
 
         # When
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         # Then
         expected = get_expected_base_email_data(
@@ -201,7 +201,7 @@ class OffererBookingRecapTest:
         )
 
         # When
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         # Then
         expected = get_expected_base_email_data(booking, must_use_token_for_payment=1)
@@ -215,7 +215,7 @@ class OffererBookingRecapTest:
         )
 
         # When
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         # Then
         expected = get_expected_base_email_data(booking, prix="Gratuit", must_use_token_for_payment=0)
@@ -228,7 +228,7 @@ class OffererBookingRecapTest:
         ActivationCodeFactory(stock=booking.stock, booking=booking, code="code_toto")
 
         # When
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         # Then
         expected = get_expected_base_email_data(booking, must_use_token_for_payment=0)
@@ -245,17 +245,17 @@ class OffererBookingRecapTest:
         )
         digital_stock = offers_factories.StockWithActivationCodesFactory()
         first_activation_code = digital_stock.activationCodes[0]
-        booking = bookings_factories.UsedBookingFactory(
-            user__email="john@example.com",
-            user__firstName="John",
-            user__lastName="Doe",
+        booking = bookings_factories.UsedIndividualBookingFactory(
+            individualBooking__user__email="john@example.com",
+            individualBooking__user__firstName="John",
+            individualBooking__user__lastName="Doe",
             stock__offer=offer,
             activationCode=first_activation_code,
             dateCreated=datetime(2018, 1, 1),
         )
 
         # When
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         # Then
         expected = get_expected_base_email_data(
@@ -281,17 +281,17 @@ class OffererBookingRecapTest:
         )
         digital_stock = offers_factories.StockWithActivationCodesFactory()
         first_activation_code = digital_stock.activationCodes[0]
-        booking = bookings_factories.UsedBookingFactory(
-            user__email="john@example.com",
-            user__firstName="John",
-            user__lastName="Doe",
+        booking = bookings_factories.UsedIndividualBookingFactory(
+            individualBooking__user__email="john@example.com",
+            individualBooking__user__firstName="John",
+            individualBooking__user__lastName="Doe",
             stock__offer=offer,
             activationCode=first_activation_code,
             dateCreated=datetime(2018, 1, 1),
         )
 
         # When
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         # Then
         expected = get_expected_base_email_data(
@@ -314,7 +314,7 @@ class OffererBookingRecapTest:
     def test_should_not_truncate_price(self):
         booking = make_booking(stock__price=5.86)
 
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         expected = get_expected_base_email_data(booking, prix="5.86 €")
         assert email_data == expected
@@ -326,7 +326,7 @@ class OffererBookingRecapTest:
             stock__offer__venue__publicName="Public name",
         )
 
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         expected = get_expected_base_email_data(booking, nom_lieu="Public name")
         assert email_data == expected
@@ -334,10 +334,10 @@ class OffererBookingRecapTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_add_user_phone_number_to_vars(self):
         # given
-        booking = make_booking(user__phoneNumber="0123456789")
+        booking = make_booking(individualBooking__user__phoneNumber="0123456789")
 
         # when
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         # then
         template_vars = email_data["Vars"]
@@ -346,10 +346,10 @@ class OffererBookingRecapTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_add_reply_to_header_with_beneficiary_email(self):
         # given
-        booking = make_booking(user__email="beneficiary@example.com")
+        booking = make_booking(individualBooking__user__email="beneficiary@example.com")
 
         # when
-        email_data = retrieve_data_for_offerer_booking_recap_email(booking)
+        email_data = retrieve_data_for_offerer_booking_recap_email(booking.individualBooking)
 
         # then
         template_headers = email_data["Headers"]

--- a/tests/emails/offerer_expired_bookings_test.py
+++ b/tests/emails/offerer_expired_bookings_test.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from pcapi.core.bookings.constants import BOOKINGS_AUTO_EXPIRY_DELAY
-from pcapi.core.bookings.factories import CancelledBookingFactory
+from pcapi.core.bookings.factories import CancelledIndividualBookingFactory
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import OffererFactory
@@ -23,9 +23,9 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled_with_new_a
     offerer = OffererFactory()
     long_ago = now - timedelta(days=31)
     dvd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
-    expired_today_dvd_booking = CancelledBookingFactory(
-        user__publicName="Dory",
-        user__email="dory@example.com",
+    expired_today_dvd_booking = CancelledIndividualBookingFactory(
+        individualBooking__user__publicName="Dory",
+        individualBooking__user__email="dory@example.com",
         stock__offer__product=dvd,
         stock__offer__name="Memento",
         stock__offer__venue__name="Mnémosyne",
@@ -35,9 +35,9 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled_with_new_a
     )
 
     cd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id)
-    expired_today_cd_booking = CancelledBookingFactory(
-        user__publicName="Dorian",
-        user__email="dorian@example.com",
+    expired_today_cd_booking = CancelledIndividualBookingFactory(
+        individualBooking__user__publicName="Dorian",
+        individualBooking__user__email="dorian@example.com",
         stock__offer__product=cd,
         stock__offer__name="Random Access Memories",
         stock__offer__venue__name="Virgin Megastore",

--- a/tests/emails/user_notification_after_stock_update_test.py
+++ b/tests/emails/user_notification_after_stock_update_test.py
@@ -27,7 +27,7 @@ class RetrieveDataToWarnUserAfterStockUpdateAffectingBookingTest:
             "MJ-TemplateLanguage": True,
             "Vars": {
                 "offer_name": booking.stock.offer.name,
-                "user_first_name": booking.user.firstName,
+                "user_first_name": booking.firstName,
                 "venue_name": booking.venue.name,
                 "event_date": "mardi 20 août 2019",
                 "event_hour": "14h",

--- a/tests/infrastructure/repository/beneficiary_bookings/beneficiary_bookings_sql_repository_test.py
+++ b/tests/infrastructure/repository/beneficiary_bookings/beneficiary_bookings_sql_repository_test.py
@@ -3,9 +3,7 @@ from datetime import timedelta
 
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
-from pcapi.core.bookings.factories import CancelledBookingFactory
-from pcapi.core.bookings.factories import UsedBookingFactory
+import pcapi.core.bookings.factories as booking_factories
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.factories import EventOfferFactory
 from pcapi.core.offers.factories import EventStockFactory
@@ -29,8 +27,8 @@ class BeneficiaryBookingsSQLRepositoryTest:
         beneficiary = BeneficiaryGrant18Factory()
         offer = ThingOfferFactory(isActive=True, url="http://url.com", product__thumbCount=1)
         stock = ThingStockFactory(offer=offer, price=0, quantity=10)
-        booking = UsedBookingFactory(
-            user=beneficiary,
+        booking = booking_factories.UsedIndividualBookingFactory(
+            individualBooking__user=beneficiary,
             stock=stock,
             token="ABCDEF",
             dateCreated=datetime(2020, 4, 22, 0, 0),
@@ -74,8 +72,8 @@ class BeneficiaryBookingsSQLRepositoryTest:
         beneficiary_2 = BeneficiaryGrant18Factory()
         offer = EventOfferFactory()
         stock = EventStockFactory(offer=offer)
-        booking1 = BookingFactory(user=beneficiary_1, stock=stock)
-        BookingFactory(user=beneficiary_2, stock=stock)
+        booking1 = booking_factories.IndividualBookingFactory(individualBooking__user=beneficiary_1, stock=stock)
+        booking_factories.IndividualBookingFactory(individualBooking__user=beneficiary_2, stock=stock)
 
         # When
         result = BeneficiaryBookingsSQLRepository().get_beneficiary_bookings(beneficiary_id=beneficiary_1.id)
@@ -94,9 +92,9 @@ class BeneficiaryBookingsSQLRepositoryTest:
         stock1 = EventStockFactory(offer=offer1)
         stock2 = EventStockFactory(offer=offer2)
         stock3 = EventStockFactory(offer=offer3)
-        BookingFactory(user=beneficiary, stock=stock1)
-        BookingFactory(user=beneficiary, stock=stock2)
-        booking3 = BookingFactory(user=beneficiary, stock=stock3)
+        booking_factories.IndividualBookingFactory(individualBooking__user=beneficiary, stock=stock1)
+        booking_factories.IndividualBookingFactory(individualBooking__user=beneficiary, stock=stock2)
+        booking3 = booking_factories.IndividualBookingFactory(individualBooking__user=beneficiary, stock=stock3)
 
         # When
         result = BeneficiaryBookingsSQLRepository().get_beneficiary_bookings(beneficiary_id=beneficiary.id)
@@ -114,8 +112,12 @@ class BeneficiaryBookingsSQLRepositoryTest:
         beneficiary = BeneficiaryGrant18Factory()
         offer = EventOfferFactory()
         stock = EventStockFactory(offer=offer)
-        booking1 = CancelledBookingFactory(user=beneficiary, stock=stock, dateCreated=two_days_ago)
-        CancelledBookingFactory(user=beneficiary, stock=stock, dateCreated=three_days_ago)
+        booking1 = booking_factories.CancelledIndividualBookingFactory(
+            individualBooking__user=beneficiary, stock=stock, dateCreated=two_days_ago
+        )
+        booking_factories.CancelledIndividualBookingFactory(
+            individualBooking__user=beneficiary, stock=stock, dateCreated=three_days_ago
+        )
 
         # When
         result = BeneficiaryBookingsSQLRepository().get_beneficiary_bookings(beneficiary_id=beneficiary.id)
@@ -134,22 +136,22 @@ class BeneficiaryBookingsSQLRepositoryTest:
 
         beneficiary = BeneficiaryGrant18Factory()
 
-        booking1 = BookingFactory(
-            user=beneficiary,
+        booking1 = booking_factories.IndividualBookingFactory(
+            individualBooking__user=beneficiary,
             stock=EventStockFactory(
                 beginningDatetime=three_days,
                 bookingLimitDatetime=now,
             ),
         )
-        booking2 = BookingFactory(
-            user=beneficiary,
+        booking2 = booking_factories.IndividualBookingFactory(
+            individualBooking__user=beneficiary,
             stock=EventStockFactory(
                 beginningDatetime=two_days,
                 bookingLimitDatetime=now,
             ),
         )
-        booking3 = BookingFactory(
-            user=beneficiary,
+        booking3 = booking_factories.IndividualBookingFactory(
+            individualBooking__user=beneficiary,
             stock=EventStockFactory(
                 beginningDatetime=two_days_bis,
                 bookingLimitDatetime=now,

--- a/tests/models/payment_test.py
+++ b/tests/models/payment_test.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 
 import pytest
 
+import pcapi.core.bookings.factories as booking_factories
 import pcapi.core.users.factories as users_factories
-from pcapi.model_creators.generic_creators import create_booking
 from pcapi.model_creators.generic_creators import create_payment
 from pcapi.model_creators.generic_creators import create_payment_message
 from pcapi.model_creators.generic_creators import create_payment_status
@@ -100,7 +100,7 @@ class PaymentDateTest:
         def test_payment_date_should_return_payment_date_for_status_sent(self, app):
             # Given
             beneficiary = users_factories.BeneficiaryGrant18Factory()
-            booking = create_booking(user=beneficiary)
+            booking = booking_factories.IndividualBookingFactory(individualBooking__user=beneficiary)
             today = datetime.utcnow()
             payment_message = create_payment_message(name="mon message")
             payment = create_payment(booking, booking.offerer, 5, payment_message=payment_message)
@@ -118,7 +118,7 @@ class PaymentDateTest:
         def test_payment_date_should_return_oldest_payment_date_for_status_sent_if_several(self, app):
             # Given
             beneficiary = users_factories.BeneficiaryGrant18Factory()
-            booking = create_booking(user=beneficiary)
+            booking = booking_factories.IndividualBookingFactory(individualBooking__user=beneficiary)
             today = datetime.utcnow()
             yesterday = datetime.utcnow() - timedelta(days=1)
             payment_message = create_payment_message(name="mon message")
@@ -138,7 +138,7 @@ class PaymentDateTest:
         def test_payment_date_should_return_no_payment_date_for_status_pending(self, app):
             # Given
             beneficiary = users_factories.BeneficiaryGrant18Factory()
-            booking = create_booking(user=beneficiary)
+            booking = booking_factories.IndividualBookingFactory(individualBooking__user=beneficiary)
             today = datetime.utcnow()
             payment_message = create_payment_message(name="mon message")
             payment = create_payment(booking, booking.offerer, 5, payment_message=payment_message)

--- a/tests/repository/payment_queries_test.py
+++ b/tests/repository/payment_queries_test.py
@@ -7,7 +7,6 @@ import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as factories
 import pcapi.core.users.factories as users_factories
-from pcapi.model_creators.generic_creators import create_booking
 from pcapi.model_creators.generic_creators import create_payment
 from pcapi.model_creators.generic_creators import create_payment_message
 from pcapi.models.bank_information import BankInformationStatus
@@ -22,7 +21,7 @@ class FindPaymentsByMessageTest:
     def test_returns_payments_matching_message(self, app):
         # given
         beneficiary = users_factories.BeneficiaryGrant18Factory()
-        booking = create_booking(user=beneficiary)
+        booking = bookings_factories.IndividualBookingFactory(individualBooking__user=beneficiary)
         offerer = booking.offerer
         transaction1 = create_payment_message(name="XML1")
         transaction2 = create_payment_message(name="XML2")
@@ -49,7 +48,7 @@ class FindPaymentsByMessageTest:
     def test_returns_nothing_if_message_is_not_matched(self, app):
         # given
         beneficiary = users_factories.BeneficiaryGrant18Factory()
-        booking = create_booking(user=beneficiary)
+        booking = bookings_factories.IndividualBookingFactory(individualBooking__user=beneficiary)
         offerer = booking.offerer
         message1 = create_payment_message(name="XML1")
         message2 = create_payment_message(name="XML2")
@@ -77,7 +76,7 @@ class FindNotProcessableWithBankInformationTest:
         venue = offers_factories.VenueFactory(postalCode="34000", departementCode="34")
         offer = offers_factories.ThingOfferFactory(product=product, venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=0, quantity=2)
-        booking = bookings_factories.UsedBookingFactory(stock=stock, quantity=2)
+        booking = bookings_factories.UsedIndividualBookingFactory(stock=stock, quantity=2)
         payment = factories.PaymentFactory(booking=booking, amount=10)
         factories.PaymentStatusFactory(payment=payment, status=TransactionStatus.NOT_PROCESSABLE)
 
@@ -99,7 +98,7 @@ class FindNotProcessableWithBankInformationTest:
         )
         offer = offers_factories.ThingOfferFactory(product=product, venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=0)
-        booking = bookings_factories.UsedBookingFactory(stock=stock)
+        booking = bookings_factories.UsedIndividualBookingFactory(stock=stock)
         not_processable_payment = factories.PaymentFactory(booking=booking, amount=10)
         factories.PaymentStatusFactory(payment=not_processable_payment, status=TransactionStatus.NOT_PROCESSABLE)
         offers_factories.BankInformationFactory(offerer=user_offerer.offerer)
@@ -122,7 +121,7 @@ class FindNotProcessableWithBankInformationTest:
         )
         offer = offers_factories.ThingOfferFactory(product=product, venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=0)
-        booking = bookings_factories.UsedBookingFactory(stock=stock)
+        booking = bookings_factories.UsedIndividualBookingFactory(stock=stock)
         not_processable_payment = factories.PaymentFactory(
             booking=booking, amount=10, iban="CF13QSDFGH456789", bic="QSDFGH8Z555"
         )
@@ -146,7 +145,7 @@ class FindNotProcessableWithBankInformationTest:
         )
         offer = offers_factories.ThingOfferFactory(product=product, venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=0)
-        booking = bookings_factories.UsedBookingFactory(stock=stock)
+        booking = bookings_factories.UsedIndividualBookingFactory(stock=stock)
         not_processable_payment = factories.PaymentFactory(
             booking=booking, amount=10, iban="CF13QSDFGH456789", bic="QSDFGH8Z555"
         )
@@ -173,7 +172,7 @@ class FindNotProcessableWithBankInformationTest:
         )
         offer = offers_factories.ThingOfferFactory(product=product, venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=0)
-        booking = bookings_factories.UsedBookingFactory(stock=stock)
+        booking = bookings_factories.UsedIndividualBookingFactory(stock=stock)
         not_processable_payment = factories.PaymentFactory(
             booking=booking, amount=10, iban="CF13QSDFGH456789", bic="QSDFGH8Z555"
         )
@@ -189,7 +188,7 @@ class FindNotProcessableWithBankInformationTest:
 
 @pytest.mark.usefixtures("db_session")
 def test_has_payment():
-    booking = bookings_factories.UsedBookingFactory()
+    booking = bookings_factories.UsedIndividualBookingFactory()
     assert not payment_queries.has_payment(booking)
 
     factories.PaymentFactory(booking=booking)

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -14,7 +14,7 @@ from google.cloud import tasks_v2
 import pytest
 
 from pcapi import settings
-from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings import factories as booking_factories
 from pcapi.core.bookings.factories import CancelledIndividualBookingFactory
 from pcapi.core.bookings.factories import IndividualBookingFactory
 from pcapi.core.fraud import factories as fraud_factories
@@ -1316,8 +1316,8 @@ class ValidatePhoneNumberTest:
 
 
 def test_suspend_account(app):
-    booking = BookingFactory()
-    user = booking.user
+    booking = booking_factories.IndividualBookingFactory()
+    user = booking.individualBooking.user
 
     access_token = create_access_token(identity=user.email)
     test_client = TestClient(app.test_client())

--- a/tests/routes/pro/delete_stock_test.py
+++ b/tests/routes/pro/delete_stock_test.py
@@ -34,7 +34,7 @@ class Returns200Test:
                 "body": f"""Ta commande "{offer.name}" a été annulée par l'offreur.""",
                 "title": "Commande annulée",
             },
-            "user_ids": [booking.userId],
+            "user_ids": [booking.individualBooking.userId],
         }
 
 

--- a/tests/routes/pro/get_all_bookings_test.py
+++ b/tests/routes/pro/get_all_bookings_test.py
@@ -293,14 +293,14 @@ class Returns200Test:
 
     @testing.override_features(**{FeatureToggle.IMPROVE_BOOKINGS_PERF.name: True})
     def when_user_is_linked_to_a_valid_offerer(self, app):
-        booking = bookings_factories.UsedBookingFactory(
+        booking = bookings_factories.UsedIndividualBookingFactory(
             dateCreated=datetime(2020, 8, 11, 12, 0, 0),
             dateUsed=datetime(2020, 8, 13, 12, 0, 0),
             token="ABCDEF",
-            user__email="beneficiary@example.com",
-            user__firstName="Hermione",
-            user__lastName="Granger",
-            user__phoneNumber="0100000000",
+            individualBooking__user__email="beneficiary@example.com",
+            individualBooking__user__firstName="Hermione",
+            individualBooking__user__lastName="Granger",
+            individualBooking__user__phoneNumber="0100000000",
         )
         pro_user = users_factories.ProFactory(email="pro@example.com")
         offers_factories.UserOffererFactory(user=pro_user, offerer=booking.offerer)

--- a/tests/routes/pro/get_booking_by_token_v2_test.py
+++ b/tests/routes/pro/get_booking_by_token_v2_test.py
@@ -22,8 +22,8 @@ class Returns200Test:
     def test_when_user_has_rights_and_regular_offer(self, client):
         # Given
         past = datetime.now() - timedelta(days=2)
-        booking = bookings_factories.BookingFactory(
-            user__email="beneficiary@example.com",
+        booking = bookings_factories.IndividualBookingFactory(
+            individualBooking__user__email="beneficiary@example.com",
             stock__beginningDatetime=past,
             stock__offer=offers_factories.EventOfferFactory(
                 extraData={
@@ -119,7 +119,7 @@ class Returns200Test:
 
     def test_when_api_key_is_provided_and_rights_and_regular_offer(self, client):
         # Given
-        booking = bookings_factories.BookingFactory()
+        booking = bookings_factories.IndividualBookingFactory()
         ApiKeyFactory(offerer=booking.offerer, prefix="test_prefix")
 
         # When
@@ -131,7 +131,7 @@ class Returns200Test:
 
     def test_when_user_has_rights_and_regular_offer_and_token_in_lower_case(self, client):
         # Given
-        booking = bookings_factories.BookingFactory(
+        booking = bookings_factories.IndividualBookingFactory(
             stock__beginningDatetime=datetime.now() - timedelta(days=2),
         )
         user_offerer = offers_factories.UserOffererFactory(offerer=booking.offerer)
@@ -159,7 +159,7 @@ class Returns401Test:
 class Returns403Test:
     def test_when_user_doesnt_have_rights_and_token_exists(self, client):
         # Given
-        booking = bookings_factories.BookingFactory()
+        booking = bookings_factories.IndividualBookingFactory()
         another_pro_user = offers_factories.UserOffererFactory().user
 
         # When
@@ -174,7 +174,7 @@ class Returns403Test:
 
     def test_when_given_api_key_not_related_to_booking_offerer(self, client):
         # Given
-        booking = bookings_factories.BookingFactory()
+        booking = bookings_factories.IndividualBookingFactory()
         ApiKeyFactory()  # another offerer's API key
 
         # When
@@ -191,7 +191,7 @@ class Returns403Test:
     def test_when_booking_not_confirmed(self, client):
         # Given
         next_week = datetime.utcnow() + timedelta(weeks=1)
-        booking = bookings_factories.BookingFactory(stock__beginningDatetime=next_week)
+        booking = bookings_factories.IndividualBookingFactory(stock__beginningDatetime=next_week)
         pro_user = offers_factories.UserOffererFactory(offerer=booking.offerer).user
 
         # When

--- a/tests/routes/pro/patch_booking_by_token_test.py
+++ b/tests/routes/pro/patch_booking_by_token_test.py
@@ -6,16 +6,7 @@ import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.users import factories as users_factories
-from pcapi.model_creators.generic_creators import create_booking
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_user_offerer
-from pcapi.model_creators.generic_creators import create_venue
-from pcapi.model_creators.specific_creators import create_event_occurrence
-from pcapi.model_creators.specific_creators import create_offer_with_event_product
-from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence
-from pcapi.model_creators.specific_creators import create_stock_with_event_offer
 from pcapi.models import Booking
-from pcapi.repository import repository
 from pcapi.utils.human_ids import humanize
 
 from tests.conftest import TestClient
@@ -25,11 +16,10 @@ from tests.conftest import TestClient
 class Returns204Test:
     class WhenUserIsAnonymousTest:
         def expect_booking_to_be_used(self, app):
-            booking = bookings_factories.BookingFactory(token="ABCDEF")
+            booking = bookings_factories.IndividualBookingFactory(token="ABCDEF")
 
             url = (
-                f"/bookings/token/{booking.token}?"
-                f"email={booking.user.email}&offer_id={humanize(booking.stock.offerId)}"
+                f"/bookings/token/{booking.token}?" f"email={booking.email}&offer_id={humanize(booking.stock.offerId)}"
             )
             response = TestClient(app.test_client()).patch(url)
 
@@ -40,7 +30,7 @@ class Returns204Test:
 
     class WhenUserIsLoggedInTest:
         def expect_booking_to_be_used(self, app):
-            booking = bookings_factories.BookingFactory(token="ABCDEF")
+            booking = bookings_factories.IndividualBookingFactory(token="ABCDEF")
             pro_user = users_factories.ProFactory(email="pro@example.com")
             offers_factories.UserOffererFactory(user=pro_user, offerer=booking.offerer)
 
@@ -53,7 +43,7 @@ class Returns204Test:
             assert booking.status is BookingStatus.USED
 
         def expect_booking_with_token_in_lower_case_to_be_used(self, app):
-            booking = bookings_factories.BookingFactory(token="ABCDEF")
+            booking = bookings_factories.IndividualBookingFactory(token="ABCDEF")
             pro_user = users_factories.ProFactory(email="pro@example.com")
             offers_factories.UserOffererFactory(user=pro_user, offerer=booking.offerer)
 
@@ -68,7 +58,9 @@ class Returns204Test:
         # FIXME: what is the purpose of this test? Are we testing that
         # Flask knows how to URL-decode parameters?
         def expect_booking_to_be_used_with_special_char_in_url(self, app):
-            booking = bookings_factories.BookingFactory(token="ABCDEF", user__email="user+plus@example.com")
+            booking = bookings_factories.IndividualBookingFactory(
+                token="ABCDEF", individualBooking__user__email="user+plus@example.com"
+            )
             pro_user = users_factories.ProFactory(email="pro@example.com")
             offers_factories.UserOffererFactory(user=pro_user, offerer=booking.offerer)
 
@@ -88,13 +80,8 @@ class Returns400Test:
     class WhenUserIsAnonymousTest:
         def when_email_is_missing(self, app):
             # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking)
-            url = "/bookings/token/{}?&offer_id={}".format(booking.token, humanize(stock.offer.id))
+            booking = bookings_factories.IndividualBookingFactory()
+            url = "/bookings/token/{}?&offer_id={}".format(booking.token, humanize(booking.stock.offer.id))
 
             # When
             response = TestClient(app.test_client()).patch(url)
@@ -107,13 +94,8 @@ class Returns400Test:
 
         def when_offer_id_is_missing(self, app):
             # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking)
-            url = "/bookings/token/{}?email={}".format(booking.token, user.email)
+            booking = bookings_factories.IndividualBookingFactory()
+            url = "/bookings/token/{}?email={}".format(booking.token, booking.email)
 
             # When
             response = TestClient(app.test_client()).patch(url)
@@ -124,12 +106,7 @@ class Returns400Test:
 
         def when_both_email_and_offer_id_are_missing(self, app):
             # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking)
+            booking = bookings_factories.IndividualBookingFactory()
             url = "/bookings/token/{}".format(booking.token)
 
             # When
@@ -147,22 +124,16 @@ class Returns400Test:
 class Returns403Test:  # Forbidden
     def when_user_is_not_attached_to_linked_offerer(self, app):
         # Given
-        user = users_factories.BeneficiaryGrant18Factory.build()
-        pro = users_factories.ProFactory.build(email="pro@example.com")
+        pro = users_factories.ProFactory(email="pro@example.com")
+        booking = bookings_factories.IndividualBookingFactory()
 
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        stock = create_stock_with_event_offer(offerer, venue, price=0)
-        booking = create_booking(user=user, stock=stock, venue=venue)
-        repository.save(booking, pro)
-        booking_id = booking.id
-        url = "/bookings/token/{}?email={}".format(booking.token, user.email)
+        url = "/bookings/token/{}?email={}".format(booking.token, booking.email)
 
         # When
-        response = TestClient(app.test_client()).with_session_auth("pro@example.com").patch(url)
+        response = TestClient(app.test_client()).with_session_auth(pro.email).patch(url)
 
         # Then
-        booking = Booking.query.get(booking_id)
+        booking = Booking.query.get(booking.id)
         assert response.status_code == 403
         assert response.json["global"] == [
             "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
@@ -190,14 +161,10 @@ class Returns404Test:
     class WhenUserIsAnonymousTest:
         def when_booking_does_not_exist(self, app):
             # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking)
+            booking = bookings_factories.IndividualBookingFactory()
+
             url = "/bookings/token/{}?email={}&offer_id={}".format(
-                booking.token, "wrong.email@test.com", humanize(stock.offer.id)
+                booking.token, "wrong.email@test.com", humanize(booking.stock.offer.id)
             )
 
             # When
@@ -210,58 +177,40 @@ class Returns404Test:
     class WhenUserIsLoggedInTest:
         def when_user_is_not_editor_and_email_does_not_match(self, app):
             # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            users_factories.AdminFactory(email="admin@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking)
-            booking_id = booking.id
+            user_admin = users_factories.AdminFactory(email="admin@example.com")
+            booking = bookings_factories.IndividualBookingFactory()
             url = "/bookings/token/{}?email={}".format(booking.token, "wrong@example.com")
 
             # When
-            response = TestClient(app.test_client()).with_session_auth("admin@example.com").patch(url)
+            response = TestClient(app.test_client()).with_session_auth(user_admin.email).patch(url)
 
             # Then
             assert response.status_code == 404
-            assert Booking.query.get(booking_id).isUsed is False
+            assert Booking.query.get(booking.id).isUsed is False
 
         def when_email_has_special_characters_but_is_not_url_encoded(self, app):
             # Given
             user = users_factories.BeneficiaryGrant18Factory(email="user+plus@example.com")
             user_admin = users_factories.AdminFactory(email="admin@example.com")
-            offerer = create_offerer()
-            user_offerer = create_user_offerer(user_admin, offerer)
-            venue = create_venue(offerer)
-            offer = create_offer_with_event_product(venue, event_name="Event Name")
-            event_occurrence = create_event_occurrence(offer)
-            stock = create_stock_from_event_occurrence(event_occurrence, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
+            booking = bookings_factories.IndividualBookingFactory(individualBooking__user=user)
 
-            repository.save(user_offerer, booking)
-            url = "/bookings/token/{}?email={}".format(booking.token, user.email)
+            url = "/bookings/token/{}?email={}".format(booking.token, booking.email)
 
             # When
-            response = TestClient(app.test_client()).with_session_auth("admin@example.com").patch(url)
+            response = TestClient(app.test_client()).with_session_auth(user_admin.email).patch(url)
             # Then
             assert response.status_code == 404
 
         def when_user_is_not_editor_and_offer_id_is_invalid(self, app):
             # Given
-            user = users_factories.BeneficiaryGrant18Factory()
-            users_factories.AdminFactory(email="admin@example.com")
-            offerer = create_offerer()
-            venue = create_venue(offerer)
-            stock = create_stock_with_event_offer(offerer, venue, price=0)
-            booking = create_booking(user=user, stock=stock, venue=venue)
-            repository.save(booking)
-            booking_id = booking.id
-            url = "/bookings/token/{}?email={}&offer_id={}".format(booking.token, user.email, humanize(123))
+            user_admin = users_factories.AdminFactory(email="admin@example.com")
+            booking = bookings_factories.IndividualBookingFactory()
+
+            url = "/bookings/token/{}?email={}&offer_id={}".format(booking.token, booking.email, humanize(123))
 
             # When
-            response = TestClient(app.test_client()).with_session_auth("admin@example.com").patch(url)
+            response = TestClient(app.test_client()).with_session_auth(user_admin.email).patch(url)
 
             # Then
             assert response.status_code == 404
-            assert Booking.query.get(booking_id).isUsed is False
+            assert Booking.query.get(booking.id).isUsed is False

--- a/tests/routes/pro/patch_booking_keep_by_token_test.py
+++ b/tests/routes/pro/patch_booking_keep_by_token_test.py
@@ -139,7 +139,7 @@ class Returns403Test:
             another_pro_user = offers_factories.UserOffererFactory().user
 
             # When
-            url = f"/v2/bookings/keep/token/{booking.token}?email={booking.user.email}"
+            url = f"/v2/bookings/keep/token/{booking.token}?email={booking.email}"
             response = client.with_session_auth(another_pro_user.email).patch(url)
 
             # Then

--- a/tests/routes/pro/patch_cancel_booking_by_token_test.py
+++ b/tests/routes/pro/patch_cancel_booking_by_token_test.py
@@ -15,7 +15,7 @@ class Returns204Test:
     def test_should_returns_204_with_cancellation_allowed(self, client):
         # Given
         stock = offers_factories.EventStockFactory(offer__name="Chouette concert")
-        booking = bookings_factories.BookingFactory(stock=stock)
+        booking = bookings_factories.IndividualBookingFactory(stock=stock)
         ApiKeyFactory(offerer=booking.offerer)
 
         # When
@@ -38,13 +38,13 @@ class Returns204Test:
                 "body": """Ta réservation "Chouette concert" a été annulée par l'offreur.""",
                 "title": "Réservation annulée",
             },
-            "user_ids": [booking.userId],
+            "user_ids": [booking.individualBooking.userId],
         }
 
     @pytest.mark.usefixtures("db_session")
     def test_should_returns_204_with_lowercase_token(self, client):
         # Given
-        booking = bookings_factories.BookingFactory()
+        booking = bookings_factories.IndividualBookingFactory()
         ApiKeyFactory(offerer=booking.offerer)
 
         # When

--- a/tests/routes/pro/post_offerer_api_key_test.py
+++ b/tests/routes/pro/post_offerer_api_key_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings import factories as booking_factories
 from pcapi.core.offerers.api import find_api_key
 from pcapi.core.offerers.factories import ApiKeyFactory
 from pcapi.core.offerers.models import ApiKey
@@ -10,7 +10,7 @@ from pcapi.utils.human_ids import humanize
 
 @pytest.mark.usefixtures("db_session")
 def test_api_key_journey(client):
-    booking = BookingFactory()
+    booking = booking_factories.IndividualBookingFactory()
     user_offerer = UserOffererFactory(offerer=booking.offerer)
     client.with_session_auth(user_offerer.user.email)
 

--- a/tests/routes/pro/validate_bookings_test.py
+++ b/tests/routes/pro/validate_bookings_test.py
@@ -9,17 +9,8 @@ import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.bookings.models as bookings_models
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.users import factories as users_factories
-from pcapi.model_creators.generic_creators import create_booking
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_user_offerer
-from pcapi.model_creators.generic_creators import create_venue
-from pcapi.model_creators.specific_creators import create_event_occurrence
-from pcapi.model_creators.specific_creators import create_offer_with_event_product
-from pcapi.model_creators.specific_creators import create_stock_from_event_occurrence
-from pcapi.model_creators.specific_creators import create_stock_with_event_offer
 from pcapi.models import Booking
 from pcapi.models import api_errors
-from pcapi.repository import repository
 from pcapi.utils.human_ids import humanize
 
 from tests.conftest import TestClient
@@ -32,7 +23,7 @@ tomorrow_minus_one_hour = tomorrow - timedelta(hours=1)
 @pytest.mark.usefixtures("db_session")
 class Returns204Test:  # No Content
     def when_user_has_rights(self, app):
-        booking = bookings_factories.BookingFactory(token="ABCDEF")
+        booking = bookings_factories.IndividualBookingFactory(token="ABCDEF")
         pro_user = users_factories.ProFactory(email="pro@example.com")
         offers_factories.UserOffererFactory(user=pro_user, offerer=booking.offerer)
 
@@ -45,7 +36,7 @@ class Returns204Test:  # No Content
         assert booking.dateUsed is not None
 
     def when_header_is_not_standard_but_request_is_valid(self, app):
-        booking = bookings_factories.BookingFactory(token="ABCDEF")
+        booking = bookings_factories.IndividualBookingFactory(token="ABCDEF")
         pro_user = users_factories.ProFactory(email="pro@example.com")
         offers_factories.UserOffererFactory(user=pro_user, offerer=booking.offerer)
 
@@ -60,9 +51,9 @@ class Returns204Test:  # No Content
     # FIXME: what is the purpose of this test? Are we testing that
     # Flask knows how to URL-decode parameters?
     def when_booking_user_email_has_special_character_url_encoded(self, app):
-        booking = bookings_factories.BookingFactory(
+        booking = bookings_factories.IndividualBookingFactory(
             token="ABCDEF",
-            user__email="user+plus@example.com",
+            individualBooking__user__email="user+plus@example.com",
         )
         pro_user = users_factories.ProFactory(email="pro@example.com")
         offers_factories.UserOffererFactory(user=pro_user, offerer=booking.offerer)
@@ -82,34 +73,29 @@ class Returns403Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_not_editor_and_valid_email(self, app):
         # Given
-        user = users_factories.BeneficiaryGrant18Factory()
         pro = users_factories.ProFactory(email="pro@example.com")
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        stock = create_stock_with_event_offer(
-            offerer, venue, price=0, beginning_datetime=tomorrow, booking_limit_datetime=tomorrow_minus_one_hour
+        stock = offers_factories.EventStockFactory(
+            price=0, beginningDatetime=tomorrow, bookingLimitDatetime=tomorrow_minus_one_hour
         )
-        booking = create_booking(user=user, stock=stock, venue=venue)
-        repository.save(booking, pro)
-        booking_id = booking.id
-        url = "/bookings/token/{}?email={}".format(booking.token, user.email)
+        booking = bookings_factories.IndividualBookingFactory(stock=stock)
+        url = "/bookings/token/{}?email={}".format(booking.token, booking.email)
 
         # When
-        response = TestClient(app.test_client()).with_session_auth("pro@example.com").patch(url)
+        response = TestClient(app.test_client()).with_session_auth(pro.email).patch(url)
 
         # Then
         assert response.status_code == 403
         assert response.json["global"] == [
             "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
         ]
-        assert not Booking.query.get(booking_id).isUsed
+        assert not Booking.query.get(booking.id).isUsed
 
     @mock.patch("pcapi.core.bookings.validation.check_is_usable")
     @pytest.mark.usefixtures("db_session")
     def when_booking_not_confirmed(self, mocked_check_is_usable, app):
         # Given
         next_week = datetime.utcnow() + timedelta(weeks=1)
-        booking = bookings_factories.BookingFactory(stock__beginningDatetime=next_week)
+        booking = bookings_factories.IndividualBookingFactory(stock__beginningDatetime=next_week)
         pro_user = users_factories.ProFactory(email="pro@example.com")
         offers_factories.UserOffererFactory(user=pro_user, offerer=booking.offerer)
         url = "/bookings/token/{}".format(booking.token)
@@ -142,45 +128,33 @@ class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_not_editor_and_invalid_email(self, app):
         # Given
-        user = users_factories.BeneficiaryGrant18Factory()
         admin_user = users_factories.AdminFactory(email="admin@example.com")
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        stock = create_stock_with_event_offer(
-            offerer, venue, price=0, beginning_datetime=tomorrow, booking_limit_datetime=tomorrow_minus_one_hour
+        stock = offers_factories.EventStockFactory(
+            price=0, beginningDatetime=tomorrow, bookingLimitDatetime=tomorrow_minus_one_hour
         )
-        booking = create_booking(user=user, stock=stock, venue=venue)
-        repository.save(booking, admin_user)
-        booking_id = booking.id
+        booking = bookings_factories.IndividualBookingFactory(stock=stock)
         url = "/bookings/token/{}?email={}".format(booking.token, "wrong@example.com")
 
         # When
-        response = TestClient(app.test_client()).with_session_auth("admin@example.com").patch(url)
+        response = TestClient(app.test_client()).with_session_auth(admin_user.email).patch(url)
 
         # Then
         assert response.status_code == 404
-        assert not Booking.query.get(booking_id).isUsed
+        assert not Booking.query.get(booking.id).isUsed
 
     @pytest.mark.usefixtures("db_session")
     def when_booking_user_email_with_special_character_not_url_encoded(self, app):
         # Given
         user = users_factories.BeneficiaryGrant18Factory(email="user+plus@example.com")
         admin_user = users_factories.AdminFactory(email="admin@example.com")
-        offerer = create_offerer()
-        user_offerer = create_user_offerer(admin_user, offerer)
-        venue = create_venue(offerer)
-        offer = create_offer_with_event_product(venue, event_name="Event Name")
-        event_occurrence = create_event_occurrence(offer, beginning_datetime=tomorrow)
-        stock = create_stock_from_event_occurrence(
-            event_occurrence, price=0, booking_limit_date=tomorrow_minus_one_hour
+        stock = offers_factories.EventStockFactory(
+            price=0, beginningDatetime=tomorrow, bookingLimitDatetime=tomorrow_minus_one_hour
         )
-        booking = create_booking(user=user, stock=stock, venue=venue)
-
-        repository.save(user_offerer, booking)
+        booking = bookings_factories.IndividualBookingFactory(individualBooking__user=user, stock=stock)
         url = "/bookings/token/{}?email={}".format(booking.token, user.email)
 
         # When
-        response = TestClient(app.test_client()).with_session_auth("admin@example.com").patch(url)
+        response = TestClient(app.test_client()).with_session_auth(admin_user.email).patch(url)
 
         # Then
         assert response.status_code == 404
@@ -188,20 +162,16 @@ class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_not_editor_and_valid_email_but_invalid_offer_id(self, app):
         # Given
-        user = users_factories.BeneficiaryGrant18Factory()
         admin_user = users_factories.AdminFactory(email="admin@example.com")
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        stock = create_stock_with_event_offer(
-            offerer, venue, price=0, beginning_datetime=tomorrow, booking_limit_datetime=tomorrow_minus_one_hour
+        stock = offers_factories.EventStockFactory(
+            price=0, beginningDatetime=tomorrow, bookingLimitDatetime=tomorrow_minus_one_hour
         )
-        booking = create_booking(user=user, stock=stock, venue=venue)
-        repository.save(booking, admin_user)
+        booking = bookings_factories.IndividualBookingFactory(stock=stock)
         booking_id = booking.id
-        url = "/bookings/token/{}?email={}&offer_id={}".format(booking.token, user.email, humanize(123))
+        url = "/bookings/token/{}?email={}&offer_id={}".format(booking.token, booking.email, humanize(123))
 
         # When
-        response = TestClient(app.test_client()).with_session_auth("admin@example.com").patch(url)
+        response = TestClient(app.test_client()).with_session_auth(admin_user.email).patch(url)
 
         # Then
         assert response.status_code == 404

--- a/tests/routes/serialization/dictifier_test.py
+++ b/tests/routes/serialization/dictifier_test.py
@@ -1,14 +1,13 @@
 import pytest
 
+from pcapi.core.bookings import factories as booking_factories
 from pcapi.core.users import factories as users_factories
-from pcapi.model_creators.generic_creators import create_booking
 from pcapi.model_creators.generic_creators import create_mediation
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_user_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_event_product
 from pcapi.model_creators.specific_creators import create_product_with_event_subcategory
-from pcapi.models import Stock
 from pcapi.repository import repository
 from pcapi.routes.serialization import as_dict
 
@@ -141,12 +140,11 @@ class AsDictTest:
     @pytest.mark.usefixtures("db_session")
     def test_returns_humanized_ids_for_foreign_keys(self, app):
         # given
-        user = users_factories.UserFactory.build(id=12, postalCode=None)
-        booking = create_booking(user=user, stock=Stock(), idx=13)
-        booking.userId = user.id
+        user = users_factories.BeneficiaryGrant18Factory(id=12)
+        individual_booking = booking_factories.IndividualBookingFactory(individualBooking__user=user).individualBooking
 
         # when
-        dict_result = as_dict(booking, includes=[])
+        dict_result = as_dict(individual_booking, includes=[])
 
         # then
         assert dict_result["userId"] == "BQ"

--- a/tests/routes/webapp/get_beneficiary_profile_test.py
+++ b/tests/routes/webapp/get_beneficiary_profile_test.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 
-from pcapi.core.bookings.factories import CancelledBookingFactory
+from pcapi.core.bookings import factories as booking_factories
 from pcapi.core.bookings.factories import IndividualBookingFactory
 from pcapi.core.users.factories import AdminFactory
 from pcapi.core.users.factories import BeneficiaryGrant18Factory
@@ -14,8 +14,8 @@ from pcapi.utils.human_ids import humanize
 from tests.conftest import TestClient
 
 
+@pytest.mark.usefixtures("db_session")
 class Returns200Test:
-    @pytest.mark.usefixtures("db_session")
     def when_user_is_logged_in_and_has_no_deposit(self, app):
         # Given
         user = BeneficiaryGrant18Factory(
@@ -63,7 +63,6 @@ class Returns200Test:
             "wallet_is_activated": False,
         }
 
-    @pytest.mark.usefixtures("db_session")
     def when_user_is_logged_in_and_has_a_deposit(self, app):
         # Given
         BeneficiaryGrant18Factory(
@@ -82,7 +81,6 @@ class Returns200Test:
         assert response.json["wallet_is_activated"] == True
         assert response.json["deposit_expiration_date"] == "2002-01-01T02:02:00Z"
 
-    @pytest.mark.usefixtures("db_session")
     def when_user_has_booked_some_offers(self, app):
         # Given
         user = BeneficiaryGrant18Factory(email="wallet_test@email.com", postalCode="93020", deposit__version=1)
@@ -102,10 +100,10 @@ class Returns200Test:
             "physical": {"initial": 200.0, "remaining": 195.0},
         }
 
-    @pytest.mark.usefixtures("db_session")
     def when_user_has_cancelled_some_offers(self, app):
         # Given
-        CancelledBookingFactory(user__email="wallet_test@email.com", user__postalCode="75130", user__deposit__version=1)
+        user = BeneficiaryGrant18Factory(email="wallet_test@email.com", postalCode="75130", deposit__version=1)
+        booking_factories.CancelledIndividualBookingFactory(individualBooking__user=user)
 
         # When
         response = (
@@ -120,7 +118,6 @@ class Returns200Test:
             "physical": {"initial": 200.0, "remaining": 200.0},
         }
 
-    @pytest.mark.usefixtures("db_session")
     def when_user_is_created_without_postal_code(self, app):
         # Given
         BeneficiaryGrant18Factory(email="wallet_test@email.com", postalCode=None, departementCode=None)
@@ -133,7 +130,6 @@ class Returns200Test:
         # Then
         assert response.status_code == 200
 
-    @pytest.mark.usefixtures("db_session")
     def when_user_is_a_pro(self, app):
         # Given
         pro = ProFactory(email="pro@example.com", postalCode=None, dateOfBirth=None)
@@ -147,7 +143,6 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json["suspensionReason"] == None
 
-    @pytest.mark.usefixtures("db_session")
     def when_user_is_an_admin(self, app):
         # Given
         AdminFactory(email="admin@example.com", postalCode=None, dateOfBirth=None)
@@ -158,7 +153,6 @@ class Returns200Test:
         # Then
         assert response.status_code == 200
 
-    @pytest.mark.usefixtures("db_session")
     def should_return_deposit_version(self, app):
         # Given
         BeneficiaryGrant18Factory(email="wallet_test@email.com", postalCode="93020", deposit__version=1)

--- a/tests/routes/webapp/get_booking_by_id_test.py
+++ b/tests/routes/webapp/get_booking_by_id_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import IndividualBookingFactory
 from pcapi.core.offers.factories import OffererFactory
 from pcapi.core.offers.factories import ThingOfferFactory
 from pcapi.core.offers.factories import ThingProductFactory
@@ -32,7 +32,7 @@ class Returns200Test:
             product=product,
         )
         stock = ThingStockFactory(offer=offer, price=0, quantity=None)
-        booking = BookingFactory(user=user, stock=stock, token="ABCDEF")
+        booking = IndividualBookingFactory(individualBooking__user=user, stock=stock, token="ABCDEF")
 
         # When
         response = TestClient(app.test_client()).with_session_auth(user.email).get("/bookings/" + humanize(booking.id))

--- a/tests/routes/webapp/get_bookings_test.py
+++ b/tests/routes/webapp/get_bookings_test.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.factories import IndividualBookingFactory
 from pcapi.core.offers.factories import ThingOfferFactory
 from pcapi.core.offers.factories import ThingStockFactory
 from pcapi.core.offers.factories import VenueFactory
@@ -27,9 +27,9 @@ class Returns200Test:
         offer2 = ThingOfferFactory()
         stock = ThingStockFactory(offer=offer, price=0, quantity=None)
         stock2 = ThingStockFactory(offer=offer2, price=0)
-        booking1 = BookingFactory(user=user1, stock=stock, token="ABCDEF")
-        BookingFactory(user=user2, stock=stock, token="GHIJK")
-        booking3 = BookingFactory(user=user1, stock=stock2, token="BBBBB")
+        booking1 = IndividualBookingFactory(individualBooking__user=user1, stock=stock, token="ABCDEF")
+        IndividualBookingFactory(individualBooking__user=user2, stock=stock, token="GHIJK")
+        booking3 = IndividualBookingFactory(individualBooking__user=user1, stock=stock2, token="BBBBB")
 
         # When
         response = TestClient(app.test_client()).with_session_auth(user1.email).get("/bookings")
@@ -103,7 +103,7 @@ class Returns200Test:
             },
             "stockId": humanize(stock.id),
             "token": "ABCDEF",
-            "userId": humanize(booking1.userId),
+            "userId": humanize(booking1.individualBooking.userId),
         }
 
     @patch("pcapi.routes.webapp.bookings.FeatureToggle.is_active", return_value=True)
@@ -117,9 +117,9 @@ class Returns200Test:
         offer2 = ThingOfferFactory()
         stock = ThingStockFactory(offer=offer, price=0, quantity=None)
         stock2 = ThingStockFactory(offer=offer2, price=0)
-        BookingFactory(user=user1, stock=stock, token="ABCDEF")
-        BookingFactory(user=user2, stock=stock, token="GHIJK")
-        BookingFactory(user=user1, stock=stock2, token="BBBBB")
+        IndividualBookingFactory(individualBooking__user=user1, stock=stock, token="ABCDEF")
+        IndividualBookingFactory(individualBooking__user=user2, stock=stock, token="GHIJK")
+        IndividualBookingFactory(individualBooking__user=user1, stock=stock2, token="BBBBB")
 
         # When
         response = TestClient(app.test_client()).with_session_auth(user1.email).get("/bookings")

--- a/tests/routes/webapp/get_favorites_test.py
+++ b/tests/routes/webapp/get_favorites_test.py
@@ -1,11 +1,11 @@
 import pytest
 
+from pcapi.core.bookings import factories as bookings_factories
+from pcapi.core.offers import factories as offers_factories
 from pcapi.core.users import factories as users_factories
-from pcapi.model_creators.generic_creators import create_booking
 from pcapi.model_creators.generic_creators import create_favorite
 from pcapi.model_creators.generic_creators import create_mediation
 from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_stock
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
 from pcapi.repository import repository
@@ -57,14 +57,9 @@ class Returns200Test:
     def when_user_is_logged_in_and_a_favorite_booked_offer_exist(self, app):
         # Given
         user = users_factories.BeneficiaryGrant18Factory()
-        offerer = create_offerer()
-        venue = create_venue(offerer, postal_code="29100", siret="12345678912341")
-        offer = create_offer_with_thing_product(venue, thumb_count=0)
-        mediation = create_mediation(offer, is_active=True)
-        favorite = create_favorite(mediation=mediation, offer=offer, user=user)
-        stock = create_stock(offer=offer, price=0)
-        booking = create_booking(user=user, stock=stock)
-        repository.save(booking, favorite)
+        favorite = users_factories.FavoriteFactory(user=user)
+        stock = offers_factories.StockFactory(offer=favorite.offer)
+        booking = bookings_factories.IndividualBookingFactory(individualBooking__user=user, stock=stock)
 
         # When
         response = TestClient(app.test_client()).with_session_auth(user.email).get("/favorites")

--- a/tests/routes/webapp/put_cancel_booking_by_id_test.py
+++ b/tests/routes/webapp/put_cancel_booking_by_id_test.py
@@ -19,10 +19,10 @@ class Returns200Test:
         # Given
         in_four_days = datetime.utcnow() + timedelta(days=4)
         stock = offers_factories.EventStockFactory(beginningDatetime=in_four_days)
-        booking = bookings_factories.BookingFactory(stock=stock)
+        booking = bookings_factories.IndividualBookingFactory(stock=stock)
 
         # When
-        client = TestClient(app.test_client()).with_session_auth(booking.user.email)
+        client = TestClient(app.test_client()).with_session_auth(booking.email)
         response = client.put(f"/bookings/{humanize(booking.id)}/cancel")
         booking = Booking.query.get(booking.id)
 
@@ -48,10 +48,10 @@ class Returns400Test:
     @pytest.mark.usefixtures("db_session")
     def when_the_booking_cannot_be_cancelled(self, app):
         # Given
-        booking = bookings_factories.UsedBookingFactory()
+        booking = bookings_factories.UsedIndividualBookingFactory()
 
         # When
-        client = TestClient(app.test_client()).with_session_auth(booking.user.email)
+        client = TestClient(app.test_client()).with_session_auth(booking.email)
         response = client.put(f"/bookings/{humanize(booking.id)}/cancel")
         booking = Booking.query.get(booking.id)
 

--- a/tests/sandboxes/scripts/bookings_recap/bookings_recap_test.py
+++ b/tests/sandboxes/scripts/bookings_recap/bookings_recap_test.py
@@ -1,6 +1,7 @@
 import pytest
 from pytest import fixture
 
+from pcapi.core.bookings.models import IndividualBooking
 from pcapi.core.users.models import User
 from pcapi.models import Booking
 from pcapi.models import Offer
@@ -27,4 +28,4 @@ class BookingsRecapTest:
         assert self._find_bookings_by_user_firstname("Loulou") == 6
 
     def _find_bookings_by_user_firstname(self, name: str) -> list[Booking]:
-        return Booking.query.join(User).filter(User.firstName == name).count()
+        return Booking.query.join(IndividualBooking).join(User).filter(User.firstName == name).count()

--- a/tests/scripts/booking/handle_expired_bookings_test.py
+++ b/tests/scripts/booking/handle_expired_bookings_test.py
@@ -201,7 +201,6 @@ class CancelExpiredBookingsTest:
         # Then
         assert pending_educational_booking.status == BookingStatus.PENDING
 
-    # TODO gvanneste
     def test_handle_expired_bookings_should_cancel_expired_individual_and_educational_bookings(self, app) -> None:
         # Given
         now = datetime.utcnow()

--- a/tests/scripts/payment/banishment_test.py
+++ b/tests/scripts/payment/banishment_test.py
@@ -2,8 +2,7 @@ import uuid
 
 import pytest
 
-import pcapi.core.users.factories as users_factories
-from pcapi.model_creators.generic_creators import create_booking
+import pcapi.core.bookings.factories as booking_factories
 from pcapi.model_creators.generic_creators import create_payment
 from pcapi.model_creators.generic_creators import create_payment_message
 from pcapi.models.payment_status import TransactionStatus
@@ -15,8 +14,7 @@ class DoBanPaymentsTest:
     @pytest.mark.usefixtures("db_session")
     def test_modify_statuses_on_given_payments(self, app):
         # given
-        user = users_factories.BeneficiaryGrant18Factory()
-        booking = create_booking(user=user)
+        booking = booking_factories.IndividualBookingFactory()
         offerer = booking.offerer
 
         transaction1 = create_payment_message(name="XML1")
@@ -48,8 +46,7 @@ class DoBanPaymentsTest:
     @pytest.mark.usefixtures("db_session")
     def test_does_not_modify_statuses_on_given_payments_if_a_payment_id_is_not_found(self, app):
         # given
-        user = users_factories.BeneficiaryGrant18Factory()
-        booking = create_booking(user=user)
+        booking = booking_factories.IndividualBookingFactory()
         offerer = booking.offerer
 
         transaction1 = create_payment_message(name="XML1")

--- a/tests/scripts/stock/soft_delete_stock_test.py
+++ b/tests/scripts/stock/soft_delete_stock_test.py
@@ -44,7 +44,7 @@ class SoftDeleteStockTest:
     @pytest.mark.usefixtures("db_session")
     def should_cancel_every_bookings_for_target_stock(self):
         # Given
-        booking = bookings_factories.BookingFactory()
+        booking = bookings_factories.IndividualBookingFactory()
 
         # When
         soft_delete_stock(booking.stock.id)

--- a/tests/scripts/suspend_suspected_fraudulent_beneficiary_users_test.py
+++ b/tests/scripts/suspend_suspected_fraudulent_beneficiary_users_test.py
@@ -1,7 +1,6 @@
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
-from pcapi.core.bookings.factories import UsedBookingFactory
+from pcapi.core.bookings import factories as booking_factories
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.users.factories import AdminFactory
 from pcapi.core.users.factories import BeneficiaryGrant18Factory
@@ -17,8 +16,8 @@ class SuspendFraudulentBeneficiaryUsersByEmailProvidersTest:
         fraudulent_emails_providers = ["example.com"]
         admin_user = AdminFactory()
         fraudulent_user = BeneficiaryGrant18Factory(email="jesuisunefraude@example.com")
-        BookingFactory(user=fraudulent_user, stock__price=1)
-        BookingFactory(user=fraudulent_user, stock__price=2)
+        booking_factories.IndividualBookingFactory(individualBooking__user=fraudulent_user, stock__price=1)
+        booking_factories.IndividualBookingFactory(individualBooking__user=fraudulent_user, stock__price=2)
 
         # When
         suspend_fraudulent_beneficiary_users_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
@@ -32,8 +31,8 @@ class SuspendFraudulentBeneficiaryUsersByEmailProvidersTest:
         fraudulent_emails_providers = ["example.com"]
         admin_user = AdminFactory()
         fraudulent_user = BeneficiaryGrant18Factory(email="jesuisunefraude@example.com")
-        booking_1 = BookingFactory(user=fraudulent_user, stock__price=1)
-        booking_2 = BookingFactory(user=fraudulent_user, stock__price=2)
+        booking_1 = booking_factories.IndividualBookingFactory(individualBooking__user=fraudulent_user, stock__price=1)
+        booking_2 = booking_factories.IndividualBookingFactory(individualBooking__user=fraudulent_user, stock__price=2)
 
         # When
         suspend_fraudulent_beneficiary_users_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
@@ -51,7 +50,9 @@ class SuspendFraudulentBeneficiaryUsersByEmailProvidersTest:
         fraudulent_emails_providers = ["example.com"]
         admin_user = AdminFactory()
         fraudulent_user = BeneficiaryGrant18Factory(email="jesuisunefraude@example.com")
-        uncancellable_booking = UsedBookingFactory(user=fraudulent_user, stock__price=1)
+        uncancellable_booking = booking_factories.UsedIndividualBookingFactory(
+            individualBooking__user=fraudulent_user, stock__price=1
+        )
 
         # When
         suspend_fraudulent_beneficiary_users_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
@@ -72,7 +73,7 @@ class SuspendFraudulentBeneficiaryUsersByEmailProvidersTest:
         )
         beneficiary_fraudulent_user_with_subdomain = BeneficiaryGrant18Factory(email="jesuisunefraude@sub.example.com")
         non_beneficiary_fraudulent_user = UserFactory(email="jesuisuneautrefraude@example.com")
-        BookingFactory(user=beneficiary_fraudulent_user, stock__price=1)
+        booking_factories.IndividualBookingFactory(individualBooking__user=beneficiary_fraudulent_user, stock__price=1)
 
         # When
         suspend_fraudulent_beneficiary_users_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
@@ -92,7 +93,7 @@ class SuspendFraudulentBeneficiaryUsersByEmailProvidersTest:
         fraudulent_emails_providers = ["gmoil.com"]
         admin_user = AdminFactory()
         non_fraudulent_user = BeneficiaryGrant18Factory(email="jenesuispasunefraude@example.com")
-        BookingFactory(user=non_fraudulent_user, stock__price=1)
+        booking_factories.IndividualBookingFactory(individualBooking__user=non_fraudulent_user, stock__price=1)
 
         # When
         suspend_fraudulent_beneficiary_users_by_email_providers(fraudulent_emails_providers, admin_user, dry_run=False)
@@ -107,8 +108,12 @@ class SuspendFraudulentBeneficiaryUsersByIdsTest:
         fraudulent_user_ids = [23]
         admin_user = AdminFactory()
         fraudulent_user = BeneficiaryGrant18Factory(id=23)
-        fraudulent_user_booking_1 = BookingFactory(user=fraudulent_user, stock__price=1)
-        fraudulent_user_booking_2 = BookingFactory(user=fraudulent_user, stock__price=2)
+        fraudulent_user_booking_1 = booking_factories.IndividualBookingFactory(
+            individualBooking__user=fraudulent_user, stock__price=1
+        )
+        fraudulent_user_booking_2 = booking_factories.IndividualBookingFactory(
+            individualBooking__user=fraudulent_user, stock__price=2
+        )
 
         suspend_fraudulent_beneficiary_users_by_ids(fraudulent_user_ids, admin_user, dry_run=False)
 
@@ -123,7 +128,9 @@ class SuspendFraudulentBeneficiaryUsersByIdsTest:
         fraudulent_user_ids = [15]
         admin_user = AdminFactory()
         fraudulent_user = BeneficiaryGrant18Factory(id=15)
-        uncancellable_booking = UsedBookingFactory(user=fraudulent_user, stock__price=1)
+        uncancellable_booking = booking_factories.UsedIndividualBookingFactory(
+            individualBooking__user=fraudulent_user, stock__price=1
+        )
 
         suspend_fraudulent_beneficiary_users_by_ids(fraudulent_user_ids, admin_user, dry_run=False)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10144


## But de la pull request

Dans le cadre des développements sur l'eac collectif ces derniers mois, nous avons scindé notre modèle `Booking` en deux : des `IndividualBooking` et des `EducationalBooking`.
Les `EducationalBooking` n'ont pas de `User` associé dans la base Pass Culture (ils sont logués via Adage).
Les deux modèles sont néanmoins reliés au modèle `Booking`, pour les données / comportements communs.
En l'état actuel, le lien entre `Booking` et `User` subsiste, et ce `userId` est dupliqué dans la table `individual_booking`. Cette PR prépare le terrain pour supprimer le lien vers `user` depuis la table `booking`.

Objectif de cette PR : Casser tous les liens `booking.user`, et passer par le `individualBooking` : `individualBooking.user` pour préparer le retrait du `User` du modèle `Booking` (PR à venir)

##  Implémentation

- Recherche des liens par module core, changement des liens, correction des tests
- Passage du `user` de la `BookingFactory` à null
- Inclusion d'un `user` dans `IndividualBookingFactory`
- Correction des tests
​
##  Informations supplémentaires

- Impacts à travers toute l'api
- Beaucoup de `generic_creators` retirés `(create_booking` notamment)
- Un prochain ticket aura pour objectif de supprimer le lien `Booking` <-> `User` dans le modèle `Booking`
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
