### PR TITLE
(PC-11548) : include eac bookings in reimbursement csv for pro

### DIFF
--- a/src/pcapi/core/payments/factories.py
+++ b/src/pcapi/core/payments/factories.py
@@ -22,7 +22,7 @@ class PaymentFactory(BaseFactory):
         model = models.Payment
 
     author = "batch"
-    booking = factory.SubFactory(bookings_factories.UsedBookingFactory)
+    booking = factory.SubFactory(bookings_factories.UsedIndividualBookingFactory)
     amount = factory.LazyAttribute(lambda payment: payment.booking.total_amount * Decimal(payment.reimbursementRate))
     recipientSiren = factory.SelfAttribute("booking.stock.offer.venue.managingOfferer.siren")
     reimbursementRule = factory.Iterator(REIMBURSEMENT_RULE_DESCRIPTIONS)

--- a/src/pcapi/repository/reimbursement_queries.py
+++ b/src/pcapi/repository/reimbursement_queries.py
@@ -8,6 +8,9 @@ from sqlalchemy import subquery
 from sqlalchemy.orm import aliased
 
 from pcapi.core.bookings.models import Booking
+from pcapi.core.bookings.models import EducationalBooking
+from pcapi.core.bookings.models import IndividualBooking
+from pcapi.core.educational.models import EducationalRedactor
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
@@ -43,7 +46,10 @@ def find_all_offerers_payments(
             (Booking.venueId == venue_id) if venue_id else (Booking.venueId is not None),
         )
         .join(Offerer)
-        .join(User)
+        .outerjoin(IndividualBooking)
+        .outerjoin(User)
+        .outerjoin(EducationalBooking)
+        .outerjoin(EducationalRedactor)
         .join(Stock)
         .join(Offer)
         .join(Venue)
@@ -52,6 +58,8 @@ def find_all_offerers_payments(
         .with_entities(
             User.lastName.label("user_lastName"),
             User.firstName.label("user_firstName"),
+            EducationalRedactor.firstName.label("redactor_firstname"),
+            EducationalRedactor.lastName.label("redactor_lastname"),
             Booking.token.label("booking_token"),
             Booking.dateUsed.label("booking_dateUsed"),
             Booking.quantity.label("booking_quantity"),
@@ -86,7 +94,10 @@ def legacy_find_all_offerers_payments(offerer_ids: list[int]) -> list[namedtuple
         Payment.query.join(payment_status_query)
         .reset_joinpoint()
         .join(Booking)
-        .join(User)
+        .outerjoin(IndividualBooking)
+        .outerjoin(User)
+        .outerjoin(EducationalBooking)
+        .outerjoin(EducationalRedactor)
         .reset_joinpoint()
         .join(Stock)
         .join(Offer)
@@ -98,6 +109,8 @@ def legacy_find_all_offerers_payments(offerer_ids: list[int]) -> list[namedtuple
         .with_entities(
             User.lastName.label("user_lastName"),
             User.firstName.label("user_firstName"),
+            EducationalRedactor.firstName.label("redactor_firstname"),
+            EducationalRedactor.lastName.label("redactor_lastname"),
             Booking.token.label("booking_token"),
             Booking.dateUsed.label("booking_dateUsed"),
             Booking.quantity.label("booking_quantity"),

--- a/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
+++ b/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
@@ -74,8 +74,8 @@ class ReimbursementDetails:
             self.payment_iban = payment_info.iban
             self.venue_name = payment_info.venue_name
             self.offer_name = payment_info.offer_name
-            self.user_last_name = payment_info.user_lastName
-            self.user_first_name = payment_info.user_firstName
+            self.user_last_name = payment_info.user_lastName or payment_info.redactor_lastname
+            self.user_first_name = payment_info.user_firstName or payment_info.redactor_firstname
             self.booking_token = payment_info.booking_token
             self.booking_used_date = payment_info.booking_dateUsed
             self.booking_total_amount = format_number_as_french(

--- a/tests/repository/reimbursement_queries_test.py
+++ b/tests/repository/reimbursement_queries_test.py
@@ -100,7 +100,15 @@ class FindAllOffererPaymentsTest:
     def test_should_return_one_payment_info_with_sent_status_when_offer_educational(self, app):
         # Given
         now = datetime.utcnow()
-        educational_booking = bookings_factories.UsedEducationalBookingFactory(dateUsed=now, token="ABCDEF")
+        educational_booking = bookings_factories.UsedEducationalBookingFactory(
+            educationalBooking__educationalRedactor__firstName="Dominique",
+            educationalBooking__educationalRedactor__lastName="Leprof",
+            dateUsed=now,
+            token="ABCDEF",
+            quantity=5,
+            amount=50,
+            stock__price=10,
+        )
 
         payment = payments_factories.PaymentFactory(
             amount=50,
@@ -125,17 +133,17 @@ class FindAllOffererPaymentsTest:
         assert payments[0] == (
             None,
             None,
-            educational_booking.firstName,
-            educational_booking.lastName,
-            educational_booking.token,
+            "Dominique",
+            "Leprof",
+            "ABCDEF",
             now,
-            1,
-            Decimal("10.00"),
-            "Product 0",
-            "1 boulevard Poissonnière",
-            "Le Petit Rintintin 0",
-            "00000000000000",
-            "1 boulevard Poissonnière",
+            educational_booking.quantity,
+            educational_booking.amount,
+            educational_booking.stock.offer.name,
+            educational_booking.stock.offer.venue.managingOfferer.address,
+            educational_booking.stock.offer.venue.name,
+            educational_booking.stock.offer.venue.siret,
+            educational_booking.stock.offer.venue.address,
             Decimal("50.00"),
             Decimal("1.00"),
             "CF13QSDFGH456789",

--- a/tests/routes/serialization/reimbursement_csv_test.py
+++ b/tests/routes/serialization/reimbursement_csv_test.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 import pytest
 
+import pcapi.core.bookings.factories as booking_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
 from pcapi.core.payments.factories import PaymentFactory
@@ -20,9 +21,9 @@ in_two_days = today + timedelta(days=2)
 reimbursement_period = (today, in_two_days)
 
 
+@pytest.mark.usefixtures("db_session")
 class ReimbursementDetailsTest:
-    @pytest.mark.usefixtures("db_session")
-    def test_reimbursementDetail_as_csv(self, app):
+    def test_reimbursementDetail_as_csv_individual_booking(self, app):
         # given
         payment = PaymentFactory(
             transactionLabel="pass Culture Pro - remboursement 1ère quinzaine 07-2019",
@@ -54,7 +55,38 @@ class ReimbursementDetailsTest:
         assert raw_csv[14] == "21,00"
         assert raw_csv[15] == "Remboursement envoyé"
 
-    @pytest.mark.usefixtures("db_session")
+    def test_reimbursementDetail_as_csv_educational_booking(self, app):
+        # given
+        booking = booking_factories.UsedEducationalBookingFactory(amount=10.5, quantity=2)
+        payment = PaymentFactory(
+            booking=booking,
+            transactionLabel="pass Culture Pro - remboursement 1ère quinzaine 07-2019",
+        )
+        payments_factories.PaymentStatusFactory(payment=payment, status=TransactionStatus.SENT)
+
+        payments_info = find_all_offerer_payments(payment.booking.offerer.id, reimbursement_period)
+
+        # when
+        raw_csv = ReimbursementDetails(payments_info[0]).as_csv_row()
+
+        # then
+        assert raw_csv[0] == "2019"
+        assert raw_csv[1] == "Juillet : remboursement 1ère quinzaine"
+        assert raw_csv[2] == payment.booking.venue.name
+        assert raw_csv[3] == payment.booking.venue.siret
+        assert raw_csv[4] == payment.booking.venue.address
+        assert raw_csv[5] == payment.iban
+        assert raw_csv[6] == payment.booking.venue.name
+        assert raw_csv[7] == payment.booking.stock.offer.name
+        assert raw_csv[8] == payment.booking.educationalBooking.educationalRedactor.lastName
+        assert raw_csv[9] == payment.booking.educationalBooking.educationalRedactor.firstName
+        assert raw_csv[10] == payment.booking.token
+        assert raw_csv[11] == payment.booking.dateUsed
+        assert raw_csv[12] == "21,00"
+        assert raw_csv[13] == f"{int(payment.reimbursementRate * 100)}%"
+        assert raw_csv[14] == "21,00"
+        assert raw_csv[15] == "Remboursement envoyé"
+
     def test_reimbursementDetail_with_custom_rule_as_csv(self, app):
         # given
         payment = PaymentWithCustomRuleFactory(
@@ -144,16 +176,56 @@ def test_generate_reimbursement_details_csv():
 
 
 @pytest.mark.usefixtures("db_session")
+def test_generate_reimbursement_details_csv_educational_booking():
+    # given
+    educational_booking = booking_factories.UsedEducationalBookingFactory(
+        stock__offer__name='Mon titre ; un peu "spécial"',
+        stock__offer__venue__name='Mon lieu ; un peu "spécial"',
+        stock__offer__venue__siret="siret-1234",
+        token="0E2722",
+        amount=10.5,
+        quantity=2,
+        dateUsed=datetime(2021, 1, 1, 12, 0),
+    )
+
+    payment = PaymentFactory(
+        booking=educational_booking,
+        iban="iban-1234",
+        transactionLabel="pass Culture Pro - remboursement 1ère quinzaine 07-2019",
+    )
+    payments_factories.PaymentStatusFactory(payment=payment, status=TransactionStatus.SENT)
+    offerer = payment.booking.offerer
+    reimbursement_details = find_all_offerer_reimbursement_details(offerer.id, reimbursement_period)
+
+    # when
+    csv = generate_reimbursement_details_csv(reimbursement_details)
+
+    # then
+    rows = csv.splitlines()
+    assert (
+        rows[0]
+        == '"Année";"Virement";"Créditeur";"SIRET créditeur";"Adresse créditeur";"IBAN";"Raison sociale du lieu";"Nom de l\'offre";"Nom utilisateur";"Prénom utilisateur";"Contremarque";"Date de validation de la réservation";"Montant de la réservation";"Barème";"Montant remboursé";"Statut du remboursement"'
+    )
+    assert (
+        rows[1]
+        == '"2019";"Juillet : remboursement 1ère quinzaine";"Mon lieu ; un peu ""spécial""";"siret-1234";"1 boulevard Poissonnière";"iban-1234";"Mon lieu ; un peu ""spécial""";"Mon titre ; un peu ""spécial""";"Khteur";"Reda";"0E2722";"2021-01-01 12:00:00";"21,00";"100%";"21,00";"Remboursement envoyé"'
+    )
+
+
+@pytest.mark.usefixtures("db_session")
 def test_find_all_offerer_reimbursement_details():
     offerer = offers_factories.OffererFactory()
     venue1 = offers_factories.VenueFactory(managingOfferer=offerer)
     venue2 = offers_factories.VenueFactory(managingOfferer=offerer)
+    educational_booking = booking_factories.UsedEducationalBookingFactory(stock__offer__venue=venue2)
     label = ("pass Culture Pro - remboursement 1ère quinzaine 07-2019",)
     payment_1 = payments_factories.PaymentFactory(booking__stock__offer__venue=venue1, transactionLabel=label)
     payment_2 = payments_factories.PaymentFactory(booking__stock__offer__venue=venue2, transactionLabel=label)
+    payment_3 = payments_factories.PaymentFactory(booking=educational_booking, transactionLabel=label)
     payments_factories.PaymentStatusFactory(payment=payment_1, status=TransactionStatus.SENT)
     payments_factories.PaymentStatusFactory(payment=payment_2, status=TransactionStatus.SENT)
+    payments_factories.PaymentStatusFactory(payment=payment_3, status=TransactionStatus.SENT)
 
     reimbursement_details = find_all_offerer_reimbursement_details(offerer.id, reimbursement_period)
 
-    assert len(reimbursement_details) == 2
+    assert len(reimbursement_details) == 3


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11548


## But de la pull request

Faire remontée les réservations eac dans le csv des remboursements

##  Implémentation

Ajout de Outerjoins dans la query qui remonte les paiements, afin de remonter les infos `EducationalBooking`
​
##  Informations supplémentaires

Modification de la sandbox pour que les `IndividualBooking` et les `EducaitonalBooking` créées remontent dans le fichier des remboursements
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
