### PR TITLE
(PC-11524): Make first column stick left and update order

### DIFF
--- a/src/pcapi/admin/custom_views/category_view.py
+++ b/src/pcapi/admin/custom_views/category_view.py
@@ -30,7 +30,8 @@ class CategoryView(BaseCustomAdminView):
 class SubcategoryView(BaseCustomAdminView):
     @expose("/", methods=["GET"])
     def subcategories(self) -> Response:
-        column_names = [field.name for field in fields(Subcategory)]
+        column_names = ["pro_label", "app_label"]
+        column_names += [field.name for field in fields(Subcategory) if field.name not in ("pro_label", "app_label")]
         column_labels = {
             "id": "Nom tech de la sous-catégorie",
             "category_id": "Nom tech de la catégorie",

--- a/src/pcapi/templates/admin/subcategories_list.html
+++ b/src/pcapi/templates/admin/subcategories_list.html
@@ -4,7 +4,14 @@
 {% block body %}
 <style>
     .sticky-top {
-        z-index: 0;
+        z-index: 1;
+    }
+
+    th:first-of-type, tr td:first-of-type{
+        background-color: #18BC9C;
+        color: white;
+        left: 0;
+        position: sticky;
     }
 </style>
 <br>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11524


## But de la pull request

Placer les colonnes pro & app label en premier dans la liste des sous-catégories, rendre sticky la première colonne
​

