### PR TITLE
sandboxes: fix getter

### DIFF
--- a/src/pcapi/sandboxes/scripts/getters/webapp_08_booking.py
+++ b/src/pcapi/sandboxes/scripts/getters/webapp_08_booking.py
@@ -67,6 +67,7 @@ def get_non_free_event_offer():
     offer = (
         query.filter(Offer.subcategoryId.in_(subcategories.EVENT_SUBCATEGORIES))
         .filter(Offer.mediations.any(Mediation.isActive == True))
+        .filter(Offer.isEducational == False)
         .join(Venue, Venue.id == Offer.venueId)
         .join(Offerer, Offerer.id == Venue.managingOffererId)
         .filter(Offerer.validationToken == None)
@@ -77,6 +78,7 @@ def get_non_free_event_offer():
         return {
             "mediationId": [humanize(m.id) for m in offer.mediations if m.isActive][0],
             "offer": get_offer_helper(offer),
+            "stockCount": len(offer.stocks),
         }
     return {}
 

--- a/tests/sandboxes/scripts/getters/webapp_08_booking_test.py
+++ b/tests/sandboxes/scripts/getters/webapp_08_booking_test.py
@@ -153,6 +153,7 @@ class GetNonFreeEventOfferTest:
                 "visualDisabilityCompliant": None,
                 "withdrawalDetails": None,
             },
+            "stockCount": 1,
         }
 
     @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
## But de la pull request

Après avoir découvert un test E2E flaky côté webapp (sans doute provoqué par l'arrivée de nouvelles offres EAC dans la sandbox), il a fallu adapter le getter de sandbox utilisé par ce test afin d'améliorer son usage côté front. 
 
