### PR TITLE
[PC-9647] feat(fraud): stop beneficiary onboarding for risky profiled users

### DIFF
--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -356,7 +356,7 @@ def _underage_user_fraud_item(birth_date: datetime.date) -> models.FraudItem:
     )
 
 
-def create_user_profiling_check(
+def on_user_profiling_result(
     user: user_models.User, profiling_infos: models.UserProfilingFraudData
 ) -> models.BeneficiaryFraudCheck:
     fraud_check = models.BeneficiaryFraudCheck(
@@ -366,10 +366,11 @@ def create_user_profiling_check(
         resultContent=profiling_infos,
     )
     repository.save(fraud_check)
+    on_user_profiling_check_result(user, profiling_infos)
     return fraud_check
 
 
-def on_user_profiling_check(
+def on_user_profiling_check_result(
     user: user_models.User,
     tmx_content: models.UserProfilingFraudData,
 ) -> None:
@@ -528,6 +529,24 @@ def validate_frauds(user: user_models.User, fraud_items: list[models.FraudItem])
 
 def has_user_passed_fraud_checks(user: user_models.User) -> bool:
     return bool(user.beneficiaryFraudResult)
+
+
+def is_risky_user_profile(user: user_models.User) -> bool:
+    user_profiling = (
+        models.BeneficiaryFraudCheck.query.filter(models.BeneficiaryFraudCheck.user == user)
+        .filter(models.BeneficiaryFraudCheck.type == models.FraudCheckType.USER_PROFILING)
+        .order_by(models.BeneficiaryFraudCheck.dateCreated.desc())
+        .first()
+    )
+
+    if user_profiling and user_profiling.source_data().risk_rating == models.UserProfilingRiskRating.HIGH:
+        return True
+
+    if not (user_profiling or FeatureToggle.ALLOW_EMPTY_USER_PROFILING.is_active()):
+        # unprofiled user and forbidden empty profiling -> risky
+        return True
+
+    return False
 
 
 def is_user_fraudster(user: user_models.User) -> bool:

--- a/src/pcapi/core/fraud/api.py
+++ b/src/pcapi/core/fraud/api.py
@@ -23,6 +23,14 @@ logger = logging.getLogger(__name__)
 
 FRAUD_RESULT_REASON_SEPARATOR = ";"
 
+USER_PROFILING_RISK_MAPPING = {
+    models.UserProfilingRiskRating.TRUSTED: models.FraudStatus.OK,
+    models.UserProfilingRiskRating.NEUTRAL: models.FraudStatus.OK,
+    models.UserProfilingRiskRating.LOW: models.FraudStatus.OK,
+    models.UserProfilingRiskRating.MEDIUM: models.FraudStatus.SUSPICIOUS,
+    models.UserProfilingRiskRating.HIGH: models.FraudStatus.KO,
+}
+
 
 def on_educonnect_result(user: user_models.User, educonnect_content: models.EduconnectContent) -> None:
     if (
@@ -204,7 +212,7 @@ def on_identity_fraud_check_result(
     return fraud_result
 
 
-def validate_id_piece_number_format_fraud_item(id_piece_number):
+def validate_id_piece_number_format_fraud_item(id_piece_number) -> models.FraudItem:
     if not id_piece_number or not id_piece_number.strip():
         return models.FraudItem(
             status=models.FraudStatus.SUSPICIOUS, detail="Le numéro de la pièce d'identité est vide"
@@ -334,7 +342,7 @@ def _get_threshold_id_fraud_item(
     return models.FraudItem(status=status, detail=f"Le champ {key} a le score {value} (minimum {threshold})")
 
 
-def _underage_user_fraud_item(birth_date: datetime.date):
+def _underage_user_fraud_item(birth_date: datetime.date) -> models.FraudItem:
     age = relativedelta(datetime.date.today(), birth_date).years
     if age in constants.ELIGIBILITY_UNDERAGE_RANGE:
         return models.FraudItem(
@@ -361,6 +369,16 @@ def create_user_profiling_check(
     return fraud_check
 
 
+def on_user_profiling_check(
+    user: user_models.User,
+    tmx_content: models.UserProfilingFraudData,
+) -> None:
+    risk_rating = tmx_content.risk_rating
+    user_profiling_status = USER_PROFILING_RISK_MAPPING[risk_rating]
+    if not user_profiling_status == models.FraudStatus.OK:
+        upsert_fraud_result(user, user_profiling_status, f"threat-metrix risk rating is {risk_rating.value}")
+
+
 def get_source_data(user: user_models.User) -> models.JouveContent:
     mapped_class = {models.FraudCheckType.DMS: models.DMSContent, models.FraudCheckType.JOUVE: models.JouveContent}
     fraud_check_type = (
@@ -374,16 +392,23 @@ def get_source_data(user: user_models.User) -> models.JouveContent:
     return mapped_class[fraud_check_type.type](**fraud_check_type.resultContent)
 
 
-def upsert_suspicious_fraud_result(user: user_models.User, reason: str) -> models.BeneficiaryFraudResult:
+def upsert_fraud_result(
+    user: user_models.User, status: models.FraudStatus, reason: str = None
+) -> models.BeneficiaryFraudResult:
     """
-    If the user has no fraud result: create one suspicious fraud result with
-    the given reason. If it already has one: update the result's reason.
+    If the user has no fraud result: create one fraud result with status and the given reason.
+    If it already has one: append the reason to the already recorded ones.
     """
+    reason = reason or ""
+    if status != models.FraudStatus.OK and not reason:
+        raise ValueError(f"a reason should be provided when setting fraud result to {status.value}")
+
     fraud_result = models.BeneficiaryFraudResult.query.filter_by(userId=user.id).one_or_none()
 
     if not fraud_result:
-        fraud_result = models.BeneficiaryFraudResult(user=user, status=models.FraudStatus.SUSPICIOUS, reason=reason)
+        fraud_result = models.BeneficiaryFraudResult(user=user, status=status, reason=reason)
     else:
+        fraud_result.status = status
         # if this function is called twice (or more) in a row with the same
         # reason, do not update the reason column with the same reason repeated
         # over and over. It makes the reason less readable and therefore less
@@ -442,7 +467,7 @@ def handle_sms_sending_limit_reached(user: user_models.User) -> models.Beneficia
     )
 
     create_internal_review_fraud_check(user, fraud_check_data)
-    return upsert_suspicious_fraud_result(user, reason)
+    return upsert_fraud_result(user, models.FraudStatus.SUSPICIOUS, reason)
 
 
 def handle_phone_validation_attempts_limit_reached(
@@ -456,7 +481,7 @@ def handle_phone_validation_attempts_limit_reached(
     )
 
     create_internal_review_fraud_check(user, fraud_check_data)
-    return upsert_suspicious_fraud_result(user, reason)
+    return upsert_fraud_result(user, models.FraudStatus.SUSPICIOUS, reason)
 
 
 def handle_document_validation_error(email: str, code: str) -> None:

--- a/src/pcapi/core/fraud/factories.py
+++ b/src/pcapi/core/fraud/factories.py
@@ -10,7 +10,6 @@ from pcapi.core import testing
 import pcapi.core.users.factories as users_factories
 
 from . import models
-from .models import UserProfilingRiskRating
 
 
 JOUVE_CTRL_VALUES = ["OK", "KO"]
@@ -48,7 +47,7 @@ class JouveContentFactory(factory.Factory):
     serviceCodeCtrl = factory.Faker("pystr")
 
 
-USERPROFILING_RATING = [rating.value for rating in UserProfilingRiskRating]
+USERPROFILING_RATING = [rating.value for rating in models.UserProfilingRiskRating]
 USERPROFILING_RESULTS = ["sucess", "failure"]
 USERPROFILING_BOOL = ["yes", "no"]
 

--- a/src/pcapi/core/fraud/factories.py
+++ b/src/pcapi/core/fraud/factories.py
@@ -10,6 +10,7 @@ from pcapi.core import testing
 import pcapi.core.users.factories as users_factories
 
 from . import models
+from .models import UserProfilingRiskRating
 
 
 JOUVE_CTRL_VALUES = ["OK", "KO"]
@@ -47,7 +48,7 @@ class JouveContentFactory(factory.Factory):
     serviceCodeCtrl = factory.Faker("pystr")
 
 
-USERPROFILING_RATING = ["neutral", "low", "good"]
+USERPROFILING_RATING = [rating.value for rating in UserProfilingRiskRating]
 USERPROFILING_RESULTS = ["sucess", "failure"]
 USERPROFILING_BOOL = ["yes", "no"]
 

--- a/src/pcapi/core/fraud/models.py
+++ b/src/pcapi/core/fraud/models.py
@@ -121,6 +121,14 @@ class DMSContent(pydantic.BaseModel):
     id_piece_number: typing.Optional[str]
 
 
+class UserProfilingRiskRating(enum.Enum):
+    TRUSTED = "trusted"
+    NEUTRAL = "neutral"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
 class UserProfilingFraudData(pydantic.BaseModel):
     account_email: str
     account_email_first_seen: typing.Optional[datetime.date]
@@ -145,7 +153,7 @@ class UserProfilingFraudData(pydantic.BaseModel):
     policy_score: int
     reason_code: typing.List[str]
     request_id: str
-    risk_rating: str
+    risk_rating: UserProfilingRiskRating
     session_id: str
     tmx_risk_rating: str
     tmx_summary_reason_code: typing.Optional[typing.List[str]]

--- a/src/pcapi/core/users/api.py
+++ b/src/pcapi/core/users/api.py
@@ -849,16 +849,7 @@ def get_next_beneficiary_validation_step(user: User) -> Optional[BeneficiaryVali
         if not user.is_phone_validated and FeatureToggle.ENABLE_PHONE_VALIDATION.is_active():
             return BeneficiaryValidationStep.PHONE_VALIDATION
 
-        user_profiling = (
-            fraud_models.BeneficiaryFraudCheck.query.filter(fraud_models.BeneficiaryFraudCheck.user == user)
-            .filter(fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.USER_PROFILING)
-            .order_by(fraud_models.BeneficiaryFraudCheck.dateCreated.desc())
-            .first()
-        )
-        if (
-            not user_profiling
-            or user_profiling.resultContent["risk_rating"] == fraud_models.UserProfilingRiskRating.HIGH.value
-        ):
+        if fraud_api.is_risky_user_profile(user):
             return None
 
         return get_id_check_validation_step(user)

--- a/src/pcapi/models/feature.py
+++ b/src/pcapi/models/feature.py
@@ -77,6 +77,7 @@ class FeatureToggle(enum.Enum):
     PAUSE_JOUVE_SUBSCRIPTION = "Mettre en pause les inscriptions depuis JOUVE"
     IMPROVE_BOOKINGS_PERF = "Améliore les performances pour la page pro des réservations"
     ENABLE_INE_WHITELIST_FILTER = "Active le filtre sur les INE whitelistés"
+    ALLOW_EMPTY_USER_PROFILING = "Autorise les inscriptions de bénéficiaires sans profile Threat Metrix"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -128,6 +129,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.ENABLE_PRO_BOOKINGS_V2,
     FeatureToggle.IMPROVE_BOOKINGS_PERF,
     FeatureToggle.PAUSE_JOUVE_SUBSCRIPTION,
+    FeatureToggle.ALLOW_EMPTY_USER_PROFILING,
 )
 
 if not settings.IS_DEV:

--- a/src/pcapi/routes/native/v1/account.py
+++ b/src/pcapi/routes/native/v1/account.py
@@ -300,5 +300,4 @@ def profiling_fraud_score(user: User, body: serializers.UserProfilingFraudReques
         logger.exception("Error while retrieving user profiling infos", exc_info=True)
     else:
         logger.info("Success when profiling user: returned userdata %r", profiling_infos.dict())
-        fraud_api.create_user_profiling_check(user, profiling_infos)
-        fraud_api.on_user_profiling_check(user, profiling_infos)
+        fraud_api.on_user_profiling_result(user, profiling_infos)

--- a/src/pcapi/routes/native/v1/account.py
+++ b/src/pcapi/routes/native/v1/account.py
@@ -301,3 +301,4 @@ def profiling_fraud_score(user: User, body: serializers.UserProfilingFraudReques
     else:
         logger.info("Success when profiling user: returned userdata %r", profiling_infos.dict())
         fraud_api.create_user_profiling_check(user, profiling_infos)
+        fraud_api.on_user_profiling_check(user, profiling_infos)

--- a/tests/core/fraud/test_api.py
+++ b/tests/core/fraud/test_api.py
@@ -256,7 +256,36 @@ class CommonTest:
 
 
 @pytest.mark.usefixtures("db_session")
-class UpsertSuspiciousFraudResultTest:
+class UpsertFraudResultTest:
+    def test_create_on_first_fraud_result(self):
+        user = users_factories.UserFactory()
+        assert fraud_models.BeneficiaryFraudResult.query.count() == 0
+
+        result = fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, "no reason at all")
+
+        assert fraud_models.BeneficiaryFraudResult.query.count() == 1
+        assert result.user == user
+        assert result.reason == "no reason at all"
+
+    def test_update_on_following_fraud_results(self):
+        user = users_factories.UserFactory()
+        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.OK)
+        assert fraud_models.BeneficiaryFraudResult.query.count() == 1
+
+        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, "no reason at all")
+        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.KO, "no reason at all")
+
+        assert fraud_models.BeneficiaryFraudResult.query.count() == 1
+
+    @pytest.mark.parametrize("fraud_status", (fraud_models.FraudStatus.SUSPICIOUS, fraud_models.FraudStatus.KO))
+    def test_reason_is_mandatory_when_not_ok(self, fraud_status):
+        user = users_factories.UserFactory()
+
+        with pytest.raises(ValueError) as excinfo:
+            fraud_api.upsert_fraud_result(user, fraud_status)
+
+        assert str(excinfo.value) == f"a reason should be provided when setting fraud result to {fraud_status.value}"
+
     def test_do_not_repeat_previous_reason_and_keep_history(self):
         """
         Test that the upsert function does updated the reason when consecutive
@@ -266,13 +295,13 @@ class UpsertSuspiciousFraudResultTest:
         first_reason = "first reason"
         second_reason = "second reason"
 
-        fraud_api.upsert_suspicious_fraud_result(user, first_reason)
-        fraud_api.upsert_suspicious_fraud_result(user, first_reason)
-        fraud_api.upsert_suspicious_fraud_result(user, first_reason)
-        fraud_api.upsert_suspicious_fraud_result(user, second_reason)
-        fraud_api.upsert_suspicious_fraud_result(user, second_reason)
-        fraud_api.upsert_suspicious_fraud_result(user, first_reason)
-        result = fraud_api.upsert_suspicious_fraud_result(user, first_reason)
+        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, first_reason)
+        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, first_reason)
+        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, first_reason)
+        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, second_reason)
+        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, second_reason)
+        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, first_reason)
+        result = fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, first_reason)
 
         assert fraud_models.BeneficiaryFraudResult.query.count() == 1
         assert result.user == user


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-9647


## But de la pull request

stopper l'inscription des utilisateurs qui sont classés en risque élevé de fraude par Thread-Metrix

##  Implémentation

- après la validation du numéro de téléphone, si un utilisateur est considéré par Thread-Metrix comme ayant un `risk_rating = high`, l'étape suivante d'inscription renvoyée est `None`
​
##  Informations supplémentaires

- un fraud result est crée/complété dans le cas ou l'utilisateur est profilé avec un risk_rating high ou medium
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] ~~J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)~~ N/A
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] ~~J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)~~ N/A
