### PR TITLE
(PC-11585) Added query params redirect=false to /saml/educonnect/login endpoint

### DIFF
--- a/src/pcapi/routes/saml/educonnect.py
+++ b/src/pcapi/routes/saml/educonnect.py
@@ -26,9 +26,15 @@ logger = logging.getLogger(__name__)
 @blueprint.saml_blueprint.route("educonnect/login", methods=["GET"])
 @authenticated_user_required
 def login_educonnect(user: user_models.User) -> Response:
+    redirect_user = request.args.get("redirect", default=True, type=bool)
     redirect_url = educonnect_api.get_login_redirect_url(user)
+    response = Response()
 
-    response = redirect(redirect_url, code=302)
+    if not redirect_user:
+        response.status_code = 200
+        response.headers["educonnect-redirect"] = redirect_url
+    else:
+        response = redirect(redirect_url, code=302)
 
     response.headers["Cache-Control"] = "no-cache, no-store"
     response.headers["Pragma"] = "no-cache"

--- a/src/pcapi/routes/saml/educonnect.py
+++ b/src/pcapi/routes/saml/educonnect.py
@@ -26,11 +26,11 @@ logger = logging.getLogger(__name__)
 @blueprint.saml_blueprint.route("educonnect/login", methods=["GET"])
 @authenticated_user_required
 def login_educonnect(user: user_models.User) -> Response:
-    redirect_user = request.args.get("redirect", default=True, type=bool)
+    should_redirect = request.args.get("redirect", default=True, type=lambda v: v.lower() == "true")
     redirect_url = educonnect_api.get_login_redirect_url(user)
     response = Response()
 
-    if not redirect_user:
+    if not should_redirect:
         response.status_code = 200
         response.headers["educonnect-redirect"] = redirect_url
     else:

--- a/tests/routes/saml/educonnect_test.py
+++ b/tests/routes/saml/educonnect_test.py
@@ -47,6 +47,15 @@ class EduconnectTest:
         user, request_id = self.connect_to_educonnect(client, app)
         assert int(app.redis_client.get(f"{self.request_id_key_prefix}{request_id}")) == user.id
 
+    def test_educonnect_login_no_redirect(self, client):
+        users_factories.UserFactory(email=self.email)
+        access_token = create_access_token(identity=self.email)
+        client.auth_header = {"Authorization": f"Bearer {access_token}"}
+        response = client.get("/saml/educonnect/login?redirect=false")
+
+        assert response.status_code == 200
+        assert response.headers["educonnect-redirect"].startswith("https://pr4.educonnect.phm.education.gouv.fr/idp")
+
     @override_settings(IS_PROD=True)
     @override_settings(API_URL_FOR_EDUCONNECT="https://backend.passculture.app")
     def test_get_educonnect_login_production(self, client, app):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11585


## But de la pull request

Ajout de fonctionnalités: 

- Ajout d'un query params `redirect` qui switch la reponse de `302 redirect` à `200` avec un header `educonnect-redirect`

##  Implémentation

- Ajout d'un query params `redirect` avec valeur par défault à `(bool) True`
​
##  Informations supplémentaires

- Nécessaire pour la version EAC Web, ou nous ouvrirons non pas la page via une redirect mais via JavaScript et un nouvel onglet.
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
