### PR TITLE
(PC-11701) : deactivate second attempt on IDCheck

### DIFF
--- a/src/pcapi/core/subscription/messages.py
+++ b/src/pcapi/core/subscription/messages.py
@@ -1,6 +1,5 @@
 import datetime
 
-import pcapi.core.users.api as users_api
 import pcapi.core.users.models as users_models
 from pcapi.repository import repository
 
@@ -79,23 +78,13 @@ def on_idcheck_invalid_document_date(user: users_models.User) -> None:
 
 def on_id_check_unread_document(user: users_models.User) -> None:
     today = datetime.date.today()
-    if user.hasCompletedIdCheck:
-        message = models.SubscriptionMessage(
-            user=user,
-            userMessage=f"Nous n'arrivons pas à traiter ton document. Consulte l'e-mail envoyé le {today:%d/%m/%Y} pour plus d'informations.",
-            callToActionTitle="Consulter mes e-mails",
-            callToActionLink=INBOX_URL,
-            callToActionIcon=models.CallToActionIcon.EMAIL,
-        )
-    else:
-        token = users_api.create_id_check_token(user)
-        message = models.SubscriptionMessage(
-            user=user,
-            userMessage="Ton dossier n’a pas pu être validé car la photo que tu as transmise est illisible.",
-            callToActionTitle="Essayer avec une autre photo",
-            callToActionLink=f"passculture://idcheck?token={token}",
-            callToActionIcon=models.CallToActionIcon.RETRY,
-        )
+    message = models.SubscriptionMessage(
+        user=user,
+        userMessage=f"Nous n'arrivons pas à traiter ton document. Consulte l'e-mail envoyé le {today:%d/%m/%Y} pour plus d'informations.",
+        callToActionTitle="Consulter mes e-mails",
+        callToActionLink=INBOX_URL,
+        callToActionIcon=models.CallToActionIcon.EMAIL,
+    )
     repository.save(message)
 
 

--- a/tests/core/users/test_api.py
+++ b/tests/core/users/test_api.py
@@ -1012,6 +1012,7 @@ class VerifyIdentityDocumentInformationsTest:
     @patch("pcapi.core.users.api.delete_object")
     @patch("pcapi.core.users.api.ask_for_identity_document_verification")
     @patch("pcapi.core.users.api._get_identity_document_informations")
+    @freeze_time("2021-10-30 09:00:00")
     def test_known_user_email_sent_when_document_is_unreadable(
         self, mocked_get_identity_informations, mocked_ask_for_identity, mocked_delete_object, app
     ):
@@ -1020,36 +1021,6 @@ class VerifyIdentityDocumentInformationsTest:
             years=users_constants.ELIGIBILITY_AGE_18, months=1
         )
         existing_user = users_factories.UserFactory(dateOfBirth=eligible_date_of_birth)
-        mocked_get_identity_informations.return_value = (existing_user.email, b"")
-        mocked_ask_for_identity.return_value = (False, "unread-document")
-
-        users_api.verify_identity_document_informations("some_path")
-
-        assert len(existing_user.beneficiaryFraudChecks) == 1
-        fraud_check = existing_user.beneficiaryFraudChecks[0]
-        assert fraud_check.type == fraud_models.FraudCheckType.INTERNAL_REVIEW
-        assert fraud_check.resultContent["message"] == "Erreur de lecture du document : unread-document"
-        assert fraud_check.resultContent["source"] == fraud_models.InternalReviewSource.DOCUMENT_VALIDATION_ERROR.value
-
-        assert subscription_models.SubscriptionMessage.query.count() == 1
-        message = subscription_models.SubscriptionMessage.query.first()
-        assert not message.popOverIcon
-        assert (
-            message.userMessage == "Ton dossier n’a pas pu être validé car la photo que tu as transmise est illisible."
-        )
-
-    @patch("pcapi.core.users.api.delete_object")
-    @patch("pcapi.core.users.api.ask_for_identity_document_verification")
-    @patch("pcapi.core.users.api._get_identity_document_informations")
-    @freeze_time("2021-10-30 09:00:00")
-    def test_known_user_email_sent_when_document_is_unreadable_and_has_completed_idcheck(
-        self, mocked_get_identity_informations, mocked_ask_for_identity, mocked_delete_object, app
-    ):
-        # Given
-        eligible_date_of_birth = datetime.combine(date.today(), time.min) - relativedelta(
-            years=users_constants.ELIGIBILITY_AGE_18, months=1
-        )
-        existing_user = users_factories.UserFactory(dateOfBirth=eligible_date_of_birth, hasCompletedIdCheck=True)
         mocked_get_identity_informations.return_value = (existing_user.email, b"")
         mocked_ask_for_identity.return_value = (False, "unread-document")
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11701

## But de la pull request

Turns out it is more complex to fix than it appeared at first.
Long story made short, we don't have an explicit workflow on the
subscription process which is hard to work around to allow
the user a second attempt on IDCheck.

