### PR TITLE
(PC-11204) Fix beneficiary_import.eligibilityType default value

### DIFF
--- a/alembic_version_conflict_detection.txt
+++ b/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-98a7c44f7ca1 (head)
+5ff1b52e2f08 (head)

--- a/src/pcapi/alembic/versions/20211110T121107_5ff1b52e2f08_change_default_eligibility_type.py
+++ b/src/pcapi/alembic/versions/20211110T121107_5ff1b52e2f08_change_default_eligibility_type.py
@@ -1,0 +1,22 @@
+"""change_default_eligibility_type
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "5ff1b52e2f08"
+down_revision = "98a7c44f7ca1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+            ALTER TABLE beneficiary_import ALTER COLUMN "eligibilityType" SET DEFAULT 'AGE18';
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/src/pcapi/models/beneficiary_import.py
+++ b/src/pcapi/models/beneficiary_import.py
@@ -35,7 +35,7 @@ class BeneficiaryImport(PcObject, Model):
         sa.Enum(EligibilityType, create_constraint=False),
         nullable=False,
         default=EligibilityType.AGE18,
-        server_default=sa.text(EligibilityType.AGE18.value),
+        server_default=sa.text(EligibilityType.AGE18.name),
     )
     beneficiary = relationship("User", foreign_keys=[beneficiaryId], backref="beneficiaryImports")
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11204


## But de la pull request

Fait suite au bug : https://sentry.internal-passculture.app/organizations/sentry/issues/227441/?project=5&referrer=slack

Il faut paramétrer la valeur par défaut sql avec la clé de l'enum plutôt qu'avec la valeur