### PR TITLE
(PC-11608) Add on hold and configurable fraud status

### DIFF
--- a/src/pcapi/core/fraud/models.py
+++ b/src/pcapi/core/fraud/models.py
@@ -27,6 +27,7 @@ class FraudStatus(enum.Enum):
     OK = "OK"
     KO = "KO"
     SUSPICIOUS = "SUSPICIOUS"
+    SUBSCRIPTION_ON_HOLD = "SUBSCRIPTION_ON_HOLD"  # todo : find a name
 
 
 class FraudReviewStatus(enum.Enum):

--- a/src/pcapi/domain/beneficiary_pre_subscription/exceptions.py
+++ b/src/pcapi/domain/beneficiary_pre_subscription/exceptions.py
@@ -10,6 +10,10 @@ class BeneficiaryIsNotEligible(CantRegisterBeneficiary):
     pass
 
 
+class SubscriptionJourneyOnHold(CantRegisterBeneficiary):
+    pass
+
+
 class FraudDetected(CantRegisterBeneficiary):
     pass
 

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -74,6 +74,7 @@ class FeatureToggle(enum.Enum):
     ENABLE_DUPLICATE_USER_RULE_WITHOUT_BIRTHDATE = "Utiliser la nouvelle règle de détection d'utilisateur en doublon"
     ENFORCE_BANK_INFORMATION_WITH_SIRET = "Forcer les informations banquaires à être liées à un SIRET."
     ENABLE_PRO_BOOKINGS_V2 = "Activer l'affichage de la page booking avec la nouvelle architecture."
+    PAUSE_JOUVE_SUBSCRIPTION = "Mettre en pause les inscriptions depuis JOUVE"
     IMPROVE_BOOKINGS_PERF = "Améliore les performances pour la page pro des réservations"
 
     def is_active(self) -> bool:
@@ -125,6 +126,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.ENFORCE_BANK_INFORMATION_WITH_SIRET,
     FeatureToggle.ENABLE_PRO_BOOKINGS_V2,
     FeatureToggle.IMPROVE_BOOKINGS_PERF,
+    FeatureToggle.PAUSE_JOUVE_SUBSCRIPTION,
 )
 
 if not settings.IS_DEV:

--- a/src/pcapi/use_cases/create_beneficiary_from_application.py
+++ b/src/pcapi/use_cases/create_beneficiary_from_application.py
@@ -10,6 +10,7 @@ from pcapi.domain import user_emails as old_user_emails
 from pcapi.domain.beneficiary_pre_subscription.exceptions import BeneficiaryIsADuplicate
 from pcapi.domain.beneficiary_pre_subscription.exceptions import CantRegisterBeneficiary
 from pcapi.domain.beneficiary_pre_subscription.exceptions import FraudDetected
+from pcapi.domain.beneficiary_pre_subscription.exceptions import SubscriptionJourneyOnHold
 from pcapi.domain.beneficiary_pre_subscription.exceptions import SuspiciousFraudDetected
 from pcapi.domain.beneficiary_pre_subscription.fraud_validator import validate_fraud
 from pcapi.domain.beneficiary_pre_subscription.validator import validate
@@ -113,6 +114,8 @@ class CreateBeneficiaryFromApplication:
             old_user_emails.send_rejection_email_to_beneficiary_pre_subscription(
                 beneficiary_pre_subscription=beneficiary_pre_subscription, beneficiary_is_eligible=True
             )
+        except SubscriptionJourneyOnHold as exc:
+            logger.warning("User subscription is on hold", extra={"applicationId": application_id, "reason": exc})
         except CantRegisterBeneficiary as cant_register_beneficiary_exception:
             exception_reason = str(cant_register_beneficiary_exception)
             logger.warning(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11608


## But de la pull request

Permettre de mettre en pause le parcours d'inscription jeune pour un traitement plus important.

##  Implémentation

Ajout d'un type de raison de fraude

##  Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)