### PR TITLE
(PC-10808) Fix: Offerer validation: fix when user_offerer is activated first

### DIFF
--- a/src/pcapi/core/users/repository.py
+++ b/src/pcapi/core/users/repository.py
@@ -172,9 +172,9 @@ def does_validated_phone_exist(phone_number: str):
     return bool(User.query.filter(User.phoneNumber == phone_number, User.is_phone_validated).count())
 
 
-def get_user_with_validated_attachment_by_offerer(offerer: Offerer) -> User:
+def get_users_with_validated_attachment_by_offerer(offerer: Offerer) -> User:
     return (
         User.query.join(UserOfferer)
         .filter(UserOfferer.validationToken.is_(None), UserOfferer.offererId == offerer.id)
-        .one()
+        .all()
     )

--- a/tests/core/users/test_repository.py
+++ b/tests/core/users/test_repository.py
@@ -10,7 +10,7 @@ from pcapi.core.offers import factories as offers_factories
 from pcapi.core.users import exceptions
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import repository
-from pcapi.core.users.repository import get_user_with_validated_attachment_by_offerer
+from pcapi.core.users.repository import get_users_with_validated_attachment_by_offerer
 from pcapi.domain.favorite.favorite import FavoriteDomain
 
 
@@ -182,7 +182,8 @@ class GetApplicantOfOffererUnderValidationTest:
         )
 
         # When
-        applicant_found = get_user_with_validated_attachment_by_offerer(applied_offerer)
+        applicants_found = get_users_with_validated_attachment_by_offerer(applied_offerer)
 
         # Then
-        assert applicant_found.id == applicant.id
+        assert len(applicants_found) == 1
+        assert applicants_found[0].id == applicant.id

--- a/tests/routes/pro/validate_offerer_test.py
+++ b/tests/routes/pro/validate_offerer_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from pcapi.core.offerers.models import Offerer
 import pcapi.core.offers.factories as offers_factories
+from pcapi.core.users.models import UserRole
 
 from tests.conftest import TestClient
 
@@ -28,6 +29,23 @@ class Returns202Test:
         offerer = Offerer.query.filter_by(id=user_offerer.offerer.id).first()
         assert offerer.isValidated is True
         assert offerer.dateValidated == datetime(2021, 6, 23, 11)
+
+    def expect_offerer_to_be_validated_even_when_user_offerer_has_already_been_activated(self, app):
+        # Given
+        offerer = offers_factories.OffererFactory(validationToken="TOKEN")
+        user_offerer1 = offers_factories.UserOffererFactory(offerer=offerer)
+        user_offerer2 = offers_factories.UserOffererFactory(validationToken=None, offerer=offerer)
+
+        # When
+        response = TestClient(app.test_client()).get(f"/validate/offerer/{offerer.validationToken}")
+
+        # Then
+        assert response.status_code == 202
+        assert response.data.decode("utf8") == "Validation effectuée"
+        offerer = Offerer.query.filter_by(id=offerer.id).first()
+        assert offerer.isValidated is True
+        assert user_offerer1.user.roles == [UserRole.PRO]
+        assert user_offerer2.user.roles == [UserRole.PRO]
 
 
 class Returns404Test:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10808


## But de la pull request

correction d'un bug qui empêche les bizdevs de valider des rattachements pro

##  Implémentation
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
