### PR TITLE
(PC-11545) fix: save educonnect user after educonnect login

### DIFF
--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -304,7 +304,9 @@ def update_beneficiary_mandatory_information(
 
 
 def update_user_information_from_external_source(
-    user: User, data: Union[fraud_models.DMSContent, fraud_models.JouveContent, fraud_models.EduconnectContent]
+    user: User,
+    data: Union[fraud_models.DMSContent, fraud_models.JouveContent, fraud_models.EduconnectContent],
+    commit=False,
 ) -> User:
     if isinstance(data, fraud_models.DMSContent):
         # FIXME: the following function does not override user.dateOfBirth, we should do it
@@ -354,6 +356,8 @@ def update_user_information_from_external_source(
 
     db.session.add(user)
     db.session.flush()
+    if commit:
+        db.session.commit()
     return user
 
 

--- a/src/pcapi/routes/saml/educonnect.py
+++ b/src/pcapi/routes/saml/educonnect.py
@@ -85,9 +85,17 @@ def on_educonnect_authentication_response() -> Response:
     try:
         subscription_api.create_beneficiary_import(user)
     except fraud_exceptions.UserAgeNotValid:
+        logger.warning(
+            "User age not valid",
+            extra={"userId": user.id, "educonnectId": educonnect_user.educonnect_id},
+        )
         error_query_param = {"code": "UserAgeNotValid"}
         return redirect(error_page_base_url + urlencode(error_query_param), code=302)
     except fraud_exceptions.UserAlreadyBeneficiary:
+        logger.warning(
+            "User already beneficiary",
+            extra={"userId": user.id, "educonnectId": educonnect_user.educonnect_id},
+        )
         error_query_param = {"code": "UserAlreadyBeneficiary"}
         return redirect(error_page_base_url + urlencode(error_query_param), code=302)
     except fraud_exceptions.FraudException as e:
@@ -106,5 +114,5 @@ def on_educonnect_authentication_response() -> Response:
         "dateOfBirth": educonnect_user.birth_date,
         "logoutUrl": educonnect_user.logout_url,
     }
-    users_api.update_user_information_from_external_source(user, educonnect_data)
+    users_api.update_user_information_from_external_source(user, educonnect_data, commit=True)
     return redirect(user_information_validation_base_url + urlencode(query_params), code=302)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11545

## But de la pull request

Fix pour sauvegarder les infos d'un utilisateur après authentification via Educonnect

##  Implémentation

Commit le changement en BDD avant de rediriger
​​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
