### PR TITLE
(PC-11578) fix eligibility datetimes

### DIFF
--- a/src/pcapi/core/users/models.py
+++ b/src/pcapi/core/users/models.py
@@ -354,10 +354,10 @@ class User(PcObject, Model, NeedsValidationMixin):
 
     @property
     def eligibility_start_datetime(self) -> Optional[datetime]:
-        if not self.dateOfBirth or not self.eligibility:
+        if not self.dateOfBirth:
             return None
 
-        if self.eligibility == EligibilityType.UNDERAGE:
+        if FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL.is_active():
             return datetime.combine(self.dateOfBirth, time(0, 0)) + relativedelta(
                 years=constants.ELIGIBILITY_UNDERAGE_RANGE[0]
             )
@@ -365,10 +365,10 @@ class User(PcObject, Model, NeedsValidationMixin):
 
     @property
     def eligibility_end_datetime(self) -> Optional[datetime]:
-        if not self.dateOfBirth or not self.eligibility:
+        if not self.dateOfBirth:
             return None
 
-        if self.eligibility == EligibilityType.UNDERAGE:
+        if FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL.is_active() and self.age < constants.ELIGIBILITY_AGE_18:
             return datetime.combine(self.dateOfBirth, time(0, 0)) + relativedelta(
                 years=constants.ELIGIBILITY_UNDERAGE_RANGE[-1] + 1
             )

--- a/tests/core/users/test_users_sql_entity.py
+++ b/tests/core/users/test_users_sql_entity.py
@@ -11,6 +11,7 @@ import sqlalchemy.exc
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.payments import api as payments_api
+from pcapi.core.testing import override_features
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as user_models
 from pcapi.model_creators.generic_creators import create_offerer
@@ -260,6 +261,7 @@ class CalculateAgeTest:
         assert users_factories.UserFactory.build(dateOfBirth=datetime(1999, 5, 1)).age == 19
 
     @freeze_time("2018-06-01")
+    @override_features(ENABLE_NATIVE_EAC_INDIVIDUAL=False)
     def test_eligibility_start_end_datetime_beneficiary(self):
         assert users_factories.UserFactory.build(dateOfBirth=None).eligibility_start_datetime is None
         assert users_factories.UserFactory.build(
@@ -270,18 +272,25 @@ class CalculateAgeTest:
         assert users_factories.UserFactory.build(
             dateOfBirth=datetime(2000, 6, 1, 5, 1)
         ).eligibility_end_datetime == datetime(2019, 6, 1, 0, 0)
+        assert users_factories.UserFactory.build(
+            dateOfBirth=datetime(2001, 6, 1, 5, 1)
+        ).eligibility_end_datetime == datetime(2020, 6, 1, 0, 0)
 
     @freeze_time("2018-06-01")
+    @override_features(ENABLE_NATIVE_EAC_INDIVIDUAL=True)
     def test_eligibility_start_end_datetime_underage_beneficiary(self):
         assert users_factories.UserFactory.build(dateOfBirth=None).eligibility_start_datetime is None
         assert users_factories.UserFactory.build(
-            dateOfBirth=datetime(2003, 6, 1, 5, 1)
-        ).eligibility_start_datetime == datetime(2018, 6, 1, 0, 0)
+            dateOfBirth=datetime(2000, 6, 1, 5, 1)
+        ).eligibility_start_datetime == datetime(2015, 6, 1, 0, 0)
 
         assert users_factories.UserFactory.build(dateOfBirth=None).eligibility_end_datetime is None
         assert users_factories.UserFactory.build(
-            dateOfBirth=datetime(2003, 6, 1, 5, 1)
-        ).eligibility_end_datetime == datetime(2021, 6, 1, 0, 0)
+            dateOfBirth=datetime(2000, 6, 1, 5, 1)
+        ).eligibility_end_datetime == datetime(2019, 6, 1, 0, 0)
+        assert users_factories.UserFactory.build(
+            dateOfBirth=datetime(2001, 6, 1, 5, 1)
+        ).eligibility_end_datetime == datetime(2019, 6, 1, 0, 0)
 
 
 @pytest.mark.usefixtures("db_session")

--- a/tests/routes/native/v1/account_test.py
+++ b/tests/routes/native/v1/account_test.py
@@ -136,7 +136,7 @@ class AccountTest:
             "depositExpirationDate": "2040-01-01T00:00:00Z",
             "eligibility": "age-18",
             "eligibilityEndDatetime": "2019-01-01T00:00:00Z",
-            "eligibilityStartDatetime": "2018-01-01T00:00:00Z",
+            "eligibilityStartDatetime": "2015-01-01T00:00:00Z",
             "isBeneficiary": True,
             "roles": ["BENEFICIARY"],
             "hasCompletedIdCheck": None,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11578


## But de la pull request

Si le FF ENABLE_NATIVE_EAC_INDIVIDUAL est désactivé, la date d'éligibilité d'un utilisateur -18ans est le jour de ses 18ans.
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
