### PR TITLE
[PC-11197] perf(backoffice beneficiary support): fix User filter for beneficiary support

### DIFF
--- a/src/pcapi/admin/custom_views/support_view.py
+++ b/src/pcapi/admin/custom_views/support_view.py
@@ -92,7 +92,10 @@ class IDPieceNumberForm(wtforms.Form):
 
 class BeneficiaryView(base_configuration.BaseAdminView):
     VIEW_FILTERS = {
-        "INTERNAL": users_models.User.has_beneficiary_role.is_(True),
+        "INTERNAL": sqlalchemy.and_(
+            users_models.User.has_admin_role.is_(False),
+            users_models.User.has_pro_role.is_(False),
+        ),
         "JOUVE": (
             users_models.User.has_beneficiary_role.is_(False)
             & users_models.User.beneficiaryFraudChecks.any(type=fraud_models.FraudCheckType.JOUVE)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11197


## But de la pull request

Corriger le filtre qui détermine quelques utilisateurs sont accessibles depuis la page de support aux bénéficiaires (les comptes suspicieux n'étaient pas accessible car ils n'ont pas encore le role bénéficiaire)

##  Implémentation

- les utilisateurs sont filtrés par exclusion des rôles PRO et ADMIN, plutôt que par filtrage sur le rôle BENEFICIARY
​
##  Informations supplémentaires

(nope)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] ~~J'ai écrit les tests nécessaires~~
- [ ] ~~J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)~~
- [ ] ~~J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)~~
- [ ] ~~J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)~~
