### PR TITLE
(PC-9246) Interface de création des règles de remboursement personnalisées

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -37,6 +37,8 @@ JWT_ADAGE_PUBLIC_KEY_FILENAME=public_key.development
 JWT_SECRET_KEY=jwt-scret-key-development
 MAILJET_NOT_YET_ELIGIBLE_LIST_ID=10210133
 OBJECT_STORAGE_URL=http://localhost/storage
+# add-or-modify-custom-reimbursement-rules: *
+PERMISSIONS=YWRkLW9yLW1vZGlmeS1jdXN0b20tcmVpbWJ1cnNlbWVudC1ydWxlczogKg==
 PRO_URL=http://localhost:3001
 RATE_LIMIT_BY_EMAIL=100/second
 RATE_LIMIT_BY_IP=100/second

--- a/.env.testing
+++ b/.env.testing
@@ -39,6 +39,8 @@ JWT_ADAGE_PUBLIC_KEY_FILENAME=public_key.testing
 MAILJET_NOT_YET_ELIGIBLE_LIST_ID=10210094
 WEBAPP_FOR_NATIVE_REDIRECTION=https://app-native.testing.internal-passculture.app
 OBJECT_STORAGE_URL=https://storage.googleapis.com/passculture-metier-ehp-testing-assets
+# add-or-modify-custom-reimbursement-rules: *
+PERMISSIONS=YWRkLW9yLW1vZGlmeS1jdXN0b20tcmVpbWJ1cnNlbWVudC1ydWxlczogKg==
 PRO_URL=https://pro.passculture-testing.beta.gouv.fr
 RECAPTCHA_RESET_PASSWORD_MINIMAL_SCORE=0.5
 REDIS_OFFER_IDS_CHUNK_SIZE=10000

--- a/alembic_version_conflict_detection.txt
+++ b/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-bf9641a0f5a8 (head)
+a5f8cf0d75da (head)

--- a/helm/pcapi/values.production.yaml
+++ b/helm/pcapi/values.production.yaml
@@ -582,6 +582,8 @@ secrets:
     version: 4
   - name: PC_GOOGLE_KEY_64
     version: 2
+  - name: PERMISSIONS
+    version: 1
   - name: PROVIDER_FNAC_BASIC_AUTHENTICATION_TOKEN
     version: 2
   - name: RECAPTCHA_SECRET

--- a/helm/pcapi/values.staging.yaml
+++ b/helm/pcapi/values.staging.yaml
@@ -535,6 +535,8 @@ secrets:
     version: 2
   - name: PC_GOOGLE_KEY_64
     version: 2
+  - name: PERMISSIONS
+    version: 1
   - name: PROVIDER_FNAC_BASIC_AUTHENTICATION_TOKEN
     version: 2
   - name: RECAPTCHA_SECRET

--- a/src/pcapi/admin/autocomplete.py
+++ b/src/pcapi/admin/autocomplete.py
@@ -1,0 +1,46 @@
+from flask_login import current_user
+import pydantic
+import sqlalchemy as sqla
+from werkzeug.exceptions import Forbidden
+
+import pcapi.core.offerers.models as offerers_models
+from pcapi.routes.apis import private_api
+from pcapi.serialization.decorator import spectree_serialize
+
+
+class Select2Query(pydantic.BaseModel):
+    q: str
+
+
+class Select2ResponseItem(pydantic.BaseModel):
+    id: int
+    text: str
+
+
+class Select2Response(pydantic.BaseModel):
+    items: list[Select2ResponseItem]
+
+
+@private_api.route("/pc/back-office/autocomplete/offerers", methods=["GET"])
+@spectree_serialize(response_model=Select2Response)
+def offerers(query: Select2Query) -> Select2Response:
+    """Autocomplete offerers on name or SIREN."""
+    if not (current_user.is_authenticated and current_user.isAdmin):
+        raise Forbidden()
+    query = (
+        offerers_models.Offerer.query.filter(
+            sqla.or_(
+                offerers_models.Offerer.name.ilike(f"%{query.q}%"),
+                offerers_models.Offerer.siren.like(f"%{query.q}%"),
+            )
+        )
+        .order_by(offerers_models.Offerer.name)
+        .limit(20)
+        .with_entities(
+            offerers_models.Offerer.id,
+            offerers_models.Offerer.name,
+            offerers_models.Offerer.siren,
+        )
+    )
+    items = [Select2ResponseItem(id=offerer_id, text=f"{name} ({siren})") for offerer_id, name, siren in query]
+    return Select2Response(items=items)

--- a/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
+++ b/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
@@ -1,0 +1,182 @@
+import collections
+import datetime
+from decimal import Decimal
+
+from flask_admin.form import SecureForm
+import markupsafe
+import pytz
+from sqlalchemy.orm import joinedload
+import wtforms.fields.core as wtf_fields
+import wtforms.fields.html5 as wtf_html5_fields
+import wtforms.validators as wtf_validators
+
+from pcapi.admin import fields
+from pcapi.admin import widgets
+from pcapi.admin.base_configuration import BaseAdminView
+from pcapi.core.categories.categories import ALL_CATEGORIES_DICT
+from pcapi.core.categories.subcategories import ALL_SUBCATEGORIES
+from pcapi.core.categories.subcategories import ALL_SUBCATEGORIES_DICT
+import pcapi.core.offerers.models as offerers_models
+import pcapi.core.payments.api as payments_api
+import pcapi.core.payments.exceptions as payments_exceptions
+import pcapi.core.payments.utils as payments_utils
+import pcapi.utils.date as date_utils
+
+
+def _get_subcategory_choices():
+    choices = collections.defaultdict(list)
+    for subcategory in ALL_SUBCATEGORIES:
+        if subcategory.is_selectable:
+            choices[ALL_CATEGORIES_DICT[subcategory.category_id].pro_label].append(
+                (subcategory.id, subcategory.pro_label)
+            )
+
+    return sorted((category_label, sorted(options, key=lambda o: o[1])) for category_label, options in choices.items())
+
+
+SUBCATEGORY_CHOICES = _get_subcategory_choices()
+
+
+def get_offerers(offerer_ids: list):
+    return [
+        {"id": str(offerer.id), "text": offerer.name}
+        for offerer in offerers_models.Offerer.query.filter(offerers_models.Offerer.id.in_(offerer_ids))
+    ]
+
+
+class AddForm(SecureForm):
+    offerer = wtf_fields.StringField(
+        "Offreur",
+        validators=[wtf_validators.DataRequired()],
+        widget=widgets.AutocompleteSelectWidget(endpoint="/pc/back-office/autocomplete/offerers", getter=get_offerers),
+    )
+    subcategories = fields.SelectMultipleFieldWithOptgroups(
+        "Sous-catégories",
+        description="Laisser vide si toutes les sous-catégories sont concernées ; sélectionnez les sous-catégories sinon. Utilisez les touches <ctrl> et <majuscule> pour sélectionner plusieurs sous-catégories.",
+        size=10,
+        choices=SUBCATEGORY_CHOICES,
+    )
+    rate = wtf_fields.IntegerField(
+        "Taux de remboursement (%)",
+        description='Un taux de remboursement (en pourcentage), compris entre 0 et 100. Par exemple, pour 95%, saisir "95"',
+        validators=[
+            wtf_validators.DataRequired(),
+            wtf_validators.NumberRange(0, 100, message="Le taux doit être compris entre %(min)s et %(max)s."),
+        ],
+    )
+    start_date = wtf_html5_fields.DateField(
+        "Date de début d'application",
+        description="Cette date ne peut pas être antérieure à demain.",
+        validators=[wtf_validators.DataRequired()],
+        widget=widgets.DateInputWithConstraint(
+            min_date=lambda _field: datetime.date.today() + datetime.timedelta(days=1)
+        ),
+    )
+    end_date = wtf_html5_fields.DateField(
+        "Date de fin d'application (optionnelle)",
+        validators=[wtf_validators.Optional()],
+        widget=widgets.DateInputWithConstraint(
+            min_date=lambda _field: datetime.date.today() + datetime.timedelta(days=2)
+        ),
+    )
+
+
+class EditForm(SecureForm):
+    end_date = wtf_html5_fields.DateField(
+        "Date de fin d'application",
+        validators=[wtf_validators.DataRequired()],
+        widget=widgets.DateInputWithConstraint(
+            min_date=lambda _field: datetime.date.today() + datetime.timedelta(days=1)
+        ),
+    )
+
+
+def format_timespan(view, context, model, name):
+    start = pytz.utc.localize(model.timespan.lower).astimezone(payments_utils.ACCOUNTING_TIMEZONE).strftime("%d/%m/%Y")
+    if model.timespan.upper:
+        end = (
+            pytz.utc.localize(model.timespan.upper).astimezone(payments_utils.ACCOUNTING_TIMEZONE).strftime("%d/%m/%Y")
+        )
+    else:
+        end = "∞"
+    return markupsafe.Markup(f"{start} → {end}")
+
+
+def format_subcategories(view, context, model, name):
+    labels = sorted(ALL_SUBCATEGORIES_DICT[subcategory_id].pro_label for subcategory_id in model.subcategories)
+    if len(labels) > 5:
+        summary = ", ".join(labels)
+        labels = ", ".join(labels[:5])
+        return markupsafe.Markup(f'<span title="{summary}">{labels}, &hellip;</span>')
+    labels = ", ".join(labels)
+    return markupsafe.Markup(labels)
+
+
+class CustomReimbursementRuleView(BaseAdminView):
+    can_create = True
+    can_edit = True
+    can_delete = False
+    column_list = [
+        "offerer.name",
+        "offerer.siren",
+        "offer.name",
+        "rate",
+        "amount",
+        "subcategories",
+        "timespan",
+    ]
+    column_labels = {
+        "offerer.name": "Offreur",
+        "offerer.siren": "SIREN",
+        "offer.name": "Offre",
+        "rate": "Taux de remboursement",
+        "amount": "Montant remboursé",
+        "subcategories": "Sous-catégories",
+        "timespan": "Dates d'application",
+    }
+    column_formatters = {
+        "subcategories": format_subcategories,
+        "timespan": format_timespan,
+    }
+    column_filters = ["offerer.name", "offer.name"]
+
+    def get_query(self):
+        return self.model.query.options(joinedload(self.model.offerer), joinedload(self.model.offer))
+
+    def get_create_form(self):
+        return AddForm
+
+    def get_edit_form(self):
+        return EditForm
+
+    def create_model(self, form):
+        start_date = date_utils.get_day_start(form.start_date.data, payments_utils.ACCOUNTING_TIMEZONE)
+        end_date = (
+            date_utils.get_day_start(form.end_date.data, payments_utils.ACCOUNTING_TIMEZONE)
+            if form.end_date.data
+            else None
+        )
+        rate = Decimal(form.rate.data / 100).quantize(Decimal("0.01"))
+        try:
+            rule = payments_api.create_reimbursement_rule(
+                offerer_id=int(form.offerer.data),
+                subcategories=form.subcategories.data,
+                rate=rate,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            return rule
+        except payments_exceptions.ReimbursementRuleValidationError as exc:
+            # XXX (dbaty, 2021-10-20): WTForms does not have form-level validation, as of 2.3.3.
+            # https://github.com/wtforms/wtforms/commit/22636b55eda9300b549c8bbaae6f9ae31595d445
+            form._fields["offerer"].errors = [str(exc)]
+            return None
+
+    def update_model(self, form, rule):
+        end_date = date_utils.get_day_start(form.end_date.data, payments_utils.ACCOUNTING_TIMEZONE)
+        try:
+            rule = payments_api.edit_reimbursement_rule(rule, end_date=end_date)
+        except payments_exceptions.ReimbursementRuleValidationError as exc:
+            form._fields["end_date"].errors = [str(exc)]
+            return None
+        return rule

--- a/src/pcapi/admin/fields.py
+++ b/src/pcapi/admin/fields.py
@@ -1,0 +1,35 @@
+import wtforms.fields as wtf_fields
+
+from . import widgets
+
+
+class SelectMultipleFieldWithOptgroups(wtf_fields.SelectMultipleField):
+    """Display a <select> widget with <optgroup> tags.
+
+    Choices should looke like this:
+
+        [
+            ("Mammal", [
+              ("id-of-elephant", "Elephant"),
+              ("id-of-kangaroo", "Kangaroo"),
+            ]),
+            ("Reptile", [
+              ("id-of-snake", "Snake"),
+            ]),
+        ]
+
+    Limitation: all options must be part of an optgroup.
+    """
+
+    widget = widgets.SelectWithOptgroups(multiple=True)
+
+    def __init__(self, *args, size=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.flattened_choices = {option[0] for group in kwargs["choices"] for option in group[1]}
+        self.size = size
+
+    def pre_validate(self, form):
+        if self.data:
+            invalid = set(self.data) - self.flattened_choices
+            if invalid:
+                raise ValueError("Les choix suivants ne sont pas valides : %s" % ", ".join(invalid))

--- a/src/pcapi/admin/install.py
+++ b/src/pcapi/admin/install.py
@@ -17,6 +17,7 @@ from pcapi.admin.custom_views.booking_view import BookingView
 from pcapi.admin.custom_views.category_view import CategoryView
 from pcapi.admin.custom_views.category_view import SubcategoryView
 from pcapi.admin.custom_views.criteria_view import CriteriaView
+from pcapi.admin.custom_views.custom_reimbursement_rule_view import CustomReimbursementRuleView
 from pcapi.admin.custom_views.feature_view import FeatureView
 from pcapi.admin.custom_views.many_offers_operations_view import ManyOffersOperationsView
 from pcapi.admin.custom_views.offerer_view import OffererView
@@ -31,6 +32,7 @@ from pcapi.admin.custom_views.venue_view import VenueView
 from pcapi.core.offerers.models import ApiKey
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offers.models import OfferValidationConfig
+from pcapi.core.payments.models import CustomReimbursementRule
 from pcapi.core.providers.models import VenueProvider
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users.models import User
@@ -198,6 +200,19 @@ def install_admin_views(admin: Admin, session: Session) -> None:
             category=Category.CUSTOM_OPERATIONS,
         )
     )
+
+    admin.add_view(
+        CustomReimbursementRuleView(
+            CustomReimbursementRule,
+            session,
+            name="Règles de remboursement personnalisées",
+            category=Category.CUSTOM_OPERATIONS,
+        )
+    )
+
+
+def install_admin_autocomplete_views():
+    from pcapi.admin import autocomplete  # pylint: disable=unused-import
 
 
 def install_admin_template_filters(app: Flask) -> None:

--- a/src/pcapi/admin/permissions.py
+++ b/src/pcapi/admin/permissions.py
@@ -1,0 +1,25 @@
+from pcapi import settings
+import pcapi.core.users.models as users_models
+
+
+def _get_permission_mapping():
+    mapping = {}
+    for line in settings.PERMISSIONS.split("\n"):
+        if not line:
+            continue
+        permission, emails = line.split(":")
+        emails = {email.strip() for email in emails.split(",")}
+        mapping[permission] = emails
+    return mapping
+
+
+def has_permission(user: users_models.User, permission: str):
+    if not user.isAdmin:  # safety belt, do not remove
+        return False
+    # Yes, we calculate the mapping on every call. It's fine:
+    # - it's fast;
+    # - testing is easier;
+    # - it's temporary, anyway.
+    mapping = _get_permission_mapping()
+    emails = mapping.get(permission, set())
+    return bool({user.email, "*"} & emails)

--- a/src/pcapi/admin/widgets.py
+++ b/src/pcapi/admin/widgets.py
@@ -1,0 +1,102 @@
+import uuid
+
+import markupsafe
+import wtforms.widgets as wtf_widgets
+import wtforms.widgets.html5 as wtf_html5_widgets
+
+
+class AutocompleteSelectWidget(wtf_widgets.Select):
+    def __init__(self, endpoint, getter, multiple=False):
+        super().__init__(multiple=multiple)
+        self.endpoint = endpoint
+        self.uuid = uuid.uuid4()
+        self.getter = getter
+
+    def __call__(self, field, **kwargs):
+        if field.data:
+            selected_ids = ",".join(field.data) if self.multiple else field.data
+            selected_data = self.getter(field.data if self.multiple else [field.data])
+        else:
+            selected_ids = ""
+            selected_data = []
+        if self.multiple:
+            selected_data_js = "[%s]" % ",".join('{id: "%(id)s", text: "%(text)s"}' % item for item in selected_data)
+        elif selected_data:
+            selected_data_js = '{id: "%(id)s", text: "%(text)s"}' % selected_data[0]
+        else:
+            selected_data_js = "null"
+        css_classes = "form-control"
+        if field.errors:
+            css_classes += " is-invalid"
+        html_id = f"{field.name}_{self.uuid}"
+        html = f'<input name="{field.name}" id="{html_id}" value="{selected_ids}">'
+        html += """
+<script>
+  document.addEventListener("DOMContentLoaded", function(event) {
+    $("#%(html_id)s").select2({
+      ajax: {
+        url: "%(url)s",
+        data: function (term, page) {
+          return {
+            q: term, // search term
+          }
+        },
+        results: function (data, page) {
+            return { results: data.items }
+        },
+      },
+      containerCssClass: "%(css_classes)s",
+      initSelection: function (element, callback) {
+        selected = %(selected_data)s
+        callback(selected)
+      },
+      minimumInputLength: 3,
+      placeholder: "Saisissez quelques lettres…",
+    });
+  });
+</script>
+""" % {
+            "css_classes": css_classes,
+            "html_id": html_id,
+            "selected_data": selected_data_js,
+            "url": self.endpoint,
+        }
+        return markupsafe.Markup(html)
+
+
+class DateInputWithConstraint(wtf_html5_widgets.DateInput):
+    def __init__(self, input_type=None, min_date=None, max_date=None):
+        super().__init__(input_type=input_type)
+        self.min_date = min_date
+        self.max_date = max_date
+
+    def __call__(self, field, **kwargs):
+        for bound_name, bound in (("min", self.min_date), ("max", self.max_date)):
+            if callable(bound):
+                bound = bound(field)
+            if bound:
+                kwargs[bound_name] = bound
+        return super().__call__(field, **kwargs)
+
+
+class SelectWithOptgroups(wtf_widgets.Select):
+    def __call__(self, field, **kwargs):
+        kwargs.setdefault("id", field.id)
+        if self.multiple:
+            kwargs["multiple"] = True
+        if "required" not in kwargs and "required" in getattr(field, "flags", []):
+            kwargs["required"] = True
+        if field.size:
+            kwargs.setdefault("size", field.size)
+        html = ["<select %s>" % wtf_widgets.html_params(name=field.name, **kwargs)]
+        for group_label, group_options in field.choices:
+            html.append("<optgroup %s>" % wtf_widgets.html_params(label=group_label))
+            for value, label in group_options:
+                if self.multiple:
+                    selected = field.coerce(value) in (field.data or [])
+                else:
+                    selected = field.coerce(value) == field.data
+                html.append(self.render_option(value, label, selected))
+            html.append("</optgroup>")
+        html.append("</select>")
+        return markupsafe.Markup("".join(html))

--- a/src/pcapi/alembic/versions/20211104T163224_a5f8cf0d75da_payments_add_customreimbursementrule_subcategories.py
+++ b/src/pcapi/alembic/versions/20211104T163224_a5f8cf0d75da_payments_add_customreimbursementrule_subcategories.py
@@ -1,0 +1,22 @@
+"""Add CustomReimbursementRule.subcategories column."""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "a5f8cf0d75da"
+down_revision = "bf9641a0f5a8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "custom_reimbursement_rule",
+        sa.Column("subcategories", postgresql.ARRAY(sa.Text()), server_default="{}", nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("custom_reimbursement_rule", "subcategories")

--- a/src/pcapi/core/payments/api.py
+++ b/src/pcapi/core/payments/api.py
@@ -2,10 +2,12 @@ import datetime
 from typing import Optional
 
 from dateutil.relativedelta import relativedelta
+import pytz
 from sqlalchemy import sql
 
 from pcapi import settings
 import pcapi.core.payments.conf as deposit_conf
+from pcapi.core.payments.models import CustomReimbursementRule
 from pcapi.core.payments.models import Deposit
 from pcapi.core.payments.models import DepositType
 from pcapi.core.payments.models import GrantedDeposit
@@ -16,9 +18,11 @@ from pcapi.models import db
 from pcapi.models.payment import Payment
 from pcapi.models.payment_status import PaymentStatus
 from pcapi.models.payment_status import TransactionStatus
+from pcapi.repository import repository
 
 from . import exceptions
-from . import repository
+from . import repository as payments_repository
+from . import validation
 
 
 def _compute_eighteenth_birthday(birth_date: datetime.datetime) -> datetime.datetime:
@@ -68,7 +72,7 @@ def create_deposit(
     if not granted_deposit:
         raise exceptions.UserNotGrantable()
 
-    if repository.does_deposit_exists_for_beneficiary_and_type(beneficiary, granted_deposit.type):
+    if payments_repository.does_deposit_exists_for_beneficiary_and_type(beneficiary, granted_deposit.type):
         raise exceptions.DepositTypeAlreadyGrantedException(granted_deposit.type)
 
     if beneficiary.has_active_deposit:
@@ -94,3 +98,39 @@ def bulk_create_payment_statuses(payment_query, status: TransactionStatus, detai
     query = sql.insert(PaymentStatus).from_select(["paymentId", "status", "detail"], sel)
     db.session.execute(query)
     db.session.commit()
+
+
+def create_reimbursement_rule(offerer_id, subcategories, rate, start_date, end_date=None):
+    rule = CustomReimbursementRule(
+        offererId=offerer_id,
+        subcategories=subcategories,
+        rate=rate,
+        timespan=(start_date, end_date),
+    )
+    validation.validate_reimbursement_rule(rule)
+    repository.save(rule)
+    return rule
+
+
+def edit_reimbursement_rule(rule, end_date):
+    # To avoid complexity, we do not allow to edit the end date of a
+    # rule that already has one.
+    if rule.timespan.upper:
+        error = "Il n'est pas possible de modifier la date de fin lorsque celle-ci est déjà définie."
+        raise exceptions.WrongDateForReimbursementRule(error)
+    # `rule.timespan.lower` is a naive datetime but it comes from the
+    # database, and is thus UTC. We hence need to localize it so that
+    # `_make_timespan()` does not convert it again. This is not needed
+    # on production (where the server timezone is UTC), but it's
+    # necessary for local development and tests that may be run
+    # under a different timezone.
+    rule.timespan = rule._make_timespan(pytz.utc.localize(rule.timespan.lower), end_date)
+    try:
+        validation.validate_reimbursement_rule(rule, check_start_date=False)
+    except exceptions.ReimbursementRuleValidationError:
+        # Make sure that the change to `timespan` is not accidentally
+        # flushed to the database.
+        db.session.expire(rule)
+        raise
+    repository.save(rule)
+    return rule

--- a/src/pcapi/core/payments/exceptions.py
+++ b/src/pcapi/core/payments/exceptions.py
@@ -13,3 +13,19 @@ class UserNotGrantable(Exception):
 
 class UserHasAlreadyActiveDeposit(UserNotGrantable):
     pass
+
+
+class ReimbursementRuleValidationError(Exception):
+    pass
+
+
+class ConflictingReimbursementRule(ReimbursementRuleValidationError):
+    pass
+
+
+class WrongDateForReimbursementRule(ReimbursementRuleValidationError):
+    pass
+
+
+class UnknownSubcategoryForReimbursementRule(ReimbursementRuleValidationError):
+    pass

--- a/src/pcapi/core/payments/models.py
+++ b/src/pcapi/core/payments/models.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 import enum
 
 import psycopg2.extras
+import pytz
 from sqlalchemy import BigInteger
 from sqlalchemy import CheckConstraint
 from sqlalchemy import Column
@@ -99,7 +100,9 @@ class CustomReimbursementRule(ReimbursementRule, Model):
 
     @classmethod
     def _make_timespan(cls, start, end=None):
-        return psycopg2.extras.DateTimeRange(start.isoformat(), end.isoformat() if end else None, bounds="[)")
+        start = start.astimezone(pytz.utc).isoformat()
+        end = end.astimezone(pytz.utc).isoformat() if end else None
+        return psycopg2.extras.DateTimeRange(start, end, bounds="[)")
 
     def is_active(self, booking: Booking):
         if booking.dateUsed < self.timespan.lower:

--- a/src/pcapi/core/payments/utils.py
+++ b/src/pcapi/core/payments/utils.py
@@ -3,7 +3,7 @@ import datetime
 import pytz
 
 
-LOCAL_TIMEZONE = pytz.timezone("Europe/Paris")
+ACCOUNTING_TIMEZONE = pytz.timezone("Europe/Paris")
 
 
 def get_cutoff_as_datetime(last_day: str) -> datetime.datetime:
@@ -13,4 +13,4 @@ def get_cutoff_as_datetime(last_day: str) -> datetime.datetime:
     """
     next_day = datetime.date.fromisoformat(last_day) + datetime.timedelta(days=1)
     first_second = datetime.datetime.combine(next_day, datetime.time.min)
-    return LOCAL_TIMEZONE.localize(first_second).astimezone(pytz.utc)
+    return ACCOUNTING_TIMEZONE.localize(first_second).astimezone(pytz.utc)

--- a/src/pcapi/core/payments/validation.py
+++ b/src/pcapi/core/payments/validation.py
@@ -1,0 +1,91 @@
+import datetime
+
+import pytz
+from sqlalchemy import or_
+
+from pcapi.core.categories.subcategories import ALL_SUBCATEGORIES_DICT
+import pcapi.utils.date as date_utils
+
+from . import exceptions
+from . import models
+from . import utils
+
+
+def validate_reimbursement_rule(rule: models.CustomReimbursementRule, check_start_date=True):
+    _check_reimbursement_rule_subcategories(rule)
+    _check_reimbursement_rule_dates(rule, check_start_date=check_start_date)
+    _check_reimbursement_rule_conflicts(rule)
+
+
+def _check_reimbursement_rule_subcategories(rule):
+    for subcategory_id in rule.subcategories:
+        if subcategory_id not in ALL_SUBCATEGORIES_DICT:
+            message = f""""{subcategory_id}" n'est pas une sous-catégorie valide."""
+            raise exceptions.UnknownSubcategoryForReimbursementRule(message)
+
+
+def _check_reimbursement_rule_dates(rule, check_start_date=True):
+    tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+    tomorrow = date_utils.get_day_start(tomorrow, utils.ACCOUNTING_TIMEZONE)
+    # If we just set the `timespan` attribute, the lower and upper
+    # bounds are string objects. If `rule` was fetched from the
+    # database, they are `datetime` objects. In that case, we must set
+    # the timezone (to UTC, which is what we store in the database) to
+    # be able to compare these objects to `tomorrow` (that has a
+    # timezone).
+    start_date = rule.timespan.lower
+    if isinstance(start_date, str):
+        start_date = datetime.datetime.fromisoformat(start_date)
+    else:
+        start_date = pytz.utc.localize(start_date)
+    end_date = rule.timespan.upper
+    if isinstance(end_date, str):
+        end_date = datetime.datetime.fromisoformat(end_date)
+    elif end_date is not None:
+        end_date = pytz.utc.localize(end_date)
+
+    if check_start_date and start_date < tomorrow:
+        message = "Impossible d'appliquer une règle de remboursement avant le jour suivant."
+        raise exceptions.WrongDateForReimbursementRule(message)
+    if end_date:
+        if end_date <= start_date:
+            message = "La date de fin d'application doit être postérieure à la date de début."
+            raise exceptions.WrongDateForReimbursementRule(message)
+        if end_date < tomorrow:
+            message = "La date de fin d'application ne peut pas être antérieure à demain."
+            raise exceptions.WrongDateForReimbursementRule(message)
+
+
+def _check_reimbursement_rule_conflicts(rule: models.CustomReimbursementRule):
+    overlapping = models.CustomReimbursementRule.query
+    overlapping = overlapping.filter(models.CustomReimbursementRule.timespan.overlaps(rule.timespan))
+    if rule.offerId:
+        overlapping = overlapping.filter_by(offerId=rule.offerId)
+    else:
+        overlapping = overlapping.filter_by(offererId=rule.offererId)
+
+    # If the new rule covers all subcategories (i.e. if it does not
+    # mention any specific subcategory), it conflicts with any rule
+    # with an overlapping timespan.
+    #
+    # If the new rule covers only _some_ subcategories, it conflicts
+    # only with rules with an overlapping timespan that:
+    # - have at least one subcategory in common;
+    # - or cover all subcategories.
+    #
+    # In other words, we can define rule1 on books and rule2 on shows
+    # with an overlapping timespan, but that's all.
+    if rule.subcategories:
+        overlapping = overlapping.filter(
+            or_(
+                models.CustomReimbursementRule.subcategories == [],
+                models.CustomReimbursementRule.subcategories.overlap(rule.subcategories),
+            )
+        )
+
+    if rule.id:
+        overlapping = overlapping.filter(models.CustomReimbursementRule.id != rule.id)
+    overlapping = {str(rule_id) for rule_id, in overlapping.with_entities(models.CustomReimbursementRule.id)}
+    if overlapping:
+        msg = f"Cette règle est en conflit avec au moins une autre règle de remboursement : {', '.join(overlapping)}"
+        raise exceptions.ConflictingReimbursementRule(msg)

--- a/src/pcapi/routes/__init__.py
+++ b/src/pcapi/routes/__init__.py
@@ -5,6 +5,7 @@ from pcapi.routes.apis import public_api
 
 
 def install_all_routes(app: Flask) -> None:
+    from pcapi.admin.install import install_admin_autocomplete_views
     from pcapi.admin.install import install_admin_template_filters
     from pcapi.admin.install import install_admin_views
     from pcapi.flask_app import admin
@@ -18,6 +19,7 @@ def install_all_routes(app: Flask) -> None:
     from pcapi.tasks.decorator import cloud_task_api
 
     install_admin_views(admin, db.session)
+    install_admin_autocomplete_views()
     install_routes(app)
     pcapi.tasks.install_handlers(app)
     install_admin_template_filters(app)

--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_occurrences.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_occurrences.py
@@ -3,7 +3,7 @@ import logging
 
 from pcapi.model_creators.specific_creators import create_event_occurrence
 from pcapi.sandboxes.scripts.utils.select import remove_every
-from pcapi.utils.date import strftime
+import pcapi.utils.date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -33,10 +33,11 @@ def create_industrial_event_occurrences(event_offers_by_name):
             name = "{} / {} / {} ".format(
                 event_offer_with_occurrences.product.name,
                 event_offer_with_occurrences.venue.name,
-                strftime(beginning_datetime),
+                beginning_datetime.strftime(date_utils.DATE_ISO_FORMAT),
             )
             event_occurrences_by_name[name] = create_event_occurrence(
-                beginning_datetime=strftime(beginning_datetime), offer=event_offer_with_occurrences
+                beginning_datetime=beginning_datetime.strftime(date_utils.DATE_ISO_FORMAT),
+                offer=event_offer_with_occurrences,
             )
 
     return event_occurrences_by_name

--- a/src/pcapi/scripts/payment/update_custom_reimbursements.py
+++ b/src/pcapi/scripts/payment/update_custom_reimbursements.py
@@ -1,3 +1,5 @@
+# FIXME (dbaty, 2021-10-29): remove this script once we're sure that
+# the new Flask-admin-based interface is enough.
 import csv
 import datetime
 from decimal import Decimal

--- a/src/pcapi/settings.py
+++ b/src/pcapi/settings.py
@@ -333,3 +333,6 @@ API_URL_FOR_EDUCONNECT = os.environ.get(
 )  # must match the url specified in the metadata file provided to educonnect
 EDUCONNECT_SP_CERTIFICATE = os.environ.get("EDUCONNECT_SP_CERTIFICATE", PUBLIC_CERTIFICATE_EXAMPLE)
 EDUCONNECT_SP_PRIVATE_KEY = os.environ.get("EDUCONNECT_SP_PRIVATE_KEY", PRIVATE_KEY_EXAMPLE)
+
+# PERMISSIONS
+PERMISSIONS = base64.b64decode(os.environ.get("PERMISSIONS", "")).decode("utf-8")

--- a/src/pcapi/utils/date.py
+++ b/src/pcapi/utils/date.py
@@ -1,4 +1,6 @@
+from datetime import date
 from datetime import datetime
+from datetime import time
 from typing import Optional
 
 from babel.dates import format_date
@@ -132,3 +134,10 @@ def get_time_in_seconds_from_datetime(date_time: datetime) -> int:
     minute_in_seconds = datetime.time(date_time).minute * 60
     seconds = datetime.time(date_time).second
     return hour_in_seconds + minute_in_seconds + seconds
+
+
+def get_day_start(dt: date, timezone) -> datetime:
+    """Return a ``datetime`` object that is the first second of the given
+    ``date`` in the given timezone.
+    """
+    return timezone.localize(datetime.combine(dt, time(0, 0)))

--- a/src/pcapi/utils/date.py
+++ b/src/pcapi/utils/date.py
@@ -83,10 +83,6 @@ class DateTimes:
         return self.datetimes == other.datetimes
 
 
-def strftime(date) -> str:
-    return date.strftime(DATE_ISO_FORMAT)
-
-
 def match_format(value: str, fmt: str) -> str:
     try:
         datetime.strptime(value, fmt)

--- a/tests/admin/autocomplete_test.py
+++ b/tests/admin/autocomplete_test.py
@@ -1,0 +1,49 @@
+import pytest
+
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.users.factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class AutocompleteOfferersTest:
+    def test_autocomplete_on_name(self, client):
+        admin = users_factories.AdminFactory()
+        offerer1 = offerers_factories.OffererFactory(name="Le Petit Rintintin", siren="12345")
+        offerer2 = offerers_factories.OffererFactory(name="Le Grand Rintintin", siren="12346")
+        offerers_factories.OffererFactory(name="La Grande Lassie")
+
+        client = client.with_session_auth(admin.email)
+        response = client.get("/pc/back-office/autocomplete/offerers?q=rintin")
+
+        assert response.status_code == 200
+        assert response.json == {
+            "items": [
+                {"id": offerer2.id, "text": "Le Grand Rintintin (12346)"},
+                {"id": offerer1.id, "text": "Le Petit Rintintin (12345)"},
+            ]
+        }
+
+    def test_autocomplete_on_siren(self, client):
+        admin = users_factories.AdminFactory()
+        offerer1 = offerers_factories.OffererFactory(name="O2", siren="12345678")
+        offerer2 = offerers_factories.OffererFactory(name="O1", siren="23456781")
+        offerers_factories.OffererFactory(name="O3", siren="1111111")
+
+        client = client.with_session_auth(admin.email)
+        response = client.get("/pc/back-office/autocomplete/offerers?q=45678")
+
+        assert response.status_code == 200
+        assert response.json == {
+            "items": [
+                {"id": offerer2.id, "text": "O1 (23456781)"},
+                {"id": offerer1.id, "text": "O2 (12345678)"},
+            ]
+        }
+
+    def test_forbidden_unless_admin(self, client):
+        user = users_factories.UserFactory()
+        client = client.with_session_auth(user.email)
+        response = client.get("/pc/back-office/autocomplete/offerers?q=rintin")
+        assert response.status_code == 403

--- a/tests/admin/custom_views/custom_reimbursement_rule_view_test.py
+++ b/tests/admin/custom_views/custom_reimbursement_rule_view_test.py
@@ -1,0 +1,52 @@
+import datetime
+import decimal
+from unittest import mock
+
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.payments.factories as payments_factories
+import pcapi.core.payments.models as payments_models
+import pcapi.core.users.factories as users_factories
+
+from tests.conftest import clean_database
+
+
+@clean_database
+@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+def test_create_rule(mocked_validate_csrf_token, client, app):
+    admin = users_factories.AdminFactory()
+    offerer = offerers_factories.OffererFactory()
+
+    data = dict(
+        offerer=offerer.id,
+        subcategories=[],
+        rate=80,
+        start_date="2030-10-01",
+        end_date="",
+    )
+    client = client.with_session_auth(admin.email)
+    response = client.post("/pc/back-office/customreimbursementrule/new/", form=data)
+
+    assert response.status_code == 302
+    rule = payments_models.CustomReimbursementRule.query.one()
+    assert rule.offerer == offerer
+    assert rule.rate == decimal.Decimal("0.8")
+    assert rule.subcategories == []
+    assert rule.timespan.lower == datetime.datetime(2030, 9, 30, 22, 0)  # UTC
+    assert rule.timespan.upper is None
+
+
+@clean_database
+@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+def test_edit_rule(mocked_validate_csrf_token, client, app):
+    admin = users_factories.AdminFactory()
+    timespan = (datetime.datetime.today() - datetime.timedelta(days=10), None)
+    rule = payments_factories.CustomReimbursementRuleFactory(timespan=timespan)
+
+    client = client.with_session_auth(admin.email)
+    data = {"end_date": "2030-10-01"}
+    response = client.post(f"/pc/back-office/customreimbursementrule/edit/?id={rule.id}", form=data)
+
+    assert response.status_code == 302
+    rule = payments_models.CustomReimbursementRule.query.one()
+    assert rule.timespan.lower == timespan[0]  # unchanged
+    assert rule.timespan.upper == datetime.datetime(2030, 9, 30, 22, 0)  # UTC

--- a/tests/admin/permissions_test.py
+++ b/tests/admin/permissions_test.py
@@ -1,0 +1,44 @@
+from pcapi.admin import permissions
+from pcapi.core.testing import override_settings
+import pcapi.core.users.factories as users_factories
+
+
+class HasPermissionTest:
+    def _make_user(self, email, is_admin=True):
+        return users_factories.UserFactory.build(email=email, isAdmin=is_admin)
+
+    @override_settings(PERMISSIONS="")
+    def test_empty_permission_list(self):
+        user = self._make_user("jane@example.com")
+        assert not permissions.has_permission(user, "unknown-permission")
+
+    @override_settings(
+        PERMISSIONS="\n".join(
+            (
+                "can-frobulate: jane@example.com",
+                "can-durlingate: john@example.com",
+                "can-tergonize: roger@example.com, jane@example.com",
+            )
+        )
+    )
+    def test_basics(self):
+        jane = self._make_user("jane@example.com")
+        john = self._make_user("john@example.com")
+        roger = self._make_user("roger@example.com")
+        assert permissions.has_permission(jane, "can-frobulate")
+        assert not permissions.has_permission(john, "can-frobulate")
+        assert not permissions.has_permission(jane, "can-durlingate")
+        assert permissions.has_permission(john, "can-durlingate")
+        assert permissions.has_permission(jane, "can-tergonize")
+        assert not permissions.has_permission(john, "can-tergonize")
+        assert permissions.has_permission(roger, "can-tergonize")
+
+    @override_settings(PERMISSIONS="can-frobulate: *")
+    def test_star(self):
+        user = self._make_user("jane@example.com")
+        assert permissions.has_permission(user, "can-frobulate")
+
+    @override_settings(PERMISSIONS="can-frobulate: *")
+    def test_admin_check(self):
+        user = users_factories.UserFactory.build(isAdmin=False, email="jane@example.com")
+        assert not permissions.has_permission(user, "can-frobulate")

--- a/tests/core/payments/test_models.py
+++ b/tests/core/payments/test_models.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 import datetime
 
 import pytest
+import pytz
 
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.offers.factories as offers_factories
@@ -41,6 +42,15 @@ class CustomReimbursementRuleTest:
         assert rule.timespan.upper == end
         assert rule.timespan.lower_inc
         assert not rule.timespan.upper_inc
+
+    def test_timespan_setter_with_timezone(self):
+        offer = offers_factories.OfferFactory()
+        tz = pytz.timezone("Europe/Paris")
+        start = tz.localize(datetime.datetime(2021, 1, 12, 0, 0))
+        rule = models.CustomReimbursementRule(timespan=(start, None), amount=1, offer=offer)
+        repository.save(rule)
+        db.session.refresh(rule)
+        assert rule.timespan.lower == datetime.datetime(2021, 1, 11, 23, 0)
 
     def test_is_active(self):
         start = datetime.datetime(2021, 1, 12, 0, 0)

--- a/tests/core/payments/test_validation.py
+++ b/tests/core/payments/test_validation.py
@@ -1,0 +1,100 @@
+import datetime
+
+import pytest
+
+from pcapi.core.categories import subcategories
+from pcapi.core.payments import exceptions
+from pcapi.core.payments import factories
+from pcapi.core.payments import models
+from pcapi.core.payments import validation
+
+
+class CustomReimbursementRuleValidationTest:
+    def _make_rule(self, **kwargs):
+        tomorrow = datetime.datetime.now() + datetime.timedelta(days=1)
+        kwargs.setdefault("offererId", 1)
+        kwargs.setdefault("rate", 0.8)
+        kwargs.setdefault("subcategories", [])
+        kwargs.setdefault("timespan", (tomorrow, None))
+        return models.CustomReimbursementRule(**kwargs)
+
+    def test_check_subcategories(self):
+        rule = self._make_rule(subcategories=[])
+        validation.validate_reimbursement_rule(rule)  # should not raise
+
+        rule.subcategories = [subcategories.SALON.id]
+        validation.validate_reimbursement_rule(rule)  # should not raise
+
+        rule.subcategories = "CYCLIMSE"
+        with pytest.raises(exceptions.UnknownSubcategoryForReimbursementRule) as exc:
+            validation.validate_reimbursement_rule(rule)
+            assert str(exc) == """"CYCLIMSE n'est pas une sous-catégorie valide."""
+
+    def test_check_start_date(self):
+        today = datetime.datetime.today()
+        tomorrow = today + datetime.timedelta(days=1)
+
+        rule = self._make_rule(timespan=(tomorrow, None))
+        validation.validate_reimbursement_rule(rule)  # should not raise
+
+        rule = self._make_rule(timespan=(today, None))
+        with pytest.raises(exceptions.WrongDateForReimbursementRule):
+            validation.validate_reimbursement_rule(rule)
+
+    def test_check_end_date(self):
+        today = datetime.datetime.today()
+        tomorrow = today + datetime.timedelta(days=1)
+        two_days_from_now = today + datetime.timedelta(days=2)
+
+        rule = self._make_rule(timespan=(tomorrow, None))
+        validation.validate_reimbursement_rule(rule)  # should not raise
+
+        rule = self._make_rule(timespan=(tomorrow, two_days_from_now))
+        validation.validate_reimbursement_rule(rule)  # should not raise
+
+        rule = self._make_rule(timespan=(tomorrow, tomorrow))
+        with pytest.raises(exceptions.WrongDateForReimbursementRule):
+            validation.validate_reimbursement_rule(rule)
+
+    @pytest.mark.usefixtures("db_session")
+    def test_check_no_conflict_if_timespans_do_not_overlap(self):
+        today = datetime.datetime.today()
+        yesterday = today - datetime.timedelta(days=1)
+        tomorrow = today + datetime.timedelta(days=1)
+        timespan1 = (yesterday, today)
+        timespan2 = (tomorrow, None)
+        rule1 = factories.CustomReimbursementRuleFactory(timespan=timespan1)
+        rule2 = self._make_rule(offererId=rule1.offererId, timespan=timespan2)
+        validation.validate_reimbursement_rule(rule2)  # should not raise
+
+    @pytest.mark.usefixtures("db_session")
+    def test_check_no_conflict_if_different_subcategories(self):
+        tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
+        timespan = (tomorrow, None)
+        rule1 = factories.CustomReimbursementRuleFactory(timespan=timespan, subcategories=["SALON"])
+        rule2 = self._make_rule(offererId=rule1.offererId, timespan=timespan, subcategories=["VOD"])
+        validation.validate_reimbursement_rule(rule2)  # should not raise
+
+    @pytest.mark.usefixtures("db_session")
+    def test_check_no_conflicts_with_itself(self):
+        tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
+        rule = factories.CustomReimbursementRuleFactory(timespan=(tomorrow, None))
+        validation.validate_reimbursement_rule(rule)
+
+    @pytest.mark.usefixtures("db_session")
+    def test_check_conflicts_if_subcategories_overlap(self):
+        tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
+        timespan = (tomorrow, None)
+        rule1 = factories.CustomReimbursementRuleFactory(timespan=timespan, subcategories=["SALON"])
+        rule2 = self._make_rule(offererId=rule1.offererId, timespan=timespan, subcategories=["VOD", "SALON"])
+        with pytest.raises(exceptions.ConflictingReimbursementRule):
+            validation.validate_reimbursement_rule(rule2)
+
+    @pytest.mark.usefixtures("db_session")
+    def test_check_conflicts_if_existing_rule_on_all_subcategories(self):
+        tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
+        timespan = (tomorrow, None)
+        rule1 = factories.CustomReimbursementRuleFactory(timespan=(tomorrow, None), subcategories=[])
+        rule2 = self._make_rule(offererId=rule1.offererId, timespan=timespan, subcategories=["VOD"])
+        with pytest.raises(exceptions.ConflictingReimbursementRule):
+            validation.validate_reimbursement_rule(rule2)

--- a/tests/domain/reimbursement_test.py
+++ b/tests/domain/reimbursement_test.py
@@ -6,7 +6,6 @@ from freezegun import freeze_time
 import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
-from pcapi.core.categories import categories
 from pcapi.core.categories import subcategories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
@@ -690,7 +689,7 @@ class CustomRuleFinderTest:
         )
         booking4 = bookings_factories.UsedBookingFactory()
         rule = payments_factories.CustomReimbursementRuleFactory(
-            offerer=offerer, categories=[categories.CINEMA.id], timespan=(yesterday, None)
+            offerer=offerer, subcategories=[subcategories.FESTIVAL_CINE.id], timespan=(yesterday, None)
         )
 
         finder = reimbursement.CustomRuleFinder()


### PR DESCRIPTION
Commits à relire séparément.

Nouveautés réutilisables :
- un widget d'autocomplétion (malheureusement basé sur l'antique version de select2 inclue dans flask-admin, publiée en 2014) ;
- un widget de date permettant de définir une date minimale et/ou une date maximale ;
- un champ et un widget `<select>` qui permet d'utiliser des `<optgroup>` ;
- et un mécanisme (très simple) de permissions pour flask-admin (cf. détails dans le message de commit correspondant).

Démo de la nouvelle interface : 

https://user-images.githubusercontent.com/471321/140398951-5dd2169d-b077-49a0-9fb7-dfd7e9a62267.mp4



