### PR TITLE
(PC-11685) fix, native: venue.publicName defaults to name

### DIFF
--- a/src/pcapi/routes/native/v1/offerers.py
+++ b/src/pcapi/routes/native/v1/offerers.py
@@ -20,7 +20,7 @@ def get_venue(venue_id: int) -> serializers.VenueResponse:
         latitude=venue.latitude,
         longitude=venue.longitude,
         city=venue.city,
-        publicName=venue.publicName,
+        publicName=venue.publicName or venue.name,
         isVirtual=venue.isVirtual,
         isPermanent=venue.isPermanent,
         withdrawalDetails=venue.withdrawalDetails,

--- a/tests/routes/native/v1/offerers_test.py
+++ b/tests/routes/native/v1/offerers_test.py
@@ -41,6 +41,14 @@ class VenuesTest:
             },
         }
 
+    def test_get_venue_public_name(self, client):
+        venue = offerer_factories.VenueFactory(isPermanent=True, publicName=None)
+
+        response = client.get(f"/native/v1/venue/{venue.id}")
+
+        assert response.status_code == 200
+        assert response.json["publicName"] == venue.name
+
     def test_get_non_permanent_venue(self, client):
         venue = offerer_factories.VenueFactory(isPermanent=False)
         response = client.get(f"/native/v1/venue/{venue.id}")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11685


## But de la pull request

Correction de la route `/native/v1/venue/<id>`. Le champ `publicName` est utilisé par l'app native et ne doit pas être vide. Si le champ publicName n'existe pas, on renseigne `venue.name`.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires