### PR TITLE
(PC-11227) Add script to fill individualBooking.depositId

### DIFF
--- a/src/pcapi/scripts/booking/fill_individual_booking_deposit_id.py
+++ b/src/pcapi/scripts/booking/fill_individual_booking_deposit_id.py
@@ -1,0 +1,57 @@
+import logging
+
+from pcapi.core.bookings import models as bookings_models
+from pcapi.core.payments import models as payments_models
+from pcapi.core.users import models as users_models
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+
+def fill_individual_booking_deposit_id(batch_size=1000):
+    individual_booking_ids = [
+        result[0]
+        for result in bookings_models.IndividualBooking.query.with_entities(bookings_models.IndividualBooking.id)
+        .filter(bookings_models.IndividualBooking.depositId.is_(None))
+        .all()
+    ]
+
+    start_index = 0
+
+    while start_index < len(individual_booking_ids):
+        print(f"Updating bookings {start_index}/{len(individual_booking_ids)}")
+        updated_bookings_count = 0
+        individual_bookings = (
+            bookings_models.IndividualBooking.query.join(users_models.User)
+            .join(
+                bookings_models.Booking,
+                bookings_models.Booking.individualBookingId == bookings_models.IndividualBooking.id,
+            )
+            .join(payments_models.Deposit, payments_models.Deposit.userId == users_models.User.id)
+            .filter(
+                bookings_models.IndividualBooking.id.in_(individual_booking_ids[start_index : start_index + batch_size])
+            )
+            .all()
+        )
+        for individual_booking in individual_bookings:
+            if individual_booking.user.deposit is None:
+                continue
+            if individual_booking.booking.dateCreated > individual_booking.user.deposit.expirationDate:
+                if individual_booking.booking.amount > 0:
+                    logger.warning(
+                        "Booking with amount > 0 made after deposit expiration date id=%s",
+                        individual_booking.booking.id,
+                    )
+                continue
+
+            individual_booking.depositId = (
+                individual_booking.user.deposit.id if individual_booking.user.deposit else None
+            )
+            updated_bookings_count += 1
+            db.session.add(individual_booking)
+
+        db.session.commit()
+        start_index += batch_size
+
+        print(f"Updated {updated_bookings_count} individual bookings")

--- a/tests/scripts/booking/fill_individual_booking_deposit_id_test.py
+++ b/tests/scripts/booking/fill_individual_booking_deposit_id_test.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+import logging
+
+from dateutil.relativedelta import relativedelta
+import pytest
+
+import pcapi.core.bookings.factories as bookings_factories
+from pcapi.scripts.booking.fill_individual_booking_deposit_id import fill_individual_booking_deposit_id
+
+
+@pytest.mark.usefixtures("db_session")
+def test_fill_individual_booking_deposit_id(caplog):
+    already_filled_bookings = bookings_factories.IndividualBookingFactory.create_batch(3)
+    to_update_bookings = bookings_factories.IndividualBookingFactory.create_batch(3, individualBooking__deposit=None)
+    not_updated_booking = bookings_factories.IndividualBookingFactory(
+        amount=0, dateCreated=(datetime.utcnow() + relativedelta(years=3)), individualBooking__deposit=None
+    )
+
+    warning_booking = bookings_factories.IndividualBookingFactory(
+        amount=10, dateCreated=(datetime.utcnow() + relativedelta(years=3)), individualBooking__deposit=None
+    )
+
+    with caplog.at_level(logging.WARNING):
+        fill_individual_booking_deposit_id(3)
+
+    for booking in already_filled_bookings + to_update_bookings:
+        assert booking.individualBooking.depositId == booking.individualBooking.user.deposit.id
+
+    assert not not_updated_booking.individualBooking.depositId
+
+    assert not warning_booking.individualBooking.depositId
+    assert caplog.messages == [f"Booking with amount > 0 made after deposit expiration date id={warning_booking.id}"]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11227


## But de la pull request

Remplir les individualBooking.depositId avec les deposit des utilisateurs. 

Avec l'introduction du pass 15-17, un utilisateur pourra avoir plusieurs deposits. Par exemple un deposit 15-17 expiré et un deposit 18 actif. Pour calculer le crédit restant sur le deposit 18, il faut prendre en compte les réservations faites sur ce deposit, et non sur l'autre.

##  Implémentation


Cas particuliers : 
- si le booking a été créé après la date d'expiration du booking et que son montant vaut 0€ -> on n'associe pas de depositId
- si le booking a été créé après la date d'expiration du booking et que son montant est > 0€ -> warning! mais il n'y a un seul cas comme ça sur staging (id = 204, créée le 2 sept 2018)
- le cas où l'utilisateur a plusieurs deposit n'est pas géré -> on prend le dernier deposit par ordre de date d'expiration mais il n'y a que 6 utilisateurs avec 2 deposits

Le script prend environ 4.5 heures sur staging (il y a 6.5 Millions d'IndividualBookings).

Utilisateurs avec 2 deposits : 
+-------+----------------------------+
| id    | dateCreated                |
|-------+----------------------------|
| 28435 | 2019-09-24 00:06:34.598071 |
| 32031 | 2019-10-09 00:04:05.579995 |
| 36850 | 2019-10-30 00:04:33.898711 |
| 44735 | 2019-11-26 00:02:44.632288 |
| 51299 | 2019-12-20 00:06:59.804768 |
| 57019 | 2020-02-03 00:05:05.143024 |
+-------+----------------------------+
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
