### PR TITLE
(MOB) Increase Sentry Max string length to have longer descriptions

### DIFF
--- a/src/pcapi/flask_app.py
+++ b/src/pcapi/flask_app.py
@@ -31,6 +31,8 @@ from pcapi.utils.sentry import init_sentry_sdk
 logger = logging.getLogger(__name__)
 
 install_logging()
+
+sentry_sdk.utils.MAX_STRING_LENGTH = 8192
 init_sentry_sdk()
 
 app = Flask(__name__, static_url_path="/static")


### PR DESCRIPTION
## But de la pull request

Augmenter la taille limite de MAX_STRING_LENGTH côté Sentry pour éviter les troncatures de descriptions

##  Implémentation

- Patch de MAX_STRING_LENGTH de sentry utils comme décrit ici: https://forum.sentry.io/t/some-stack-traces-are-truncated/7309/2

Avant:
![Capture d’écran 2021-11-10 à 12 30 52](https://user-images.githubusercontent.com/19763200/141105569-c3f0e594-913d-44f6-89d5-7cb975895190.png)


Après:
![Capture d’écran 2021-11-10 à 12 30 20](https://user-images.githubusercontent.com/19763200/141105511-7c08b7f1-c7c1-469b-b59a-b97650032f65.png)


​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
