### PR TITLE
(PC-11219) Enable exunderage beneficiary -> beneficiary transition

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-5ff1b52e2f08 (head)
+42ebfa8a45aa (head)

--- a/api/src/pcapi/admin/custom_views/support_view.py
+++ b/api/src/pcapi/admin/custom_views/support_view.py
@@ -21,6 +21,7 @@ import pcapi.core.fraud.api as fraud_api
 import pcapi.core.fraud.models as fraud_models
 from pcapi.core.subscription import messages as subscription_messages
 import pcapi.core.subscription.api as subscription_api
+import pcapi.core.subscription.exceptions as subscription_exceptions
 import pcapi.core.subscription.models as subscription_models
 import pcapi.core.users.api as users_api
 import pcapi.core.users.models as users_models
@@ -258,7 +259,10 @@ class BeneficiaryView(base_configuration.BaseAdminView):
         )
         if review.review == fraud_models.FraudReviewStatus.OK.value:
             users_api.update_user_information_from_external_source(user, fraud_api.get_source_data(user))
-            subscription_api.activate_beneficiary(user, "fraud_validation")
+            try:
+                subscription_api.activate_beneficiary(user, "fraud_validation")
+            except subscription_exceptions.CannotUpgradeBeneficiaryRole:
+                flask.flash("L'utilisateur est déjà bénéficiaire", "error")
             flask.flash(f"L'utilisateur à été activé comme bénéficiaire {user.firstName} {user.lastName}")
 
         elif review.review == fraud_models.FraudReviewStatus.REDIRECTED_TO_DMS.value:

--- a/api/src/pcapi/alembic/versions/20211107T190936_42ebfa8a45aa_add_fraud_result_eligibilitytype.py
+++ b/api/src/pcapi/alembic/versions/20211107T190936_42ebfa8a45aa_add_fraud_result_eligibilitytype.py
@@ -1,0 +1,24 @@
+"""add_fraud_result_eligibilityType
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from pcapi.core.users import models as users_models
+
+
+# revision identifiers, used by Alembic.
+revision = "42ebfa8a45aa"
+down_revision = "bf9641a0f5a8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "beneficiary_fraud_result",
+        sa.Column("eligibilityType", sa.TEXT(), server_default=users_models.EligibilityType.AGE18.name, nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_column("beneficiary_fraud_result", "eligibilityType")

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -198,9 +198,6 @@ def on_identity_fraud_check_result(
 ) -> models.BeneficiaryFraudResult:
     fraud_items: list[models.FraudItem] = []
 
-    fraud_items.append(_check_user_has_no_active_deposit(user))
-    fraud_items.append(_check_user_email_is_validated(user))
-
     if beneficiary_fraud_check.type == models.FraudCheckType.JOUVE:
         fraud_items += jouve_fraud_checks(user, beneficiary_fraud_check)
         eligibilityType = user_models.EligibilityType.AGE18
@@ -214,6 +211,10 @@ def on_identity_fraud_check_result(
         eligibilityType = user_models.EligibilityType.UNDERAGE
     else:
         raise Exception("The fraud_check type is not known")
+
+    fraud_items.append(_check_user_has_no_active_deposit(user, eligibilityType))
+    fraud_items.append(_check_user_email_is_validated(user))
+    fraud_items.append(_check_user_not_already_beneficiary(user, eligibilityType))
 
     fraud_result = validate_frauds(user, fraud_items, eligibilityType)
     if (
@@ -286,15 +287,28 @@ def _whitelisted_ine_fraud_item(ine_hash: str) -> models.FraudItem:
     )
 
 
-def _check_user_has_no_active_deposit(user: user_models.User) -> models.FraudItem:
+def _check_user_has_no_active_deposit(
+    user: user_models.User, eligibility: user_models.EligibilityType
+) -> models.FraudItem:
     if user.has_active_deposit:
-        is_underage = user.age in constants.ELIGIBILITY_UNDERAGE_RANGE
         return models.FraudItem(
             status=models.FraudStatus.KO,
             detail=(
                 "L’utilisateur est déjà bénéfiaire, avec un portefeuille non expiré. "
-                f"Il ne peut pas prétendre au pass culture {'15-17 ans' if is_underage else '18 ans'}"
+                f"Il ne peut pas prétendre au pass culture {'15-17 ans' if eligibility == user_models.EligibilityType.UNDERAGE else '18 ans'}"
             ),
+        )
+    return models.FraudItem(status=models.FraudStatus.OK, detail=None)
+
+
+def _check_user_not_already_beneficiary(
+    user: user_models.User, eligibility: user_models.EligibilityType
+) -> models.FraudItem:
+    if not user.can_upgrade_beneficiary_role(eligibility):
+        return models.FraudItem(
+            status=models.FraudStatus.KO,
+            detail=(f"L’utilisateur est déjà bénéfiaire du pass {eligibility.name}"),
+            reason_code=models.FraudReasonCode.ALREADY_BENEFICIARY,
         )
     return models.FraudItem(status=models.FraudStatus.OK, detail=None)
 

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -32,7 +32,9 @@ USER_PROFILING_RISK_MAPPING = {
 }
 
 
-def on_educonnect_result(user: user_models.User, educonnect_content: models.EduconnectContent) -> None:
+def on_educonnect_result(
+    user: user_models.User, educonnect_content: models.EduconnectContent
+) -> Optional[models.BeneficiaryFraudResult]:
     if (
         models.BeneficiaryFraudCheck.query.filter(
             models.BeneficiaryFraudCheck.user == user,
@@ -42,7 +44,7 @@ def on_educonnect_result(user: user_models.User, educonnect_content: models.Educ
     ):
         # TODO: figure out if we update the current fraud check, keep the original or allow multiple fraud checks
         # Currently keeping the first one and ignoring any new one
-        return
+        return user.beneficiaryFraudResults[0] if user.beneficiaryFraudResults else None
 
     fraud_check = models.BeneficiaryFraudCheck(
         user=user,
@@ -51,7 +53,8 @@ def on_educonnect_result(user: user_models.User, educonnect_content: models.Educ
         resultContent=educonnect_content.dict(),
     )
     repository.save(fraud_check)
-    on_identity_fraud_check_result(user, fraud_check)
+
+    return on_identity_fraud_check_result(user, fraud_check)
 
 
 def on_jouve_result(user: user_models.User, jouve_content: models.JouveContent) -> None:
@@ -200,20 +203,26 @@ def on_identity_fraud_check_result(
 
     if beneficiary_fraud_check.type == models.FraudCheckType.JOUVE:
         fraud_items += jouve_fraud_checks(user, beneficiary_fraud_check)
+        eligibilityType = user_models.EligibilityType.AGE18
 
     elif beneficiary_fraud_check.type == models.FraudCheckType.DMS:
         fraud_items += dms_fraud_checks(user, beneficiary_fraud_check)
+        eligibilityType = user_models.EligibilityType.AGE18
 
     elif beneficiary_fraud_check.type == models.FraudCheckType.EDUCONNECT:
         fraud_items += educonnect_fraud_checks(user, beneficiary_fraud_check)
+        eligibilityType = user_models.EligibilityType.UNDERAGE
+    else:
+        raise Exception("The fraud_check type is not known")
 
-    fraud_result = validate_frauds(user, fraud_items)
+    fraud_result = validate_frauds(user, fraud_items, eligibilityType)
     if (
         beneficiary_fraud_check.type == models.FraudCheckType.JOUVE
         and FeatureToggle.PAUSE_JOUVE_SUBSCRIPTION.is_active()
     ):
         fraud_result.status = models.FraudStatus.SUBSCRIPTION_ON_HOLD
     repository.save(fraud_result)
+
     return fraud_result
 
 
@@ -385,7 +394,10 @@ def on_user_profiling_check_result(
     risk_rating = tmx_content.risk_rating
     user_profiling_status = USER_PROFILING_RISK_MAPPING[risk_rating]
     if not user_profiling_status == models.FraudStatus.OK:
-        upsert_fraud_result(user, user_profiling_status, f"threat-metrix risk rating is {risk_rating.value}")
+        upsert_fraud_result(
+            user, user_profiling_status, user.eligibility, f"threat-metrix risk rating is {risk_rating.value}"
+        )
+
         from pcapi.core.subscription import messages as subscription_messages
 
         subscription_messages.on_user_subscription_journey_stopped(user)
@@ -405,20 +417,30 @@ def get_source_data(user: user_models.User) -> models.JouveContent:
 
 
 def upsert_fraud_result(
-    user: user_models.User, status: models.FraudStatus, reason: str = None
+    user: user_models.User,
+    status: models.FraudStatus,
+    eligibilityType: Optional[user_models.EligibilityType],
+    reason: str = None,
 ) -> models.BeneficiaryFraudResult:
     """
     If the user has no fraud result: create one fraud result with status and the given reason.
     If it already has one: append the reason to the already recorded ones.
     """
+    if not eligibilityType:
+        eligibilityType = user_models.EligibilityType.AGE18
     reason = reason or ""
     if status != models.FraudStatus.OK and not reason:
         raise ValueError(f"a reason should be provided when setting fraud result to {status.value}")
 
-    fraud_result = models.BeneficiaryFraudResult.query.filter_by(userId=user.id).one_or_none()
+    fraud_result = models.BeneficiaryFraudResult.query.filter(
+        models.BeneficiaryFraudResult.userId == user.id,
+        models.BeneficiaryFraudResult.eligibilityType == eligibilityType,
+    ).one_or_none()
 
     if not fraud_result:
-        fraud_result = models.BeneficiaryFraudResult(user=user, status=status, reason=reason)
+        fraud_result = models.BeneficiaryFraudResult(
+            user=user, status=status, reason=reason, eligibilityType=eligibilityType
+        )
     else:
         fraud_result.status = status
         # if this function is called twice (or more) in a row with the same
@@ -479,7 +501,7 @@ def handle_sms_sending_limit_reached(user: user_models.User) -> models.Beneficia
     )
 
     create_internal_review_fraud_check(user, fraud_check_data)
-    return upsert_fraud_result(user, models.FraudStatus.SUSPICIOUS, reason)
+    return upsert_fraud_result(user, models.FraudStatus.SUSPICIOUS, user.eligibility, reason)
 
 
 def handle_phone_validation_attempts_limit_reached(
@@ -493,7 +515,7 @@ def handle_phone_validation_attempts_limit_reached(
     )
 
     create_internal_review_fraud_check(user, fraud_check_data)
-    return upsert_fraud_result(user, models.FraudStatus.SUSPICIOUS, reason)
+    return upsert_fraud_result(user, models.FraudStatus.SUSPICIOUS, user.eligibility, reason)
 
 
 def handle_document_validation_error(email: str, code: str) -> None:
@@ -508,7 +530,9 @@ def handle_document_validation_error(email: str, code: str) -> None:
         logger.warning("fraud internal validation : Cannot find user with email %s", email)
 
 
-def validate_frauds(user: user_models.User, fraud_items: list[models.FraudItem]) -> models.BeneficiaryFraudResult:
+def validate_frauds(
+    user: user_models.User, fraud_items: list[models.FraudItem], eligibilityType: user_models.EligibilityType
+) -> models.BeneficiaryFraudResult:
     if all(fraud_item.status == models.FraudStatus.OK for fraud_item in fraud_items):
         status = models.FraudStatus.OK
     elif any(fraud_item.status == models.FraudStatus.KO for fraud_item in fraud_items):
@@ -516,16 +540,18 @@ def validate_frauds(user: user_models.User, fraud_items: list[models.FraudItem])
     else:
         status = models.FraudStatus.SUSPICIOUS
 
-    if user.beneficiaryFraudResult:
-        fraud_result = user.beneficiaryFraudResult
+    existing_fraud_result = models.BeneficiaryFraudResult.query.filter(
+        models.BeneficiaryFraudResult.userId == user.id,
+        models.BeneficiaryFraudResult.eligibilityType == eligibilityType,
+    ).one_or_none()
+
+    if existing_fraud_result:
+        fraud_result = existing_fraud_result
         # ensure we never overwrite a previously validated status
         if fraud_result.status != models.FraudStatus.OK:
             fraud_result.status = status
     else:
-        fraud_result = models.BeneficiaryFraudResult(
-            user=user,
-            status=status,
-        )
+        fraud_result = models.BeneficiaryFraudResult(user=user, status=status, eligibilityType=eligibilityType)
     fraud_result.reason = f" {FRAUD_RESULT_REASON_SEPARATOR} ".join(
         fraud_item.detail for fraud_item in fraud_items if fraud_item.status != models.FraudStatus.OK
     )
@@ -539,7 +565,7 @@ def validate_frauds(user: user_models.User, fraud_items: list[models.FraudItem])
 
 
 def has_user_passed_fraud_checks(user: user_models.User) -> bool:
-    return bool(user.beneficiaryFraudResult)
+    return bool(user.beneficiaryFraudResults)
 
 
 def is_risky_user_profile(user: user_models.User) -> bool:
@@ -561,4 +587,7 @@ def is_risky_user_profile(user: user_models.User) -> bool:
 
 
 def is_user_fraudster(user: user_models.User) -> bool:
-    return user.beneficiaryFraudResult.status != models.FraudStatus.OK
+    return any(
+        beneficiary_fraud_result.status != models.FraudStatus.OK
+        for beneficiary_fraud_result in user.beneficiaryFraudResults
+    )

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -11,6 +11,7 @@ import sqlalchemy
 import sqlalchemy.dialects.postgresql
 import sqlalchemy.orm
 
+from pcapi.core.users import models as users_models
 from pcapi.models.db import Model
 from pcapi.models.pc_object import PcObject
 
@@ -223,7 +224,13 @@ class BeneficiaryFraudResult(PcObject, Model):
     userId = sqlalchemy.Column(sqlalchemy.BigInteger, sqlalchemy.ForeignKey("user.id"), index=True, nullable=False)
 
     user = sqlalchemy.orm.relationship(
-        "User", foreign_keys=[userId], backref=sqlalchemy.orm.backref("beneficiaryFraudResult", uselist=False)
+        "User", foreign_keys=[userId], backref=sqlalchemy.orm.backref("beneficiaryFraudResults")
+    )
+
+    eligibilityType = sqlalchemy.Column(
+        sqlalchemy.Enum(users_models.EligibilityType, create_constraint=False),
+        nullable=False,
+        server_default=sqlalchemy.text(users_models.EligibilityType.AGE18.name),
     )
 
     status = sqlalchemy.Column(sqlalchemy.Enum(FraudStatus, create_constraint=False))

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -5,6 +5,7 @@ from pcapi.core.fraud import exceptions as fraud_exceptions
 import pcapi.core.fraud.models as fraud_models
 from pcapi.core.mails.transactional.users import accepted_as_beneficiary_email
 from pcapi.core.payments import api as payments_api
+from pcapi.core.subscription import exceptions as subscription_exceptions
 from pcapi.core.users import api as users_api
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users import exceptions as users_exception
@@ -75,6 +76,9 @@ def activate_beneficiary(
     else:
         eligibility = users_models.EligibilityType.AGE18
 
+    if not user.can_upgrade_beneficiary_role:
+        raise exceptions.CannotUpgradeBeneficiaryRole()
+
     if eligibility == users_models.EligibilityType.UNDERAGE:
         user.add_underage_beneficiary_role()
     elif eligibility == users_models.EligibilityType.AGE18:
@@ -104,11 +108,15 @@ def check_and_activate_beneficiary(
 ) -> users_models.User:
     with pcapi_repository.transaction():
         user = users_repository.get_and_lock_user(userId)
-        # TODO: Handle switch from underage_beneficiary to beneficiary
-        if user.is_beneficiary or not user.hasCompletedIdCheck:
+
+        if not user.hasCompletedIdCheck:
             db.session.rollback()
             return user
-        user = activate_beneficiary(user, deposit_source, has_activated_account)
+        try:
+            user = activate_beneficiary(user, deposit_source, has_activated_account)
+        except subscription_exceptions.CannotUpgradeBeneficiaryRole:
+            db.session.rollback()
+            return user
         return user
 
 

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -83,6 +83,7 @@ def activate_beneficiary(
         user.add_underage_beneficiary_role()
     elif eligibility == users_models.EligibilityType.AGE18:
         user.add_beneficiary_role()
+        user.remove_underage_beneficiary_role()
     else:
         raise users_exception.InvalidEligibilityTypeException()
 

--- a/api/src/pcapi/core/subscription/exceptions.py
+++ b/api/src/pcapi/core/subscription/exceptions.py
@@ -8,3 +8,7 @@ class BeneficiaryImportMissingException(SubscriptionException):
 
 class BeneficiaryFraudResultMissing(SubscriptionException):
     pass
+
+
+class CannotUpgradeBeneficiaryRole(SubscriptionException):
+    pass

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -37,6 +37,7 @@ from pcapi.core.mails.transactional.users.email_address_change import send_infor
 from pcapi.core.mails.transactional.users.email_confirmation_email import send_email_confirmation_email
 import pcapi.core.payments.api as payment_api
 from pcapi.core.subscription import api as subscription_api
+from pcapi.core.subscription import exceptions as subscription_exceptions
 from pcapi.core.subscription import messages as subscription_messages
 import pcapi.core.subscription.repository as subscription_repository
 from pcapi.core.users import models as users_models
@@ -260,7 +261,10 @@ def validate_phone_number_and_activate_user(user: User, code: str) -> User:
     validate_phone_number(user, code)
 
     if not steps_to_become_beneficiary(user):
-        subscription_api.activate_beneficiary(user)
+        try:
+            subscription_api.activate_beneficiary(user)
+        except subscription_exceptions.CannotUpgradeBeneficiaryRole:
+            pass
 
 
 def update_beneficiary_mandatory_information(

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -38,7 +38,6 @@ from pcapi.core.mails.transactional.users.email_confirmation_email import send_e
 import pcapi.core.payments.api as payment_api
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import messages as subscription_messages
-from pcapi.core.subscription.models import BeneficiaryPreSubscription
 import pcapi.core.subscription.repository as subscription_repository
 from pcapi.core.users import models as users_models
 from pcapi.core.users.external import update_external_user
@@ -63,8 +62,6 @@ from pcapi.domain import user_emails as old_user_emails
 from pcapi.domain.password import random_hashed_password
 from pcapi.domain.postal_code.postal_code import PostalCode
 from pcapi.domain.user_activation import create_beneficiary_from_application
-from pcapi.models import BeneficiaryImport
-from pcapi.models import ImportStatus
 from pcapi.models.db import db
 from pcapi.models.feature import FeatureToggle
 from pcapi.models.user_offerer import UserOfferer
@@ -248,7 +245,9 @@ def steps_to_become_beneficiary(user: User) -> list[BeneficiaryValidationStep]:
         missing_steps.append(BeneficiaryValidationStep.PHONE_VALIDATION)
 
     beneficiary_import = subscription_repository.get_beneficiary_import_for_beneficiary(user)
-    if not beneficiary_import:
+    if not beneficiary_import or (
+        beneficiary_import.eligibilityType == EligibilityType.UNDERAGE and user.has_underage_beneficiary_role
+    ):
         missing_steps.append(BeneficiaryValidationStep.ID_CHECK)
 
     if not user.hasCompletedIdCheck:
@@ -286,6 +285,7 @@ def update_beneficiary_mandatory_information(
 
     if (
         not steps_to_become_beneficiary(user)
+        # the 2 following checks are useless because if there is no missing step
         and fraud_api.has_user_passed_fraud_checks(user)
         and not fraud_api.is_user_fraudster(user)
     ):
@@ -361,31 +361,6 @@ def update_user_information_from_external_source(
     if commit:
         db.session.commit()
     return user
-
-
-def attach_beneficiary_import_details(
-    beneficiary: User,
-    beneficiary_pre_subscription: BeneficiaryPreSubscription,
-    status: ImportStatus = ImportStatus.CREATED,
-) -> None:
-    beneficiary_import = BeneficiaryImport.query.filter_by(
-        applicationId=beneficiary_pre_subscription.application_id,
-        sourceId=beneficiary_pre_subscription.source_id,
-        source=beneficiary_pre_subscription.source,
-        beneficiary=beneficiary,
-    ).one_or_none()
-    if not beneficiary_import:
-        beneficiary_import = BeneficiaryImport()
-
-        beneficiary_import.applicationId = beneficiary_pre_subscription.application_id
-        beneficiary_import.sourceId = beneficiary_pre_subscription.source_id
-        beneficiary_import.source = beneficiary_pre_subscription.source
-        beneficiary_import.beneficiary = beneficiary
-
-    beneficiary_import.setStatus(status=status)
-    beneficiary_import.beneficiary = beneficiary
-
-    repository.save(beneficiary_import)
 
 
 def request_email_confirmation(user: User) -> None:

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -820,8 +820,7 @@ def get_id_check_validation_step(user: User) -> Optional[BeneficiaryValidationSt
 
 
 def get_next_beneficiary_validation_step(user: User) -> Optional[BeneficiaryValidationStep]:
-    # TODO: Handle switch from underage_beneficiary to beneficiary
-    if user.is_beneficiary or user.eligibility is None:
+    if not user.can_upgrade_beneficiary_role() or user.eligibility is None:
         return None
 
     if user.eligibility == EligibilityType.AGE18:

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -9,12 +9,13 @@ from dateutil.relativedelta import relativedelta
 import factory
 from factory.declarations import LazyAttribute
 
+from pcapi.core.fraud import models as fraud_models
 import pcapi.core.payments.api as payments_api
 from pcapi.core.payments.models import DepositType
 from pcapi.core.testing import BaseFactory
+from pcapi.core.users import models as users_models
 import pcapi.core.users.constants as users_constants
 from pcapi.core.users.external.educonnect import models as educonnect_models
-import pcapi.core.users.models
 from pcapi.models import BeneficiaryImport
 from pcapi.models import BeneficiaryImportStatus
 from pcapi.models import user_session
@@ -29,9 +30,29 @@ from . import models
 DEFAULT_PASSWORD = "user@AZERTY123"
 
 
+class BeneficiaryImportStatusFactory(BaseFactory):
+    class Meta:
+        model = BeneficiaryImportStatus
+
+    status = ImportStatus.CREATED.value
+    date = factory.Faker("date_time_between", start_date="-30d", end_date="-1d")
+    detail = factory.Faker("sentence", nb_words=3)
+    beneficiaryImport = factory.SubFactory("pcapi.core.users.factories.BeneficiaryImportFactory")
+    author = factory.SubFactory("pcapi.core.users.factories.UserFactory")
+
+
+class BeneficiaryImportFactory(BaseFactory):
+    class Meta:
+        model = BeneficiaryImport
+
+    applicationId = factory.Sequence(lambda n: n)
+    beneficiary = factory.SubFactory("pcapi.core.users.factories.UserFactory")
+    source = BeneficiaryImportSources.jouve.value
+
+
 class UserFactory(BaseFactory):
     class Meta:
-        model = pcapi.core.users.models.User
+        model = users_models.User
 
     email = factory.Sequence("jean.neige{}@example.com".format)
     address = factory.Sequence("{} place des noces rouges".format)
@@ -65,7 +86,7 @@ class UserFactory(BaseFactory):
 
 class AdminFactory(BaseFactory):
     class Meta:
-        model = pcapi.core.users.models.User
+        model = users_models.User
 
     email = factory.Sequence("un.admin{}@example.com".format)
     address = factory.Sequence("{} rue des détectives".format)
@@ -76,7 +97,7 @@ class AdminFactory(BaseFactory):
     publicName = "Frank Columbo"
     isEmailValidated = True
     isAdmin = True
-    roles = [pcapi.core.users.models.UserRole.ADMIN]
+    roles = [users_models.UserRole.ADMIN]
     hasSeenProTutorials = True
 
     @classmethod
@@ -98,7 +119,7 @@ class AdminFactory(BaseFactory):
 
 class BeneficiaryGrant18Factory(BaseFactory):
     class Meta:
-        model = pcapi.core.users.models.User
+        model = users_models.User
 
     email = factory.Sequence("jeanne.doux{}@example.com".format)
     address = factory.Sequence("{} rue des machines".format)
@@ -111,9 +132,10 @@ class BeneficiaryGrant18Factory(BaseFactory):
     departementCode = "75"
     firstName = "Jeanne"
     lastName = "Doux"
+    hasCompletedIdCheck = True
     isEmailValidated = True
     isAdmin = False
-    roles = [pcapi.core.users.models.UserRole.BENEFICIARY]
+    roles = [users_models.UserRole.BENEFICIARY]
     hasSeenProTutorials = True
 
     @classmethod
@@ -146,16 +168,64 @@ class BeneficiaryGrant18Factory(BaseFactory):
 
         return DepositGrantFactory(user=obj, **kwargs)
 
+    @factory.post_generation
+    def beneficiaryImports(obj, create, extracted, **kwargs):  # pylint: disable=no-self-argument
+        if not create:
+            return None
+
+        beneficiary_import = BeneficiaryImportFactory(
+            beneficiary=obj,
+            source=BeneficiaryImportSources.educonnect.value
+            if obj.eligibility == users_models.EligibilityType.UNDERAGE
+            else BeneficiaryImportSources.jouve.value,
+            eligibilityType=obj.eligibility,
+        )
+        BeneficiaryImportStatusFactory(beneficiaryImport=beneficiary_import, author=None)
+        return beneficiary_import
+
+    @factory.post_generation
+    def beneficiaryFraudChecks(obj, create, extracted, **kwargs):  # pylint: disable=no-self-argument
+        import pcapi.core.fraud.factories as fraud_factories
+
+        if not create:
+            return None
+
+        return fraud_factories.BeneficiaryFraudCheckFactory(
+            user=obj,
+            type=fraud_models.FraudCheckType.EDUCONNECT
+            if obj.eligibility == users_models.EligibilityType.UNDERAGE
+            else fraud_models.FraudCheckType.JOUVE,
+            resultContent=fraud_factories.EduconnectContentFactory(
+                first_name=obj.firstName,
+                last_name=obj.lastName,
+                birth_date=obj.dateOfBirth.date(),
+                ine_hash=obj.ineHash,
+            )
+            if obj.eligibility == users_models.EligibilityType.UNDERAGE
+            else fraud_factories.JouveContentFactory(firstName=obj.firstName, lastName=obj.lastName),
+        )
+
+    @factory.post_generation
+    def beneficiaryFraudResults(obj, create, extracted, **kwargs):  # pylint: disable=no-self-argument
+        import pcapi.core.fraud.factories as fraud_factories
+
+        if not create:
+            return None
+
+        return fraud_factories.BeneficiaryFraudResultFactory(
+            user=obj, status=fraud_models.FraudStatus.OK, eligibilityType=obj.eligibility, reason=None
+        )
+
 
 class UnderageBeneficiaryFactory(BeneficiaryGrant18Factory):
     class Params:
         subscription_age = 15
 
-    roles = [pcapi.core.users.models.UserRole.UNDERAGE_BENEFICIARY]
+    roles = [users_models.UserRole.UNDERAGE_BENEFICIARY]
     dateOfBirth = LazyAttribute(
         lambda o: datetime.combine(date.today(), time(0, 0)) - relativedelta(years=o.subscription_age, months=5)
     )
-    dateCreated = LazyAttribute(lambda o: o.dateOfBirth + relativedelta(years=o.subscription_age, hours=12))
+    dateCreated = LazyAttribute(lambda user: user.dateOfBirth + relativedelta(years=user.subscription_age, hours=12))
     ineHash = factory.Sequence(lambda _: "".join(random.choices(string.ascii_lowercase + string.digits, k=32)))
 
     @factory.post_generation
@@ -171,7 +241,7 @@ class UnderageBeneficiaryFactory(BeneficiaryGrant18Factory):
 
 class ProFactory(BaseFactory):
     class Meta:
-        model = pcapi.core.users.models.User
+        model = users_models.User
 
     email = factory.Sequence("ma.librairie{}@example.com".format)
     address = factory.Sequence("{} rue des cinémas".format)
@@ -182,7 +252,7 @@ class ProFactory(BaseFactory):
     publicName = "René Coty"
     isEmailValidated = True
     isAdmin = False
-    roles = [pcapi.core.users.models.UserRole.PRO]
+    roles = [users_models.UserRole.PRO]
     hasSeenProTutorials = True
 
     @classmethod
@@ -247,26 +317,6 @@ class FavoriteFactory(BaseFactory):
 
     offer = factory.SubFactory("pcapi.core.offers.factories.OfferFactory")
     user = factory.SubFactory(UserFactory)
-
-
-class BeneficiaryImportFactory(BaseFactory):
-    class Meta:
-        model = BeneficiaryImport
-
-    applicationId = factory.Sequence(lambda n: n)
-    beneficiary = factory.SubFactory("pcapi.core.users.factories.UserFactory")
-    source = BeneficiaryImportSources.jouve.value
-
-
-class BeneficiaryImportStatusFactory(BaseFactory):
-    class Meta:
-        model = BeneficiaryImportStatus
-
-    status = ImportStatus.CREATED.value
-    date = factory.Faker("date_time_between", start_date="-30d", end_date="-1d")
-    detail = factory.Faker("sentence", nb_words=3)
-    beneficiaryImport = factory.SubFactory(BeneficiaryImportFactory)
-    author = factory.SubFactory("pcapi.core.users.factories.UserFactory")
 
 
 # DepositFactory in users module to avoid import loops

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -497,6 +497,15 @@ class User(PcObject, Model, NeedsValidationMixin):
         subscriptions = self.get_notification_subscriptions()
         return subscriptions.marketing_push
 
+    def can_upgrade_beneficiary_role(self, eligibility: Optional[EligibilityType] = None) -> bool:
+        if not eligibility:
+            eligibility = self.eligibility
+
+        return bool(eligibility) and (
+            (eligibility == EligibilityType.UNDERAGE and not self.is_beneficiary)
+            or (eligibility == EligibilityType.AGE18 and not self.has_beneficiary_role)
+        )
+
 
 class ExpenseDomain(enum.Enum):
     ALL = "all"

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -442,6 +442,10 @@ class User(PcObject, Model, NeedsValidationMixin):
         if self.has_admin_role:  # pylint: disable=using-constant-test
             self.roles.remove(UserRole.ADMIN)
 
+    def remove_underage_beneficiary_role(self) -> None:
+        if self.has_underage_beneficiary_role:  # pylint: disable=using-constant-test
+            self.roles.remove(UserRole.UNDERAGE_BENEFICIARY)
+
     def remove_beneficiary_role(self) -> None:
         if self.has_beneficiary_role:  # pylint: disable=using-constant-test
             self.roles.remove(UserRole.BENEFICIARY)

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -88,7 +88,7 @@ def get_and_lock_user(user_id: int) -> User:
     # older from the SQLAlchemy's session.
     user = User.query.filter_by(id=user_id).populate_existing().with_for_update().one_or_none()
     if not user:
-        raise exceptions.UserDoesNotExist
+        raise exceptions.UserDoesNotExist()
     return user
 
 

--- a/api/src/pcapi/domain/beneficiary_pre_subscription/validator.py
+++ b/api/src/pcapi/domain/beneficiary_pre_subscription/validator.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from pcapi.core.fraud import api as fraud_api
 from pcapi.core.subscription.models import BeneficiaryPreSubscription
+from pcapi.core.users.models import EligibilityType
 from pcapi.core.users.models import User
 from pcapi.domain.beneficiary_pre_subscription.exceptions import BeneficiaryIsADuplicate
 from pcapi.domain.beneficiary_pre_subscription.exceptions import BeneficiaryIsNotEligible
@@ -101,13 +102,17 @@ def validate(
     beneficiary_pre_subscription: BeneficiaryPreSubscription,
     preexisting_account: User = None,
     ignore_id_piece_number_field: bool = False,
+    eligibility: EligibilityType = EligibilityType.AGE18,
 ) -> None:
     _check_subscription_on_hold(beneficiary_pre_subscription)
     _check_department_is_eligible(beneficiary_pre_subscription)
     if not preexisting_account:
         _check_email_is_not_taken(beneficiary_pre_subscription)
     else:
-        if preexisting_account.is_beneficiary or not preexisting_account.isEmailValidated:
+        if (
+            not preexisting_account.can_upgrade_beneficiary_role(eligibility)
+            or not preexisting_account.isEmailValidated
+        ):
             raise BeneficiaryIsADuplicate(f"Email {beneficiary_pre_subscription.email} is already taken.")
     _check_not_a_duplicate(beneficiary_pre_subscription)
     if not ignore_id_piece_number_field:

--- a/api/src/pcapi/repository/user_queries.py
+++ b/api/src/pcapi/repository/user_queries.py
@@ -59,7 +59,6 @@ def beneficiary_by_civility_query(
     interval: timedelta = None,
     exclude_email: Optional[str] = None,
 ) -> Query:
-    # TODO: Handle switch from underage_beneficiary to beneficiary
     civility_predicate = (
         (matching(User.firstName, first_name)) & (matching(User.lastName, last_name)) & (User.is_beneficiary == True)
     )

--- a/api/src/pcapi/routes/external/users_subscription.py
+++ b/api/src/pcapi/routes/external/users_subscription.py
@@ -3,6 +3,7 @@ import logging
 from pcapi.connectors import api_demarches_simplifiees
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import messages as subscription_messages
+from pcapi.core.users.models import EligibilityType
 from pcapi.models import BeneficiaryImportSources
 from pcapi.models import ImportStatus
 from pcapi.repository import repository
@@ -61,6 +62,7 @@ def dms_webhook_update_application_status(form: dms_validation.DMSWebhookRequest
             BeneficiaryImportSources.demarches_simplifiees,
             "Webhook status update",
             import_status,
+            eligibilityType=EligibilityType.AGE18,
         )
 
     if form.state == api_demarches_simplifiees.GraphQLApplicationStates.draft:

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -158,8 +158,7 @@ def resend_email_validation(body: serializers.ResendEmailValidationRequest) -> N
 @spectree_serialize(api=blueprint.api, response_model=serializers.GetIdCheckTokenResponse)
 @authenticated_user_required
 def get_id_check_token(user: User) -> serializers.GetIdCheckTokenResponse:
-    # TODO: Handle switch from underage_beneficiary to beneficiary
-    if not user.is_eligible or user.is_beneficiary:
+    if not user.can_upgrade_beneficiary_role():
         raise ApiErrors({"code": "USER_NOT_ELIGIBLE"})
     try:
         id_check_token = api.create_id_check_token(user)

--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -85,11 +85,11 @@ def on_educonnect_authentication_response() -> Response:
         last_name=educonnect_user.last_name,
     )
 
-    fraud_api.on_educonnect_result(user, educonnect_content)
+    fraud_result = fraud_api.on_educonnect_result(user, educonnect_content)
 
     error_page_base_url = f"{settings.WEBAPP_V2_URL}/idcheck/educonnect/erreur?"
     try:
-        subscription_api.create_beneficiary_import(user)
+        subscription_api.create_beneficiary_import(user, fraud_result)
     except fraud_exceptions.UserAgeNotValid:
         logger.warning(
             "User age not valid",

--- a/api/src/pcapi/scripts/beneficiary/remote_import.py
+++ b/api/src/pcapi/scripts/beneficiary/remote_import.py
@@ -169,8 +169,7 @@ def process_application(
         fraud_api.on_dms_fraud_check(user, information)
     except Exception as exc:  # pylint: disable=broad-except
         logger.exception("Error on dms fraud check result: %s", exc)
-    # TODO: Handle switch from underage_beneficiary to beneficiary
-    if user.is_beneficiary is True:
+    if user.has_beneficiary_role:
         _process_rejection(information, procedure_id=procedure_id, reason="Compte existant avec cet email")
         return
 

--- a/api/src/pcapi/scripts/beneficiary/remote_tag_has_completed.py
+++ b/api/src/pcapi/scripts/beneficiary/remote_tag_has_completed.py
@@ -33,8 +33,7 @@ def run(
         user = already_existing_user(details["dossier"]["email"])
 
         if user:
-            # TODO: Handle switch from underage_beneficiary to beneficiary
-            if user.is_beneficiary:
+            if user.has_beneficiary_role:
                 logger.warning(
                     "[BATCH][REMOTE TAG HAS COMPLETED] User is already beneficiary",
                     extra={"user": user.id, "procedure": procedure_id},

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -182,26 +182,30 @@
   </div>
   <div class="col">
     <h3>Résultat de l'algorithme</h3>
-    {% if model.beneficiaryFraudResult %}
+    {% for beneficiary_fraud_result in model.beneficiaryFraudResults|reverse %}
     <table class="table">
       <tr>
+        <th scope="row">Souscription</th>
+        <td>{{ "pass 15-17" if beneficiary_fraud_result.eligibilityType.value == "underage" else "pass 18 ans" }}</td>
+      </tr>
+      <tr>
         <th scope="row">Etat</th>
-        <td>{{ model.beneficiaryFraudResult.status.value }}</td>
+        <td>{{ beneficiary_fraud_result.status.value }}</td>
       </tr>
       <tr>
         <th scope="row">Date de création</th>
-        <td>{{ model.beneficiaryFraudResult.dateCreated.strftime('le %d/%m/%Y à %H:%M:%S') }}</dd>
+        <td>{{ beneficiary_fraud_result.dateCreated.strftime('le %d/%m/%Y à %H:%M:%S') }}</dd>
         </td>
       </tr>
       <tr>
         <th scope="row">Dernière mise à jour</th>
-        <td>{% if model.beneficiaryFraudResult.dateUpdated %}{{ model.beneficiaryFraudResult.dateUpdated.strftime('le
+        <td>{% if beneficiary_fraud_result.dateUpdated %}{{ beneficiary_fraud_result.dateUpdated.strftime('le
           %d/%m/%Y à %H:%M:%S') }}{% else %}Inconnue{% endif %}</dd>
         </td>
       </tr>
       <tr>
         <th scope="row">Explication</th>
-        <td>{{ model.beneficiaryFraudResult.reason }}</dd>
+        <td>{{ beneficiary_fraud_result.reason }}</dd>
         </td>
       </tr>
     </table>
@@ -209,7 +213,7 @@
     <div class="card card-body">
       Aucun résultat de fraude
     </div>
-    {% endif %}
+    {% endfor %}
   </div>
   {% if model.beneficiaryFraudReview %}
   <div class="col">

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -326,7 +326,8 @@ class UpdateIDPieceNumberTest:
 
         assert response.status_code == 302
 
-        assert user.beneficiaryFraudResult.status == fraud_models.FraudStatus.OK
+        assert len(user.beneficiaryFraudResults) == 1
+        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
         assert fraud_check.resultContent["bodyPieceNumberCtrl"] == "OK"
         assert fraud_check.resultContent["bodyPieceNumber"] == id_piece_number
         assert user.idPieceNumber == id_piece_number
@@ -347,7 +348,8 @@ class UpdateIDPieceNumberTest:
         )
         assert response.status_code == 302
 
-        assert user.beneficiaryFraudResult.status == fraud_models.FraudStatus.OK
+        assert len(user.beneficiaryFraudResults) == 1
+        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
         assert fraud_check.resultContent["id_piece_number"] == id_piece_number
         assert user.idPieceNumber == id_piece_number
         assert user.has_beneficiary_role
@@ -374,7 +376,8 @@ class UpdateIDPieceNumberTest:
         )
         assert response.status_code == 302
 
-        assert user.beneficiaryFraudResult.status == fraud_models.FraudStatus.OK
+        assert len(user.beneficiaryFraudResults) == 1
+        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
         assert fraud_check.resultContent["id_piece_number"] == id_piece_number
         assert user.idPieceNumber == id_piece_number
         assert user.has_beneficiary_role

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -321,7 +321,7 @@ class CommonFraudCheckTest:
 
     def test_duplicate_user_fraud_ok(self):
         fraud_item = fraud_api._duplicate_user_fraud_item(
-            first_name="Jean", last_name="Michel", birth_date=datetime.date.today()
+            first_name="Jean", last_name="Michel", birth_date=datetime.date.today(), excluded_email="jean@michel.com"
         )
 
         assert fraud_item.status == fraud_models.FraudStatus.OK
@@ -329,10 +329,24 @@ class CommonFraudCheckTest:
     def test_duplicate_user_fraud_suspicious(self):
         user = users_factories.BeneficiaryGrant18Factory()
         fraud_item = fraud_api._duplicate_user_fraud_item(
-            first_name=user.firstName, last_name=user.lastName, birth_date=user.dateOfBirth.date()
+            first_name=user.firstName,
+            last_name=user.lastName,
+            birth_date=user.dateOfBirth.date(),
+            excluded_email="jean@michel.com",
         )
 
         assert fraud_item.status == fraud_models.FraudStatus.SUSPICIOUS
+
+    def test_duplicate_user_ok_if_self_found(self):
+        user = users_factories.BeneficiaryGrant18Factory()
+        fraud_item = fraud_api._duplicate_user_fraud_item(
+            first_name=user.firstName,
+            last_name=user.lastName,
+            birth_date=user.dateOfBirth.date(),
+            excluded_email=user.email,
+        )
+
+        assert fraud_item.status == fraud_models.FraudStatus.OK
 
     @pytest.mark.parametrize(
         "fraud_check_type",
@@ -505,11 +519,13 @@ class EduconnectFraudTest:
 
     @pytest.mark.parametrize("age", [14, 18])
     def test_age_fraud_check_ko(self, age):
+        user = users_factories.UserFactory()
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.EDUCONNECT,
             resultContent=fraud_factories.EduconnectContentFactory(age=age),
+            user=user,
         )
-        result = fraud_api.educonnect_fraud_checks(beneficiary_fraud_check=fraud_check)
+        result = fraud_api.educonnect_fraud_checks(user, beneficiary_fraud_check=fraud_check)
 
         age_check = next(
             fraud_check
@@ -523,17 +539,18 @@ class EduconnectFraudTest:
 
     @pytest.mark.parametrize("age", [15, 16, 17])
     def test_age_fraud_check_ok(self, age):
+        user = users_factories.UserFactory()
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.EDUCONNECT,
             resultContent=fraud_factories.EduconnectContentFactory(age=age),
         )
-        result = fraud_api.educonnect_fraud_checks(beneficiary_fraud_check=fraud_check)
+        result = fraud_api.educonnect_fraud_checks(user, beneficiary_fraud_check=fraud_check)
 
         age_check = next(
             (
-                fraud_check
-                for fraud_check in result
-                if fraud_check.reason_code == fraud_models.FraudReasonCode.AGE_NOT_VALID
+                fraud_item
+                for fraud_item in result
+                if fraud_item.reason_code == fraud_models.FraudReasonCode.AGE_NOT_VALID
             ),
             None,
         )
@@ -542,6 +559,7 @@ class EduconnectFraudTest:
     @override_features(ENABLE_NATIVE_EAC_INDIVIDUAL=True)
     def test_duplicates_fraud_checks(self):
         already_existing_user = users_factories.UnderageBeneficiaryFactory(subscription_age=15)
+        user = users_factories.UserFactory()
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.EDUCONNECT,
             resultContent=fraud_factories.EduconnectContentFactory(
@@ -549,27 +567,45 @@ class EduconnectFraudTest:
                 last_name=already_existing_user.lastName,
                 birth_date=already_existing_user.dateOfBirth,
             ),
+            user=user,
         )
-        result = fraud_api.educonnect_fraud_checks(fraud_check)
+        result = fraud_api.educonnect_fraud_checks(user, fraud_check)
 
         duplicate_check = next(
-            fraud_check
-            for fraud_check in result
-            if fraud_check.reason_code == fraud_models.FraudReasonCode.DUPLICATE_USER
+            fraud_item for fraud_item in result if fraud_item.reason_code == fraud_models.FraudReasonCode.DUPLICATE_USER
         )
 
         assert duplicate_check.status == fraud_models.FraudStatus.SUSPICIOUS
         assert duplicate_check.detail == f"Duplicat de l'utilisateur {already_existing_user.id}"
 
     @override_features(ENABLE_NATIVE_EAC_INDIVIDUAL=True)
+    def test_same_user_is_not_duplicate(self):
+        underage_user = users_factories.UnderageBeneficiaryFactory(subscription_age=15)
+
+        fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
+            type=fraud_models.FraudCheckType.EDUCONNECT,
+            resultContent=fraud_factories.EduconnectContentFactory(
+                first_name=underage_user.firstName,
+                last_name=underage_user.lastName,
+                birth_date=underage_user.dateOfBirth,
+            ),
+            user=underage_user,
+        )
+        result = fraud_api.educonnect_fraud_checks(underage_user, fraud_check)
+
+        assert not any(fraud_item.reason_code == fraud_models.FraudReasonCode.DUPLICATE_USER for fraud_item in result)
+
+    @override_features(ENABLE_NATIVE_EAC_INDIVIDUAL=True)
     def test_ine_duplicates_fraud_checks(self):
         fraud_factories.IneHashWhitelistFactory(ine_hash="ylwavk71o3jiwyla83fxk5pcmmu0ws01")
         same_ine_user = users_factories.UnderageBeneficiaryFactory(ineHash="ylwavk71o3jiwyla83fxk5pcmmu0ws01")
+        user_in_validation = users_factories.UserFactory()
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.EDUCONNECT,
             resultContent=fraud_factories.EduconnectContentFactory(ine_hash=same_ine_user.ineHash),
+            user=user_in_validation,
         )
-        result = fraud_api.educonnect_fraud_checks(fraud_check)
+        result = fraud_api.educonnect_fraud_checks(user_in_validation, fraud_check)
 
         duplicate_ine_check = next(
             fraud_check
@@ -584,12 +620,14 @@ class EduconnectFraudTest:
 
     @override_features(ENABLE_NATIVE_EAC_INDIVIDUAL=True)
     def test_ine_whitelisted_fraud_checks_pass(self):
+        user = users_factories.UserFactory()
         fraud_factories.IneHashWhitelistFactory(ine_hash="identifiantWhitelisté1")
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.EDUCONNECT,
             resultContent=fraud_factories.EduconnectContentFactory(ine_hash="identifiantWhitelisté1"),
+            user=user,
         )
-        result = fraud_api.educonnect_fraud_checks(fraud_check)
+        result = fraud_api.educonnect_fraud_checks(user, fraud_check)
 
         duplicate_ine_check = next(
             (
@@ -603,12 +641,13 @@ class EduconnectFraudTest:
 
     @override_features(ENABLE_NATIVE_EAC_INDIVIDUAL=True)
     def test_ine_whitelisted_fraud_checks_fail(self):
+        user = users_factories.UserFactory()
         fraud_factories.IneHashWhitelistFactory(ine_hash="identifiantWhitelisté1")
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.EDUCONNECT,
             resultContent=fraud_factories.EduconnectContentFactory(ine_hash="identifiantWhitelisté2"),
         )
-        result = fraud_api.educonnect_fraud_checks(fraud_check)
+        result = fraud_api.educonnect_fraud_checks(user, fraud_check)
 
         duplicate_ine_check = next(
             fraud_check

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -260,7 +260,9 @@ class UpsertFraudResultTest:
         user = users_factories.UserFactory()
         assert fraud_models.BeneficiaryFraudResult.query.count() == 0
 
-        result = fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, "no reason at all")
+        result = fraud_api.upsert_fraud_result(
+            user, fraud_models.FraudStatus.SUSPICIOUS, users_models.EligibilityType.AGE18, "no reason at all"
+        )
 
         assert fraud_models.BeneficiaryFraudResult.query.count() == 1
         assert result.user == user
@@ -268,11 +270,15 @@ class UpsertFraudResultTest:
 
     def test_update_on_following_fraud_results(self):
         user = users_factories.UserFactory()
-        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.OK)
+        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.OK, users_models.EligibilityType.AGE18)
         assert fraud_models.BeneficiaryFraudResult.query.count() == 1
 
-        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, "no reason at all")
-        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.KO, "no reason at all")
+        fraud_api.upsert_fraud_result(
+            user, fraud_models.FraudStatus.SUSPICIOUS, users_models.EligibilityType.AGE18, "no reason at all"
+        )
+        fraud_api.upsert_fraud_result(
+            user, fraud_models.FraudStatus.KO, users_models.EligibilityType.AGE18, "no reason at all"
+        )
 
         assert fraud_models.BeneficiaryFraudResult.query.count() == 1
 
@@ -281,7 +287,7 @@ class UpsertFraudResultTest:
         user = users_factories.UserFactory()
 
         with pytest.raises(ValueError) as excinfo:
-            fraud_api.upsert_fraud_result(user, fraud_status)
+            fraud_api.upsert_fraud_result(user, fraud_status, users_models.EligibilityType.AGE18)
 
         assert str(excinfo.value) == f"a reason should be provided when setting fraud result to {fraud_status.value}"
 
@@ -294,13 +300,27 @@ class UpsertFraudResultTest:
         first_reason = "first reason"
         second_reason = "second reason"
 
-        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, first_reason)
-        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, first_reason)
-        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, first_reason)
-        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, second_reason)
-        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, second_reason)
-        fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, first_reason)
-        result = fraud_api.upsert_fraud_result(user, fraud_models.FraudStatus.SUSPICIOUS, first_reason)
+        fraud_api.upsert_fraud_result(
+            user, fraud_models.FraudStatus.SUSPICIOUS, users_models.EligibilityType.AGE18, first_reason
+        )
+        fraud_api.upsert_fraud_result(
+            user, fraud_models.FraudStatus.SUSPICIOUS, users_models.EligibilityType.AGE18, first_reason
+        )
+        fraud_api.upsert_fraud_result(
+            user, fraud_models.FraudStatus.SUSPICIOUS, users_models.EligibilityType.AGE18, first_reason
+        )
+        fraud_api.upsert_fraud_result(
+            user, fraud_models.FraudStatus.SUSPICIOUS, users_models.EligibilityType.AGE18, second_reason
+        )
+        fraud_api.upsert_fraud_result(
+            user, fraud_models.FraudStatus.SUSPICIOUS, users_models.EligibilityType.AGE18, second_reason
+        )
+        fraud_api.upsert_fraud_result(
+            user, fraud_models.FraudStatus.SUSPICIOUS, users_models.EligibilityType.AGE18, first_reason
+        )
+        result = fraud_api.upsert_fraud_result(
+            user, fraud_models.FraudStatus.SUSPICIOUS, users_models.EligibilityType.AGE18, first_reason
+        )
 
         assert fraud_models.BeneficiaryFraudResult.query.count() == 1
         assert result.user == user
@@ -515,7 +535,8 @@ class EduconnectFraudTest:
             "last_name": "Ellingson",
             "birth_date": birth_date,
         }
-        assert user.beneficiaryFraudResult.status == fraud_models.FraudStatus.OK
+        assert len(user.beneficiaryFraudResults) == 1
+        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
 
     @pytest.mark.parametrize("age", [14, 18])
     def test_age_fraud_check_ko(self, age):

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -148,7 +148,8 @@ class EduconnectFlowTest:
             == "https://webapp-v2.example.com/idcheck/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
-        assert user.beneficiaryFraudResult.status == fraud_models.FraudStatus.OK
+        assert len(user.beneficiaryFraudResults) == 1
+        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
 
         beneficiary_import = BeneficiaryImport.query.filter_by(beneficiaryId=user.id).one_or_none()
         assert beneficiary_import is not None

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -956,9 +956,9 @@ class SendPhoneValidationCodeTest:
         assert content["phone_number"] == "+33601020304"
 
         # check that a fraud result has also been created
-        assert user.beneficiaryFraudResult
-        assert user.beneficiaryFraudResult.status == fraud_models.FraudStatus.SUSPICIOUS
-        assert user.beneficiaryFraudResult.reason == expected_reason
+        assert len(user.beneficiaryFraudResults) == 1
+        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.SUSPICIOUS
+        assert user.beneficiaryFraudResults[0].reason == expected_reason
 
     def test_send_phone_validation_code_already_beneficiary(self, app):
         user = users_factories.BeneficiaryGrant18Factory(
@@ -1224,9 +1224,9 @@ class ValidatePhoneNumberTest:
         assert content["phone_number"] == "+33607080900"
 
         # check that a fraud result has also been created
-        assert user.beneficiaryFraudResult
-        assert user.beneficiaryFraudResult.status == fraud_models.FraudStatus.SUSPICIOUS
-        assert user.beneficiaryFraudResult.reason == expected_reason
+        assert len(user.beneficiaryFraudResults) == 1
+        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.SUSPICIOUS
+        assert user.beneficiaryFraudResults[0].reason == expected_reason
 
     def test_wrong_code(self, app):
         user = users_factories.UserFactory(phoneNumber="+33607080900")

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -133,7 +133,8 @@ class EduconnectTest:
             "ine_hash": ine_hash,
             "last_name": "SENS",
         }
-        assert user.beneficiaryFraudResult.status == fraud_models.FraudStatus.OK
+        assert len(user.beneficiaryFraudResults) == 1
+        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
         beneficiary_import = BeneficiaryImport.query.filter_by(beneficiaryId=user.id).one_or_none()
         assert beneficiary_import.currentStatus == ImportStatus.CREATED
         assert user.firstName == "Max"
@@ -244,4 +245,4 @@ class EduconnectTest:
 
         assert response.status_code == 302
         assert response.location.startswith("https://webapp-v2.example.com/idcheck/validation")
-        assert user.beneficiaryFraudResult.status == fraud_models.FraudStatus.OK
+        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK

--- a/api/tests/scripts/beneficiary/remote_import_test.py
+++ b/api/tests/scripts/beneficiary/remote_import_test.py
@@ -721,7 +721,8 @@ class RunIntegrationTest:
         assert fraud_content.birth_date == user.dateOfBirth.date()
         assert fraud_content.address == "11 Rue du Test"
 
-        fraud_result = user.beneficiaryFraudResult
+        assert len(user.beneficiaryFraudResults) == 1
+        fraud_result = user.beneficiaryFraudResults[0]
         assert fraud_result.status == fraud_models.FraudStatus.KO
         assert "Le n° de téléphone de l'utilisateur n'est pas validé" in fraud_result.reason
         assert BeneficiaryImport.query.count() == 1
@@ -864,8 +865,8 @@ class RunIntegrationTest:
         assert len(user.beneficiaryFraudChecks) == 1
         assert user.beneficiaryFraudChecks[0].type == fraud_models.FraudCheckType.DMS
 
-        assert user.beneficiaryFraudResult.status == fraud_models.FraudStatus.SUSPICIOUS
-        assert f"Duplicat de l'utilisateur {existing_user.id}" in user.beneficiaryFraudResult.reason
+        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.SUSPICIOUS
+        assert f"Duplicat de l'utilisateur {existing_user.id}" in user.beneficiaryFraudResults[0].reason
 
         beneficiary_import = BeneficiaryImport.query.first()
         assert beneficiary_import.source == "demarches_simplifiees"
@@ -965,10 +966,10 @@ class RunIntegrationTest:
         assert beneficiary_import.beneficiary == applicant
         assert beneficiary_import.currentStatus == ImportStatus.REJECTED
 
-        assert applicant.beneficiaryFraudResult.status == fraud_models.FraudStatus.SUSPICIOUS
+        assert applicant.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.SUSPICIOUS
         assert (
             f"Le n° de cni 1234123412 est déjà pris par l'utilisateur {beneficiary.id}"
-            in applicant.beneficiaryFraudResult.reason
+            in applicant.beneficiaryFraudResults[0].reason
         )
 
     @override_features(FORCE_PHONE_VALIDATION=False)
@@ -1069,8 +1070,8 @@ class RunIntegrationTest:
         beneficiary_import = BeneficiaryImport.query.filter_by(applicationId=123).first()
         assert beneficiary_import.currentStatus == ImportStatus.DUPLICATE
 
-        assert applicant.beneficiaryFraudResult.status == fraud_models.FraudStatus.SUSPICIOUS
-        assert f"Duplicat de l'utilisateur {beneficiary.id}" in applicant.beneficiaryFraudResult.reason
+        assert applicant.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.SUSPICIOUS
+        assert f"Duplicat de l'utilisateur {beneficiary.id}" in applicant.beneficiaryFraudResults[0].reason
 
     @patch("pcapi.scripts.beneficiary.remote_import.get_application_details")
     @patch(

--- a/api/tests/scripts/beneficiary/remote_import_test.py
+++ b/api/tests/scripts/beneficiary/remote_import_test.py
@@ -12,6 +12,8 @@ from pcapi.connectors.api_demarches_simplifiees import DMSGraphQLClient
 import pcapi.core.fraud.factories as fraud_factories
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.mails.testing as mails_testing
+from pcapi.core.payments.models import Deposit
+from pcapi.core.payments.models import DepositType
 import pcapi.core.subscription.models as subscription_models
 from pcapi.core.testing import override_features
 from pcapi.core.users import api as users_api
@@ -633,9 +635,7 @@ class RunIntegrationTest:
             dateOfBirth=AGE18_ELIGIBLE_BIRTH_DATE,
         )
 
-        remote_import.run(
-            procedure_id=6712558,
-        )
+        remote_import.run(procedure_id=6712558)
 
         # then
         assert users_models.User.query.count() == 1
@@ -653,6 +653,43 @@ class RunIntegrationTest:
         assert beneficiary_import.beneficiary == user
         assert beneficiary_import.currentStatus == ImportStatus.CREATED
         assert len(push_testing.requests) == 1
+
+    @override_features(FORCE_PHONE_VALIDATION=False)
+    @patch(
+        "pcapi.scripts.beneficiary.remote_import.get_closed_application_ids_for_demarche_simplifiee",
+    )
+    @patch("pcapi.scripts.beneficiary.remote_import.get_application_details")
+    def test_import_exunderage_beneficiary(
+        self, get_application_details, get_closed_application_ids_for_demarche_simplifiee
+    ):
+
+        with freezegun.freeze_time(datetime.utcnow() - relativedelta(years=3)):
+            users_factories.UnderageBeneficiaryFactory(
+                email="john.doe@example.com",
+                firstName="john",
+                lastName="doe",
+                dateOfBirth=AGE18_ELIGIBLE_BIRTH_DATE,
+                subscription_age=15,
+            )
+
+        get_closed_application_ids_for_demarche_simplifiee.side_effect = self._get_all_applications_ids
+        get_application_details.side_effect = self._get_details
+
+        remote_import.run(procedure_id=6712558)
+
+        # then
+        assert users_models.User.query.count() == 1
+        user = users_models.User.query.first()
+
+        assert user.has_beneficiary_role
+
+        deposits = Deposit.query.filter_by(user=user).all()
+        age_18_deposit = next(deposit for deposit in deposits if deposit.type == DepositType.GRANT_18)
+
+        assert len(deposits) == 2
+        assert age_18_deposit.amount == 300
+
+        assert BeneficiaryImport.query.count() == 2
 
     @patch(
         "pcapi.scripts.beneficiary.remote_import.get_closed_application_ids_for_demarche_simplifiee",


### PR DESCRIPTION
## Implémentation

Il faut notamment autoriser plusieurs `beneficiaryFraudResults` par utilisateur.
Ce comportement est temporaire : nous prévoyons de supprimer cette entité.

Pour l'instant on a hard codé : 
- Dossier DMS -> souscription pass 18
- Dossier Jouve -> souscription pass 18
- Dossier Educonnect -> souscription pass 15-17