### PR TITLE
(PC-11243): add not null venue_provider venueIdAtOfferProvider constraint

### DIFF
--- a/api/src/pcapi/alembic/versions/20211109T163416_a0a822d365ac_add_not_null_venue_provider_venue_id_at_offer_provider_step_1.py
+++ b/api/src/pcapi/alembic/versions/20211109T163416_a0a822d365ac_add_not_null_venue_provider_venue_id_at_offer_provider_step_1.py
@@ -1,0 +1,23 @@
+"""add_not_null_venue_provider_venue_id_at_offer_provider
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "a0a822d365ac"
+down_revision = "194844a36610"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+            ALTER TABLE venue_provider DROP CONSTRAINT IF EXISTS venueid_at_offer_provider_not_null_constraint;
+            ALTER TABLE venue_provider ADD CONSTRAINT venueid_at_offer_provider_not_null_constraint CHECK ("venueIdAtOfferProvider" IS NOT NULL) NOT VALID;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("venueid_at_offer_provider_not_null_constraint", table_name="venue_provider")

--- a/api/src/pcapi/alembic/versions/20211110T080547_010aba57cb3e_add_not_null_venue_provider_venue_id_at_offer_provider_step_2.py
+++ b/api/src/pcapi/alembic/versions/20211110T080547_010aba57cb3e_add_not_null_venue_provider_venue_id_at_offer_provider_step_2.py
@@ -1,0 +1,31 @@
+"""add_not_null_venue_provider_venue_id_at_offer_provider_step_2
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+from pcapi import settings
+
+
+revision = "010aba57cb3e"
+down_revision = "a0a822d365ac"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.execute(
+        """
+        SET SESSION statement_timeout = '900s'
+        """
+    )
+    op.execute("ALTER TABLE venue_provider VALIDATE CONSTRAINT venueid_at_offer_provider_not_null_constraint;")
+    op.execute(
+        f"""
+        SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/api/src/pcapi/alembic/versions/20211110T080553_f2cb5833253a_add_not_null_venue_provider_venue_id_at_offer_provider_step_3.py
+++ b/api/src/pcapi/alembic/versions/20211110T080553_f2cb5833253a_add_not_null_venue_provider_venue_id_at_offer_provider_step_3.py
@@ -1,0 +1,18 @@
+"""add_not_null_venue_provider_venue_id_at_offer_provider_step_3
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "f2cb5833253a"
+down_revision = "010aba57cb3e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("venue_provider", "venueIdAtOfferProvider", nullable=False)
+
+
+def downgrade():
+    pass

--- a/api/src/pcapi/alembic/versions/20211110T080556_32c7ca9be253_add_not_null_venue_provider_venue_id_at_offer_provider_step_4.py
+++ b/api/src/pcapi/alembic/versions/20211110T080556_32c7ca9be253_add_not_null_venue_provider_venue_id_at_offer_provider_step_4.py
@@ -1,0 +1,22 @@
+"""add_not_null_venue_provider_venue_id_at_offer_provider_step_4
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "32c7ca9be253"
+down_revision = "f2cb5833253a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint("venueid_at_offer_provider_not_null_constraint", table_name="venue_provider")
+
+
+def downgrade():
+    op.execute(
+        """
+            ALTER TABLE venue_provider ADD CONSTRAINT venueid_at_offer_provider_not_null_constraint CHECK ("venueIdAtOfferProvider" IS NOT NULL) NOT VALID;
+        """
+    )

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -82,7 +82,7 @@ class VenueProvider(PcObject, Model, ProvidableMixin, DeactivableMixin):
 
     provider = relationship("Provider", foreign_keys=[providerId])
 
-    venueIdAtOfferProvider = Column(String(70))
+    venueIdAtOfferProvider = Column(String(70), nullable=False)
 
     lastSyncDate = Column(DateTime, nullable=True)
 

--- a/api/tests/admin/custom_views/venue_provider_view_test.py
+++ b/api/tests/admin/custom_views/venue_provider_view_test.py
@@ -129,7 +129,7 @@ class EditModelTest:
             allocine_quantity=222,
             provider=provider.id,
             venue=venue.id,
-            venueIdAtOfferProvider=None,
+            venueIdAtOfferProvider="ABCDEF12345",
         )
 
         client.with_session_auth("user@example.com")

--- a/api/tests/local_providers/provider_manager_test.py
+++ b/api/tests/local_providers/provider_manager_test.py
@@ -9,6 +9,7 @@ import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.categories import subcategories
 from pcapi.core.offerers.factories import APIProviderFactory
 from pcapi.core.offerers.factories import AllocineProviderFactory
+from pcapi.core.offerers.factories import AllocineVenueProviderFactory
 from pcapi.core.offerers.factories import VenueProviderFactory
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import Offer
@@ -16,11 +17,9 @@ from pcapi.local_providers.provider_manager import do_update
 from pcapi.local_providers.provider_manager import synchronize_data_for_provider
 from pcapi.local_providers.provider_manager import synchronize_venue_provider
 from pcapi.local_providers.provider_manager import synchronize_venue_providers_for_provider
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.generic_creators import create_venue_provider
-from pcapi.model_creators.provider_creators import activate_provider
 from pcapi.repository import repository
 
 from tests.local_providers.provider_test_utils import TestLocalProvider
@@ -158,12 +157,11 @@ class SynchronizeVenueProviderTest:
         self, mock_do_update, mock_get_provider_class, app
     ):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
+        offerer = offers_factories.OffererFactory()
+        venue = offers_factories.VenueFactory(managingOfferer=offerer)
 
-        provider = activate_provider("AllocineStocks")
-        allocine_venue_provider = create_allocine_venue_provider(venue, provider, is_duo=True)
-        repository.save(allocine_venue_provider)
+        provider = AllocineProviderFactory()
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue, provider=provider)
 
         mock_provider_class = MagicMock()
         mock_get_provider_class.return_value = mock_provider_class

--- a/api/tests/models/allocine_venue_provider_price_rule_test.py
+++ b/api/tests/models/allocine_venue_provider_price_rule_test.py
@@ -1,10 +1,13 @@
 import pytest
 
+from pcapi.core.offerers.factories import AllocineProviderFactory
+from pcapi.core.offerers.factories import AllocineVenueProviderFactory
+from pcapi.core.offerers.factories import AllocineVenueProviderPriceRuleFactory
+from pcapi.core.offers.factories import OffererFactory
+from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.providers.models import AllocineVenueProviderPriceRule
-from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.domain.price_rule import PriceRule
 from pcapi.model_creators.generic_creators import create_allocine_venue_provider
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider_price_rule
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.provider_creators import activate_provider
@@ -16,17 +19,13 @@ class AllocineVenueProviderPriceRuleTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_add_price_rules_to_venue_provider(self, app):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        allocine_venue_provider_price_rule = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=10
+        offerer = OffererFactory()
+        venue = VenueFactory(managingOfferer=offerer)
+        allocine_provider = AllocineProviderFactory()
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue, provider=allocine_provider)
+        AllocineVenueProviderPriceRuleFactory(
+            allocineVenueProvider=allocine_venue_provider, priceRule=PriceRule.default, price=10
         )
-
-        # When
-        repository.save(allocine_venue_provider_price_rule)
 
         # Then
         assert len(allocine_venue_provider.priceRules) == 1
@@ -34,18 +33,16 @@ class AllocineVenueProviderPriceRuleTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_raise_error_when_price_is_negative(self, app):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=-4
-        )
+        allocine_venue_provider = AllocineVenueProviderFactory()
+
+        allocine_venue_provider_price_rule = AllocineVenueProviderPriceRule()
+        allocine_venue_provider_price_rule.allocineVenueProvider = allocine_venue_provider
+        allocine_venue_provider_price_rule.priceRule = PriceRule.default
+        allocine_venue_provider_price_rule.price = -4
 
         # When
         with pytest.raises(ApiErrors) as error:
-            repository.save(venue_provider_price_rule)
+            repository.save(allocine_venue_provider_price_rule)
 
         # Then
         assert error.value.errors["global"] == ["Vous ne pouvez renseigner un prix négatif"]
@@ -53,21 +50,20 @@ class AllocineVenueProviderPriceRuleTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_raise_error_when_saving_existing_rule_price(self, app):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = activate_provider("AllocineStocks")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=10
+        allocine_venue_provider = AllocineVenueProviderFactory()
+
+        AllocineVenueProviderPriceRuleFactory(
+            allocineVenueProvider=allocine_venue_provider, priceRule=PriceRule.default, price=10
         )
-        repository.save(venue_provider_price_rule)
-        venue_provider_price_rule2 = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=12
-        )
+
+        allocine_venue_provider_price_rule_2 = AllocineVenueProviderPriceRule()
+        allocine_venue_provider_price_rule_2.allocineVenueProvider = allocine_venue_provider
+        allocine_venue_provider_price_rule_2.priceRule = PriceRule.default
+        allocine_venue_provider_price_rule_2.price = 12
 
         # When
         with pytest.raises(ApiErrors) as error:
-            repository.save(venue_provider_price_rule2)
+            repository.save(allocine_venue_provider_price_rule_2)
 
         # Then
         assert error.value.errors["global"] == ["Vous ne pouvez avoir qu''un seul prix par catégorie"]
@@ -75,18 +71,16 @@ class AllocineVenueProviderPriceRuleTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_raise_error_when_saving_wrong_format_price(self, app):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        price = "wrong_price_format"
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=price
-        )
+        allocine_venue_provider = AllocineVenueProviderFactory()
+
+        allocine_venue_provider_price_rule = AllocineVenueProviderPriceRule()
+        allocine_venue_provider_price_rule.allocineVenueProvider = allocine_venue_provider
+        allocine_venue_provider_price_rule.priceRule = PriceRule.default
+        allocine_venue_provider_price_rule.price = "wrong_price_format"
 
         # When
         with pytest.raises(ApiErrors) as error:
-            repository.save(venue_provider_price_rule)
+            repository.save(allocine_venue_provider_price_rule)
 
         # Then
         assert error.value.errors == {"global": ["Le prix doit être un nombre décimal"]}

--- a/api/tests/models/allocine_venue_provider_test.py
+++ b/api/tests/models/allocine_venue_provider_test.py
@@ -1,27 +1,20 @@
 import pytest
 
+from pcapi.core.offerers.factories import AllocineProviderFactory
+from pcapi.core.offerers.factories import AllocineVenueProviderFactory
+from pcapi.core.offerers.factories import ProviderFactory
+from pcapi.core.offerers.factories import VenueProviderFactory
+from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.providers.models import AllocineVenueProvider
 from pcapi.core.providers.models import VenueProvider
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_provider
-from pcapi.model_creators.generic_creators import create_venue
-from pcapi.model_creators.generic_creators import create_venue_provider
 from pcapi.model_creators.provider_creators import activate_provider
-from pcapi.repository import repository
 
 
 class AllocineVenueProviderTest:
     @pytest.mark.usefixtures("db_session")
     def test_allocine_venue_provider_should_inherit_from_venue_provider(self, app):
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-
         provider_allocine = activate_provider("AllocineStocks")
-
-        allocine_venue_provider = create_allocine_venue_provider(venue, provider_allocine, is_duo=True)
-
-        repository.save(allocine_venue_provider)
+        AllocineVenueProviderFactory(provider=provider_allocine, isDuo=True)
 
         assert VenueProvider.query.count() == 1
         assert AllocineVenueProvider.query.count() == 1
@@ -32,17 +25,13 @@ class AllocineVenueProviderTest:
 
     @pytest.mark.usefixtures("db_session")
     def test_query_venue_provider_load_allocine_venue_provider_attributes_when_connected_to_allocine(self, app):
-        offerer = create_offerer()
-        venue = create_venue(offerer)
+        venue = VenueFactory()
 
-        provider_allocine = activate_provider("AllocineStocks")
-        provider = create_provider(local_class="TestLocalProvider")
+        provider_allocine = AllocineProviderFactory()
+        provider = ProviderFactory(localClass="TestLocalProvider")
 
-        venue_provider = create_venue_provider(venue, provider)
-
-        allocine_venue_provider = create_allocine_venue_provider(venue, provider_allocine, is_duo=True)
-
-        repository.save(venue_provider, allocine_venue_provider)
+        VenueProviderFactory(venue=venue, provider=provider)
+        AllocineVenueProviderFactory(venue=venue, provider=provider_allocine, isDuo=True)
 
         assert VenueProvider.query.count() == 2
         assert AllocineVenueProvider.query.count() == 1

--- a/api/tests/repository/venue_provider_queries_test.py
+++ b/api/tests/repository/venue_provider_queries_test.py
@@ -1,9 +1,9 @@
 import pytest
 
 from pcapi.core.offerers.factories import APIProviderFactory
+from pcapi.core.offerers.factories import AllocineVenueProviderFactory
 from pcapi.core.providers.models import AllocineVenueProvider
 from pcapi.core.providers.models import VenueProvider
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.generic_creators import create_venue_provider
@@ -70,15 +70,11 @@ class GetVenueProviderByIdTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_return_matching_venue_provider_with_allocine_attributes(self):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        titelive_provider = activate_provider("AllocineStocks")
-        venue_provider = create_allocine_venue_provider(venue, titelive_provider)
-        repository.save(venue_provider)
+        allocine_venue_provider = AllocineVenueProviderFactory()
 
         # When
-        existing_venue_provider = get_venue_provider_by_id(venue_provider.id)
+        existing_venue_provider = get_venue_provider_by_id(allocine_venue_provider.id)
 
         # Then
-        assert existing_venue_provider == venue_provider
-        assert isinstance(venue_provider, AllocineVenueProvider)
+        assert existing_venue_provider == allocine_venue_provider
+        assert isinstance(allocine_venue_provider, AllocineVenueProvider)

--- a/api/tests/scripts/venue/modify_allocine_price_rule_for_venue_test.py
+++ b/api/tests/scripts/venue/modify_allocine_price_rule_for_venue_test.py
@@ -2,14 +2,11 @@ from decimal import Decimal
 
 import pytest
 
+from pcapi.core.offerers.factories import AllocineVenueProviderFactory
+from pcapi.core.offerers.factories import AllocineVenueProviderPriceRuleFactory
+from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.providers.models import AllocineVenueProviderPriceRule
 from pcapi.domain.price_rule import PriceRule
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider_price_rule
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_provider
-from pcapi.model_creators.generic_creators import create_venue
-from pcapi.repository import repository
 from pcapi.scripts.venue.modify_allocine_price_rule_for_venue import modify_allocine_price_rule_for_venue_by_id
 from pcapi.scripts.venue.modify_allocine_price_rule_for_venue import modify_allocine_price_rule_for_venue_by_siret
 
@@ -20,15 +17,11 @@ class ModifyAllocinePriceRuleForVenueTest:
         # Given
         initial_price = Decimal(7.5)
         new_price = Decimal(8)
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = create_provider(local_class="TestLocalProvider")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        allocine_venue_provider_price_rule = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=initial_price
+        venue = VenueFactory()
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue)
+        allocine_venue_provider_price_rule = AllocineVenueProviderPriceRuleFactory(
+            allocineVenueProvider=allocine_venue_provider, priceRule=PriceRule.default, price=initial_price
         )
-
-        repository.save(allocine_venue_provider_price_rule)
 
         # When
         modify_allocine_price_rule_for_venue_by_id(venue.id, new_price)
@@ -41,15 +34,10 @@ class ModifyAllocinePriceRuleForVenueTest:
         # Given
         initial_price = Decimal(7.5)
         new_price = Decimal(8)
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = create_provider(local_class="TestLocalProvider")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        allocine_venue_provider_price_rule = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=initial_price
+        allocine_venue_provider_price_rule = AllocineVenueProviderPriceRuleFactory(
+            priceRule=PriceRule.default, price=initial_price
         )
-
-        repository.save(allocine_venue_provider_price_rule)
+        venue = allocine_venue_provider_price_rule.allocineVenueProvider.venue
 
         # When
         modify_allocine_price_rule_for_venue_by_siret(venue.siret, new_price)
@@ -61,10 +49,7 @@ class ModifyAllocinePriceRuleForVenueTest:
     def should_not_update_allocine_price_rule_when_there_is_no_venue_provider_associated_to_the_venue(self, app):
         # Given
         new_price = Decimal(8)
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-
-        repository.save(venue)
+        venue = VenueFactory()
 
         # When
         modify_allocine_price_rule_for_venue_by_siret(venue.siret, new_price)
@@ -76,12 +61,8 @@ class ModifyAllocinePriceRuleForVenueTest:
     def should_not_update_allocine_price_rule_when_there_is_no_allocine_price_rule_associated_to_the_venue(self, app):
         # Given
         new_price = Decimal(8)
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = create_provider(local_class="TestLocalProvider")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-
-        repository.save(allocine_venue_provider)
+        venue = VenueFactory()
+        AllocineVenueProviderFactory(venue=venue)
 
         # When
         modify_allocine_price_rule_for_venue_by_siret(venue.siret, new_price)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11243


## But de la pull request
Rendre la colonne `venueIdAtOfferProvider` dans la table `venue_provider` non nullable


##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
