### PR TITLE
(PC-11548) : correct sandbox - create user_offerer instead of fetching existing one

### DIFF
--- a/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_educational_bookings.py
+++ b/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_educational_bookings.py
@@ -1,7 +1,5 @@
 import datetime
 
-from sqlalchemy.orm import joinedload
-
 from pcapi.core.bookings.factories import EducationalBookingFactory
 from pcapi.core.bookings.factories import UsedEducationalBookingFactory
 from pcapi.core.bookings.models import BookingStatus
@@ -10,8 +8,6 @@ from pcapi.core.offers.factories import EducationalEventStockFactory
 from pcapi.core.offers.factories import MediationFactory
 from pcapi.core.offers.factories import UserOffererFactory
 from pcapi.core.offers.factories import VenueFactory
-from pcapi.core.users.models import User
-from pcapi.models.user_offerer import UserOfferer
 from pcapi.sandboxes.scripts.utils.storage_utils import store_public_object_from_sandbox_assets
 
 
@@ -83,11 +79,8 @@ def create_industrial_educational_bookings() -> None:
     UserOffererFactory(validationToken=None, offerer=venue.managingOfferer)
 
     educational_redactor = educational_factories.EducationalRedactorFactory(email="compte.test@education.gouv.fr")
-    user_offerer_reimbursements = (
-        UserOfferer.query.join(User)
-        .filter(User.email == "pctest.pro93.0@example.com")
-        .options(joinedload(UserOfferer.offerer))
-        .first()
+    user_offerer_reimbursements = UserOffererFactory(
+        validationToken=None, user__email="pc.test.payments.eac@example.com"
     )
     venue_reimbursements = VenueFactory(
         name="Théâtre des potirons", isPermanent=True, managingOfferer=user_offerer_reimbursements.offerer


### PR DESCRIPTION


Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11548


## But de la pull request

Dans la PR précédente du même ticket, dans la sandbox `create_educational_bookings`, je récupérais un UserOfferer déjà créé en base (le but était d'avoir un user connu pour faciliter la recette par les PO).
Il a été exposé que cette façon de faire dans la sandbox pouvait poser des soucis de synchronisation.

##  Implémentation

Création d'un UserOfferer spécifique à partir de la factory
​
##  Informations supplémentaires

N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
