### PR TITLE
WIP Commit msg Hook

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo -e "Checking commit message format"
+MSG_FILE=$1
+cz check --commit-msg-file $MSG_FILE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,34 @@ multi_line_output = 3
 sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER"
 skip_gitignore = true
 use_parentheses = true
+
+[tool.commitizen]
+name = "cz_customize"
+
+[tool.commitizen.customize]
+message_template = "({{jira_ticket}}) {{change_type}}[{{scope}}]: {{message}}"
+example = "(PC-12345) feat:[pass culture] this feature enable customize through config file"
+schema = "(<ticket_number>) <type>:<scope>: <subject>\n<BLANK LINE>\n<body>\n<BLANK LINE>\n"
+schema_pattern = "(\\(|\\[)PC-\\d+(\\)|\\]) ?(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump):(\\[[\\w\\s]+\\])?[\\w\\s]+$"
+
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "jira_ticket"
+message = "Jira ticket number. e.g. PC-XXXX"
+
+[[tool.commitizen.customize.questions]]
+type = "list"
+name = "change_type"
+choices = [{value = "fix", name = "fix: A bug fix."}, {value = "feat",name = "feat: A new feature."}, {value = "docs", name = "docs: Documentation only changes"},{value = "style",name = "style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"},{value = "refactor",name = "refactor: A code change that neither fixes a bug nor adds a feature"},{value = "perf",name = "perf: A code change that improves performance"},{value = "test",name = "test: Adding missing or correcting existing tests"},{value = "build",name = "build: Changes that affect the build system or external dependencies (example scopes: pip, docker, npm)"},{value = "ci",name = "ci: Changes to our CI configuration files and scripts (example scopes: GitLabCI)"},]
+message = "Select the type of change you are committing"
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "scope"
+message = "The scope of this commit"
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "message"
+message = "The commit message"

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,3 +76,4 @@ tzlocal<3.0.0
 Werkzeug==1.0.1
 wheel==0.35.1
 WTForms-SQLAlchemy
+commitizen


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX


## But de la pull request

Ajouter un check sur le format de message de commit

##  Implémentation

- Ajout du hook commit-msg pour lancer `cz check` sur le message de commit
​
##  Informations supplémentaires

- Doc commitizen pour la customisation: https://commitizen-tools.github.io/commitizen/customization/#customize-configuration
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
