### PR TITLE
BSR : fix data format in exception raised in adage jwt decorator

### DIFF
--- a/src/pcapi/routes/adage_iframe/security.py
+++ b/src/pcapi/routes/adage_iframe/security.py
@@ -33,7 +33,7 @@ def adage_jwt_required(route_function):
                 raise ForbiddenError({"Authorization": "Unrecognized token"})
             except ExpiredSignatureError as expired_signature_error:
                 logger.warning("Token has expired", extra={"error": expired_signature_error})
-                raise InvalidTokenError({"Token expired"})
+                raise InvalidTokenError("Token expired")
 
             if not adage_jwt_decoded.get("exp"):
                 logger.warning("Token does not contain an expiration date")
@@ -49,6 +49,6 @@ def adage_jwt_required(route_function):
             kwargs["authenticated_information"] = authenticated_information
             return route_function(*args, **kwargs)
 
-        raise ForbiddenError({"Authorization": ["Unrecognized token"]})
+        raise ForbiddenError({"Authorization": "Unrecognized token"})
 
     return wrapper


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX


## But de la pull request

Corriger un mauvais format transmis à l'exception dans la fonction décorateur pour le jwt adage

##  Implémentation

Harmonisation : dans l'exception `InvalidTokenError`, on passe une string car l'exception indique déjà le type d'erreur (authentication / authorization)
​
##  Informations supplémentaires

N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
