### PR TITLE
[PC(10266] routes.pro.venues: fix bulk update offers accessibility

### DIFF
--- a/src/pcapi/routes/pro/venues.py
+++ b/src/pcapi/routes/pro/venues.py
@@ -112,13 +112,10 @@ def edit_venue(venue_id: str, body: EditVenueBodyModel) -> GetVenueResponseModel
     )
     have_withdrawal_details_changes = body.withdrawalDetails != venue.withdrawalDetails
     venue = offerers_api.update_venue(venue, body.contact, **update_venue_attrs)
+    venue_attrs = as_dict(venue)
 
     if have_accessibility_changes and body.isAccessibilityAppliedOnAllOffers:
-        edited_accessibility = edited_accessibility = {
-            field: update_venue_attrs[field]
-            for field in accessibility_fields
-            if field in update_venue_attrs and update_venue_attrs[field] != venue_attrs[field]
-        }
+        edited_accessibility = {field: venue_attrs[field] for field in accessibility_fields}
         update_all_venue_offers_accessibility_job.delay(venue, edited_accessibility)
 
     if FeatureToggle.ENABLE_VENUE_WITHDRAWAL_DETAILS.is_active():

--- a/tests/routes/pro/patch_venue_test.py
+++ b/tests/routes/pro/patch_venue_test.py
@@ -171,7 +171,13 @@ class Returns200Test:
         assert venue.audioDisabilityCompliant == True
 
         mocked_update_all_venue_offers_accessibility_job.assert_called_once_with(
-            venue, {"audioDisabilityCompliant": True}
+            venue,
+            {
+                "audioDisabilityCompliant": True,
+                "mentalDisabilityCompliant": venue.mentalDisabilityCompliant,
+                "motorDisabilityCompliant": venue.motorDisabilityCompliant,
+                "visualDisabilityCompliant": venue.visualDisabilityCompliant,
+            },
         )
 
     @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10266

Lorsqu'on édite les valeurs d’accessibilité d'une offre on veux tout le jeu d'information (moteur, visuel, audio, mental) et non pas la ou les valeurs modifiées