### PR TITLE
(PC-11701) : fix in-app message crash for IDCheck's unread-document

### DIFF
--- a/src/pcapi/core/subscription/messages.py
+++ b/src/pcapi/core/subscription/messages.py
@@ -78,14 +78,24 @@ def on_idcheck_invalid_document_date(user: users_models.User) -> None:
 
 
 def on_id_check_unread_document(user: users_models.User) -> None:
-    token = users_api.create_id_check_token(user)
-    message = models.SubscriptionMessage(
-        user=user,
-        userMessage="Ton dossier n’a pas pu être validé car la photo que tu as transmise est illisible.",
-        callToActionTitle="Essayer avec une autre photo",
-        callToActionLink=f"passculture://idcheck?token={token}",
-        callToActionIcon=models.CallToActionIcon.RETRY,
-    )
+    today = datetime.date.today()
+    if user.hasCompletedIdCheck:
+        message = models.SubscriptionMessage(
+            user=user,
+            userMessage=f"Nous n'arrivons pas à traiter ton document. Consulte l'e-mail envoyé le {today:%d/%m/%Y} pour plus d'informations.",
+            callToActionTitle="Consulter mes e-mails",
+            callToActionLink=INBOX_URL,
+            callToActionIcon=models.CallToActionIcon.EMAIL,
+        )
+    else:
+        token = users_api.create_id_check_token(user)
+        message = models.SubscriptionMessage(
+            user=user,
+            userMessage="Ton dossier n’a pas pu être validé car la photo que tu as transmise est illisible.",
+            callToActionTitle="Essayer avec une autre photo",
+            callToActionLink=f"passculture://idcheck?token={token}",
+            callToActionIcon=models.CallToActionIcon.RETRY,
+        )
     repository.save(message)
 
 

--- a/tests/core/users/test_api.py
+++ b/tests/core/users/test_api.py
@@ -1,5 +1,6 @@
 from datetime import date
 from datetime import datetime
+from datetime import time
 from datetime import timedelta
 from decimal import Decimal
 from pathlib import Path
@@ -1015,7 +1016,10 @@ class VerifyIdentityDocumentInformationsTest:
         self, mocked_get_identity_informations, mocked_ask_for_identity, mocked_delete_object, app
     ):
         # Given
-        existing_user = users_factories.UserFactory()
+        eligible_date_of_birth = datetime.combine(date.today(), time.min) - relativedelta(
+            years=users_constants.ELIGIBILITY_AGE_18, months=1
+        )
+        existing_user = users_factories.UserFactory(dateOfBirth=eligible_date_of_birth)
         mocked_get_identity_informations.return_value = (existing_user.email, b"")
         mocked_ask_for_identity.return_value = (False, "unread-document")
 
@@ -1032,6 +1036,37 @@ class VerifyIdentityDocumentInformationsTest:
         assert not message.popOverIcon
         assert (
             message.userMessage == "Ton dossier n’a pas pu être validé car la photo que tu as transmise est illisible."
+        )
+
+    @patch("pcapi.core.users.api.delete_object")
+    @patch("pcapi.core.users.api.ask_for_identity_document_verification")
+    @patch("pcapi.core.users.api._get_identity_document_informations")
+    @freeze_time("2021-10-30 09:00:00")
+    def test_known_user_email_sent_when_document_is_unreadable_and_has_completed_idcheck(
+        self, mocked_get_identity_informations, mocked_ask_for_identity, mocked_delete_object, app
+    ):
+        # Given
+        eligible_date_of_birth = datetime.combine(date.today(), time.min) - relativedelta(
+            years=users_constants.ELIGIBILITY_AGE_18, months=1
+        )
+        existing_user = users_factories.UserFactory(dateOfBirth=eligible_date_of_birth, hasCompletedIdCheck=True)
+        mocked_get_identity_informations.return_value = (existing_user.email, b"")
+        mocked_ask_for_identity.return_value = (False, "unread-document")
+
+        users_api.verify_identity_document_informations("some_path")
+
+        assert len(existing_user.beneficiaryFraudChecks) == 1
+        fraud_check = existing_user.beneficiaryFraudChecks[0]
+        assert fraud_check.type == fraud_models.FraudCheckType.INTERNAL_REVIEW
+        assert fraud_check.resultContent["message"] == "Erreur de lecture du document : unread-document"
+        assert fraud_check.resultContent["source"] == fraud_models.InternalReviewSource.DOCUMENT_VALIDATION_ERROR.value
+
+        assert subscription_models.SubscriptionMessage.query.count() == 1
+        message = subscription_models.SubscriptionMessage.query.first()
+        assert not message.popOverIcon
+        assert (
+            message.userMessage
+            == "Nous n'arrivons pas à traiter ton document. Consulte l'e-mail envoyé le 30/10/2021 pour plus d'informations."
         )
 
     @patch("pcapi.core.users.api.delete_object")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11701


## But de la pull request

The in-app message for IDCheck's unread-document error possibly
has a race issue that could result in a crash and retry whenever
a user had the unread-document code after it confirmed the
general conditions.
General conditions would flag the user as hasCompletedIdCheck
which would raise an exception when requested a new idcheck
token leading to a post IDCheck crash and endless retries
on IDCheck step.
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
