### PR TITLE
Pc command update process offers from database

### DIFF
--- a/src/pcapi/scripts/algolia_indexing/commands.py
+++ b/src/pcapi/scripts/algolia_indexing/commands.py
@@ -10,32 +10,34 @@ blueprint = Blueprint(__name__, __name__)
 
 
 @blueprint.cli.command("process_offers")
-def process_offers():
+def process_offers() -> None:
     search.index_offers_in_queue(stop_only_when_empty=True)
 
 
 @blueprint.cli.command("process_offers_by_venue")
-def process_offers_by_venue():
+def process_offers_by_venue() -> None:
     search.index_offers_of_venues_in_queue()
 
 
 @blueprint.cli.command("process_offers_from_database")
 @click.option("--clear", help="Clear search index", type=bool, default=False)
 @click.option("-ep", "--ending-page", help="Ending page for indexing offers", type=int, default=None)
-@click.option("-l", "--limit", help="Number of offers per page", type=int, default=10_000)
+@click.option("-s", "--batch-size", help="Number of offers per page", type=int, default=10_000)
 @click.option("-sp", "--starting-page", help="Starting page for indexing offers", type=int, default=0)
 def process_offers_from_database(
     clear: bool,
     ending_page: int,
-    limit: int,
+    batch_size: int,
     starting_page: int,
-):
+) -> None:
     if clear:
         search.unindex_all_offers()
-    batch_indexing_offers_in_algolia_from_database(ending_page=ending_page, limit=limit, starting_page=starting_page)
+    batch_indexing_offers_in_algolia_from_database(
+        ending_page=ending_page, batch_size=batch_size, starting_page=starting_page
+    )
 
 
 @blueprint.cli.command("process_expired_offers")
 @click.option("-a", "--all", help="Bypass the two days limit to delete all expired offers", default=False)
-def process_expired_offers(all_offers: bool):
+def process_expired_offers(all_offers: bool) -> None:
     offers_api.unindex_expired_offers(process_all_expired=all_offers)

--- a/src/pcapi/scripts/algolia_indexing/indexing.py
+++ b/src/pcapi/scripts/algolia_indexing/indexing.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from pcapi.core import search
 from pcapi.repository import offer_queries
@@ -10,14 +11,12 @@ logger = logging.getLogger(__name__)
 def batch_indexing_offers_in_algolia_from_database(
     ending_page: int = None, batch_size: int = 10000, starting_page: int = 0
 ) -> None:
-    page = starting_page
-    while True:
-        if ending_page and ending_page == page:
-            break
+    if not ending_page:
+        ending_page = sys.maxsize
 
+    for page in range(starting_page, ending_page):
         offer_ids = offer_queries.get_paginated_active_offer_ids(limit=batch_size, page=page)
         if not offer_ids:
             break
         search.reindex_offer_ids(offer_ids)
         logger.info("[ALGOLIA] Processed %d offers from page %d", len(offer_ids), page)
-        page += 1

--- a/src/pcapi/scripts/algolia_indexing/indexing.py
+++ b/src/pcapi/scripts/algolia_indexing/indexing.py
@@ -8,14 +8,14 @@ logger = logging.getLogger(__name__)
 
 
 def batch_indexing_offers_in_algolia_from_database(
-    ending_page: int = None, limit: int = 10000, starting_page: int = 0
+    ending_page: int = None, batch_size: int = 10000, starting_page: int = 0
 ) -> None:
     page = starting_page
     while True:
         if ending_page and ending_page == page:
             break
 
-        offer_ids = offer_queries.get_paginated_active_offer_ids(limit=limit, page=page)
+        offer_ids = offer_queries.get_paginated_active_offer_ids(limit=batch_size, page=page)
         if not offer_ids:
             break
         search.reindex_offer_ids(offer_ids)

--- a/tests/scripts/algolia_indexing/indexing_test.py
+++ b/tests/scripts/algolia_indexing/indexing_test.py
@@ -14,7 +14,7 @@ class BatchIndexingOffersInAlgoliaFromDatabaseTest:
         mock_get_paginated_active_offer_ids.side_effect = [[1], []]
 
         # When
-        batch_indexing_offers_in_algolia_from_database(ending_page=None, batch_size=1, starting_page=0)
+        batch_indexing_offers_in_algolia_from_database(batch_size=1, starting_page=0)
 
         # Then
         assert mock_get_paginated_active_offer_ids.call_count == 2
@@ -29,7 +29,7 @@ class BatchIndexingOffersInAlgoliaFromDatabaseTest:
         mock_get_paginated_active_offer_ids.side_effect = [[1], [2], []]
 
         # When
-        batch_indexing_offers_in_algolia_from_database(ending_page=None, batch_size=1, starting_page=0)
+        batch_indexing_offers_in_algolia_from_database(batch_size=1, starting_page=0)
 
         # Then
         assert mock_get_paginated_active_offer_ids.call_count == 3

--- a/tests/scripts/algolia_indexing/indexing_test.py
+++ b/tests/scripts/algolia_indexing/indexing_test.py
@@ -14,7 +14,7 @@ class BatchIndexingOffersInAlgoliaFromDatabaseTest:
         mock_get_paginated_active_offer_ids.side_effect = [[1], []]
 
         # When
-        batch_indexing_offers_in_algolia_from_database(ending_page=None, limit=1, starting_page=0)
+        batch_indexing_offers_in_algolia_from_database(ending_page=None, batch_size=1, starting_page=0)
 
         # Then
         assert mock_get_paginated_active_offer_ids.call_count == 2
@@ -29,7 +29,7 @@ class BatchIndexingOffersInAlgoliaFromDatabaseTest:
         mock_get_paginated_active_offer_ids.side_effect = [[1], [2], []]
 
         # When
-        batch_indexing_offers_in_algolia_from_database(ending_page=None, limit=1, starting_page=0)
+        batch_indexing_offers_in_algolia_from_database(ending_page=None, batch_size=1, starting_page=0)
 
         # Then
         assert mock_get_paginated_active_offer_ids.call_count == 3
@@ -47,7 +47,7 @@ class BatchIndexingOffersInAlgoliaFromDatabaseTest:
         mock_get_paginated_active_offer_ids.side_effect = [[1], [2], []]
 
         # When
-        batch_indexing_offers_in_algolia_from_database(ending_page=1, limit=1, starting_page=0)
+        batch_indexing_offers_in_algolia_from_database(ending_page=1, batch_size=1, starting_page=0)
 
         # Then
         mock_reindex_offer_ids.assert_called_once_with([1])


### PR DESCRIPTION
## But de la pull request

Renommer un paramètre d'une commande, afin de le rendre plus clair : la valeur de limit est utilisé à chaque requête SQL effectuée, donc ce n'est pas une limite global mais le nombre max d'objets par page.

Et au passage, remplacer une un `while True` par un `range` parce que ça me paraît un peu plus lisible.