### PR TITLE
(PC-8173) Fix tag deletion from Flask-Admin

### DIFF
--- a/src/pcapi/models/offer_criterion.py
+++ b/src/pcapi/models/offer_criterion.py
@@ -10,8 +10,8 @@ from pcapi.models.pc_object import PcObject
 class OfferCriterion(PcObject, Model):
     offerId = Column(BigInteger, ForeignKey("offer.id"), index=True, nullable=False)
 
-    offer = relationship("Offer", foreign_keys=[offerId], backref="offerCriteria")
+    offer = relationship("Offer", foreign_keys=[offerId])
 
     criterionId = Column(BigInteger, ForeignKey("criterion.id"), nullable=False)
 
-    criterion = relationship("Criterion", foreign_keys=[criterionId], backref="offerCriteria")
+    criterion = relationship("Criterion", foreign_keys=[criterionId])

--- a/tests/admin/custom_views/criteria_view_test.py
+++ b/tests/admin/custom_views/criteria_view_test.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+
+import pcapi.core.offers.factories as offers_factories
+import pcapi.core.users.factories as users_factories
+
+from tests.conftest import TestClient
+from tests.conftest import clean_database
+
+
+class CriteriaViewTest:
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_delete_criterion(self, mocked_validate_csrf_token, app):
+        users_factories.AdminFactory(email="admin@example.com")
+
+        offer = offers_factories.OfferFactory()
+        criterion = offers_factories.CriterionFactory(name="test_delete_criterion")
+        offers_factories.OfferCriterionFactory(offer=offer, criterion=criterion)
+
+        assert len(offer.criteria) == 1
+
+        data = dict(id=criterion.id)
+        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+
+        response = client.post("/pc/back-office/criterion/delete/", form=data)
+
+        assert response.status_code == 302
+        assert len(offer.criteria) == 0

--- a/tests/admin/custom_views/criteria_view_test.py
+++ b/tests/admin/custom_views/criteria_view_test.py
@@ -3,14 +3,13 @@ from unittest.mock import patch
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 
-from tests.conftest import TestClient
 from tests.conftest import clean_database
 
 
 class CriteriaViewTest:
     @clean_database
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_criterion(self, mocked_validate_csrf_token, app):
+    def test_delete_criterion(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 
         offer = offers_factories.OfferFactory()
@@ -20,9 +19,9 @@ class CriteriaViewTest:
         assert len(offer.criteria) == 1
 
         data = dict(id=criterion.id)
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+        api_client = client.with_session_auth("admin@example.com")
 
-        response = client.post("/pc/back-office/criterion/delete/", form=data)
+        response = api_client.post("/pc/back-office/criterion/delete/", form=data)
 
         assert response.status_code == 302
         assert len(offer.criteria) == 0


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-8173


## But de la pull request

Bug : une exception se produit lorsque l'admin tente de supprimer un tag dans Flask-Admin, si ce tag est associé à une ou plusieurs offres.

##  Implémentation

Suppression des _backref_ dans les _relationship_ de l'objet Criterion.
En effet ces _backref_ ne sont utilisées nulle part et causent une double requête à la suppression du Criterion : DELETE puis UPDATE sur les mêmes OfferCriterion.
​
##  Informations supplémentaires

Voir détails dans le ticket JIRA :
https://passculture.atlassian.net/browse/PC-8173

Le test ajouté est _Failed_ sans la correction, et _Passed_ après correction.
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-8173-delete-tag-from-flask-admin
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
