### PR TITLE
(PC-11716) : limit the query count on /venues

### DIFF
--- a/src/pcapi/core/offerers/repository.py
+++ b/src/pcapi/core/offerers/repository.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+import sqlalchemy.orm as sqla_orm
+
 from pcapi.core.offerers.models import ApiKey
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import Venue
@@ -46,8 +48,10 @@ def get_filtered_venues(
     validated_offerer: Optional[bool] = None,
     validated_offerer_for_user: Optional[bool] = None,
 ) -> list[Venue]:
-    query = Venue.query.join(Offerer, Offerer.id == Venue.managingOffererId).join(
-        UserOfferer, UserOfferer.offererId == Offerer.id
+    query = (
+        Venue.query.join(Offerer, Offerer.id == Venue.managingOffererId)
+        .join(UserOfferer, UserOfferer.offererId == Offerer.id)
+        .options(sqla_orm.joinedload(Venue.managingOfferer))
     )
     if not user_is_admin:
         query = query.filter(UserOfferer.userId == pro_user_id)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11716


## But de la pull request

The venues route was issuing one query per offerer which kills
the performance on the route. This aims to improve the route's
performance.

##  Implémentation

By using a joinedload, we ensure the associated offerers are
loaded along with each venue which drop the query count to
a single one.
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
